### PR TITLE
Fixed an env variable missmatch error

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,9 +19,9 @@ management:
 
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   thymeleaf:
     cache: false


### PR DESCRIPTION
This pr includes following improvements:

- Fixed an env variable missmatch error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized database configuration to use Spring’s SPRING_DATASOURCE_* environment variables for URL, username, and password.
  - Deployments should update environment settings to SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, and SPRING_DATASOURCE_PASSWORD (replacing previous DB_* variables).
  - No changes to other application settings or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->