### PR TITLE
user fetch fix for role assignment

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -53,7 +53,7 @@ public class KeycloakGroupController {
             @RequestParam Long employeeId,
             @RequestParam String orgRole
     ) {
-        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
+        Employee employee = employeeRepository.findByIdAndOrganizationIdWithUser(employeeId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId + " in organization "));
 
         User user = employee.getUser();
@@ -70,7 +70,7 @@ public class KeycloakGroupController {
             @RequestParam Long employeeId,
             @RequestParam String orgRole
     ) {
-        Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
+        Employee employee = employeeRepository.findByIdAndOrganizationIdWithUser(employeeId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + employeeId + " in organization"));
 
         User user = employee.getUser();

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -47,6 +47,9 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     @Query("SELECT e FROM Employee e WHERE e.id = :id AND e.organization.id = :orgId")
     Optional<Employee> findByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
+    @Query("SELECT e FROM Employee e JOIN FETCH e.user WHERE e.id = :id AND e.organization.id = :orgId")
+    Optional<Employee> findByIdAndOrganizationIdWithUser(@Param("id") Long id, @Param("orgId") Long orgId);
+
     @Query("SELECT e FROM Employee e WHERE e.user.id = :userId AND e.organization.id = :orgId")
     Optional<Employee> findByUserIdAndOrganizationId(@Param("userId") Long userId, @Param("orgId") Long orgId);
     /**


### PR DESCRIPTION
1. Added findByIdAndOrganizationIdWithUser to EmployeeRepository — uses JOIN
  FETCH e.user to eagerly load the user in the same query.
  2. Updated both assignOrgRole and unassignOrgRole in KeycloakGroupController
  to use this new method instead of findByIdAndOrganizationId.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal data fetching efficiency for role management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->