### PR TITLE
leave request controller fixes, role-based access corrections, and Keycloak group enhancements

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/DtoConversions/EmployeeDtoConvertor.java
+++ b/src/main/java/org/tornotron/echno_backend/DtoConversions/EmployeeDtoConvertor.java
@@ -29,6 +29,7 @@ public class EmployeeDtoConvertor {
     public static EmployeeDto convertEmployeeToDto(Employee employee,FileStorageService fileStorageService) {
         EmployeeDto dto = new EmployeeDto();
         dto.setId(employee.getId());
+        dto.setEmployeeId(employee.getEmployeeId());
         dto.setOrganizationId(employee.getOrganization().getId());
         dto.setOrganizationName(employee.getOrganization().getOrganizationName());
         dto.setSalary(employee.getSalary());

--- a/src/main/java/org/tornotron/echno_backend/DtoConversions/OrganizationDtoConvertor.java
+++ b/src/main/java/org/tornotron/echno_backend/DtoConversions/OrganizationDtoConvertor.java
@@ -19,6 +19,7 @@ public class OrganizationDtoConvertor {
     private static EmployeeDto convertEmployeeToEmployeeDto(Employee employee) {
         EmployeeDto employeeDto = new EmployeeDto();
         employeeDto.setId(employee.getId());
+        employeeDto.setEmployeeId(employee.getEmployeeId());
         employeeDto.setEmployeeName(employee.getEmployeeName());
         employeeDto.setDesignation(employee.getDesignation());
         employeeDto.setDepartment(employee.getDepartment());

--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -6,6 +6,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.employee.Employee;
@@ -13,8 +14,6 @@ import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.EmployeeService;
 import org.tornotron.echno_backend.user.User;
 import org.tornotron.echno_backend.user.UserRepository;
-
-import java.util.List;
 
 @Validated
 @RestController
@@ -50,25 +49,18 @@ public class KeycloakGroupController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User added to keycloak Org"));
     }
 
-    @GetMapping("/assignRole/userId/{userId}/organizationId/{organizationId}")
+    @GetMapping("/assignRole")
     public ResponseEntity<ApiResponse> assignOrgRole(
-            @PathVariable Long userId,
-            @PathVariable Long organizationId,
+            @RequestParam Long employeeId,
             @RequestParam String orgRole
     ) {
-        User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new ResourceNotFoundException("User not found with id: "+ userId));
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId + " in organization "));
 
-        if (user.getKeycloakId() == null) {
-            throw new IllegalStateException("User does not have a keycloak ID");
+        User user = employee.getUser();
+        if (user == null || user.getKeycloakId() == null) {
+            throw new IllegalStateException("Employee does not have a Keycloak user");
         }
-
-        // Find the employee record for this user in this organization
-        List<Employee> employees = employeeRepository.findEmployeesByOrganization_Id(organizationId);
-        Employee employee = employees.stream()
-                .filter(e -> e.getUser().getId().equals(userId))
-                .findFirst()
-                .orElseThrow(() -> new ResourceNotFoundException("Employee not found for user " + userId + " in organization " + organizationId));
 
         employeeService.assignOrgRole(employee.getId(), OrgRole.valueOf(orgRole));
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User assigned a role"));

--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -32,10 +32,9 @@ public class KeycloakGroupController {
         this.employeeRepository = employeeRepository;
     }
 
-    @GetMapping("/assign/userId/{userId}/organizationId/{organizationId}")
+    @PostMapping("/assign")
     public ResponseEntity<ApiResponse> assignUserToKeycloakOrg(
-            @PathVariable Long userId,
-            @PathVariable Long organizationId
+            @RequestParam Long userId
     ) {
         // Look up the user by database ID to get their Keycloak ID
         User user = userRepository.findById(userId)
@@ -45,11 +44,11 @@ public class KeycloakGroupController {
             throw new IllegalStateException("User does not have a Keycloak ID");
         }
 
-        keycloakGroupService.addUserToOrganization(user.getKeycloakId(), organizationId.toString());
+        keycloakGroupService.addUserToOrganization(user.getKeycloakId(), TenantContext.getCurrentOrgId().toString());
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User added to keycloak Org"));
     }
 
-    @GetMapping("/assignRole")
+    @PostMapping("/assignRole")
     public ResponseEntity<ApiResponse> assignOrgRole(
             @RequestParam Long employeeId,
             @RequestParam String orgRole
@@ -64,5 +63,22 @@ public class KeycloakGroupController {
 
         employeeService.assignOrgRole(employee.getId(), OrgRole.valueOf(orgRole));
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User assigned a role"));
+    }
+
+    @PostMapping("/unassignRole")
+    public ResponseEntity<ApiResponse> unassignOrgRole(
+            @RequestParam Long employeeId,
+            @RequestParam String orgRole
+    ) {
+        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId + " in organization"));
+
+        User user = employee.getUser();
+        if (user == null || user.getKeycloakId() == null) {
+            throw new IllegalStateException("Employee does not have a Keycloak user");
+        }
+
+        employeeService.removeOrgRole(employee.getId(), OrgRole.valueOf(orgRole));
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Role unassigned from user"));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
+++ b/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
@@ -33,6 +33,7 @@ public enum OrgRole {
     }
 
     private static final Set<OrgRole> MANAGER_ROLES = Set.of(
+            SYSTEM_ADMIN,
             ORG_MANAGER,
             HR_ADMIN,
             PROJECT_MANAGER

--- a/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
+++ b/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.common.enums;
 
+import java.util.List;
+import java.util.Set;
+
 /**
  * Defines the roles that can be assigned to users within a specific organization.
  *
@@ -27,5 +30,19 @@ public enum OrgRole {
 
     public String getGroupName() {
         return groupName;
+    }
+
+    private static final Set<OrgRole> MANAGER_ROLES = Set.of(
+            ORG_MANAGER,
+            HR_ADMIN,
+            PROJECT_MANAGER
+    );
+
+    public static Set<OrgRole> getManagerRoles() {
+        return MANAGER_ROLES;
+    }
+
+    public static boolean isManagerRole(OrgRole role) {
+        return MANAGER_ROLES.contains(role);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/Employee.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/Employee.java
@@ -37,6 +37,10 @@ public class Employee implements TenantScopedEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
+    /** The organization-specific identifier for the employee. */
+    @Column(name = "employee_id")
+    private String employeeId;
+
     /** The employee's job title or designation. */
     @Column(name = "designation", nullable = true)
     private String designation;

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -9,6 +9,7 @@ import org.tornotron.echno_backend.user.User;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Repository interface for {@link Employee} entities.
@@ -22,6 +23,9 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
      * @return An {@link Optional} containing the found {@link Employee}, or {@link Optional#empty()} if no employee with the given name exists.
      */
     Optional<Employee> findEmployeeByEmployeeName(String employeeName);
+
+    @Query("SELECT DISTINCT e FROM Employee e JOIN e.orgRoles r WHERE r IN :roles")
+    List<Employee> findEmployeesByOrgRoles(@Param("roles") Set<OrgRole> roles);
 
     /**
      * Checks if an employee record exists for a given user and organization.
@@ -69,4 +73,7 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
 
     @Query("SELECT e FROM Employee e JOIN e.orgRoles r WHERE e.organization.id = :orgId AND r = :role")
     List<Employee> findByOrganizationIdAndOrgRole(Long orgId, OrgRole role);
+
+    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END FROM Employee e JOIN e.orgRoles r WHERE e.id = :employeeId AND r IN :roles")
+    boolean existsByIdAndOrgRolesIn(@Param("employeeId") Long employeeId, @Param("roles") Set<OrgRole> roles);
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -23,6 +23,7 @@ import org.tornotron.echno_backend.user.UserRepository;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -123,6 +124,7 @@ public class EmployeeService {
         employee.setDepartment(employeeJoinOrgDto.getDepartment());
         employee.setJoiningDate(employeeJoinOrgDto.getJoiningDate());
         employee.setSalary(employeeJoinOrgDto.getSalary());
+        employee.setEmployeeId(employeeJoinOrgDto.getEmployeeId());
 
         if (employeeJoinOrgDto.getManagerId() != null) {
             Employee manager = employeeRepository.findById(employeeJoinOrgDto.getManagerId())
@@ -239,6 +241,9 @@ public class EmployeeService {
     private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee) {
         updates.forEach((key, value) -> {
             switch (key) {
+                case "employeeId":
+                    employee.setEmployeeId((String) value);
+                    break;
                 case "employeeName":
                     employee.setEmployeeName((String) value);
                     break;
@@ -246,16 +251,25 @@ public class EmployeeService {
                     employee.setDesignation((String) value);
                     break;
                 case "joiningDate":
-                    employee.setJoiningDate(LocalDateTime.parse((String) value));
+                    employee.setJoiningDate(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
                     break;
                 case "phoneNumber":
                     employee.setPhoneNumber((String) value);
+                    break;
+                case "salary":
+                    employee.setSalary((Double) value);
+                    break;
+                case "shiftTiming":
+                    employee.setShiftTiming((String) value);
+                    break;
+                case "department":
+                    employee.setDepartment((String) value);
                     break;
                 case "emailAddress":
                     employee.setEmailAddress((String) value);
                     break;
                 case "dateOfBirth":
-                    employee.setDateOfBirth(LocalDateTime.parse((String) value));
+                    employee.setDateOfBirth(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
                     break;
                 case "managerId":
                     Long managerId = ((Number) value).longValue();

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -246,7 +246,7 @@ public class EmployeeService {
                     employee.setDesignation((String) value);
                     break;
                 case "joiningDate":
-                    employee.setJoiningDate((LocalDateTime) value);
+                    employee.setJoiningDate(LocalDateTime.parse((String) value));
                     break;
                 case "phoneNumber":
                     employee.setPhoneNumber((String) value);
@@ -255,7 +255,7 @@ public class EmployeeService {
                     employee.setEmailAddress((String) value);
                     break;
                 case "dateOfBirth":
-                    employee.setDateOfBirth((LocalDateTime) value);
+                    employee.setDateOfBirth(LocalDateTime.parse((String) value));
                     break;
                 case "managerId":
                     Long managerId = ((Number) value).longValue();
@@ -421,7 +421,7 @@ public class EmployeeService {
 
     @Transactional(readOnly = true)
     public List<EmployeeDto> readAllTheManagers() {
-        return employeeRepository.findEmployeesByIsManager(true)
+        return employeeRepository.findEmployeesByOrgRoles(OrgRole.getManagerRoles())
                 .stream()
                 .map(employee -> EmployeeDtoConvertor.convertEmployeeToDto(employee,fileStorageService))
                 .collect(Collectors.toList());

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -20,6 +20,8 @@ public class EmployeeCreationDto {
 
     private LocalDateTime joiningDate;
 
+    private String employeeId;
+
     private Double salary;
 
     private Long managerId;

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -13,6 +13,7 @@ import java.util.Set;
 @Data
 public class EmployeeDto {
     private Long id;
+    private String employeeId;
     private Long organizationId;
     private String organizationName;
     private String employeeName;

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
@@ -20,6 +20,8 @@ public class EmployeeJoinOrgDto {
 
     private LocalDateTime joiningDate;
 
+    private String employeeId;
+
     private Double salary;
 
     private Long managerId;
@@ -30,8 +32,6 @@ public class EmployeeJoinOrgDto {
     @Size(min = 3, max = 50, message = "status must be between 3 and 50 characters")
     @Enumerated(EnumType.STRING)
     private String status = "active";
-
-    private String employeeId;
 
     private String employeeName;
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalRepository.java
@@ -14,6 +14,11 @@ public interface LeaveApprovalRepository extends JpaRepository<LeaveApproval, Lo
 
     Optional<LeaveApproval> findByLeaveRequestIdAndApprovalLevel(Long leaveRequestId, Integer approvalLevel);
 
+    Optional<LeaveApproval> findFirstByLeaveRequestIdAndApprovalLevelAndActionOrderByCreatedAtDesc(
+            Long leaveRequestId,
+            Integer approvalLevel,
+            ApprovalAction action);
+
     Optional<LeaveApproval> findByLeaveRequestIdAndApproverId(Long leaveRequestId, Long approverId);
 
     List<LeaveApproval> findByApproverIdAndAction(Long approverId, ApprovalAction action);

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -115,9 +115,7 @@ public class LeaveApprovalService {
 
         validateApprover(request, dto.getApproverId());
 
-        LeaveApproval approval = approvalRepository
-                .findByLeaveRequestIdAndApprovalLevel(requestId, request.getCurrentApprovalLevel())
-                .orElseThrow(() -> new ResourceNotFoundException("Approval record not found"));
+        LeaveApproval approval = getPendingApproval(request.getId(), request.getCurrentApprovalLevel());
 
         approval.setAction(ApprovalAction.APPROVED);
         approval.setComments(dto.getComments());
@@ -141,9 +139,7 @@ public class LeaveApprovalService {
 
         validateApprover(request, dto.getApproverId());
 
-        LeaveApproval approval = approvalRepository
-                .findByLeaveRequestIdAndApprovalLevel(requestId, request.getCurrentApprovalLevel())
-                .orElseThrow(() -> new ResourceNotFoundException("Approval record not found"));
+        LeaveApproval approval = getPendingApproval(request.getId(), request.getCurrentApprovalLevel());
 
         approval.setAction(ApprovalAction.REJECTED);
         approval.setComments(dto.getComments());
@@ -177,9 +173,7 @@ public class LeaveApprovalService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Employee not found with id: " + dto.getDelegateToId()));
 
-        LeaveApproval currentApproval = approvalRepository
-                .findByLeaveRequestIdAndApprovalLevel(requestId, request.getCurrentApprovalLevel())
-                .orElseThrow();
+        LeaveApproval currentApproval = getPendingApproval(request.getId(), request.getCurrentApprovalLevel());
 
         currentApproval.setAction(ApprovalAction.DELEGATED);
         currentApproval.setComments(dto.getComments());
@@ -246,9 +240,7 @@ public class LeaveApprovalService {
     private void advanceToNextLevel(LeaveRequest request) {
         int nextLevel = request.getCurrentApprovalLevel() + 1;
 
-        LeaveApproval nextApproval = approvalRepository
-                .findByLeaveRequestIdAndApprovalLevel(request.getId(), nextLevel)
-                .orElseThrow(() -> new ResourceNotFoundException("Next approval level not found"));
+        LeaveApproval nextApproval = getPendingApproval(request.getId(), nextLevel);
 
         request.setCurrentApprovalLevel(nextLevel);
         request.setCurrentApprover(nextApproval.getApprover());
@@ -323,5 +315,16 @@ public class LeaveApprovalService {
 
                     transactionRepository.save(transaction);
                 });
+    }
+
+    private LeaveApproval getPendingApproval(Long requestId, Integer approvalLevel) {
+        return approvalRepository
+                .findFirstByLeaveRequestIdAndApprovalLevelAndActionOrderByCreatedAtDesc(
+                        requestId,
+                        approvalLevel,
+                        ApprovalAction.PENDING)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Pending approval record not found for request " + requestId +
+                        " at level " + approvalLevel));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -44,7 +44,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -44,7 +44,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/summary")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -69,7 +69,7 @@ public class LeaveBalanceControllerWeb {
     }
 
     @GetMapping("/transactions")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(balanceService.getTransactionHistory(employeeId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -56,7 +56,7 @@ public class LeavePolicyControllerWeb {
 //    }
 
     @GetMapping("/employee")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(policyService.getApplicablePoliciesForEmployee(employeeId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -61,18 +61,15 @@ public class LeaveRequestController {
 
     @GetMapping("/organizationId/{organizationId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
-    public ResponseEntity<Page<LeaveRequestDto>> getOrganizationRequests(
-            @PathVariable Long organizationId,
-            Pageable pageable) {
-        return ResponseEntity.ok(requestService.getRequestsByOrganization(organizationId, pageable));
+    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
+        return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
 
     @GetMapping("/pending-approvals")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
-            @RequestParam Long approverId,
-            Pageable pageable) {
-        return ResponseEntity.ok(requestService.getPendingApprovals(approverId, pageable).getContent());
+            @RequestParam Long approverId) {
+        return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
     }
 
     @GetMapping("/pending-approvals/count")

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -44,7 +44,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/employee")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequests(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -59,20 +59,17 @@ public class LeaveRequestControllerWeb {
         return ResponseEntity.ok(requestService.getRequestsByEmployeeAndStatus(employeeId, status));
     }
 
-//    @GetMapping("/organization")
-//    @PreAuthorize()
-//    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests(
-//            @RequestParam Long organizationId,
-//            Pageable pageable) {
-//        return ResponseEntity.ok(requestService.getRequestsByOrganization(organizationId, pageable).getContent());
-//    }
+    @GetMapping("/organization")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
+        return ResponseEntity.ok(requestService.getRequestsByOrganization());
+    }
 
     @GetMapping("/pending-approvals")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admim','hr-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
-            @RequestParam Long approverId,
-            Pageable pageable) {
-        return ResponseEntity.ok(requestService.getPendingApprovals(approverId, pageable).getContent());
+            @RequestParam Long approverId) {
+        return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
     }
 
     @GetMapping("/pending-approvals/count")
@@ -113,7 +110,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/conflicts")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LocalDate>> getConflictingDates(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -122,7 +119,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("/calculate-days")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<Map<String, Double>> calculateDays(
             @RequestBody Map<String, String> body) {
         LocalDate startDate = LocalDate.parse(body.get("startDate"));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -65,6 +65,13 @@ public class LeaveRequestControllerWeb {
         return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
 
+    @GetMapping("/approver")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    public ResponseEntity<List<LeaveRequestDto>> getRequestsByApprover(
+            @RequestParam Long approverId) {
+        return ResponseEntity.ok(requestService.getRequestsByApprover(approverId));
+    }
+
     @GetMapping("/pending-approvals")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
@@ -81,9 +88,10 @@ public class LeaveRequestControllerWeb {
     }
 
     @PatchMapping("/update")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @RequestParam Long requestId,
+            @RequestParam Long employeeId,
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(requestService.updateRequest(requestId, updates));
     }
@@ -95,9 +103,10 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("/cancel")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @RequestParam Long requestId,
+            @RequestParam Long employeeId,
             @RequestBody Map<String, String> body) {
         String reason = body.get("reason");
         return ResponseEntity.ok(requestService.cancelRequest(requestId, reason));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
@@ -28,6 +28,11 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
 
     List<LeaveRequest> findByCurrentApproverIdAndStatus(Long approverId, LeaveStatus status);
 
+    @Query("SELECT DISTINCT lr FROM LeaveRequest lr " +
+           "JOIN lr.approvals la " +
+           "WHERE la.approver.id = :approverId")
+    List<LeaveRequest> findDistinctByApproverParticipation(@Param("approverId") Long approverId);
+
     @Query("SELECT lr FROM LeaveRequest lr WHERE lr.employee.id = :employeeId " +
            "AND lr.status NOT IN ('CANCELLED', 'REJECTED', 'WITHDRAWN') " +
            "AND (:excludeRequestId IS NULL OR lr.id != :excludeRequestId) " +

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
@@ -22,19 +22,21 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
 
     List<LeaveRequest> findByEmployeeIdAndStatus(Long employeeId, LeaveStatus status);
 
-    Page<LeaveRequest> findByOrganizationId(Long organizationId, Pageable pageable);
+    List<LeaveRequest> findByOrganizationId(Long organizationId);
 
-    Page<LeaveRequest> findByCurrentApproverId(Long approverId, Pageable pageable);
+    List<LeaveRequest> findByCurrentApproverId(Long approverId);
 
     List<LeaveRequest> findByCurrentApproverIdAndStatus(Long approverId, LeaveStatus status);
 
     @Query("SELECT lr FROM LeaveRequest lr WHERE lr.employee.id = :employeeId " +
            "AND lr.status NOT IN ('CANCELLED', 'REJECTED', 'WITHDRAWN') " +
+           "AND (:excludeRequestId IS NULL OR lr.id != :excludeRequestId) " +
            "AND ((lr.startDate <= :endDate AND lr.endDate >= :startDate))")
     List<LeaveRequest> findOverlappingRequests(
             @Param("employeeId") Long employeeId,
             @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
+            @Param("endDate") LocalDate endDate,
+            @Param("excludeRequestId") Long excludeRequestId);
 
     @Query("SELECT COALESCE(SUM(lr.totalDays), 0) FROM LeaveRequest lr " +
            "WHERE lr.employee.id = :employeeId " +

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -99,7 +99,9 @@ public class LeaveRequestService {
 
         if (saved.getStatus() == LeaveStatus.PENDING_APPROVAL) {
             approvalService.initializeApprovalChain(saved);
-            updatePendingBalance(saved, true);
+            if (saved.getStatus() == LeaveStatus.PENDING_APPROVAL) {
+                updatePendingBalance(saved, true);
+            }
         }
 
         return LeaveRequestDtoConvertor.convertToDto(saved);
@@ -137,7 +139,15 @@ public class LeaveRequestService {
 
     @Transactional(readOnly = true)
     public List<LeaveRequestDto> getPendingApprovals(Long approverId) {
-        return requestRepository.findByCurrentApproverId(approverId)
+        return requestRepository.findByCurrentApproverIdAndStatus(approverId, LeaveStatus.PENDING_APPROVAL)
+                .stream()
+                .map(LeaveRequestDtoConvertor::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeaveRequestDto> getRequestsByApprover(Long approverId) {
+        return requestRepository.findDistinctByApproverParticipation(approverId)
                 .stream()
                 .map(LeaveRequestDtoConvertor::convertToDto)
                 .collect(Collectors.toList());
@@ -206,7 +216,9 @@ public class LeaveRequestService {
         LeaveRequest saved = requestRepository.save(request);
 
         approvalService.initializeApprovalChain(saved);
-        updatePendingBalance(saved, true);
+        if (saved.getStatus() == LeaveStatus.PENDING_APPROVAL) {
+            updatePendingBalance(saved, true);
+        }
 
         return LeaveRequestDtoConvertor.convertToDto(saved);
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -63,7 +63,7 @@ public class LeaveRequestService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave policy not found with id: " + dto.getLeavePolicyId()));
 
-        validateRequest(employee, policy, dto);
+        validateRequest(employee, policy, dto, null);
 
         double totalDays = calculateTotalDays(
                 dto.getStartDate(),
@@ -128,15 +128,19 @@ public class LeaveRequestService {
     }
 
     @Transactional(readOnly = true)
-    public Page<LeaveRequestDto> getRequestsByOrganization(Long organizationId, Pageable pageable) {
-        return requestRepository.findByOrganizationId(organizationId, pageable)
-                .map(LeaveRequestDtoConvertor::convertToDto);
+    public List<LeaveRequestDto> getRequestsByOrganization() {
+        return requestRepository.findByOrganizationId(TenantContext.getCurrentOrgId())
+                .stream()
+                .map(LeaveRequestDtoConvertor::convertToDto)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public Page<LeaveRequestDto> getPendingApprovals(Long approverId, Pageable pageable) {
-        return requestRepository.findByCurrentApproverId(approverId, pageable)
-                .map(LeaveRequestDtoConvertor::convertToDto);
+    public List<LeaveRequestDto> getPendingApprovals(Long approverId) {
+        return requestRepository.findByCurrentApproverId(approverId)
+                .stream()
+                .map(LeaveRequestDtoConvertor::convertToDto)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -195,7 +199,8 @@ public class LeaveRequestService {
         validateRequest(
                 request.getEmployee(),
                 request.getLeavePolicy(),
-                createDtoFromRequest(request));
+                createDtoFromRequest(request),
+                request.getId());
 
         request.setStatus(LeaveStatus.PENDING_APPROVAL);
         LeaveRequest saved = requestRepository.save(request);
@@ -258,8 +263,13 @@ public class LeaveRequestService {
 
     @Transactional(readOnly = true)
     public List<LocalDate> getConflictingDates(Long employeeId, LocalDate startDate, LocalDate endDate) {
+        return getConflictingDates(employeeId, startDate, endDate, null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LocalDate> getConflictingDates(Long employeeId, LocalDate startDate, LocalDate endDate, Long excludeRequestId) {
         List<LeaveRequest> overlapping = requestRepository.findOverlappingRequests(
-                employeeId, startDate, endDate);
+                employeeId, startDate, endDate, excludeRequestId);
 
         return overlapping.stream()
                 .flatMap(req -> req.getStartDate().datesUntil(req.getEndDate().plusDays(1)))
@@ -300,7 +310,7 @@ public class LeaveRequestService {
         return total;
     }
 
-    private void validateRequest(Employee employee, LeavePolicy policy, LeaveRequestCreationDto dto) {
+    private void validateRequest(Employee employee, LeavePolicy policy, LeaveRequestCreationDto dto, Long excludeRequestId) {
         if (dto.getStartDate().isAfter(dto.getEndDate())) {
             throw new InvalidRequestException("Start date cannot be after end date");
         }
@@ -353,7 +363,7 @@ public class LeaveRequestService {
         }
 
         List<LocalDate> conflicts = getConflictingDates(
-                employee.getId(), dto.getStartDate(), dto.getEndDate());
+                employee.getId(), dto.getStartDate(), dto.getEndDate(), excludeRequestId);
         if (!conflicts.isEmpty()) {
             throw new InvalidRequestException(
                     "Leave already exists for dates: " + conflicts);

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.DtoConversions.OrganizationDtoConvertor;
 import org.tornotron.echno_backend.DtoConversions.ProjectInviteCodeDtoConvertor;
+import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -76,8 +77,7 @@ public class ProjectInviteCodeService {
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization not found with id: "+ organizationId));
         if (inviteCodeGenerationDto.getManagerId() != null) {
-            Set<Long> managerIdSet = new HashSet<>(employeeRepository.findAllManagerIds());
-            if (!managerIdSet.contains(inviteCodeGenerationDto.getManagerId())) {
+            if (!employeeRepository.existsByIdAndOrgRolesIn(inviteCodeGenerationDto.getManagerId(), OrgRole.getManagerRoles())) {
                 throw new ResourceNotFoundException("Manager with id: " + inviteCodeGenerationDto.getManagerId() + " does not exist");
             }
         }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -118,6 +118,9 @@
     <!-- Replace team_member with project-employee many-to-many -->
     <include file="db/changelog/v1.3/062-create-project-employees.xml"/>
 
+    <!-- Add employee_id column for human-friendly identifiers -->
+    <include file="db/changelog/v1.3/063-add-employee-id-to-employee.xml"/>
+
     <!-- Tag v1.3 release -->
     <include file="db/changelog/v1.3/060-tag-v1.3.xml"/>
 

--- a/src/main/resources/db/changelog/v1.3/063-add-employee-id-to-employee.xml
+++ b/src/main/resources/db/changelog/v1.3/063-add-employee-id-to-employee.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="063-add-employee-id-to-employee" author="echno">
+        <addColumn tableName="employee">
+            <column name="employee_id" type="VARCHAR(100)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Summary

  - Leave request access control: Fixed update and cancel endpoints to use isSelfInCurrentTenant authorization instead of admin-only access, allowing employees to manage their own requests.
  Added employeeId request param to support this check.
  - Leave balance access control: Corrected authorization on /summary (relaxed to tenant membership check) and /transactions (scoped to self-only), aligning permissions with actual use
  cases.
  - Pending approvals fix: getPendingApprovals now correctly filters by PENDING_APPROVAL status to exclude already-actioned requests.
  - New endpoint — fetch by approver: Added GET /approver endpoint to retrieve all leave requests where a given employee has participated in the approval chain (via JPQL join query on
  approvals).
  - Leave approval service refactor: Extracted a reusable getPendingApproval() helper that queries only PENDING action records, ensuring delegated/re-initiated approvals are resolved
  correctly without stale matches.
  - Conditional pending balance update: Guard added so updatePendingBalance is only called when the status is actually PENDING_APPROVAL.
  - Keycloak group controller refactor: Migrated assign and assignRole endpoints from GET with path variables to POST with request params; tenant context now sourced from TenantContext
  rather than path. Added new POST /unassignRole endpoint for removing org roles from employees.
