### PR TITLE
ci(iitm): fix tailnet route acceptance

### DIFF
--- a/.github/workflows/deploy-staging-iitm.yml
+++ b/.github/workflows/deploy-staging-iitm.yml
@@ -106,15 +106,20 @@ jobs:
 
       # The lab node is not a tailnet device: it sits on 10.24.6.0/24 behind the
       # hp-z / OptiPlex subnet routers. The runner joins as tag:ci-deploy (a
-      # deployer tag, distinct from any host tag) and accepts that route, which
-      # the ACL grants to tag:ci-deploy.
-      - name: Join the tailnet and accept the lab route
+      # deployer tag, distinct from any host tag); the ACL grants that tag the
+      # lab route.
+      - name: Join the tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci-deploy
-          args: --accept-routes
+
+      # The action's own `tailscale up` already sets --accept-routes, so passing
+      # it again through args fails ("flag provided multiple times"). Enable the
+      # subnet route in a separate step instead, so the runner can reach the node.
+      - name: Accept the lab subnet route
+        run: sudo tailscale set --accept-routes=true
 
       - name: Install Ansible
         run: python3 -m pip install --quiet ansible-core docker


### PR DESCRIPTION
The tailscale action already passes `--accept-routes` in its `tailscale up`; passing it again via `args` failed with "flag provided multiple times". Enable route acceptance in a separate `tailscale set` step instead. Fixes the deploy step of the IITM workflow.