### PR TITLE
Centralizing attachment module

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -1,0 +1,60 @@
+package org.tornotron.echno_backend.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+
+import java.time.Duration;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/attachment/web")
+@Validated
+public class AttachmentControllerWeb {
+
+    private final AttachmentService attachmentService;
+    private final FileStorageService fileStorageService;
+
+    public AttachmentControllerWeb(AttachmentService attachmentService, FileStorageService fileStorageService) {
+        this.attachmentService = attachmentService;
+        this.fileStorageService = fileStorageService;
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,value = "entityType/{entityType}/entityId/{entityId}")
+    public ResponseEntity<List<AttachmentDto>> creatAttachment(@RequestParam(value = "attachments",required = true)List<MultipartFile> attachments,
+                                                         @PathVariable String entityType,
+                                                         @PathVariable Long entityId)  {
+        return ResponseEntity.status(HttpStatus.CREATED).body(attachmentService.uploadAttachments(attachments,entityType,entityId,entityType.toLowerCase())
+                .stream()
+                .map(attachment -> {
+                    AttachmentDto dto = new AttachmentDto();
+                    dto.setId(attachment.getId());
+                    dto.setEntityType(attachment.getEntityType());
+                    dto.setContentType(attachment.getContentType());
+                    dto.setFileSize(attachment.getFileSize());
+                    dto.setFileName(attachment.getOriginalFilename());
+                    dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
+                    dto.setCreatedAt(attachment.getCreatedAt().toString());
+                    return dto;
+                }).toList());
+    }
+
+    @GetMapping("/entityId/{entityId}/entityType/{entityType}")
+    public ResponseEntity<List<AttachmentDto>> readAttachments(@PathVariable String entityType,
+                                                               @PathVariable Long entityId) {
+        return ResponseEntity.status(HttpStatus.OK).body(attachmentService.getAttachments(entityType,entityId));
+    }
+
+    @DeleteMapping("/attachmentId/{attachmentId}")
+    public ResponseEntity<ApiResponse> deleteAttachment(@PathVariable Long attachmentId) {
+        attachmentService.deleteAttachment(attachmentId);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Deleted Attachment"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -27,7 +27,7 @@ public class AttachmentControllerWeb {
         this.fileStorageService = fileStorageService;
     }
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,value = "entityType/{entityType}/entityId/{entityId}")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,value = "/entityId/{entityId}/entityType/{entityType}")
     public ResponseEntity<List<AttachmentDto>> creatAttachment(@RequestParam(value = "attachments",required = true)List<MultipartFile> attachments,
                                                          @PathVariable String entityType,
                                                          @PathVariable Long entityId)  {

--- a/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 @Data
 public class AttachmentDto {
+    private Long id;
     private String url;
     private String entityType;
     private String contentType;

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -100,6 +100,7 @@ public class AttachmentService {
                 .stream()
                 .map(attachment -> {
                     AttachmentDto dto = new AttachmentDto();
+                    dto.setId(attachment.getId());
                     dto.setEntityType(attachment.getEntityType());
                     dto.setContentType(attachment.getContentType());
                     dto.setFileSize(attachment.getFileSize());

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -30,7 +30,6 @@ public class UserControllerWeb {
 
     private final UserService userService;
     private final ObjectMapper objectMapper;
-    private final AttachmentService attachmentService;
 
     /**
      * Constructs a UserController with the given UserService.
@@ -38,11 +37,9 @@ public class UserControllerWeb {
      * @param userService The service for handling user-related business logic.
      * @param objectMapper The ObjectMapper for JSON processing.
      */
-    public UserControllerWeb(UserService userService, ObjectMapper objectMapper,AttachmentService
-                             attachmentService) {
+    public UserControllerWeb(UserService userService, ObjectMapper objectMapper) {
         this.userService = userService;
         this.objectMapper = objectMapper;
-        this.attachmentService = attachmentService;
     }
 
     /**
@@ -112,18 +109,6 @@ public class UserControllerWeb {
                 : Map.of();
         return ResponseEntity.status(HttpStatus.OK).body(userService.partialUpdateAnUser(updates, id, profilePicture, cv));
     }
-
-    @GetMapping("/userId/{userId}/attachmentType/{attachmentType}")
-    public ResponseEntity<List<AttachmentDto>> readAttachments(@PathVariable String attachmentType,@PathVariable Long userId) {
-        return ResponseEntity.status(HttpStatus.OK).body(attachmentService.getAttachments(attachmentType,userId));
-    }
-
-    @DeleteMapping("/attachmentId/{attachmentId}")
-    public ResponseEntity<ApiResponse> deleteAttachment(@PathVariable Long attachmentId) {
-        attachmentService.deleteAttachment(attachmentId);
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Attachment deleted"));
-    }
-
     /**
      * Updates multiple users in a batch.
      *


### PR DESCRIPTION
This pr includes following improvements:

   - Implemented AttachmentControllerWeb to centralize attachment management, providing endpoints for creating, reading, and deleting attachments.
   - Refactored UserControllerWeb to remove redundant attachment handling logic.
   - Updated AttachmentDto to include the id field for better client-side handling.
   - Fixed the order of path variables in the createAttachment endpoint to ensure correct parameter mapping.