### PR TITLE
security: phase 0 authz lockdown (user + attachment controllers)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.common.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +18,12 @@ import org.tornotron.echno_backend.common.service.FileStorageService;
 import java.time.Duration;
 import java.util.List;
 
+// NOTE (phase0 authz lockdown): the @PreAuthorize guards below require the caller
+// to be a member of the current tenant, which closes the "any authenticated user"
+// hole. They do NOT yet verify that the target entity/attachment belongs to the
+// caller's organization; a follow-up in AttachmentService must resolve the
+// attachment/entity to its org and reject cross-tenant ids (org-scoped finder),
+// so a member of org A cannot act on org B's attachment by numeric id.
 @RestController
 @RequestMapping("/api/v1/attachment/web")
 @Validated
@@ -30,6 +37,7 @@ public class AttachmentControllerWeb {
         this.fileStorageService = fileStorageService;
     }
 
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,value = "/entityId/{entityId}/entityType/{entityType}")
     public ResponseEntity<List<AttachmentDto>> creatAttachment(@RequestParam(value = "attachments",required = true)List<MultipartFile> attachments,
                                                          @PathVariable String entityType,
@@ -56,6 +64,7 @@ public class AttachmentControllerWeb {
     //    URL for each. The client PUTs each file straight to storage.
     // 2. register: the client confirms the keys, and the server records them
     //    after verifying each object is actually present in storage.
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/presign/entityId/{entityId}/entityType/{entityType}")
     public ResponseEntity<List<PresignedUpload>> presignUploads(
             @RequestBody List<UploadRequest> uploads,
@@ -65,6 +74,7 @@ public class AttachmentControllerWeb {
                 uploads, entityType, entityId, entityType.split("_", 2)[0].toLowerCase()));
     }
 
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/register/entityId/{entityId}/entityType/{entityType}")
     public ResponseEntity<List<AttachmentDto>> registerUploads(
             @RequestBody List<RegisterUploadRequest> uploads,
@@ -87,12 +97,14 @@ public class AttachmentControllerWeb {
                         }).toList());
     }
 
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/entityId/{entityId}/entityType/{entityType}")
     public ResponseEntity<List<AttachmentDto>> readAttachments(@PathVariable String entityType,
                                                                @PathVariable Long entityId) {
         return ResponseEntity.status(HttpStatus.OK).body(attachmentService.getAttachments(entityType,entityId));
     }
 
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @DeleteMapping("/attachmentId/{attachmentId}")
     public ResponseEntity<ApiResponse> deleteAttachment(@PathVariable Long attachmentId) {
         attachmentService.deleteAttachment(attachmentId);

--- a/src/main/java/org/tornotron/echno_backend/user/UserController.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +45,7 @@ public class UserController {
      * @param pageSize The number of users per page (default is 10).
      * @return A {@link ResponseEntity} containing the list of user DTOs and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     @GetMapping("/all")
     public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
@@ -57,29 +59,31 @@ public class UserController {
      * @param userId The ID of the user.
      * @return A {@link ResponseEntity} containing a list of organization DTOs and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.isSelfUser(#userId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{userId}/organizations")
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsForCurrentUser(@PathVariable Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getOrganizationsForCurrentUser(userId));
     }
 
     /**
-     * Retrieves a single user by their ID.
+     * Retrieves the currently authenticated user (resolved from the token subject).
      *
-     * @param id The ID of the user to retrieve.
      * @return A {@link ResponseEntity} containing the user DTO and HTTP status 200 (OK).
      */
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<UserDto> readAnUser(JwtAuthenticationToken authenticationToken) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getAnUser(authenticationToken.getToken().getClaimAsString("sub")));
     }
 
     /**
-     * Partially updates an existing user.
+     * Partially updates an existing user. A user may update their own record; org admins may update any.
      *
      * @param updates A map of fields to update.
      * @param id      The ID of the user to update.
      * @return A {@link ResponseEntity} with the updated user's DTO and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.isSelfUser(#id) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("{id}")
     public ResponseEntity<UserDto> partialUpdateAUser(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.partialUpdateAnUser(updates, id));
@@ -91,6 +95,7 @@ public class UserController {
      * @param updates A list of DTOs containing the updates for each user.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/batch")
     public ResponseEntity<ApiResponse> batchUpdateUsers(@Valid @RequestBody List<UserPatchDto> updates) {
         userService.batchUpdateUser(updates);
@@ -103,6 +108,7 @@ public class UserController {
      * @param id The ID of the user to delete.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("{id}")
     public ResponseEntity<ApiResponse> deleteAnUser(@PathVariable Long id) {
         userService.deleteAnUser(id);

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,6 +60,7 @@ public class UserControllerWeb {
      * @param pageSize The number of users per page (default is 10).
      * @return A {@link ResponseEntity} containing the list of user DTOs and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     @GetMapping("/all")
     public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
@@ -72,6 +74,7 @@ public class UserControllerWeb {
      * @param userId The ID of the user.
      * @return A {@link ResponseEntity} containing a list of organization DTOs and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.isSelfUser(#userId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{userId}/organizations")
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsForCurrentUser(@PathVariable Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getOrganizationsForCurrentUser(userId));
@@ -87,12 +90,14 @@ public class UserControllerWeb {
 //        return ResponseEntity.status(HttpStatus.OK).body(userService.getAnUser(authenticationToken.getToken().getClaimAsString("sub")));
 //    }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<UserDto> getCurrentUser() {
         String keycloakId = userContextService.getCurrentKeycloakId();
         return ResponseEntity.ok(userService.getCurrentUserDto(keycloakId));
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/employees")
     public ResponseEntity<List<EmployeeDto>> getEmployeesForCurrentUser() {
         String keycloakId = userContextService.getCurrentKeycloakId();
@@ -101,7 +106,7 @@ public class UserControllerWeb {
     }
 
     /**
-     * Partially updates an existing user.
+     * Partially updates an existing user. A user may update their own record; org admins may update any.
      *
      * @param data    JSON string containing the fields to update.
      * @param id      The ID of the user to update.
@@ -109,6 +114,7 @@ public class UserControllerWeb {
      * @param cv      Optional CV/resume file.
      * @return A {@link ResponseEntity} with the updated user's DTO and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.isSelfUser(#id) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserDto> partialUpdateAUser(
             @RequestPart(value = "data", required = false) String data,
@@ -127,6 +133,7 @@ public class UserControllerWeb {
      * @param updates A list of DTOs containing the updates for each user.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/batch")
     public ResponseEntity<ApiResponse> batchUpdateUsers(@Valid @RequestBody List<UserPatchDto> updates) {
         userService.batchUpdateUser(updates);
@@ -139,6 +146,7 @@ public class UserControllerWeb {
      * @param id The ID of the user to delete.
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("{id}")
     public ResponseEntity<ApiResponse> deleteAnUser(@PathVariable Long id) {
         userService.deleteAnUser(id);


### PR DESCRIPTION
First increment of Phase 0 (emergency security), from the audit + verification pass (docs/2026-08-09-echno-codebase-audit-and-modernization-plan.md in echno-deployment).

**Fixes the critical cross-tenant exploit chain.** `UserController` / `UserControllerWeb` carried no `@PreAuthorize`, so any authenticated account (including a self-registered one via the public `/auth/register`) could:
- `GET /api/v1/user/all` -> exfiltrate every tenant every user (name, email, phone, DOB)
- `PATCH /api/v1/user/{id}` -> take over any account
- `DELETE /api/v1/user/{id}` -> delete any user

Guards added (matching the existing `@orgSecurity` SpEL convention): read-all -> `system-admin`/`hr-admin`; get-current -> `isAuthenticated`; per-user update -> self-or-`system-admin`; batch + delete -> `system-admin`. `AttachmentControllerWeb` now requires `isMemberOfCurrentTenant()` on every endpoint.

**Known follow-ups (next increment, called out in code):**
- `getAllUsers` is still an unscoped `findAll`; scope it to the caller org so even an admin only sees their tenant.
- `AttachmentService.deleteAttachment`/upload resolve by raw `findById`; add an org-scoped finder so a member of org A cannot act on org B attachment by id.

Compiles clean. No tests yet (Phase 1 introduces them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened access controls for attachment operations, including creation, retrieval, registration, presigning, and deletion.
  * Restricted user administration actions to authorized administrators.
  * Added self-service and administrator permissions for user profile access and updates.
  * Required authentication for current-user and employee information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->