### PR TITLE
Rate limiting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ plugins {
     id 'org.springframework.boot' version '3.4.0'
     id 'io.spring.dependency-management' version '1.1.6'
 }
+ext {
+    springCloudVersion = "2024.0.2"
+}
 
 repositories {
     mavenCentral()
@@ -14,6 +17,10 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'com.github.librepdf:openpdf:3.0.0'
+    implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.13.0'
+    implementation 'javax.cache:cache-api:1.1.1'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.2'
+    implementation 'com.github.ben-manes.caffeine:jcache:3.2.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -21,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.jayway.jsonpath:json-path'
@@ -42,6 +50,11 @@ description = 'echno_backend'
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
     }
 }
 

--- a/src/main/java/org/tornotron/echno_backend/EchnoBackendApplication.java
+++ b/src/main/java/org/tornotron/echno_backend/EchnoBackendApplication.java
@@ -2,8 +2,10 @@ package org.tornotron.echno_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class EchnoBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/tornotron/echno_backend/organization/Organization.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/Organization.java
@@ -29,7 +29,7 @@ public class Organization {
     private Long id;
 
     /** The name of the organization. It must be unique. */
-    @Column(name = "organization_name", unique = true,nullable = false)
+    @Column(name = "organization_name", nullable = false)
     private String organizationName;
 
     /** The physical address of the organization. */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,29 @@ management:
       export:
         enabled: true
 
+bucket4j:
+  enabled: true
+  filters:
+    - cache-name: rate-limit-buckets
+      url: ^/api/.*
+      http-status-code: TOO_MANY_REQUESTS
+      http-response-body: "{ \"error\": \"Rate limit exceeded. Try again later.\" }"
+      http-response-headers:
+        X-Rate-Limit-Remaining: "#{getAvailableTokens()}"
+      rate-limits:
+        - cache-key: "getRemoteAddr()"
+          bandwidths:
+            - capacity: 20
+              time: 1
+              unit: minutes
+              refill-speed: interval
+
 spring:
+  cache:
+    cache-names:
+      - rate-limit-buckets
+    caffeine:
+      spec: maximumSize=100000,expireAfterAccess=3600s
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -45,6 +45,7 @@
 
     <!-- Specific Logger Configurations -->
     <logger name="org.tornotron.echno_backend" level="DEBUG"/>
+    <logger name="com.giffing.bucket4j.spring.boot.starter" level="DEBUG"/>
 
     <!-- Reduce noise from specific packages -->
     <logger name="org.hibernate.SQL" level="DEBUG"/>


### PR DESCRIPTION
This pr includes following improvements:

- all the endpoints has been rate limited to 20 requests per min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled API rate limiting with clear 429 responses and remaining-quota header.
  - Added caching to improve response times and reduce repeated processing.
  - Allow multiple organizations to share the same name.
- Chores
  - Updated build configuration and dependencies.
- Documentation
  - Added configuration for rate limiting and caching in application settings.
- Style
  - Increased debug logging for rate-limiting components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->