### PR TITLE
Implement Organization-Scoped RBAC with Keycloak Integration

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
@@ -6,9 +6,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Security service for organization-level authorization checks.
@@ -35,6 +39,14 @@ import java.util.Collection;
 @Service("orgSecurity")
 @Slf4j
 public class OrganizationSecurityService {
+
+    private final UserContextService userContextService;
+    private final EmployeeRepository employeeRepository;
+
+    public OrganizationSecurityService(UserContextService userContextService, EmployeeRepository employeeRepository) {
+        this.userContextService = userContextService;
+        this.employeeRepository = employeeRepository;
+    }
 
     /**
      * Checks if the currently authenticated user is a member of the specified organization.
@@ -142,6 +154,41 @@ public class OrganizationSecurityService {
             log.debug("No current tenant org ID set in TenantContext");
             return false;
         }
+        return hasAnyOrgRole(orgId, roles);
+    }
+
+    /**
+     * Checks if the current user IS the given employee, OR has any of the specified
+     * org-scoped roles in the current tenant organization.
+     *
+     * This allows employees to perform actions on their own records while restricting
+     * actions on other employees' records to users with admin roles.
+     *
+     * Usage in @PreAuthorize:
+     *   @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')")
+     *
+     * @param employeeId the employee ID to check against the current user
+     * @param roles one or more admin role names that bypass the self-check
+     * @return true if the current user is the employee or has an admin role
+     */
+    public boolean isSelfOrHasAnyOrgRole(Long employeeId, String... roles) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (orgId == null) {
+            log.debug("No current tenant org ID set in TenantContext");
+            return false;
+        }
+
+        // Check if the current user IS this employee
+        Long currentUserId = userContextService.getCurrentUserId();
+        if (currentUserId != null) {
+            Optional<Employee> employee = employeeRepository.findByIdAndOrganizationId(employeeId, orgId);
+            if (employee.isPresent() && employee.get().getUser().getId().equals(currentUserId)) {
+                log.debug("Self-check passed: user {} is employee {}", currentUserId, employeeId);
+                return true;
+            }
+        }
+
+        // Fall back to admin role check
         return hasAnyOrgRole(orgId, roles);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -41,22 +41,22 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
      */
     @PostMapping("/joinOrganization/userId/{userId}/organizationId/{orgId}")
-//    @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.joinOrganization(userId, orgId, employeeJoinOrgDto));
     }
 
-    /**
-     * Creates a new employee.
-     *
-     * @param employeeCreationDto DTO containing the details for the new employee.
-     * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
-     */
-    @PostMapping
+//    /**
+//     * Creates a new employee.
+//     *
+//     * @param employeeCreationDto DTO containing the details for the new employee.
+//     * @return A {@link ResponseEntity} with the created employee's DTO and HTTP status 201 (Created).
+//     */
+//    @PostMapping
 //    @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
-    public ResponseEntity<EmployeeDto> createEmployee(@Valid @RequestBody EmployeeCreationDto employeeCreationDto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.addEmployee(employeeCreationDto));
-    }
+//    public ResponseEntity<EmployeeDto> createEmployee(@Valid @RequestBody EmployeeCreationDto employeeCreationDto) {
+//        return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.addEmployee(employeeCreationDto));
+//    }
 
     /**
      * Retrieves a list of all employees.
@@ -64,7 +64,6 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the list of employee DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-//    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return new ResponseEntity<>(employeeService.displayAllEmployees(),HttpStatus.OK);
     }
@@ -76,24 +75,23 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the employee DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-//    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
         EmployeeDto employee = employeeService.displayAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(employee);
     }
 
 
-    /**
-     * Retrieves all employees belonging to a specific organization.
-     *
-     * @param id The ID of the organization.
-     * @return A {@link ResponseEntity} containing a list of employee DTOs for the specified organization and HTTP status 200 (OK).
-     */
-    @GetMapping("/organization/{id}")
+//    /**
+//     * Retrieves all employees belonging to a specific organization.
+//     *
+//     * @param id The ID of the organization.
+//     * @return A {@link ResponseEntity} containing a list of employee DTOs for the specified organization and HTTP status 200 (OK).
+//     */
+//    @GetMapping("/organization/{id}")
 //    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
-    public ResponseEntity<List<EmployeeDto>> readEmployeesByOrganizationId(@PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(employeeService.displayEmployeesByOrganization(id));
-    }
+//    public ResponseEntity<List<EmployeeDto>> readEmployeesByOrganizationId(@PathVariable Long id) {
+//        return ResponseEntity.status(HttpStatus.OK).body(employeeService.displayEmployeesByOrganization(id));
+//    }
 
     /**
      * Partially updates an existing employee.
@@ -103,24 +101,23 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @PatchMapping("{id}")
-//    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')")
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(@RequestBody Map<String,Object> updates, @PathVariable Long id) {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
     }
 
-    /**
-     * Updates multiple employees in a batch.
-     *
-     * @param updates A list of DTOs containing the updates for each employee.
-     * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
-     */
-    @PatchMapping("/batch")
-//    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
-    public ResponseEntity<ApiResponse> batchUpdateEmployees(@Valid @RequestBody List<EmployeePatchDto> updates) {
-        employeeService.batchUpdateEmployees(updates);
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
-    }
+//    /**
+//     * Updates multiple employees in a batch.
+//     *
+//     * @param updates A list of DTOs containing the updates for each employee.
+//     * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
+//     */
+//    @PatchMapping("/batch")
+//    public ResponseEntity<ApiResponse> batchUpdateEmployees(@Valid @RequestBody List<EmployeePatchDto> updates) {
+//        employeeService.batchUpdateEmployees(updates);
+//        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
+//    }
 
     /**
      * Deletes an employee by their ID.
@@ -129,7 +126,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
-//    @PreAuthorize("hasAuthority('employee:delete') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> deleteEmployee(@PathVariable Long id) {
         employeeService.deleteAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" has been deleted"));
@@ -143,7 +140,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the updated employee DTO and HTTP status 200 (OK).
      */
     @PutMapping("/employeeId/{employeeId}/managerId/{managerId}")
-//    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     public ResponseEntity<EmployeeDto> assignManager(@PathVariable Long employeeId, @PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.assignManager(employeeId, managerId));
     }
@@ -155,7 +152,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the updated employee DTO and HTTP status 200 (OK).
      */
     @DeleteMapping("/employeeId/{employeeId}/manager")
-//    @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     public ResponseEntity<EmployeeDto> removeManager(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.removeManager(employeeId));
     }
@@ -167,7 +164,6 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing a list of employee DTOs who report to the manager and HTTP status 200 (OK).
      */
     @GetMapping("/managerId/{managerId}/subordinates")
-//    @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
     public ResponseEntity<List<EmployeeDto>> getDirectSubordinates(@PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getDirectSubordinates(managerId));
     }
@@ -183,11 +179,13 @@ public class EmployeeControllerWeb {
     }
 
     @PostMapping("/{employeeId}/roles")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     public ResponseEntity<EmployeeDto> assignOrgRole(@PathVariable Long employeeId, @Valid @RequestBody OrgRoleAssignmentDto dto) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.assignOrgRole(employeeId, dto.getRole()));
     }
 
     @DeleteMapping("/{employeeId}/roles/{role}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     public ResponseEntity<EmployeeDto> removeOrgRole(@PathVariable Long employeeId, @PathVariable OrgRole role) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.removeOrgRole(employeeId, role));
     }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.employee;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.user.User;
@@ -39,6 +40,11 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
      */
     List<Employee> findEmployeesByOrganization_Id(Long organizationId);
 
+    @Query("SELECT e FROM Employee e WHERE e.id = :id AND e.organization.id = :orgId")
+    Optional<Employee> findByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
+
+    @Query("SELECT e FROM Employee e WHERE e.user.id = :userId AND e.organization.id = :orgId")
+    Optional<Employee> findByUserIdAndOrganizationId(@Param("userId") Long userId, @Param("orgId") Long orgId);
     /**
      * Finds employees by a list of their names.
      *

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import lombok.extern.slf4j.Slf4j;
 import org.tornotron.echno_backend.DtoConversions.EmployeeDtoConvertor;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -195,10 +196,10 @@ public class EmployeeService {
      */
     @Transactional(readOnly = true)
     public EmployeeDto displayAnEmployee(Long id) {
-        EmployeeDto employeeDto = employeeRepository.findById(id)
+        EmployeeDto employeeDto = employeeRepository.findByIdAndOrganizationId(id,TenantContext.getCurrentOrgId())
                 .map(EmployeeDtoConvertor::convertEmployeeToDto)
                 .orElse(null);
-        if(employeeDto==null) {
+        if(employeeDto == null) {
             throw new ResourceNotFoundException("Employee not found with id: "+id);
         } else {
             return employeeDto;
@@ -427,7 +428,7 @@ public class EmployeeService {
 
     @Transactional
     public EmployeeDto assignOrgRole(Long employeeId, OrgRole role) {
-        Employee employee = employeeRepository.findById(employeeId)
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId));
 
         employee.getOrgRoles().add(role);
@@ -450,7 +451,7 @@ public class EmployeeService {
 
     @Transactional
     public EmployeeDto removeOrgRole(Long employeeId, OrgRole role) {
-        Employee employee = employeeRepository.findById(employeeId)
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId));
 
         employee.getOrgRoles().remove(role);
@@ -473,7 +474,7 @@ public class EmployeeService {
 
     @Transactional(readOnly = true)
     public Set<OrgRole> getOrgRoles(Long employeeId) {
-        Employee employee = employeeRepository.findById(employeeId)
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId));
         return employee.getOrgRoles();
     }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationRepository.java
@@ -41,4 +41,12 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
     )
     List<Organization> findAllByUserEmail(@Param("email") String email);
 
+    @Query(
+            "SELECT o FROM Organization o " +
+                    "JOIN o.employees e " +
+                    "JOIN e.user u " +
+                    "WHERE o.id = :organizationId AND u.email = :email"
+    )
+    Optional<Organization> findByIdAndUserEmail(@Param("organizationId") Long organizationId, @Param("email") String email);
+
 }

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.projectInviteCode;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.organization.dto.OrganizationDto;
@@ -34,6 +35,7 @@ public class ProjectInviteCodeController {
     }
 
     @GetMapping("/organizationId/{organizationId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<ProjectInviteCodeDto>> readAllInviteCodes(@PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.OK).body(projectInviteCodeService.readAllProjectInviteCodes(organizationId));
     }
@@ -45,6 +47,7 @@ public class ProjectInviteCodeController {
      * @return A {@link ResponseEntity} with the created invite code DTO and HTTP status 201 (Created).
      */
     @PostMapping("/generateCode/organizationId/{organizationId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ProjectInviteCodeDto> createInviteCode(@Valid @RequestBody InviteCodeGenerationDto inviteCodeGenerationDto,
                                                                  @PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(projectInviteCodeService.generateInviteCode(inviteCodeGenerationDto,organizationId));
@@ -71,6 +74,7 @@ public class ProjectInviteCodeController {
      * @return A {@link ResponseEntity} with the updated invite code DTO and HTTP status 200 (OK).
      */
     @PatchMapping("/{inviteCodeId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ProjectInviteCodeDto> patchInviteCode(@PathVariable Long inviteCodeId,
                                                                  @Valid @RequestBody InviteCodePatchDto patchDto) {
         return ResponseEntity.ok(projectInviteCodeService.patchInviteCode(inviteCodeId, patchDto));


### PR DESCRIPTION
Summary
  This PR introduces a comprehensive Organization-Scoped Role-Based Access Control (RBAC) system. It integrates OrganizationSecurityService with Keycloak groups to enforce fine-grained
  permissions at the organization level. This ensures that actions like managing employees, assigning roles, and generating invite codes are restricted to authorized personnel (e.g.,
  system-admin, hr-admin) within a specific organization context.

  Key Changes


   * Security Architecture:
       * Added OrganizationSecurityService: A dedicated service bean (@orgSecurity) for usage in @PreAuthorize annotations.
       * Implemented checks for:
           * Membership (isMember)
           * Specific Organization Roles (hasOrgRole)
           * Self-access vs. Admin override (isSelfOrHasAnyOrgRole) - allowing employees to update their own profiles while restricting others.


   * Employee Management (`EmployeeService` & `EmployeeControllerWeb`):
       * Keycloak Sync: Employee creation, deletion, and role changes now automatically sync with Keycloak groups/roles via KeycloakGroupService.
       * Role Management: Added endpoints to assign and remove specific OrgRoles (e.g., system-admin, hr-admin) to employees.
       * Validation: Enhanced manager assignment logic to prevent circular references and ensure managers belong to the same organization.
       * Endpoint Security: Secured all critical endpoints using the new @orgSecurity checks.


   * Invitation System (`ProjectInviteCodeController`):
       * Restricted invite code generation and retrieval to organization administrators (system-admin, hr-admin).

   * Data Access:
       * Updated EmployeeRepository and OrganizationRepository with JPQL queries to support org-scoped data retrieval and validation.


  Technical Details
   * Authorization Strategy: The system now checks for authorities patterned as ORG_{orgId}_ROLE_{roleName}, which maps to Keycloak subgroups.
   * Self-Service Updates: implemented isSelfOrHasAnyOrgRole to allow users to patch their own employee records (e.g., phone number, address) without needing full admin privileges.
