### PR TITLE
Resolve the deployment host without relying on MagicDNS

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -120,6 +120,14 @@ jobs:
         working-directory: deployment/ansible
         run: ansible-galaxy collection install -r requirements.yml -p collections
 
+      # A runner that joins the tailnet does not get MagicDNS, so neither the
+      # short name nor the fully qualified one resolves. The Tailscale CLI reads
+      # the peer address straight from the network map, which needs no DNS at
+      # all, and that address is handed to Ansible directly.
+      - name: Resolve the host on the tailnet
+        id: host
+        run: echo "ip=$(tailscale ip -4 echno-staging)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy
         working-directory: deployment/ansible
         run: |
@@ -128,6 +136,7 @@ jobs:
           # A job-scoped registry token, so no standing credential for pulling
           # private images is left behind on the host.
           ansible-playbook -i inventory/staging-do.yml playbooks/deploy-apps.yml \
+            -e "ansible_host=${{ steps.host.outputs.ip }}" \
             -e "echno_backend_image_digest=${{ needs.build.outputs.digest }}" \
             -e "vault_ghcr_pull_token=${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
The first CI deployment failed at the connection step: a runner joining the tailnet does not receive tailnet DNS, so neither `echno-staging` nor `echno-staging.tail3d1f2d.ts.net` resolved.

The Tailscale CLI reads a peer's address straight from the network map, with no DNS involved. The workflow now does that and passes the address to Ansible.

Preferred over turning on DNS acceptance for the runner, because it removes the dependency instead of adding another moving part that has to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployment reliability by resolving the target host’s Tailscale IPv4 address before deployment.
  * Ensured deployment connects directly to the resolved host address instead of relying on hostname or DNS resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->