### PR TITLE
Refactor invite code API endpoints for clarity and consistency

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -10,7 +10,7 @@ import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodeGenerationDto
 import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodeValidationDto;
 
 @RestController
-@RequestMapping("/api/v1/invites")
+@RequestMapping("/api/v1/invitation")
 @Validated
 public class ProjectInviteCodeController {
 
@@ -20,7 +20,7 @@ public class ProjectInviteCodeController {
         this.projectInviteCodeService = projectInviteCodeService;
     }
 
-    @PostMapping("/createCode")
+    @PostMapping("/generateCode")
     public ResponseEntity<ApiResponse> createInviteCode(@Valid @RequestBody InviteCodeGenerationDto inviteCodeGenerationDto) {
         projectInviteCodeService.generateInviteCode(inviteCodeGenerationDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse("Invite Code Created Successfully"));


### PR DESCRIPTION
This pr includes following improvements:

- changed main requestmapping of invite code from "/api/v1/invites" to "/api/v1/invitation
- changed postmapping for invite code to "/generateCode"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed invite-related API endpoints: base path changed from /api/v1/invites to /api/v1/invitation, and the invite code creation route is now POST /api/v1/invitation/generateCode (was /createCode). This is a breaking change; update client integrations accordingly.
  * No changes to request or response payloads—only routing paths were updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->