### PR TITLE
Implement RBAC for Leave Module & Fix Actuator Filter

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
@@ -20,6 +20,11 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
     private final KeycloakAuthorizationService authorizationService;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/actuator");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String authHeader = request.getHeader("Authorization");

--- a/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/OrganizationSecurityService.java
@@ -148,6 +148,44 @@ public class OrganizationSecurityService {
      * @param roles one or more role names to check
      * @return true if the user has at least one of the specified roles in the current tenant organization
      */
+    /**
+     * Checks if the current user is a member of the current tenant organization.
+     *
+     * Usage in @PreAuthorize: @orgSecurity.isMemberOfCurrentTenant()
+     */
+    /**
+     * Checks if the current user IS the given employee within the current tenant organization.
+     *
+     * Useful for composing fine-grained checks in @PreAuthorize:
+     *   @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('hr-admin')")
+     *
+     * @param employeeId the employee ID to check against the current user
+     */
+    public boolean isSelfInCurrentTenant(Long employeeId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (orgId == null) {
+            log.debug("No current tenant org ID set in TenantContext");
+            return false;
+        }
+        Long currentUserId = userContextService.getCurrentUserId();
+        if (currentUserId == null) {
+            return false;
+        }
+        Optional<Employee> employee = employeeRepository.findByIdAndOrganizationId(employeeId, orgId);
+        boolean result = employee.isPresent() && employee.get().getUser().getId().equals(currentUserId);
+        log.debug("Self-in-tenant check for employee {}: {}", employeeId, result);
+        return result;
+    }
+
+    public boolean isMemberOfCurrentTenant() {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (orgId == null) {
+            log.debug("No current tenant org ID set in TenantContext");
+            return false;
+        }
+        return isMember(orgId);
+    }
+
     public boolean hasAnyOrgRoleForCurrentTenant(String... roles) {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
@@ -24,7 +24,7 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/approve")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> approve(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -32,7 +32,7 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/reject")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> reject(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -40,7 +40,7 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/delegate")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> delegate(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -48,21 +48,21 @@ public class LeaveApprovalControllerWeb {
     }
 
     @GetMapping("/history")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalHistory(
             @RequestParam Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalHistory(requestId));
     }
 
     @GetMapping("/chain")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalChain(
             @RequestParam Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalChain(requestId));
     }
 
     @GetMapping("/can-approve")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Boolean>> canApprove(
             @RequestParam Long requestId,
             @RequestParam Long employeeId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.leave;
 
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.leave.dto.LeaveBalanceAdjustmentDto;
@@ -24,7 +25,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -33,7 +34,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/specific")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
             @RequestParam Long employeeId,
             @RequestParam Long policyId,
@@ -43,7 +44,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/summary")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -52,7 +53,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @PostMapping("/recalculate")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveBalanceDto>> recalculateBalances(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -61,21 +62,21 @@ public class LeaveBalanceControllerWeb {
     }
 
     @PostMapping("/adjust")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveTransactionDto> adjustBalance(
             @Valid @RequestBody LeaveBalanceAdjustmentDto dto) {
         return ResponseEntity.ok(balanceService.adjustBalance(dto));
     }
 
     @GetMapping("/transactions")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(balanceService.getTransactionHistory(employeeId));
     }
 
     @GetMapping("/transactions-by-balance")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionsByBalance(
             @RequestParam Long balanceId) {
         return ResponseEntity.ok(balanceService.getTransactionsByBalance(balanceId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
@@ -22,7 +22,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/organization")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveCalendarDto>> getOrganizationCalendar(
             @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
@@ -32,7 +32,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/department")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveCalendarDto>> getDepartmentCalendar(
             @RequestParam Long organizationId,
             @RequestParam String department,
@@ -43,7 +43,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/employee")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveCalendarDto>> getEmployeeCalendar(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -53,7 +53,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/team")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveCalendarDto>> getTeamCalendar(
             @RequestParam Long managerId,
             @RequestParam LocalDate startDate,
@@ -63,7 +63,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/grouped")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<LocalDate, List<LeaveCalendarDto>>> getCalendarGroupedByDate(
             @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
@@ -73,7 +73,7 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/count")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Long>> getEmployeesOnLeaveCount(
             @RequestParam Long organizationId,
             @RequestParam LocalDate date) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.leave;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -24,7 +25,7 @@ public class LeavePolicyControllerWeb {
     }
 
     @PostMapping
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     public ResponseEntity<LeavePolicyDto> createPolicy(
             @Valid @RequestBody LeavePolicyCreationDto dto) {
         LeavePolicyDto created = policyService.createPolicy(dto);
@@ -32,36 +33,37 @@ public class LeavePolicyControllerWeb {
     }
 
     @GetMapping("/policy")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> getPolicy(@RequestParam Long policyId) {
         return ResponseEntity.ok(policyService.getPolicy(policyId));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeavePolicyDto>> getAllPolicies() {
         return ResponseEntity.status(HttpStatus.OK).body(policyService.getAllPolicies());
     }
 
-    @GetMapping("/organization")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    public ResponseEntity<List<LeavePolicyDto>> getPoliciesByOrganization(
-            @RequestParam Long organizationId,
-            @RequestParam(required = false, defaultValue = "false") Boolean includeInactive) {
-        if (includeInactive) {
-            return ResponseEntity.ok(policyService.getAllPoliciesByOrganization(organizationId));
-        }
-        return ResponseEntity.ok(policyService.getPoliciesByOrganization(organizationId));
-    }
+//    @GetMapping("/organization")
+//    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+//    public ResponseEntity<List<LeavePolicyDto>> getPoliciesByOrganization(
+//            @RequestParam Long organizationId,
+//            @RequestParam(required = false, defaultValue = "false") Boolean includeInactive) {
+//        if (includeInactive) {
+//            return ResponseEntity.ok(policyService.getAllPoliciesByOrganization(organizationId));
+//        }
+//        return ResponseEntity.ok(policyService.getPoliciesByOrganization(organizationId));
+//    }
 
     @GetMapping("/employee")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(policyService.getApplicablePoliciesForEmployee(employeeId));
     }
 
     @PatchMapping("/update")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @RequestParam Long policyId,
             @RequestBody Map<String, Object> updates) {
@@ -69,21 +71,21 @@ public class LeavePolicyControllerWeb {
     }
 
     @DeleteMapping("/deactivate")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> deactivatePolicy(@RequestParam Long policyId) {
         policyService.deactivatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy deactivated successfully"));
     }
 
     @PostMapping("/activate")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> activatePolicy(@RequestParam Long policyId) {
         policyService.activatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
     }
 
     @PostMapping("/duplicate")
-//    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @RequestParam Long policyId,
             @RequestParam Long targetOrganizationId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
@@ -13,6 +13,8 @@ public interface LeavePolicyRepository extends JpaRepository<LeavePolicy, Long> 
 
     List<LeavePolicy> findByOrganizationId(Long organizationId);
 
+    Optional<LeavePolicy> findByIdAndOrganization_Id(Long id, Long organizationId);
+
     Optional<LeavePolicy> findByOrganizationIdAndLeaveTypeCode(Long organizationId, String leaveTypeCode);
 
     boolean existsByOrganizationIdAndLeaveTypeCode(Long organizationId, String leaveTypeCode);

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -6,12 +6,14 @@ import org.springframework.validation.annotation.Validated;
 import org.tornotron.echno_backend.DtoConversions.LeavePolicyDtoConvertor;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeavePolicyCreationDto;
 import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -26,19 +28,21 @@ public class LeavePolicyService {
     private final LeavePolicyRepository policyRepository;
     private final OrganizationRepository organizationRepository;
     private final EmployeeRepository employeeRepository;
+    private final UserContextService userContextService;
 
     public LeavePolicyService(
             LeavePolicyRepository policyRepository,
             OrganizationRepository organizationRepository,
-            EmployeeRepository employeeRepository) {
+            EmployeeRepository employeeRepository, UserContextService userContextService) {
         this.policyRepository = policyRepository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
+        this.userContextService = userContextService;
     }
 
     @Transactional
     public LeavePolicyDto createPolicy(LeavePolicyCreationDto dto) {
-        Organization organization = organizationRepository.findById(dto.getOrganizationId())
+        Organization organization = organizationRepository.findByIdAndUserEmail(TenantContext.getCurrentOrgId(), userContextService.getCurrentUserEmail())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Organization not found with id: " + dto.getOrganizationId()));
 
@@ -76,7 +80,7 @@ public class LeavePolicyService {
 
     @Transactional(readOnly = true)
     public LeavePolicyDto getPolicy(Long policyId) {
-        LeavePolicy policy = policyRepository.findById(policyId)
+        LeavePolicy policy = policyRepository.findByIdAndOrganization_Id(policyId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + policyId));
         return LeavePolicyDtoConvertor.convertToDto(policy);
@@ -117,7 +121,7 @@ public class LeavePolicyService {
 
     @Transactional(readOnly = true)
     public List<LeavePolicyDto> getApplicablePoliciesForEmployee(Long employeeId) {
-        Employee employee = employeeRepository.findById(employeeId)
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Employee not found with id: " + employeeId));
 
@@ -138,7 +142,7 @@ public class LeavePolicyService {
 
     @Transactional
     public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates) {
-        LeavePolicy policy = policyRepository.findById(policyId)
+        LeavePolicy policy = policyRepository.findByIdAndOrganization_Id(policyId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + policyId));
 
@@ -179,7 +183,7 @@ public class LeavePolicyService {
 
     @Transactional
     public void deactivatePolicy(Long policyId) {
-        LeavePolicy policy = policyRepository.findById(policyId)
+        LeavePolicy policy = policyRepository.findByIdAndOrganization_Id(policyId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + policyId));
 
@@ -189,7 +193,7 @@ public class LeavePolicyService {
 
     @Transactional
     public void activatePolicy(Long policyId) {
-        LeavePolicy policy = policyRepository.findById(policyId)
+        LeavePolicy policy = policyRepository.findByIdAndOrganization_Id(policyId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + policyId));
 
@@ -199,11 +203,11 @@ public class LeavePolicyService {
 
     @Transactional
     public LeavePolicyDto duplicatePolicy(Long policyId, Long targetOrganizationId) {
-        LeavePolicy source = policyRepository.findById(policyId)
+        LeavePolicy source = policyRepository.findByIdAndOrganization_Id(policyId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + policyId));
 
-        Organization targetOrg = organizationRepository.findById(targetOrganizationId)
+        Organization targetOrg = organizationRepository.findByIdAndUserEmail(targetOrganizationId,userContextService.getCurrentUserEmail())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Organization not found with id: " + targetOrganizationId));
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -31,8 +31,9 @@ public class LeaveRequestController {
     @PostMapping
 //    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
     public ResponseEntity<LeaveRequestDto> createRequest(
+            @RequestParam Long employeeId,
             @Valid @RequestBody LeaveRequestCreationDto dto) {
-        LeaveRequestDto created = requestService.createRequest(dto);
+        LeaveRequestDto created = requestService.createRequest(dto,employeeId);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
@@ -22,26 +23,28 @@ public class LeaveRequestControllerWeb {
 
     private final LeaveRequestService requestService;
 
+
     public LeaveRequestControllerWeb(LeaveRequestService requestService) {
         this.requestService = requestService;
     }
 
     @PostMapping
-//    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<LeaveRequestDto> createRequest(
+            @RequestParam Long employeeId,
             @Valid @RequestBody LeaveRequestCreationDto dto) {
-        LeaveRequestDto created = requestService.createRequest(dto);
+        LeaveRequestDto created = requestService.createRequest(dto,employeeId);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping("/request")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> getRequest(@RequestParam Long requestId) {
         return ResponseEntity.ok(requestService.getRequest(requestId));
     }
 
     @GetMapping("/employee")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequests(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -49,23 +52,23 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/employee-by-status")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequestsByStatus(
             @RequestParam Long employeeId,
             @RequestParam LeaveStatus status) {
         return ResponseEntity.ok(requestService.getRequestsByEmployeeAndStatus(employeeId, status));
     }
 
-    @GetMapping("/organization")
-//    @PreAuthorize("hasAuthority('leave:admin')")
-    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests(
-            @RequestParam Long organizationId,
-            Pageable pageable) {
-        return ResponseEntity.ok(requestService.getRequestsByOrganization(organizationId, pageable).getContent());
-    }
+//    @GetMapping("/organization")
+//    @PreAuthorize()
+//    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests(
+//            @RequestParam Long organizationId,
+//            Pageable pageable) {
+//        return ResponseEntity.ok(requestService.getRequestsByOrganization(organizationId, pageable).getContent());
+//    }
 
     @GetMapping("/pending-approvals")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admim','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
             @RequestParam Long approverId,
             Pageable pageable) {
@@ -73,7 +76,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/pending-approvals/count")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
             @RequestParam Long approverId) {
         long count = requestService.getPendingApprovalCount(approverId);
@@ -81,21 +84,21 @@ public class LeaveRequestControllerWeb {
     }
 
     @PatchMapping("/update")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @RequestParam Long requestId,
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(requestService.updateRequest(requestId, updates));
     }
 
-    @PostMapping("/submit")
-//    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
-    public ResponseEntity<LeaveRequestDto> submitRequest(@RequestParam Long requestId) {
+    @PostMapping("employeeId/{employeeId}/submit")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    public ResponseEntity<LeaveRequestDto> submitRequest(@RequestParam Long requestId,@PathVariable Long employeeId) {
         return ResponseEntity.ok(requestService.submitRequest(requestId));
     }
 
     @PostMapping("/cancel")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @RequestParam Long requestId,
             @RequestBody Map<String, String> body) {
@@ -103,14 +106,14 @@ public class LeaveRequestControllerWeb {
         return ResponseEntity.ok(requestService.cancelRequest(requestId, reason));
     }
 
-    @PostMapping("/withdraw")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
-    public ResponseEntity<LeaveRequestDto> withdrawRequest(@RequestParam Long requestId) {
+    @PostMapping("employeeId/{employeeId}/withdraw")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    public ResponseEntity<LeaveRequestDto> withdrawRequest(@RequestParam Long requestId,@PathVariable Long employeeId) {
         return ResponseEntity.ok(requestService.withdrawRequest(requestId));
     }
 
     @GetMapping("/conflicts")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LocalDate>> getConflictingDates(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -119,7 +122,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("/calculate-days")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Double>> calculateDays(
             @RequestBody Map<String, String> body) {
         LocalDate startDate = LocalDate.parse(body.get("startDate"));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
@@ -9,10 +9,13 @@ import org.tornotron.echno_backend.leave.enums.LeaveStatus;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long> {
 
     List<LeaveRequest> findByEmployeeId(Long employeeId);
+
+    Optional<LeaveRequest> findByIdAndOrganization_Id(Long id, Long organizationId);
 
     Page<LeaveRequest> findByEmployeeId(Long employeeId, Pageable pageable);
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated;
 import org.tornotron.echno_backend.DtoConversions.LeaveRequestDtoConvertor;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
@@ -53,12 +54,12 @@ public class LeaveRequestService {
     }
 
     @Transactional
-    public LeaveRequestDto createRequest(LeaveRequestCreationDto dto) {
-        Employee employee = employeeRepository.findById(dto.getEmployeeId())
+    public LeaveRequestDto createRequest(LeaveRequestCreationDto dto,Long employeeId) {
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Employee not found with id: " + dto.getEmployeeId()));
 
-        LeavePolicy policy = policyRepository.findById(dto.getLeavePolicyId())
+        LeavePolicy policy = policyRepository.findByIdAndOrganization_Id(dto.getLeavePolicyId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + dto.getLeavePolicyId()));
 
@@ -106,7 +107,7 @@ public class LeaveRequestService {
 
     @Transactional(readOnly = true)
     public LeaveRequestDto getRequest(Long requestId) {
-        LeaveRequest request = requestRepository.findById(requestId)
+        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request not found with id: " + requestId));
         return LeaveRequestDtoConvertor.convertToDtoWithHandover(request, employeeRepository);
@@ -146,7 +147,7 @@ public class LeaveRequestService {
 
     @Transactional
     public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates) {
-        LeaveRequest request = requestRepository.findById(requestId)
+        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request not found with id: " + requestId));
 
@@ -183,7 +184,7 @@ public class LeaveRequestService {
 
     @Transactional
     public LeaveRequestDto submitRequest(Long requestId) {
-        LeaveRequest request = requestRepository.findById(requestId)
+        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request not found with id: " + requestId));
 
@@ -207,7 +208,7 @@ public class LeaveRequestService {
 
     @Transactional
     public LeaveRequestDto cancelRequest(Long requestId, String reason) {
-        LeaveRequest request = requestRepository.findById(requestId)
+        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request not found with id: " + requestId));
 

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
@@ -24,7 +24,7 @@ public class NotificationControllerWeb {
     }
 
     @GetMapping
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Page<NotificationDto>> getNotifications(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -32,14 +32,14 @@ public class NotificationControllerWeb {
     }
 
     @GetMapping("/unread")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<NotificationDto>> getUnreadNotifications(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(notificationService.getUnreadNotifications(employeeId));
     }
 
     @GetMapping("/unread-count")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Long>> getUnreadCount(
             @RequestParam Long employeeId) {
         long count = notificationService.getUnreadCount(employeeId);
@@ -47,14 +47,14 @@ public class NotificationControllerWeb {
     }
 
     @PatchMapping("/read")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> markAsRead(@RequestParam Long notificationId) {
         notificationService.markAsRead(notificationId);
         return ResponseEntity.ok(new ApiResponse("Notification marked as read"));
     }
 
     @PostMapping("/mark-all-read")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Integer>> markAllAsRead(
             @RequestParam Long employeeId) {
         int count = notificationService.markAllAsRead(employeeId);


### PR DESCRIPTION
 This PR secures the Leave Module by implementing Role-Based Access Control (RBAC) checks across all relevant controllers. It ensures that users can only access and modify leave-related data within their authorized
  organization. Additionally, it includes a fix to bypass authentication filters for Actuator endpoints.

  Key Changes:


   * Authorization Enforcement:
       * Added @PreAuthorize checks to LeaveApproval, LeaveBalance, LeaveCalendar, LeavePolicy, LeaveRequest, and Notification controllers.
       * Introduced OrganizationSecurityService with isMemberOfOrganization method to validate user membership.
   * Service Layer Updates:
       * Refactored LeavePolicyService and LeaveRequestService to align with the new security requirements.
       * Enhanced repositories (LeavePolicyRepository, LeaveRequestRepository) to support secure data retrieval.
   * Infrastructure Fixes:
       * Updated RPTExchangeFilter to explicitly bypass all /actuator/* requests, preventing filter interference with health and metrics endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multi-tenant support with organization-scoped access control across leave management endpoints.

* **Security**
  * Added role-based authorization checks (system-admin/hr-admin) for leave operations, approvals, and notifications.

* **Breaking Changes**
  * Leave request creation now requires an employee ID parameter.
  * Submit/withdraw leave request endpoints updated to path-based URLs.
  * Removed organization-based leave policy retrieval endpoint.
  * Notification response field renamed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->