### PR TITLE
ci(iitm): join as tag:cloud-staging

### DIFF
--- a/.github/workflows/deploy-staging-iitm.yml
+++ b/.github/workflows/deploy-staging-iitm.yml
@@ -105,15 +105,14 @@ jobs:
           path: deployment
 
       # The lab node is not a tailnet device: it sits on 10.24.6.0/24 behind the
-      # hp-z / OptiPlex subnet routers. The runner joins as tag:ci-deploy (a
-      # deployer tag, distinct from any host tag); the ACL grants that tag the
-      # lab route.
+      # hp-z / OptiPlex subnet routers. The runner joins as tag:cloud-staging,
+      # which the ACL grants the lab route.
       - name: Join the tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci-deploy
+          tags: tag:cloud-staging
 
       # The action's own `tailscale up` already sets --accept-routes, so passing
       # it again through args fails ("flag provided multiple times"). Enable the


### PR DESCRIPTION
Use the proven tag:cloud-staging for the IITM runner so the deploy path can be exercised. tag:ci-deploy migration deferred (OAuth client would not mint it despite the tag being added; needs diagnosis).