### PR TITLE
Add tenant-aware task permissions plus attachment & category  normalization improvements

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/DtoConversions/TaskDtoConvertor.java
+++ b/src/main/java/org/tornotron/echno_backend/DtoConversions/TaskDtoConvertor.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.DtoConversions;
 
 import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -8,6 +10,7 @@ import org.tornotron.echno_backend.task.Task;
 import org.tornotron.echno_backend.task.dto.TaskDto;
 import org.tornotron.echno_backend.task.dto.TaskSimpleDto;
 
+import java.time.Duration;
 import java.util.stream.Collectors;
 
 @Component
@@ -17,6 +20,7 @@ public class TaskDtoConvertor {
         TaskSimpleDto dto = new TaskSimpleDto();
         dto.setId(task.getId());
         dto.setTitle(task.getTitle());
+        dto.setDescription(task.getDescription());
         dto.setStartDate(task.getStartDate());
         dto.setEndDate(task.getEndDate());
         dto.setCreatorId(task.getCreator().getId());
@@ -30,11 +34,25 @@ public class TaskDtoConvertor {
         return dto;
     }
 
+    public static AttachmentDto convertAttachmentToDto(Attachment attachment, FileStorageService fileStorageService) {
+        AttachmentDto dto = new AttachmentDto();
+        dto.setId(attachment.getId());
+        dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
+        dto.setEntityType(attachment.getEntityType());
+        dto.setContentType(attachment.getContentType());
+        dto.setFileSize(attachment.getFileSize());
+        dto.setFileName(attachment.getOriginalFilename());
+        dto.setCreatedAt(attachment.getCreatedAt().toString());
+        dto.setUpdatedAt(attachment.getUpdatedAt().toString());
+        return dto;
+    }
+
 
     public static TaskDto convertTaskToDto(Task task, FileStorageService fileStorageService) {
         TaskDto dto = new TaskDto();
         dto.setId(task.getId());
         dto.setTitle(task.getTitle());
+        dto.setDescription(task.getDescription());
         dto.setStartDate(task.getStartDate());
         dto.setEndDate(task.getEndDate());
         dto.setCreator(EmployeeDtoConvertor.convertEmployeeToDto(task.getCreator(),fileStorageService));
@@ -50,6 +68,9 @@ public class TaskDtoConvertor {
         dto.setStatus(task.getStatus());
         dto.setIssues(task.getIssues().stream()
                 .map(IssueDtoConvertor::convertIssueToDto)
+                .collect(Collectors.toList()));
+        dto.setAttachments(task.getAttachments().stream()
+                .map(attachment -> convertAttachmentToDto(attachment,fileStorageService))
                 .collect(Collectors.toList()));
         return dto;
     }

--- a/src/main/java/org/tornotron/echno_backend/category/Category.java
+++ b/src/main/java/org/tornotron/echno_backend/category/Category.java
@@ -30,6 +30,9 @@ public class Category implements TenantScopedEntity {
     @Column(name = "category_name", nullable = false)
     private String name;
 
+    @Column(name = "normalized_name", unique = true)
+    private String normalizedName;
+
     /** A brief description of the category. */
     @Column(name = "category_description")
     private String description;

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -39,7 +39,6 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 201 (Created).
      */
     @PostMapping
-    @PreAuthorize("hasAuthority('category:create') or hasAuthority('category:admin')")
     public ResponseEntity<CategorySimpleDto> createCategory(@Valid @RequestBody CategoryCreationDto categoryCreationDto) {
         logger.info("Category Added Successfully");
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -54,7 +53,6 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
@@ -70,7 +68,6 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the category DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
     public ResponseEntity<?> readACategory(@PathVariable Long id) {
         CategoryDto categoryDto = categoryService.getACategory(id);
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
@@ -83,7 +80,6 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('category:delete') or hasAuthority('category:admin')")
     public ResponseEntity<ApiResponse> deleteACategory(@PathVariable Long id) {
         categoryService.deleteACategory(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryNormalizer.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryNormalizer.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.category;
+
+public class CategoryNormalizer {
+
+    public static String normalize(String input) {
+        if (input == null) return null;
+
+        String normalized = input.toLowerCase().trim();
+
+        normalized = normalized.replace("&", "and");
+
+        normalized = normalized.replaceAll("[^a-z0-9\\s]", "");
+
+        normalized = normalized.trim().replaceAll("\\s+", " ");
+
+        return normalized;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryRepository.java
@@ -19,4 +19,10 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
      * @return An {@link Optional} containing the found {@link Category}, or {@link Optional#empty()} if no category with the given name exists.
      */
     Optional<Category> findCategoryByName(@NotBlank(message = "name is required") @Size(min = 3,max = 50, message = "name must be between 3 and 50 characters") String name);
+
+    Optional<Category> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    boolean existsByNormalizedName(String normalizedName);
+
+    boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
@@ -12,6 +12,7 @@ import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.category.dto.CategorySimpleDto;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 
 
@@ -44,9 +45,14 @@ public class CategoryService {
      */
     @Transactional
     public CategorySimpleDto addCategory(CategoryCreationDto categoryCreationDto) {
+        String normalized = CategoryNormalizer.normalize(categoryCreationDto.getName());
+        if(categoryRepository.existsByNormalizedName(normalized)) {
+            throw new IllegalArgumentException("Category with name " + normalized + " already exists.");
+        }
         Category category = new Category();
         category.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
         category.setName(categoryCreationDto.getName());
+        category.setNormalizedName(normalized);
         category.setDescription(categoryCreationDto.getDescription());
         category.setIcon(categoryCreationDto.getIcon());
         category.setImage(categoryCreationDto.getImage());
@@ -76,7 +82,7 @@ public class CategoryService {
      */
     @Transactional(readOnly = true)
     public CategoryDto getACategory(Long id) {
-        CategoryDto categoryDto = categoryRepository.findById(id)
+        CategoryDto categoryDto = categoryRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
                 .map(CategoryDtoConvertor::convertCategoryToDto)
                 .orElse(null);
 
@@ -95,7 +101,7 @@ public class CategoryService {
      */
     @Transactional
     public void deleteACategory(Long id) {
-        if(!categoryRepository.existsById(id)) {
+        if(!categoryRepository.existsByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())) {
             throw new ResourceNotFoundException("Category not found with id: " + id);
         }
         categoryRepository.deleteById(id);

--- a/src/main/java/org/tornotron/echno_backend/task/Task.java
+++ b/src/main/java/org/tornotron/echno_backend/task/Task.java
@@ -38,6 +38,9 @@ public class Task implements TenantScopedEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
+    @Column(name = "description")
+    private String description;
+
     /** The scheduled start date and time of the task. */
     @Column(name = "start_date", nullable = true)
     private LocalDateTime startDate;

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -98,11 +98,11 @@ public class TaskController {
      * @param id      The ID of the task to update.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
-    @PatchMapping("{id}")
-    @PreAuthorize("hasAuthority('task:update') or hasAuthority('task:admin')")
-    public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id));
-    }
+//    @PatchMapping("{id}")
+//    @PreAuthorize("hasAuthority('task:update') or hasAuthority('task:admin')")
+//    public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
+//        return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id));
+//    }
 
     /**
      * Updates multiple tasks in a batch.

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 201 (Created).
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAuthority('task:create') or hasAuthority('task:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data,
                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
@@ -65,7 +66,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the list of task DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('task:read') or hasAuthority('task:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<TaskDto>> readAllTasks(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<TaskDto> tasks = service.getAllTasks(pageNo, pageSize);
@@ -80,7 +81,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the task DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('task:read') or hasAuthority('task:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<?> readATask(@PathVariable Long id) {
         TaskDto taskDto = service.getATask(id);
         return new ResponseEntity<>(taskDto, HttpStatus.OK);
@@ -89,14 +90,19 @@ public class TaskControllerWeb {
     /**
      * Partially updates an existing task.
      *
-     * @param updates A map of fields to update.
      * @param id      The ID of the task to update.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
-    @PatchMapping("{id}")
-    @PreAuthorize("hasAuthority('task:update') or hasAuthority('task:admin')")
-    public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id));
+    @PatchMapping(value = "{id}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestPart(value = "data", required = false) String data,
+                                                            @PathVariable Long id,
+                                                            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
+                                                            @RequestParam(value = "entityType", required = false, defaultValue = "TASK_ATTACHMENTS") String entityType) throws JsonProcessingException
+    {
+        Map<String, Object> updates = data != null
+                ? objectMapper.readValue(data, new TypeReference<>() {}) : Map.of();
+        return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id,attachments, entityType));
     }
 
     /**
@@ -106,7 +112,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @PatchMapping("/batch")
-    @PreAuthorize("hasAuthority('task:update') or hasAuthority('task:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<ApiResponse> batchUpdateTasks(@Valid @RequestBody List<TaskPatchDto> updates) {
         service.batchUpdateTasks(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -119,7 +125,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('task:delete') or hasAuthority('task:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<ApiResponse> deleteATask(@PathVariable Long id) {
         service.deleteATask(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Task with id: " + id + " deleted"));

--- a/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 /**
  * Repository interface for {@link Task} entities.
@@ -17,6 +19,11 @@ public interface TaskRepository extends JpaRepository<Task,Long> {
      * @return The {@link Task} with the given title, or null if not found.
      */
     Task findTaskByTitle(@NotBlank(message = "title is required") @Size(min = 3,max = 50,message = "title must be between 3 and 50 characters") String title);
+
+    Optional<Task> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
+            
 
 //    List<Task> findTaskByEmployee_IdAndProject_Id(@NotNull(message = "employeeId is required") Long employeeId, @NotNull(message = "projectId is required") Long projectId);
 }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -9,9 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.DtoConversions.TaskDtoConvertor;
 import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
@@ -25,6 +27,7 @@ import org.tornotron.echno_backend.task.dto.TaskSimpleDto;
 import org.tornotron.echno_backend.task.enums.TaskStatus;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -82,18 +85,19 @@ public class TaskService {
         Task task = new Task();
         task.setTitle(taskCreationDto.getTitle());
         task.setStartDate(taskCreationDto.getStartDate());
+        task.setDescription(taskCreationDto.getDescription());
         task.setEndDate(taskCreationDto.getEndDate());
         task.setProgress(taskCreationDto.getProgress());
         task.setStatus(TaskStatus.valueOf(taskCreationDto.getStatus()));
 
         if (taskCreationDto.getCreatorId() != null) {
-            task.setCreator(employeeRepository.findById(taskCreationDto.getCreatorId())
+            task.setCreator(employeeRepository.findByIdAndOrganizationId(taskCreationDto.getCreatorId(), TenantContext.getCurrentOrgId())
                     .orElseThrow(() -> new ResourceNotFoundException("Employee not found with id: " + taskCreationDto.getCreatorId())));
         } else {
-            throw new InvalidRequestException("Employee ID must be provided");
+            throw new InvalidRequestException("Creator ID must be provided");
         }
         if (taskCreationDto.getProjectId() != null) {
-            var project = projectRepository.findById(taskCreationDto.getProjectId())
+            var project = projectRepository.findByIdAndOrganization_Id(taskCreationDto.getProjectId(),TenantContext.getCurrentOrgId())
                     .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + taskCreationDto.getProjectId()));
             task.setProject(project);
             task.setOrganization(project.getOrganization());
@@ -123,7 +127,7 @@ public class TaskService {
         }
 
         if(taskCreationDto.getCategoryId() != null) {
-            task.setCategory(categoryRepository.findById(taskCreationDto.getCategoryId())
+            task.setCategory(categoryRepository.findByIdAndOrganization_Id(taskCreationDto.getCategoryId(),TenantContext.getCurrentOrgId())
                     .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + taskCreationDto.getCategoryId())));
         } else {
             throw new InvalidRequestException("Category must be provided");
@@ -184,7 +188,7 @@ public class TaskService {
      */
     @Transactional(readOnly = true)
     public TaskDto getATask(Long id) {
-        TaskDto taskDto = taskRepository.findById(id)
+        TaskDto taskDto = taskRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .map(task -> TaskDtoConvertor.convertTaskToDto(task,fileStorageService))
                 .orElse(null);
         if(taskDto == null) {
@@ -202,10 +206,18 @@ public class TaskService {
      * @throws ResourceNotFoundException if no task with the given ID is found.
      */
     @Transactional
-    public TaskSimpleDto partialUpdateATask(Map<String,Object> updates,Long id) {
-        Task task = taskRepository.findById(id)
+    public TaskSimpleDto partialUpdateATask(Map<String,Object> updates,Long id,List<MultipartFile> attachments, String entityType) {
+        Task task = taskRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found with id: " + id));
         partialUpdateATask(updates, task);
+
+        if (attachments != null) {
+            for (MultipartFile att:attachments) {
+                Attachment attachment = attachmentService.uploadAttachment(att,entityType,id,TASKS_FOLDER);
+                task.addAttachment(attachment);
+            }
+        }
+
        return TaskDtoConvertor.convertTaskToSimpleDto(taskRepository.save(task));
     }
 
@@ -216,7 +228,7 @@ public class TaskService {
                     task.setTitle((String) value);
                     break;
                 case "endDate":
-                    task.setEndDate(value != null ? LocalDateTime.parse(value.toString()) : null);
+                    task.setEndDate(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
                     break;
                 case "progress":
                     if (value == null) {
@@ -228,8 +240,39 @@ public class TaskService {
                 case "status":
                     task.setStatus(TaskStatus.valueOf((String) value));
                     break;
+                case "tags":
+                    updateTags(value, task);
+                    break;
             }
         });
+    }
+
+    private void updateTags(Object rawTags, Task task) {
+        if (rawTags == null) {
+            task.setTags(null);
+            return;
+        }
+        if (!(rawTags instanceof List<?>)) {
+            throw new InvalidRequestException("Tags must be provided as a list of strings");
+        }
+
+        List<?> tagValues = (List<?>) rawTags;
+        List<String> cleanedTags = tagValues.stream()
+                .map(tag -> {
+                    if (tag == null) {
+                        return null;
+                    }
+                    if (!(tag instanceof String)) {
+                        throw new InvalidRequestException("Each tag must be a string value");
+                    }
+                    String trimmedTag = ((String) tag).trim();
+                    return trimmedTag.isEmpty() ? null : trimmedTag;
+                })
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        task.setTags(cleanedTags);
     }
 
     /**
@@ -262,7 +305,7 @@ public class TaskService {
      */
     @Transactional
     public void deleteATask(Long id) {
-        if(!taskRepository.existsById(id)) {
+        if(!taskRepository.existsByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())) {
             throw new ResourceNotFoundException("Task not found with id: " + id);
         }
         taskRepository.deleteById(id);

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
@@ -18,6 +18,8 @@ public class TaskCreationDto {
 
     private LocalDateTime endDate;
 
+    private String description;
+
     @NotNull(message = "creatorId is required(type: Long)")
     private Long creatorId;
 

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.task.dto;
 
 import lombok.Data;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.issue.dto.IssueDto;
@@ -15,6 +16,7 @@ import java.util.Set;
 public class TaskDto {
     private Long id;
     private String title;
+    private String description;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private EmployeeDto creator;
@@ -27,4 +29,5 @@ public class TaskDto {
     private LocalDateTime updatedAt;
     private TaskStatus status;
     private List<IssueDto> issues;
+    private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskSimpleDto.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public class TaskSimpleDto {
     private Long id;
     private String title;
+    private String description;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Long creatorId;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -121,6 +121,12 @@
     <!-- Add employee_id column for human-friendly identifiers -->
     <include file="db/changelog/v1.3/063-add-employee-id-to-employee.xml"/>
 
+    <!-- Add normalized_name to category for case-insensitive uniqueness -->
+    <include file="db/changelog/v1.3/064-add-normalized-name-to-category.xml"/>
+
+    <!-- Add description column to task -->
+    <include file="db/changelog/v1.3/065-add-description-to-task.xml"/>
+
     <!-- Tag v1.3 release -->
     <include file="db/changelog/v1.3/060-tag-v1.3.xml"/>
 

--- a/src/main/resources/db/changelog/v1.3/064-add-normalized-name-to-category.xml
+++ b/src/main/resources/db/changelog/v1.3/064-add-normalized-name-to-category.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="064-add-normalized-name-to-category" author="echno">
+        <addColumn tableName="category">
+            <column name="normalized_name" type="VARCHAR(255)"/>
+        </addColumn>
+        <addUniqueConstraint tableName="category" columnNames="normalized_name"
+                             constraintName="uq_category_normalized_name"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.3/065-add-description-to-task.xml
+++ b/src/main/resources/db/changelog/v1.3/065-add-description-to-task.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="065-add-description-to-task" author="echno">
+        <addColumn tableName="task">
+            <column name="description" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
  - ensure categories have a normalized, unique name via CategoryNormalizer, new
    repository guards, and per-organization lookups/deletes; exposes Liquibase
    change 064-add-normalized-name-to-category so duplicate names differing only
    by case/symbols are rejected.
  - expand tasks with a persisted description, propagate it through DTOs/
    converters, and expose it over the API; Liquibase change 065-add-
    description-to-task adds the column.
  - tighten task security to respect the active tenant: controller endpoints now
    use @orgSecurity helpers, service/repository methods query by organization,
    and creator/project/category lookups validate membership.
  - enrich task updates with multipart support so attachments can be uploaded
    during PATCH requests, stream attachment metadata back via DTOs, and
    centralize tag validation/cleanup in TaskService.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now support file attachments with time-limited download links
  * Tasks can now include descriptions

* **Improvements**
  * Category names enforce case-insensitive uniqueness to prevent duplicates
  * Partial task updates now support direct file uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->