### PR TITLE
fix missing employee fields and add org role assignment support

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/DtoConversions/OrganizationDtoConvertor.java
+++ b/src/main/java/org/tornotron/echno_backend/DtoConversions/OrganizationDtoConvertor.java
@@ -42,6 +42,7 @@ public class OrganizationDtoConvertor {
         employeeDto.setCvUrl(employee.getUser().getCvUrl());
         employeeDto.setEmergencyContact(employee.getUser().getEmergencyContact());
         employeeDto.setRole(employee.getUser().getRole());
+        employeeDto.setOrgRoles(employee.getOrgRoles());
         employeeDto.setProfilePictureUrl(employee.getUser().getProfilePictureUrl());
         employeeDto.setCreatedAt(employee.getUser().getCreatedAt());
         employeeDto.setUpdatedAt(employee.getUser().getUpdatedAt());

--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -3,10 +3,7 @@ package org.tornotron.echno_backend.common.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -56,7 +53,8 @@ public class KeycloakGroupController {
     @GetMapping("/assignRole/userId/{userId}/organizationId/{organizationId}")
     public ResponseEntity<ApiResponse> assignOrgRole(
             @PathVariable Long userId,
-            @PathVariable Long organizationId
+            @PathVariable Long organizationId,
+            @RequestParam String orgRole
     ) {
         User user = userRepository.findById(userId)
                         .orElseThrow(() -> new ResourceNotFoundException("User not found with id: "+ userId));
@@ -72,7 +70,7 @@ public class KeycloakGroupController {
                 .findFirst()
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found for user " + userId + " in organization " + organizationId));
 
-        employeeService.assignOrgRole(employee.getId(), OrgRole.SYSTEM_ADMIN);
+        employeeService.assignOrgRole(employee.getId(), OrgRole.valueOf(orgRole));
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User assigned a role"));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -245,6 +245,9 @@ public class EmployeeService {
                 case "designation":
                     employee.setDesignation((String) value);
                     break;
+                case "joiningDate":
+                    employee.setJoiningDate((LocalDateTime) value);
+                    break;
                 case "phoneNumber":
                     employee.setPhoneNumber((String) value);
                     break;


### PR DESCRIPTION
Summary

  - Fixed missing designation field in the employee update function
  - Added joiningDate field to the employee update endpoint
  - Added the ability for authorized users to set an organization role via the Keycloak group controller
  - Added missing orgRole mapper for employee in the organization DTO convertor

  Changes

  - EmployeeService.java – Added designation and joiningDate fields to the update logic to ensure they are persisted correctly
  - KeycloakGroupController.java – Refactored to allow setting org role through an allowed user, simplifying the controller logic
  - OrganizationDtoConvertor.java – Added the missing orgRole mapping for employee in the organization context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employees can now have their joining date updated during profile management operations.
  * Role assignment operations now support flexible, dynamic role selection based on specific organizational requirements.

* **Improvements**
  * Organization roles are now properly synchronized and reflected across employee records, ensuring improved data consistency throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->