### PR TITLE
Match the deployment host on its unique tailnet name

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -120,13 +120,26 @@ jobs:
         working-directory: deployment/ansible
         run: ansible-galaxy collection install -r requirements.yml -p collections
 
-      # A runner that joins the tailnet does not get MagicDNS, so neither the
-      # short name nor the fully qualified one resolves. The Tailscale CLI reads
-      # the peer address straight from the network map, which needs no DNS at
-      # all, and that address is handed to Ansible directly.
+      # A runner that joins the tailnet does not receive tailnet DNS, so no
+      # hostname resolves. The address is read from the network map instead.
+      #
+      # Matched on DNSName, which is unique, rather than HostName, which is not:
+      # the retired droplet still reports HostName "echno-staging" while its
+      # DNSName is "echno-legacy". Matching on the hostname returns both and
+      # could deploy to the machine being replaced.
       - name: Resolve the host on the tailnet
         id: host
-        run: echo "ip=$(tailscale ip -4 echno-staging)" >> "$GITHUB_OUTPUT"
+        run: |
+          ip=$(tailscale status --json \
+            | jq -r '.Peer[] | select(.DNSName | startswith("echno-staging.")) | .TailscaleIPs[0]')
+          count=$(printf '%s\n' "$ip" | grep -c . || true)
+          if [ "$count" -ne 1 ]; then
+            echo "Expected exactly one host, matched $count:"
+            printf '%s\n' "$ip"
+            exit 1
+          fi
+          echo "Deploying to $ip"
+          echo "ip=$ip" >> "$GITHUB_OUTPUT"
 
       - name: Deploy
         working-directory: deployment/ansible


### PR DESCRIPTION
`tailscale ip <hostname>` resolves through DNS, which a runner joining the tailnet does not have, so the address came back empty and the deploy failed.

The address is now read from the network map instead.

Matching on `DNSName` rather than `HostName` matters, and this was a near miss: the retired droplet still reports `HostName: echno-staging` while its `DNSName` is `echno-legacy`. Matching on hostname returned **both machines**, so a deployment could have landed on the host being replaced. The step now fails unless exactly one host matches.