### PR TITLE
ci: IITM becomes the staging deploy target (retire DO staging)

### DIFF
--- a/.github/workflows/deploy-staging-iitm.yml
+++ b/.github/workflows/deploy-staging-iitm.yml
@@ -14,11 +14,14 @@ name: Staging (IITM)
 #   * it authenticates to the fereydon account with a key and a become password
 #     rather than as deploy over Tailscale SSH.
 #
-# workflow_dispatch, not merge-triggered: while the DO box still exists a merge
-# to staging deploys there. Switch the trigger to pull_request closed on staging
-# once DO staging is retired and this is the only staging.
+# IITM is now the staging environment: a merge into `staging` deploys here (the
+# DO staging box was retired to save cost). workflow_dispatch stays for manual
+# runs.
 
 on:
+  pull_request:
+    types: [closed]
+    branches: [staging]
   workflow_dispatch:
 
 concurrency:
@@ -34,6 +37,8 @@ env:
 
 jobs:
   build:
+    # workflow_dispatch carries no pull request, so let it through explicitly.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,9 +12,10 @@ name: Staging
 # path serves CI, an operator's laptop, and the IIT Madras host.
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [staging]
+  # The DO staging box was destroyed to save cost, so this no longer fires on a
+  # merge; the merge-to-staging deploy now targets IITM (deploy-staging-iitm.yml).
+  # It remains here, dispatch-only, to rebuild and redeploy the DO box from the
+  # IaC if it is ever brought back.
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
DO staging is being destroyed to save cost. A merge into `staging` now deploys to IITM (echno.in); the DO staging workflow becomes dispatch-only so the box can still be rebuilt from the IaC when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated staging deployment automation to run after pull requests are merged into the staging branch.
  - Prevented deployments from running when pull requests are closed without being merged.
  - Retained manual deployment options for rebuilding or redeploying staging environments when needed.
  - Clarified the current staging environment deployment path and fallback process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->