### PR TITLE
organization scoping (multi-tenancy) to the finance module and endpoints protection

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/numbering/DocumentSequence.java
+++ b/src/main/java/org/tornotron/echno_backend/common/numbering/DocumentSequence.java
@@ -2,18 +2,25 @@ package org.tornotron.echno_backend.common.numbering;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "document_sequence",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"doc_type", "fiscal_year"}))
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_document_sequence_org_type_year",
+                columnNames = {"organization_id", "doc_type", "fiscal_year"}))
 @Data
 public class DocumentSequence {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 
     @Column(name = "doc_type", nullable = false, length = 10)
     private String docType;

--- a/src/main/java/org/tornotron/echno_backend/common/numbering/DocumentSequenceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/common/numbering/DocumentSequenceRepository.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public interface DocumentSequenceRepository extends JpaRepository<DocumentSequence, UUID> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT s FROM DocumentSequence s WHERE s.docType = :type AND s.fiscalYear = :fy")
-    Optional<DocumentSequence> findByDocTypeAndFiscalYearForUpdate(String type, int fy);
+    @Query("SELECT s FROM DocumentSequence s WHERE s.organization.id = :orgId " +
+            "AND s.docType = :type AND s.fiscalYear = :fy")
+    Optional<DocumentSequence> findByOrgAndDocTypeAndFiscalYearForUpdate(Long orgId, String type, int fy);
 }

--- a/src/main/java/org/tornotron/echno_backend/common/numbering/EntryNumberGenerator.java
+++ b/src/main/java/org/tornotron/echno_backend/common/numbering/EntryNumberGenerator.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -13,13 +15,16 @@ import java.time.Month;
 public class EntryNumberGenerator {
 
     private final DocumentSequenceRepository repo;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public String next(String docType) {
         int fy = currentFiscalYear(LocalDate.now());
-        DocumentSequence seq = repo.findByDocTypeAndFiscalYearForUpdate(docType, fy)
+        Long orgId = TenantContext.getCurrentOrgId();
+        DocumentSequence seq = repo.findByOrgAndDocTypeAndFiscalYearForUpdate(orgId, docType, fy)
                 .orElseGet(() -> {
                     DocumentSequence s = new DocumentSequence();
+                    s.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
                     s.setDocType(docType);
                     s.setFiscalYear(fy);
                     s.setNextValue(1L);

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/domain/CompanyBankAccount.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/domain/CompanyBankAccount.java
@@ -4,16 +4,20 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "company_bank_accounts")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter
 @NoArgsConstructor
-public class CompanyBankAccount extends BaseEntity {
+public class CompanyBankAccount extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -43,4 +47,8 @@ public class CompanyBankAccount extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "ledger_account_id", nullable = false)
     private Account ledgerAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/repositories/CompanyBankAccountRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/repositories/CompanyBankAccountRepository.java
@@ -1,13 +1,23 @@
 package org.tornotron.echno_backend.finance.bank.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.tornotron.echno_backend.finance.bank.domain.CompanyBankAccount;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface CompanyBankAccountRepository extends JpaRepository<CompanyBankAccount, UUID> {
     List<CompanyBankAccount> findByActiveTrue();
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT c FROM CompanyBankAccount c WHERE c.id = :id")
+    Optional<CompanyBankAccount> findScopedById(@Param("id") UUID id);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.finance.bank.domain.CompanyBankAccount;
 import org.tornotron.echno_backend.finance.bank.dtos.CompanyBankAccountDto;
 import org.tornotron.echno_backend.finance.bank.dtos.CreateCompanyBankAccountRequest;
@@ -23,6 +24,7 @@ public class CompanyBankAccountService {
     private final CompanyBankAccountRepository repository;
     private final AccountRepository accountRepository;
     private final CompanyBankAccountMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(readOnly = true)
     public List<CompanyBankAccountDto> findAll() {
@@ -36,14 +38,14 @@ public class CompanyBankAccountService {
 
     @Transactional(readOnly = true)
     public CompanyBankAccountDto findById(UUID id) {
-        return repository.findById(id)
+        return repository.findScopedById(id)
                 .map(mapper::toDto)
                 .orElseThrow(() -> new ResourceNotFoundException("Company Bank Account not found: " + id));
     }
 
     @Transactional
     public CompanyBankAccountDto create(CreateCompanyBankAccountRequest req) {
-        Account ledgerAccount = accountRepository.findById(req.ledgerAccountId())
+        Account ledgerAccount = accountRepository.findScopedById(req.ledgerAccountId())
                 .orElseThrow(() -> new AccountNotFoundException(req.ledgerAccountId()));
 
         CompanyBankAccount account = new CompanyBankAccount();
@@ -54,13 +56,14 @@ public class CompanyBankAccountService {
         account.setSwiftCode(req.swiftCode());
         account.setDefault(req.isDefault());
         account.setLedgerAccount(ledgerAccount);
+        account.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         return mapper.toDto(repository.save(account));
     }
 
     @Transactional
     public CompanyBankAccountDto deactivate(UUID id) {
-        CompanyBankAccount account = repository.findById(id)
+        CompanyBankAccount account = repository.findScopedById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Company Bank Account not found: " + id));
         account.setActive(false);
         return mapper.toDto(account);

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
@@ -21,21 +21,25 @@ public class CompanyBankAccountControllerWeb {
     private final CompanyBankAccountService service;
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public List<CompanyBankAccountDto> list(@RequestParam(defaultValue = "true") boolean activeOnly) {
         return activeOnly ? service.findAllActive() : service.findAll();
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public CompanyBankAccountDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<CompanyBankAccountDto> create(@Valid @RequestBody CreateCompanyBankAccountRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PostMapping("/{id}/deactivate")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public CompanyBankAccountDto deactivate(@PathVariable UUID id) {
         return service.deactivate(id);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/domain/Invoice.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/domain/Invoice.java
@@ -4,9 +4,12 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -16,15 +19,16 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "invoices",
-        uniqueConstraints = @UniqueConstraint(name = "uk_invoice_number", columnNames = "invoice_number"),
+        uniqueConstraints = @UniqueConstraint(name = "uk_invoice_number", columnNames = {"organization_id", "invoice_number"}),
         indexes = {
                 @Index(name = "idx_invoice_customer", columnList = "customer_id"),
                 @Index(name = "idx_invoice_status", columnList = "status"),
                 @Index(name = "idx_invoice_date", columnList = "invoice_date")
         })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter
 @NoArgsConstructor
-public class Invoice extends BaseEntity {
+public class Invoice extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -67,6 +71,10 @@ public class Invoice extends BaseEntity {
 
     @Column(length = 500)
     private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 
     @OneToMany(mappedBy = "invoice", cascade = CascadeType.ALL, orphanRemoval = true,
             fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
@@ -9,6 +9,7 @@ import org.tornotron.echno_backend.common.configuration.MoneyUtils;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
@@ -45,6 +46,7 @@ public class InvoiceService {
     private final EntryNumberGenerator numberGen;
     private final InvoiceMapper mapper;
     private final InvoicePostingProperties postingProps;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(readOnly = true)
     public InvoiceDto findById(UUID id) {
@@ -58,7 +60,7 @@ public class InvoiceService {
             throw new InvalidJournalException("Due date cannot be before invoice date");
         }
 
-        Customer customer = customerRepo.findById(req.customerId())
+        Customer customer = customerRepo.findScopedById(req.customerId())
                 .orElseThrow(() -> new ResourceNotFoundException("Customer not found: " + req.customerId()));
         if (!customer.isActive()) {
             throw new InvalidJournalException("Customer is inactive: " + customer.getCode());
@@ -76,6 +78,7 @@ public class InvoiceService {
         inv.setDueDate(req.dueDate());
         inv.setStatus(InvoiceStatus.DRAFT);
         inv.setNotes(req.notes());
+        inv.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         BigDecimal subtotal = BigDecimal.ZERO;
         BigDecimal taxTotal = BigDecimal.ZERO;
@@ -204,7 +207,7 @@ public class InvoiceService {
                 JournalEntry reversal = journalRepo.findByIdWithLines(inv.getJournalEntryId())
                         .map(je -> postingService.reverse(je.getId(),
                                 new ReverseJournalRequest(reason)).id())
-                        .map(id -> journalRepo.findById(id).orElseThrow())
+                        .map(id -> journalRepo.findScopedById(id).orElseThrow())
                         .orElseThrow(() -> new InvalidJournalException("Original JE not found"));
                 inv.setReversalJournalEntryId(reversal.getId());
                 inv.setStatus(InvoiceStatus.CANCELLED);

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
@@ -20,21 +21,25 @@ public class InvoiceControllerWeb {
     private final InvoiceService service;
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<InvoiceDto> createDraft(@Valid @RequestBody CreateInvoiceRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.createDraft(req));
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public InvoiceDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @PostMapping("/{id}/issue")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public InvoiceDto issue(@PathVariable UUID id) {
         return service.issue(id);
     }
 
     @PostMapping("/{id}/cancel")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public InvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
         return service.cancel(id, reason);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/Account.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/Account.java
@@ -5,17 +5,21 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "accounts",
-        uniqueConstraints = @UniqueConstraint(name = "uk_accounts_code", columnNames = "code"))
+        uniqueConstraints = @UniqueConstraint(name = "uk_accounts_code", columnNames = {"organization_id", "code"}))
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter
 @Setter
 @NoArgsConstructor
-public class Account extends BaseEntity {
+public class Account extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -40,6 +44,10 @@ public class Account extends BaseEntity {
 
     @Column(length = 500)
     private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 
 }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/Customer.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/Customer.java
@@ -5,20 +5,24 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "customers",
-        uniqueConstraints = @UniqueConstraint(name = "uk_customers_code", columnNames = "code"),
+        uniqueConstraints = @UniqueConstraint(name = "uk_customers_code", columnNames = {"organization_id", "code"}),
         indexes = {
             @Index(name = "idx_customer_name", columnList = "name"),
             @Index(name = "idx_customer_gstin", columnList = "gstin")
         })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter
 @Setter
 @NoArgsConstructor
-public class Customer extends BaseEntity {
+public class Customer extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -55,4 +59,8 @@ public class Customer extends BaseEntity {
 
     @Column(nullable = false)
     private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/JournalEntry.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/domain/JournalEntry.java
@@ -4,7 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,10 +21,11 @@ import java.util.UUID;
             @Index(name = "idx_je_status", columnList = "status"),
             @Index(name = "idx_je_reference", columnList = "reference")
        },
-       uniqueConstraints = @UniqueConstraint(name = "uk_je_number",columnNames = "entry_number"))
+       uniqueConstraints = @UniqueConstraint(name = "uk_je_number", columnNames = {"organization_id", "entry_number"}))
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter
 @NoArgsConstructor
-public class JournalEntry extends BaseEntity{
+public class JournalEntry extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -54,6 +58,10 @@ public class JournalEntry extends BaseEntity{
 
     @Column(name = "source_id")
     private UUID sourceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 
     @OneToMany(mappedBy = "journalEntry", cascade = CascadeType.ALL, orphanRemoval = true,
             fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
@@ -12,6 +12,14 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface AccountRepository extends JpaRepository<Account, UUID> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT a FROM Account a WHERE a.id = :id")
+    Optional<Account> findScopedById(@Param("id") UUID id);
+
     Optional<Account> findByCode(String code);
     List<Account> findByType(AccountType type);
     List<Account> findByActiveTrue();

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/CustomerRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/CustomerRepository.java
@@ -3,12 +3,22 @@ package org.tornotron.echno_backend.finance.ledger.repositories;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface CustomerRepository extends JpaRepository<Customer, UUID> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT c FROM Customer c WHERE c.id = :id")
+    Optional<Customer> findScopedById(@Param("id") UUID id);
+
     Optional<Customer> findByCode(String code);
     boolean existsByCode(String code);
     Page<Customer> findByNameContainingIgnoreCaseAndActive(String name, boolean active, Pageable pageable);

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/JournalEntryRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/JournalEntryRepository.java
@@ -14,6 +14,14 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface JournalEntryRepository extends JpaRepository<JournalEntry, UUID> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT je FROM JournalEntry je WHERE je.id = :id")
+    Optional<JournalEntry> findScopedById(UUID id);
+
     Optional<JournalEntry> findByEntryNumber(String entryNumber);
 
     @EntityGraph(attributePaths = {"lines", "lines.account"})

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountDto;
@@ -26,6 +27,7 @@ public class AccountService {
     private final AccountRepository repo;
     private final AccountMapper mapper;
     private final AccountCodeGenerator codeGenerator;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(readOnly = true)
     public List<AccountDto> findAllAccounts() {
@@ -79,7 +81,7 @@ public class AccountService {
 
     @Transactional(readOnly = true)
     public AccountDto findAccountById(UUID id) {
-        return mapper.toDto(repo.findById(id)
+        return mapper.toDto(repo.findScopedById(id)
                 .orElseThrow(() -> new AccountNotFoundException(id)));
     }
 
@@ -93,7 +95,7 @@ public class AccountService {
     public AccountDto create(CreateAccountRequest req) {
         Account parent = null;
         if(req.parentId() != null) {
-            parent = repo.findById(req.parentId())
+            parent = repo.findScopedById(req.parentId())
                     .orElseThrow(() -> new AccountNotFoundException(req.parentId()));
         }
 
@@ -126,6 +128,7 @@ public class AccountService {
         account.setDescription(req.description());
         account.setActive(true);
         account.setParent(parent);
+        account.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
         return mapper.toDto(repo.save(account));
     }
 
@@ -138,7 +141,7 @@ public class AccountService {
 
     @Transactional
     public AccountDto deactivate(UUID id) {
-        Account account = repo.findById(id)
+        Account account = repo.findScopedById(id)
                 .orElseThrow(() -> new AccountNotFoundException(id));
         account.setActive(false);
         return mapper.toDto(account);

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/CustomerService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/CustomerService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
 import org.tornotron.echno_backend.finance.ledger.dtos.CreateCustomerRequest;
 import org.tornotron.echno_backend.finance.ledger.dtos.CustomerDto;
@@ -22,6 +23,7 @@ public class CustomerService {
 
     private final CustomerRepository repo;
     private final CustomerMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(readOnly = true)
     public Page<CustomerDto> search(String name, Pageable pageable) {
@@ -51,6 +53,7 @@ public class CustomerService {
         customer.setCreditLimit(req.getCreditLimit());
         customer.setPaymentTermsDays(req.getPaymentTermsDays() == null ? 30 : req.getPaymentTermsDays());
         customer.setActive(true);
+        customer.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
         return mapper.toDto(repo.save(customer));
     }
 
@@ -74,7 +77,7 @@ public class CustomerService {
     }
 
     Customer getEntity(UUID id) {
-        return repo.findById(id)
+        return repo.findScopedById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Customer not found: "+ id));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.common.configuration.MoneyUtils;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.UnbalancedEntryException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
@@ -44,6 +45,7 @@ public class JournalPostingService {
     private final AccountRepository accountRepo;
     private final EntryNumberGenerator numberGen;
     private final JournalEntryMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
 
     // ============================================================
     // Public API
@@ -71,6 +73,7 @@ public class JournalPostingService {
         entry.setStatus(JournalStatus.POSTED);
         entry.setSourceType(sourceType);
         entry.setSourceId(sourceId);
+        entry.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         // Pre-fetch all accounts in one query to avoid N+1
         List<UUID> accountIds = req.lines().stream()

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountTreeDto;
@@ -21,31 +22,37 @@ public class AccountControllerWeb {
     private final AccountService service;
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public List<AccountDto> list(@RequestParam(defaultValue = "true") boolean activeOnly) {
         return activeOnly ? service.findAllActiveAccounts() : service.findAllAccounts();
     }
 
     @GetMapping("/tree")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public List<AccountTreeDto> tree() {
         return service.findAccountTree();
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public AccountDto get(@PathVariable UUID id) {
         return service.findAccountById(id);
     }
 
     @GetMapping("/by-code/{code}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public AccountDto getByCode(@PathVariable String code) {
         return service.findByAccountByCode(code);
     }
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<AccountDto> create(@Valid @RequestBody CreateAccountRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PostMapping("/{id}/deactivate")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public AccountDto deactivate(@PathVariable UUID id) {
         return service.deactivate(id);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/CustomerControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/CustomerControllerWeb.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.ledger.dtos.CreateCustomerRequest;
 import org.tornotron.echno_backend.finance.ledger.dtos.CustomerDto;
@@ -23,26 +24,31 @@ public class CustomerControllerWeb {
     private final CustomerService service;
 
     @GetMapping("/all")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public List<CustomerDto> list(@RequestParam(required = false) String name, Pageable pageable) {
         return service.search(name, pageable).getContent();
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public CustomerDto get(@RequestParam UUID id) {
         return service.findById(id);
     }
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<CustomerDto> create(@Valid @RequestBody CreateCustomerRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public CustomerDto update(@PathVariable UUID id, @Valid @RequestBody UpdateCustomerRequest req) {
         return service.update(id, req);
     }
 
     @PostMapping("/{id}/deactivate")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<Void> deactivate(@PathVariable UUID id) {
         service.deactivate(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.ledger.dtos.JournalEntryDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
@@ -22,16 +23,19 @@ public class JournalEntryControllerWeb {
     private final JournalPostingService service;
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<JournalEntryDto> post(@Valid @RequestBody PostJournalRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.post(req));
     }
 
     @GetMapping()
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public JournalEntryDto get(@RequestParam UUID id) {
         return service.findById(id);
     }
 
     @GetMapping("/all")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<List<JournalEntryDto>> getAll(@RequestParam(defaultValue = "0") int pageNo,
                                         @RequestParam(defaultValue = "10") int pageSize) {
         Page<JournalEntryDto> journalEntries = service.findAll(pageNo,pageSize);
@@ -39,6 +43,7 @@ public class JournalEntryControllerWeb {
     }
 
     @PostMapping("/reverse")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<JournalEntryDto> reverse(
             @RequestParam UUID id,
             @Valid @RequestBody ReverseJournalRequest req) {

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/domain/Payment.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/domain/Payment.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.finance.bank.domain.CompanyBankAccount;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
+import org.tornotron.echno_backend.organization.Organization;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -18,16 +21,17 @@ import java.util.UUID;
 @Entity
 @Table(name = "payments",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_payment_number", columnNames = "payment_number"),
-                @UniqueConstraint(name = "uk_payment_idem",   columnNames = "idempotency_key")
+                @UniqueConstraint(name = "uk_payment_number", columnNames = {"organization_id", "payment_number"}),
+                @UniqueConstraint(name = "uk_payment_idem",   columnNames = {"organization_id", "idempotency_key"})
         },
         indexes = {
                 @Index(name = "idx_payment_customer", columnList = "customer_id"),
                 @Index(name = "idx_payment_date",     columnList = "payment_date")
         })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter
 @NoArgsConstructor
-public class Payment extends BaseEntity {
+public class Payment extends BaseEntity implements TenantScopedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -61,6 +65,10 @@ public class Payment extends BaseEntity {
 
     @Column(length = 500)
     private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
 
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true,
         fetch = FetchType.LAZY)

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.DuplicateIdempotencyKeyException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
@@ -49,6 +50,7 @@ public class PaymentService {
     private final EntryNumberGenerator numberGen;
     private final PaymentMapper mapper;
     private final InvoicePostingProperties postingProps;
+    private final TenantEntityHelper tenantEntityHelper;
 
     @Transactional(readOnly = true)
     public PaymentDto findById(UUID id) {
@@ -79,9 +81,9 @@ public class PaymentService {
         }
 
         // 3. Load customer + company bank account
-        Customer customer = customerRepo.findById(req.customerId())
+        Customer customer = customerRepo.findScopedById(req.customerId())
                 .orElseThrow(() -> new ResourceNotFoundException("Customer not found: " + req.customerId()));
-        CompanyBankAccount companyBank = companyBankRepo.findById(req.companyBankAccountId())
+        CompanyBankAccount companyBank = companyBankRepo.findScopedById(req.companyBankAccountId())
                 .orElseThrow(() -> new ResourceNotFoundException("Company Bank Account not found: " + req.companyBankAccountId()));
 
         Account bankLedger = companyBank.getLedgerAccount();
@@ -133,6 +135,7 @@ public class PaymentService {
         payment.setExternalReference(req.externalReference());
         payment.setIdempotencyKey(idempotencyKey);
         payment.setNotes(req.notes());
+        payment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         for (Invoice inv : lockedInvoices) {
             BigDecimal alloc = allocByInvoice.get(inv.getId());

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/web/PaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/web/PaymentControllerWeb.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.payment.dtos.PaymentDto;
 import org.tornotron.echno_backend.finance.payment.dtos.RecordPaymentRequest;
@@ -19,6 +20,7 @@ public class PaymentControllerWeb {
     private final PaymentService service;
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ResponseEntity<PaymentDto> record(
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody RecordPaymentRequest req
@@ -27,6 +29,7 @@ public class PaymentControllerWeb {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public PaymentDto get(@PathVariable UUID id) {
         return service.findById(id);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/service/ReportService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/service/ReportService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 import org.tornotron.echno_backend.finance.report.dtos.BalanceSheetReport;
 import org.tornotron.echno_backend.finance.report.dtos.ProfitAndLossReport;
@@ -27,6 +28,8 @@ public class ReportService {
 
     @Transactional(readOnly = true)
     public TrialBalanceReport trailBalanceReport(LocalDate asOfDate) {
+        // Native SQL bypasses the Hibernate orgFilter, so scope by organization explicitly.
+        Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
                 SELECT a.code, a.name, a.type,
                                    COALESCE(SUM(l.debit), 0)  AS total_debit,
@@ -36,16 +39,21 @@ public class ReportService {
                             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id
                                   AND je.status = 'POSTED'
                                   AND je.entry_date <= :asOf
+                """
+                + jeOrgJoin(orgId)
+                + acctOrgWhere(orgId)
+                + """
                             GROUP BY a.code, a.name, a.type
                             HAVING COALESCE(SUM(l.debit), 0) <> 0
                                 OR COALESCE(SUM(l.credit), 0) <> 0
                             ORDER BY a.code
                 """;
 
+        var query = em.createNativeQuery(sql).setParameter("asOf", asOfDate);
+        if (orgId != null) query.setParameter("orgId", orgId);
+
         @SuppressWarnings("unchecked")
-        List<Object[]> raw = em.createNativeQuery(sql)
-                .setParameter("asOf", asOfDate)
-                .getResultList();
+        List<Object[]> raw = query.getResultList();
 
         List<TrialBalanceRow> rows = new ArrayList<>();
         BigDecimal totalDebit = BigDecimal.ZERO;
@@ -93,6 +101,8 @@ public class ReportService {
             throw new IllegalArgumentException("toDate cannot be before fromDate");
         }
 
+        // Native SQL bypasses the Hibernate orgFilter, so scope by organization explicitly.
+        Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
                 SELECT a.code, a.name, a.type,
                                    COALESCE(SUM(l.debit), 0)  AS total_debit,
@@ -102,16 +112,24 @@ public class ReportService {
                             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id
                                   AND je.status = 'POSTED'
                                   AND je.entry_date BETWEEN :from AND :to
+                """
+                + jeOrgJoin(orgId)
+                + """
                             WHERE a.type IN ('INCOME', 'EXPENSE')
+                """
+                + acctOrgAnd(orgId)
+                + """
                             GROUP BY a.code, a.name, a.type
                             ORDER BY a.code
               """;
 
-        @SuppressWarnings("unchecked")
-        List<Object[]> raw = em.createNativeQuery(sql)
+        var query = em.createNativeQuery(sql)
                 .setParameter("from", fromDate)
-                .setParameter("to", toDate)
-                .getResultList();
+                .setParameter("to", toDate);
+        if (orgId != null) query.setParameter("orgId", orgId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> raw = query.getResultList();
 
         List<ProfitAndLossReport.AccountLine> income = new ArrayList<>();
         List<ProfitAndLossReport.AccountLine> expense = new ArrayList<>();
@@ -157,6 +175,8 @@ public class ReportService {
 
     @Transactional(readOnly = true)
     public BalanceSheetReport balanceSheet(LocalDate asOfDate) {
+        // Native SQL bypasses the Hibernate orgFilter, so scope by organization explicitly.
+        Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
             SELECT a.code, a.name, a.type,
                    COALESCE(SUM(l.debit), 0)  AS total_debit,
@@ -166,15 +186,22 @@ public class ReportService {
             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id
                   AND je.status = 'POSTED'
                   AND je.entry_date <= :asOf
+            """
+                + jeOrgJoin(orgId)
+                + """
             WHERE a.type IN ('ASSET', 'LIABILITY', 'EQUITY')
+            """
+                + acctOrgAnd(orgId)
+                + """
             GROUP BY a.code, a.name, a.type
             ORDER BY a.code
             """;
 
+        var query = em.createNativeQuery(sql).setParameter("asOf", asOfDate);
+        if (orgId != null) query.setParameter("orgId", orgId);
+
         @SuppressWarnings("unchecked")
-        List<Object[]> raw = em.createNativeQuery(sql)
-                .setParameter("asOf", asOfDate)
-                .getResultList();
+        List<Object[]> raw = query.getResultList();
 
         List<BalanceSheetReport.AccountLine> assets = new ArrayList<>();
         List<BalanceSheetReport.AccountLine> liabilities = new ArrayList<>();
@@ -259,6 +286,25 @@ public class ReportService {
 
 
 
+
+    /**
+     * Org predicate for the {@code journal_entries} table, emitted inside the LEFT JOIN ON
+     * clause so outer-join semantics are preserved (accounts with no activity still appear).
+     * Empty when there is no tenant context (e.g. a global admin viewing all organizations).
+     */
+    private static String jeOrgJoin(Long orgId) {
+        return orgId != null ? "      AND je.organization_id = :orgId\n" : "";
+    }
+
+    /** Org predicate for the {@code accounts} table as a fresh WHERE (query has none of its own). */
+    private static String acctOrgWhere(Long orgId) {
+        return orgId != null ? "            WHERE a.organization_id = :orgId\n" : "";
+    }
+
+    /** Org predicate for the {@code accounts} table appended to an existing WHERE clause. */
+    private static String acctOrgAnd(Long orgId) {
+        return orgId != null ? "            AND a.organization_id = :orgId\n" : "";
+    }
 
     private static BigDecimal toBig(Object o) {
         return switch (o) {

--- a/src/main/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWeb.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.finance.report.web;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,6 +22,7 @@ public class ReportControllerWeb {
     private final ReportService service;
 
     @GetMapping("/trial-balance")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public TrialBalanceReport trialBalance(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate asOfDate
             ) {
@@ -28,6 +30,7 @@ public class ReportControllerWeb {
     }
 
     @GetMapping("/profit-and-loss")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public ProfitAndLossReport profitAndLoss(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
@@ -35,6 +38,7 @@ public class ReportControllerWeb {
     }
 
     @GetMapping("/balance-sheet")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public BalanceSheetReport balanceSheet(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate asOfDate) {
         return service.balanceSheet(asOfDate);

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -223,4 +223,7 @@
     <include file="db/changelog/v4.0/018-create-finance-payment-allocations.xml"/>
     <include file="db/changelog/v4.0/019-create-company-bank-accounts.xml"/>
 
+    <!-- v4.0 - Finance multi-tenancy (organization scoping) -->
+    <include file="db/changelog/v4.0/021-add-org-scope-to-finance.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/021-add-org-scope-to-finance.xml
+++ b/src/main/resources/db/changelog/v4.0/021-add-org-scope-to-finance.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- ==============================================================
+         Adds organization scoping (multi-tenancy) to the finance module.
+         Each tenant-scoped table gets a nullable organization_id FK + index,
+         and its global unique constraints become composite (organization_id, ...)
+         so the same code/number can be reused across organizations.
+
+         The column add (+FK+index) and the unique-constraint swap are kept in
+         separate changeSets: CockroachDB runs each changeSet in its own
+         transaction, so the new column is committed before a unique constraint
+         references it.
+         ============================================================== -->
+
+    <!-- ===================== accounts ===================== -->
+    <changeSet id="org-scope-001-accounts-column" author="echno">
+        <addColumn tableName="accounts">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="accounts"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_accounts_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="accounts" indexName="idx_accounts_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-001-accounts-unique" author="echno">
+        <dropUniqueConstraint tableName="accounts" constraintName="uk_accounts_code"/>
+        <addUniqueConstraint tableName="accounts"
+                             columnNames="organization_id, code"
+                             constraintName="uk_accounts_code"/>
+    </changeSet>
+
+    <!-- ===================== customers ===================== -->
+    <changeSet id="org-scope-002-customers-column" author="echno">
+        <addColumn tableName="customers">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="customers"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_customers_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="customers" indexName="idx_customers_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-002-customers-unique" author="echno">
+        <dropUniqueConstraint tableName="customers" constraintName="uk_customers_code"/>
+        <addUniqueConstraint tableName="customers"
+                             columnNames="organization_id, code"
+                             constraintName="uk_customers_code"/>
+    </changeSet>
+
+    <!-- ===================== journal_entries ===================== -->
+    <changeSet id="org-scope-003-journal-entries-column" author="echno">
+        <addColumn tableName="journal_entries">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="journal_entries"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_journal_entries_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="journal_entries" indexName="idx_journal_entries_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-003-journal-entries-unique" author="echno">
+        <dropUniqueConstraint tableName="journal_entries" constraintName="uk_je_number"/>
+        <addUniqueConstraint tableName="journal_entries"
+                             columnNames="organization_id, entry_number"
+                             constraintName="uk_je_number"/>
+    </changeSet>
+
+    <!-- ===================== invoices ===================== -->
+    <changeSet id="org-scope-004-invoices-column" author="echno">
+        <addColumn tableName="invoices">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="invoices"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_invoices_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="invoices" indexName="idx_invoices_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-004-invoices-unique" author="echno">
+        <dropUniqueConstraint tableName="invoices" constraintName="uk_invoice_number"/>
+        <addUniqueConstraint tableName="invoices"
+                             columnNames="organization_id, invoice_number"
+                             constraintName="uk_invoice_number"/>
+    </changeSet>
+
+    <!-- ===================== payments ===================== -->
+    <changeSet id="org-scope-005-payments-column" author="echno">
+        <addColumn tableName="payments">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="payments"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_payments_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="payments" indexName="idx_payments_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-005-payments-unique" author="echno">
+        <dropUniqueConstraint tableName="payments" constraintName="uk_payment_number"/>
+        <addUniqueConstraint tableName="payments"
+                             columnNames="organization_id, payment_number"
+                             constraintName="uk_payment_number"/>
+        <dropUniqueConstraint tableName="payments" constraintName="uk_payment_idem"/>
+        <addUniqueConstraint tableName="payments"
+                             columnNames="organization_id, idempotency_key"
+                             constraintName="uk_payment_idem"/>
+    </changeSet>
+
+    <!-- ===================== company_bank_accounts (no unique to swap) ===================== -->
+    <changeSet id="org-scope-006-company-bank-accounts-column" author="echno">
+        <addColumn tableName="company_bank_accounts">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="company_bank_accounts"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_company_bank_accounts_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="company_bank_accounts" indexName="idx_company_bank_accounts_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <!-- ===================== document_sequence ===================== -->
+    <changeSet id="org-scope-007-document-sequence-column" author="echno">
+        <addColumn tableName="document_sequence">
+            <column name="organization_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="document_sequence"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_document_sequence_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+        <createIndex tableName="document_sequence" indexName="idx_document_sequence_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="org-scope-007-document-sequence-unique" author="echno">
+        <dropUniqueConstraint tableName="document_sequence" constraintName="uk_document_sequence_type_year"/>
+        <addUniqueConstraint tableName="document_sequence"
+                             columnNames="organization_id, doc_type, fiscal_year"
+                             constraintName="uk_document_sequence_org_type_year"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Changes Made                                                                                                                                                                                                                
                                                                                                                                                                                                                              
  - Added organization_id to every tenant-scoped finance table via a new Liquibase changelog (v4.0/021-add-org-scope-to-finance.xml), including FK to organization (ON DELETE RESTRICT), an index per table, and conversion of
  global unique constraints (e.g. uk_accounts_code, uk_customers_code) into composite (organization_id, code) constraints so codes and document numbers can repeat across organizations. Column-add and constraint-swap are   
  split into separate changeSets because CockroachDB runs each changeSet in its own transaction.                                                                                                                              
  - Made the finance domain entities tenant-aware — Account, Customer, Invoice, JournalEntry, Payment, CompanyBankAccount, and DocumentSequence now implement TenantScopedEntity, carry a lazy @ManyToOne Organization, and   
  declare the Hibernate @Filter(name = "orgFilter").                                                                                                                                                                          
  - Updated services to resolve the current tenant through TenantEntityHelper.resolveCurrentOrganization() on create, and switched lookups from findById to new tenant-aware repository methods (findScopedById and friends)  
  in AccountService, CustomerService, InvoiceService, JournalPostingService, PaymentService, and CompanyBankAccountService.                                                                                                   
  - Scoped ReportService explicitly by TenantContext.getCurrentOrgId() — trial balance, P&L, and balance sheet use native SQL, which bypasses the Hibernate filter, so the organization join/predicate is composed into the   
  query and bound as a parameter.                                                                                                                                                                                             
  - Made EntryNumberGenerator and DocumentSequenceRepository tenant-aware so invoice/journal numbering sequences are allocated per organization rather than globally.                                                         
  - Enforced access control at the controller layer with @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant(...)") on all finance web endpoints (accounts, customers, invoices, journal entries, payments, bank        
  accounts, reports).                                                                                                                                                                                                         
                                                                                                                                                                                                                              
  Impact                                                                                                                                                                                                                      
                                                                                                                                                                                                                              
  - Closes a cross-tenant data-exposure gap: finance data was previously global, so any authenticated user could read or mutate another organization's accounts, invoices, and payments. Reads are now filtered at the        
  persistence layer and endpoints are gated by org role.                                                                                                                                                                      
  - Defense in depth — the Hibernate filter covers ORM access by default rather than relying on every query author remembering to filter, and the explicit TenantContext scoping in ReportService covers the native-SQL paths 
  the filter cannot reach.                                                                                                                                                                                                    
  - Brings the finance module in line with the multi-tenancy contract already used elsewhere in the codebase (TenantScopedEntity, TenantEntityHelper, orgSecurity), removing it as a one-off exception and giving later       
  finance features a scoping pattern to follow.                                                                                                                                                                               
  - Per-organization numbering sequences remove a scalability constraint: document numbers no longer contend across the whole install.                                                                                        
  - Note for reviewers: organization_id is nullable so the migration applies to existing rows without a backfill. A follow-up backfill and a NOT NULL tightening are worth planning.                                          
                                                                                                                                                                                                                              
  Related Issues                                                                                                                                                                                                              
                                                                                                                                                                                                                              
  - Continues the finance module work merged from finance-module.                                                                                                                                                             
  - Extends the tenancy foundation from organization-level-multitenancy / multitenancy-setup.                                                                                                                                 
  - Add issue links here.                                                                                                                                                                                                     
                                                                                                                                                                                                                              
  Checklist                                                                                                                                                                                                                   
                                                                                                                                                                                                                              
  - [ ] Code has been reviewed by at least one team member.                                                                                                                                                                   
  - [ ] Documentation has been updated (if applicable).                                                                                                                                                                       
  - [ ] Changes follow the established coding standards and best practices.                                                                                                                                                   
  - [ ] Tests have been written and/or existing tests have been updated (if applicable).                                                                                                                                      
  - [ ] Relevant issues have been addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Finance records and reports are now isolated by organization, preventing cross-organization data access.
  * Numbering, account, customer, invoice, payment, journal, and bank account identifiers can now repeat across organizations.
  * Finance endpoints now enforce organization-role permissions for key operations.
* **Bug Fixes**
  * Improved organization-aware lookups and report filtering to prevent accidental cross-organization results.
  * Newly created finance records are automatically associated with the active organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->