### PR TITLE
set tenant context after organization creation

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.DtoConversions.OrganizationDtoConvertor;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -102,6 +103,7 @@ public class OrganizationService {
 
         EmployeeJoinOrgDto joinOrgDto = new EmployeeJoinOrgDto();
         EmployeeDto employeeDto = employeeService.joinOrganization(currentUser.getId(), savedOrganization.getId(), joinOrgDto);
+        TenantContext.setCurrentOrgId(savedOrganization.getId());
         employeeService.assignOrgRole(employeeDto.getId(), OrgRole.SYSTEM_ADMIN);
 
         if (attachments != null && !attachments.isEmpty()) {


### PR DESCRIPTION
This pr includes following fix: 

- Updates the organization creation flow to explicitly set the TenantContext
    to the new organization ID immediately after the user joins it. This ensures
   that subsequent operations, such as assigning the SYSTEM_ADMIN role, are
   executed within the correct tenant scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the current organization context was not properly established after organization creation and user assignment, preventing incorrect organization references in subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->