### PR TITLE
Add OpenAPI/Swagger UI documentation with configurable public access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation('com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'com.github.librepdf:openpdf:3.0.0'
     implementation 'software.amazon.awssdk:s3:2.41.10'
     implementation 'org.liquibase:liquibase-core:5.0.1'

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
@@ -37,6 +37,10 @@ public class SecurityConfig {
     @Value("${keycloak.frontend.web-origin}")
     private List<String> allowedOrigins;
 
+    @Value("${springdoc.swagger-ui.public-access:false}")
+    private boolean swaggerPublicAccess;
+
+    private static final String[] SWAGGER_PATHS = {"/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**"};
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, RPTExchangeFilter rPTExchangeFilter, TenantFilter tenantFilter) throws Exception{
@@ -45,12 +49,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .addFilterBefore(rPTExchangeFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(tenantFilter, BearerTokenAuthenticationFilter.class)
-                        .authorizeHttpRequests(auth -> auth
-                                .requestMatchers(HttpMethod.POST, "/api/"+backend_version+"/auth/register").permitAll()
-                                .requestMatchers("/actuator/**").permitAll()
-                                .anyRequest()
-                                .authenticated()
-                        )
+                        .authorizeHttpRequests(auth -> {
+                                auth.requestMatchers(HttpMethod.POST, "/api/"+backend_version+"/auth/register").permitAll()
+                                .requestMatchers("/actuator/**").permitAll();
+                                if (swaggerPublicAccess) {
+                                    auth.requestMatchers(SWAGGER_PATHS).permitAll();
+                                }
+                                auth.anyRequest().authenticated();
+                        })
                         .oauth2ResourceServer(oauth2 -> oauth2
                                 .jwt(Customizer.withDefaults())
                                 .jwt(jwt -> jwt

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,6 +140,9 @@ spring:
     change-log: classpath:db/changelog/db.changelog-master.xml
     contexts: v3
 
+springdoc:
+  swagger-ui:
+    public-access: true
 
 server:
   tomcat:


### PR DESCRIPTION
This pull request integrates Swagger UI (via SpringDoc OpenAPI) into the backend to provide interactive API documentation. The Swagger UI access is made configurable through application
  properties, allowing it to be publicly accessible in development environments while keeping it secured behind authentication in production.

  Changes Made

  - Added springdoc-openapi-starter-webmvc-ui:2.8.6 dependency to build.gradle for OpenAPI documentation support.
  - Updated SecurityConfig.java to conditionally permit public access to Swagger UI endpoints (/swagger-ui/**, /swagger-ui.html, /v3/api-docs/**) based on a configurable property.
  - Introduced springdoc.swagger-ui.public-access property in application.yml (defaulting to true) to control whether Swagger UI bypasses authentication.
  - Refactored the authorizeHttpRequests block from a chained lambda to a block lambda to support conditional authorization rules.

  Impact

  - Developers and API consumers can now explore and test API endpoints via the Swagger UI without needing separate tools like Postman.
  - The configurable public access flag ensures Swagger UI can be locked down in production by setting springdoc.swagger-ui.public-access: false, preventing unauthorized access to API
  documentation.
  - The refactored security configuration is more readable and extensible for adding future conditional access rules.
  - No breaking changes to existing endpoints or authentication behavior.

  Related Issues

  - N/A

  Checklist

  - Code has been reviewed by at least one team member.
  - Documentation has been updated (if applicable).
  - Changes follow the established coding standards and best practices.
  - Tests have been written and/or existing tests have been updated (if applicable).
  - Relevant issues have been addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive API documentation interface, enabling users to explore and test API endpoints directly.
  * Implemented configurable public access to API documentation controlled via application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->