### PR TITLE
security: bound Keycloak client + quiet per-request logging (phase 0)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
@@ -6,11 +6,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.Map;
 
 
@@ -24,7 +26,16 @@ public class KeycloakAuthorizationService {
     @Value("${jwt.auth.converter.resource-id}")
     private String clientId;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    // Bounded timeouts so a slow or hung Keycloak cannot pin Tomcat worker threads
+    // indefinitely (this exchange runs on every authenticated request).
+    private final RestTemplate restTemplate;
+
+    public KeycloakAuthorizationService() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+        factory.setReadTimeout(Duration.ofSeconds(5));
+        this.restTemplate = new RestTemplate(factory);
+    }
 
     public String exchangeForRPT(String accessToken) {
         String tokenEndpoint = issuerUri + "/protocol/openid-connect/token";

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
@@ -34,27 +34,27 @@ public class TenantFilter extends OncePerRequestFilter {
         try {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-            log.info("[TenantFilter] path={}, auth={}, authorities={}",
+            log.debug("[TenantFilter] path={}, auth={}, authorities={}",
                     request.getRequestURI(),
                     authentication != null ? authentication.getName() : "null",
                     authentication != null ? authentication.getAuthorities() : "N/A");
 
             if (authentication == null || !authentication.isAuthenticated()) {
-                log.info("[TenantFilter] No authentication, skipping");
+                log.debug("[TenantFilter] No authentication, skipping");
                 filterChain.doFilter(request, response);
                 return;
             }
 
             // Check if user is a global admin — bypass tenant context
             if (hasAuthority(authentication, ORG_ADMIN_AUTHORITY)) {
-                log.info("[TenantFilter] Global admin detected, bypassing tenant filter");
+                log.debug("[TenantFilter] Global admin detected, bypassing tenant filter");
                 TenantContext.setBypass(true);
                 filterChain.doFilter(request, response);
                 return;
             }
 
             String orgHeader = request.getHeader(ORG_HEADER);
-            log.info("[TenantFilter] X-Organization-Id header={}", orgHeader);
+            log.debug("[TenantFilter] X-Organization-Id header={}", orgHeader);
 
             if (orgHeader != null && !orgHeader.isBlank()) {
                 Long orgId;
@@ -72,7 +72,7 @@ public class TenantFilter extends OncePerRequestFilter {
                 }
 
                 TenantContext.setCurrentOrgId(orgId);
-                log.info("[TenantFilter] Tenant context set to organization {}", orgId);
+                log.debug("[TenantFilter] Tenant context set to organization {}", orgId);
 
             } else {
                 // No header — try to infer from single membership

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -41,7 +41,7 @@
     </root>
 
     <!-- Specific Logger Configurations -->
-    <logger name="org.tornotron.echno_backend" level="DEBUG"/>
+    <logger name="org.tornotron.echno_backend" level="INFO"/>
     <logger name="com.giffing.bucket4j.spring.boot.starter" level="DEBUG"/>
 
     <!-- Reduce noise from specific packages -->


### PR DESCRIPTION
Phase 0 backend hardening (safe, non-behavioural changes; stacks on #321/#322).

- **Keycloak client timeouts**: `KeycloakAuthorizationService` used `new RestTemplate()` with no timeout, and the RPT exchange runs on every authenticated request, so a slow/hung Keycloak could pin all Tomcat workers (150) indefinitely. Now 3s connect / 5s read.
- **Logging**: `TenantFilter` logged the principal and full granted-authority list plus org context at INFO on every request. Dropped to DEBUG (no authorization data in prod logs, much less volume). Prod app logger set INFO (was DEBUG).

Compiles clean. Deferred to later increments (need more care): requiring auth / management-port for actuator (Prometheus scrapes it), gating Swagger, and JWT issuer/audience validation (risk of breaking auth without the real iss/aud, best done with tests).