### PR TITLE
security: scope user directory to the caller tenant (phase 0)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.user;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,6 +26,18 @@ public interface UserRepository extends JpaRepository<User,Long> {
      */
     @Query("SELECT DISTINCT e.organization FROM Employee  e WHERE e.user.id = :userId")
     List<Organization> findOrganizationsByUserId(@Param("userId") Long userId);
+
+    /**
+     * Finds the distinct users who have an employment in the given organization.
+     * Used to scope the user directory to the caller's tenant (User is not itself
+     * a tenant-scoped entity, so it must be scoped via Employee).
+     *
+     * @param organizationId The organization to scope by.
+     * @param pageable       Pagination.
+     * @return A page of {@link User}s belonging to that organization.
+     */
+    @Query("SELECT DISTINCT e.user FROM Employee e WHERE e.organization.id = :organizationId")
+    Page<User> findUsersByOrganizationId(@Param("organizationId") Long organizationId, Pageable pageable);
 
     /**
      * Finds a user by their name.

--- a/src/main/java/org/tornotron/echno_backend/user/UserService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserService.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -210,8 +212,16 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public Page<UserDto> getAllUsers(int pageNo, int pageSize) {
+        // Scope the directory to the caller's tenant. User is not a tenant-scoped
+        // entity, so the Hibernate org filter does not apply here; without this a
+        // findAll returns every tenant's users. Fail closed if there is no org
+        // context (the controller guard should already prevent that).
+        Long organizationId = TenantContext.getCurrentOrgId();
+        if (organizationId == null) {
+            throw new AccessDeniedException("No organization context; cannot list users.");
+        }
         Pageable pageable = PageRequest.of(pageNo,pageSize, Sort.by(Sort.Direction.ASC,"id"));
-        return userRepository.findAll(pageable)
+        return userRepository.findUsersByOrganizationId(organizationId, pageable)
                 .map(usr -> UserDtoConvertor.convertUserToDto(usr,fileStorageService));
     }
 


### PR DESCRIPTION
Phase 0, increment 2 (follows #321). Fixes the service-layer half of the user lockdown.

`getAllUsers` ran `userRepository.findAll(pageable)` on the non-tenant `User` entity, so even a correctly-authorized `system-admin`/`hr-admin` (guarded by #321) still saw **every tenant every user**. Now it scopes to the caller org via the `Employee` relation (`TenantContext.getCurrentOrgId()`), with a new `UserRepository.findUsersByOrganizationId(orgId, pageable)`, and fails closed if there is no org context.

Stacks cleanly on #321 (different files: services vs controllers). Compiles clean.

Next increments: attachment-service org-scoped finder, org-batch per-id membership check, JWT issuer/audience validation, and the actuator/log/Keycloak hardening.