### PR TITLE
Log to stdout instead of a file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,8 @@ RUN groupadd --system --gid 1001 echno \
 
 WORKDIR /app
 
-# The application's logback configuration writes to /app/logs. Running as a
-# non-root user in a root-owned directory, it cannot create that, and the
-# container exits on startup.
-#
-# Worth revisiting in the application itself: a container writing logs to a file
-# traps them inside its own filesystem, where the log collector never sees them
-# and they vanish with the container. Logging to stdout would let the platform
-# handle collection, retention and rotation.
-RUN mkdir -p /app/logs && chown -R echno:echno /app
+# Owned by the runtime user, which runs unprivileged.
+RUN chown -R echno:echno /app
 
 COPY --from=builder --chown=echno:echno /build/build/libs/*.jar /app/echno-backend.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,17 @@ RUN groupadd --system --gid 1001 echno \
  && useradd --system --uid 1001 --gid echno --home /app --shell /usr/sbin/nologin echno
 
 WORKDIR /app
+
+# The application's logback configuration writes to /app/logs. Running as a
+# non-root user in a root-owned directory, it cannot create that, and the
+# container exits on startup.
+#
+# Worth revisiting in the application itself: a container writing logs to a file
+# traps them inside its own filesystem, where the log collector never sees them
+# and they vanish with the container. Logging to stdout would let the platform
+# handle collection, retention and rotation.
+RUN mkdir -p /app/logs && chown -R echno:echno /app
+
 COPY --from=builder --chown=echno:echno /build/build/libs/*.jar /app/echno-backend.jar
 
 USER echno

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!--
+      Logs go to stdout and to Loki, never to a file.
+
+      A container writing logs into its own filesystem traps them where the
+      collector cannot reach them, and loses them entirely when the container is
+      replaced, which happens on every deployment. Writing to stdout lets the
+      container runtime handle collection, rotation and retention, and is what
+      the log shipper reads.
+    -->
     <!-- Console Appender with enhanced pattern -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -25,23 +34,9 @@
         </format>
     </appender>
 
-    <!-- File Appender for Rolling Logs -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/application.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <!-- Root Logger Configuration -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
         <appender-ref ref="LOKI"/>
     </root>
 


### PR DESCRIPTION
The container exits on startup: logback writes to `/app/logs`, and the hardened image runs as a non-root user in a root-owned directory.

Creating the directory would have fixed the crash and left the real problem in place. A container writing logs into its own filesystem puts them where the collector cannot reach them, and loses them entirely when the container is replaced, which is every deployment. We now run Grafana Alloy to collect container logs, and it only sees stdout.

So the file appender is removed. Logs go to stdout and to Loki, and the runtime handles collection, rotation and retention.