### PR TITLE
ci(iitm): runner joins as tag:ci-deploy via dedicated OAuth client

### DIFF
--- a/.github/workflows/deploy-staging-iitm.yml
+++ b/.github/workflows/deploy-staging-iitm.yml
@@ -105,14 +105,15 @@ jobs:
           path: deployment
 
       # The lab node is not a tailnet device: it sits on 10.24.6.0/24 behind the
-      # hp-z / OptiPlex subnet routers. The runner joins as tag:cloud-staging,
-      # which the ACL grants the lab route.
+      # hp-z / OptiPlex subnet routers. The runner joins as tag:ci-deploy (a
+      # dedicated deployer tag, not a host tag), which the ACL grants the lab
+      # route. Its OAuth client is scoped to exactly that one tag.
       - name: Join the tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:cloud-staging
+          oauth-client-id: ${{ secrets.TS_CI_DEPLOY_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CI_DEPLOY_SECRET }}
+          tags: tag:ci-deploy
 
       # The action's own `tailscale up` already sets --accept-routes, so passing
       # it again through args fails ("flag provided multiple times"). Enable the


### PR DESCRIPTION
The IITM deploy runner now joins the tailnet as `tag:ci-deploy`, minted by a dedicated OAuth client scoped to exactly that tag (new secrets `TS_CI_DEPLOY_CLIENT_ID` / `TS_CI_DEPLOY_SECRET`). This stops overloading `tag:cloud-staging` (a host tag) as a deployer identity. The DO staging workflow is untouched (keeps `TS_OAUTH_*` + `tag:cloud-staging`, retiring with #31).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging deployment workflow to use dedicated CI deployment access.
  * Improved deployment authentication and network access scoping for staging infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->