### PR TITLE
Add direct-to-storage uploads via pre-signed URLs

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -6,6 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
+import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
+import org.tornotron.echno_backend.common.dto.UploadRequest;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -44,6 +47,44 @@ public class AttachmentControllerWeb {
                     dto.setCreatedAt(attachment.getCreatedAt().toString());
                     return dto;
                 }).toList());
+    }
+
+    // Direct-to-storage upload, in two steps, so large files never pass through
+    // the API or the CDN in front of it.
+    //
+    // 1. presign: the client declares the files, and gets a short-lived upload
+    //    URL for each. The client PUTs each file straight to storage.
+    // 2. register: the client confirms the keys, and the server records them
+    //    after verifying each object is actually present in storage.
+    @PostMapping("/presign/entityId/{entityId}/entityType/{entityType}")
+    public ResponseEntity<List<PresignedUpload>> presignUploads(
+            @RequestBody List<UploadRequest> uploads,
+            @PathVariable String entityType,
+            @PathVariable Long entityId) {
+        return ResponseEntity.ok(attachmentService.presignUploads(
+                uploads, entityType, entityId, entityType.split("_", 2)[0].toLowerCase()));
+    }
+
+    @PostMapping("/register/entityId/{entityId}/entityType/{entityType}")
+    public ResponseEntity<List<AttachmentDto>> registerUploads(
+            @RequestBody List<RegisterUploadRequest> uploads,
+            @PathVariable String entityType,
+            @PathVariable Long entityId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                attachmentService.registerUploads(
+                        uploads, entityType, entityId, entityType.split("_", 2)[0].toLowerCase())
+                        .stream()
+                        .map(attachment -> {
+                            AttachmentDto dto = new AttachmentDto();
+                            dto.setId(attachment.getId());
+                            dto.setEntityType(attachment.getEntityType());
+                            dto.setContentType(attachment.getContentType());
+                            dto.setFileSize(attachment.getFileSize());
+                            dto.setFileName(attachment.getOriginalFilename());
+                            dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
+                            dto.setCreatedAt(attachment.getCreatedAt().toString());
+                            return dto;
+                        }).toList());
     }
 
     @GetMapping("/entityId/{entityId}/entityType/{entityType}")

--- a/src/main/java/org/tornotron/echno_backend/common/dto/PresignedUpload.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/PresignedUpload.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.common.dto;
+
+/**
+ * A short-lived, write-only URL for uploading a single object directly to
+ * storage, along with the key the object will occupy.
+ *
+ * <p>Uploading direct to storage keeps large files off the application and out
+ * of the CDN in front of it, which caps request bodies at 100 MB and times out
+ * at 100 seconds.
+ *
+ * @param key         where the object will live; pass this back when registering it
+ * @param url         pre-signed PUT target, valid only for this key
+ * @param contentType the type the upload must declare, since it is signed
+ * @param expiresInSeconds lifetime of the URL
+ */
+public record PresignedUpload(
+        String key,
+        String url,
+        String contentType,
+        long expiresInSeconds
+) {
+}

--- a/src/main/java/org/tornotron/echno_backend/common/dto/RegisterUploadRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/RegisterUploadRequest.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.common.dto;
+
+/**
+ * A client's confirmation that an object has been uploaded to storage, so the
+ * application can record it as an attachment.
+ *
+ * <p>The key must be one the server issued from a prior presign call. The
+ * server does not trust the client's word that the object exists: it verifies
+ * the object is present in storage before recording it.
+ *
+ * @param key         the storage key returned by the presign step
+ * @param filename    original filename, for display
+ * @param contentType the object's content type
+ * @param fileSize    size in bytes
+ */
+public record RegisterUploadRequest(
+        String key,
+        String filename,
+        String contentType,
+        Long fileSize
+) {
+}

--- a/src/main/java/org/tornotron/echno_backend/common/dto/UploadRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/UploadRequest.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.common.dto;
+
+/**
+ * A client's declaration of a file it intends to upload directly to storage.
+ *
+ * <p>The server presigns a URL for it and checks it against existing
+ * attachments, without the file ever passing through the application.
+ *
+ * @param filename    the original name, used for the storage key and dedup
+ * @param contentType the type the upload will declare; it is signed, so the
+ *                    client must send exactly this on the PUT
+ * @param fileSize    declared size in bytes, used for duplicate detection
+ */
+public record UploadRequest(
+        String filename,
+        String contentType,
+        Long fileSize
+) {
+}

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.common.dto.StoredFile;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
+import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
+import org.tornotron.echno_backend.common.dto.UploadRequest;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -27,6 +30,10 @@ import java.util.Set;
  */
 @Service
 public class AttachmentService {
+
+    // Pre-signed upload URLs are single-purpose and short-lived; long enough for
+    // a large file on a slow site connection, not long enough to be worth reusing.
+    private static final java.time.Duration UPLOAD_URL_EXPIRY = java.time.Duration.ofMinutes(15);
 
     private final AttachmentRepository attachmentRepository;
     private final FileStorageService fileStorageService;
@@ -80,32 +87,7 @@ public class AttachmentService {
             attachment.setContentType(storedFile.contentType());
             attachment.setFileSize(storedFile.size());
             attachment.setOriginalFilename(originalFile.getOriginalFilename());
-            switch (folder) {
-                case "organization":
-                    attachment.setOrganization(organizationRepository.findById(entityId).orElse(null));
-                    break;
-
-                case "project":
-                case "projects":
-                    attachment.setProject(projectRepository.findById(entityId).orElse(null));
-                    break;
-
-                case "task":
-                    attachment.setTask(taskRepository.findById(entityId).orElse(null));
-                    break;
-
-                case "issue":
-                    attachment.setIssue(issueRepository.findById(entityId).orElse(null));
-                    break;
-
-                case "user":
-                    attachment.setUser(userRepository.findById(entityId).orElse(null));
-                    break;
-
-                case "attendance":
-                    attachment.setAttendance(attendanceRepository.findById(entityId).orElse(null));
-                    break;
-            }
+            linkToEntity(attachment, folder, entityId);
             attachments.add(attachmentRepository.save(attachment));
         }
 
@@ -226,6 +208,91 @@ public class AttachmentService {
      * @param files The list of files to validate
      * @throws IllegalArgumentException if duplicate files are found
      */
+    /**
+     * Associates an attachment with its owning entity. Extracted so both the
+     * streaming upload and the pre-signed upload paths record the association
+     * the same way.
+     */
+    private void linkToEntity(Attachment attachment, String folder, Long entityId) {
+        switch (folder) {
+            case "organization" -> attachment.setOrganization(organizationRepository.findById(entityId).orElse(null));
+            case "project", "projects" -> attachment.setProject(projectRepository.findById(entityId).orElse(null));
+            case "task" -> attachment.setTask(taskRepository.findById(entityId).orElse(null));
+            case "issue" -> attachment.setIssue(issueRepository.findById(entityId).orElse(null));
+            case "user" -> attachment.setUser(userRepository.findById(entityId).orElse(null));
+            case "attendance" -> attachment.setAttendance(attendanceRepository.findById(entityId).orElse(null));
+            default -> { }
+        }
+    }
+
+    /**
+     * Issues pre-signed upload URLs so a client uploads directly to storage.
+     *
+     * <p>The streaming path puts every byte through the API and the CDN in front
+     * of it, which caps request bodies at 100 MB and times out at 100 seconds.
+     * Site media routinely exceeds both. This path takes the file off the API
+     * entirely; the client uploads to storage and then calls registerUploads.
+     */
+    public List<PresignedUpload> presignUploads(List<UploadRequest> requests, String entityType, Long entityId, String folder) {
+        if (requests == null || requests.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> signatures = new ArrayList<>();
+        List<PresignedUpload> presigned = new ArrayList<>();
+        for (UploadRequest request : requests) {
+            if (request.filename() == null || request.filename().isBlank()) {
+                throw new IllegalArgumentException("Each upload request must name a file");
+            }
+            String signature = request.filename() + "_" + request.fileSize();
+            if (!signatures.add(signature)) {
+                throw new IllegalArgumentException("Duplicate file in request: " + request.filename());
+            }
+            if (attachmentRepository.existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
+                    entityType, entityId, request.filename(), request.fileSize())) {
+                throw new IllegalArgumentException("Attachment already exists: " + request.filename());
+            }
+            presigned.add(fileStorageService.generateUploadUrl(
+                    folder, request.filename(), request.contentType(), UPLOAD_URL_EXPIRY));
+        }
+        return presigned;
+    }
+
+    /**
+     * Records attachments the client has finished uploading directly to storage.
+     *
+     * <p>Each key must be one this service issued, and the object must actually
+     * be present: the client's claim is verified against storage rather than
+     * trusted, so a caller cannot register a row for an object that was never
+     * uploaded.
+     */
+    public List<Attachment> registerUploads(List<RegisterUploadRequest> requests, String entityType, Long entityId, String folder) {
+        if (requests == null || requests.isEmpty()) {
+            return List.of();
+        }
+
+        List<Attachment> attachments = new ArrayList<>();
+        for (RegisterUploadRequest request : requests) {
+            if (request.key() == null || request.key().isBlank()) {
+                throw new IllegalArgumentException("Each registration must reference a storage key");
+            }
+            if (!fileStorageService.objectExists(request.key())) {
+                throw new IllegalArgumentException("No uploaded object found for key: " + request.key());
+            }
+
+            Attachment attachment = new Attachment();
+            attachment.setEntityType(entityType);
+            attachment.setEntityId(entityId);
+            attachment.setStorageKey(request.key());
+            attachment.setContentType(request.contentType());
+            attachment.setFileSize(request.fileSize());
+            attachment.setOriginalFilename(request.filename());
+            linkToEntity(attachment, folder, entityId);
+            attachments.add(attachmentRepository.save(attachment));
+        }
+        return attachments;
+    }
+
     private void validateNoExistingAttachments(List<MultipartFile> files, String entityType, Long entityId) {
         List<String> existing = new ArrayList<>();
         for (MultipartFile file : files) {

--- a/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.common.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
 import org.tornotron.echno_backend.common.dto.StoredFile;
 import org.tornotron.echno_backend.common.exception.FileUploadException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -10,9 +11,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -72,6 +76,56 @@ public class FileStorageService {
 
 
         return new StoredFile(key,file.getContentType(), file.getSize());
+    }
+
+    /**
+     * Whether an object is present in storage. Used to confirm a client has
+     * actually completed a pre-signed upload before it is recorded, rather than
+     * trusting the client's word.
+     */
+    public boolean objectExists(String key) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Builds a key and a pre-signed PUT URL so a client can upload straight to
+     * object storage.
+     *
+     * <p>The alternative, streaming the file through this service, puts every
+     * upload through the CDN in front of it, which caps request bodies at 100 MB
+     * and times out at 100 seconds. Site media routinely exceeds both. Uploading
+     * direct to storage removes that ceiling and takes the traffic off the
+     * application entirely.
+     *
+     * <p>The URL is write-only, limited to the single key it names, and expires.
+     * The caller registers the object afterwards using the returned key.
+     */
+    public PresignedUpload generateUploadUrl(String folder, String filename, String contentType, Duration expiry) {
+        if (filename == null || filename.isBlank()) {
+            throw new FileUploadException("Filename is required to presign an upload");
+        }
+
+        String key = buildKey(folder, filename);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .acl(ObjectCannedACL.PRIVATE)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest =
+                s3Presigner.presignPutObject(r -> r
+                        .signatureDuration(expiry)
+                        .putObjectRequest(putObjectRequest)
+                );
+
+        return new PresignedUpload(key, presignedRequest.url().toString(), contentType, expiry.toSeconds());
     }
 
     public String generateDownloadUrl(String key, Duration expiry) {


### PR DESCRIPTION
Attachment uploads stream through the API as multipart form data. With the API behind Cloudflare, every upload is capped at a **100 MB body and a 100 second timeout**, and construction site media routinely exceeds both. Raising the nginx body limit does not help, because the ceiling is Cloudflare's.

This adds a two-step path that takes the file off the API entirely:

1. **presign** — the client declares the files it intends to upload and gets a short-lived pre-signed PUT URL for each. It uploads straight to object storage.
2. **register** — the client confirms the keys, and the server records the attachments **after verifying each object is actually present in storage**, so a client cannot register a row for something it never uploaded.

Downloads already work this way (`generateDownloadUrl`); this is the same mechanism for the write path. The existing multipart endpoint is unchanged, so small uploads keep working and clients adopt the direct path where it matters.

The folder-to-entity linking is extracted into one method shared by both paths, so an attachment is associated the same way however it arrived.

New endpoints under `/api/v1/attachment/web`: `POST /presign/...` and `POST /register/...`.

Compiles clean. Worth a look at the two-step contract before the frontend wires it up.