### PR TITLE
test: first real backend test (EncryptionService) — phase 1

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/common/configuration/EncryptionServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/EncryptionServiceTest.java
@@ -1,0 +1,60 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link EncryptionService}. Pure (no Spring context): the key is
+ * a constructor argument, so the service is instantiated directly. Verifies the
+ * AES/GCM round-trip, per-encryption random IV, and authenticated-decryption
+ * guarantees the app relies on for encrypting sensitive fields at rest.
+ */
+class EncryptionServiceTest {
+
+    // Fixed Base64-encoded 256-bit AES keys for deterministic tests.
+    private static final String KEY_A = "+EOVKh6q7e3H0zeLYr9Cny32oRAGU9V1IZ37tSykzu4=";
+    private static final String KEY_B = "/unPw5cnTt285okMEfF4exfc+jQAj91eoI1aHKHCvww=";
+
+    private final EncryptionService encryptionService = new EncryptionService(KEY_A);
+
+    @Test
+    void encryptThenDecryptRoundTrips() {
+        String plain = "sensitive-value-123";
+        String encrypted = encryptionService.encrypt(plain);
+
+        assertNotEquals(plain, encrypted, "ciphertext must not equal the plaintext");
+        assertEquals(plain, encryptionService.decrypt(encrypted));
+    }
+
+    @Test
+    void encryptUsesARandomIvSoRepeatedEncryptionsDiffer() {
+        String plain = "same-input";
+
+        assertNotEquals(
+                encryptionService.encrypt(plain),
+                encryptionService.encrypt(plain),
+                "each encryption must use a fresh random IV");
+    }
+
+    @Test
+    void decryptWithADifferentKeyFails() {
+        String encrypted = encryptionService.encrypt("secret");
+        EncryptionService other = new EncryptionService(KEY_B);
+
+        assertThrows(RuntimeException.class, () -> other.decrypt(encrypted));
+    }
+
+    @Test
+    void tamperedCiphertextFailsAuthentication() {
+        String encrypted = encryptionService.encrypt("secret");
+        char[] chars = encrypted.toCharArray();
+        int i = chars.length - 3; // flip a character inside the ciphertext/tag
+        chars[i] = (chars[i] == 'A') ? 'B' : 'A';
+
+        assertThrows(RuntimeException.class,
+                () -> encryptionService.decrypt(new String(chars)));
+    }
+}


### PR DESCRIPTION
Phase 1 (echno-backend). Foundation.

The backend had a single test with its body commented out, so the CI `Test` step (`./gradlew test`) gated on nothing (its own comment notes it exists precisely so the first real test starts gating merges).

Adds the first real suite: **`EncryptionService`** (AES/GCM), which the audit called out as correct and which protects sensitive fields at rest. Pure unit test (no Spring context, no database):
- encrypt → decrypt round-trips
- each encryption uses a fresh random IV (repeated encryptions differ)
- decryption with a different key fails
- a tampered ciphertext fails GCM authentication

Verified locally (`./gradlew test` -> BUILD SUCCESSFUL, 4 passing). The existing CI `Test` step now verifies real behaviour.

Next backend increments (heavier, need a JDK on the lab build host): a `@WebMvcTest` security-slice to lock in the `@PreAuthorize` authz fixes from #321, then Testcontainers (CockroachDB) integration tests for tenant isolation, plus JaCoCo + Spotless/SpotBugs in the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for encryption and decryption behavior.
  * Verified randomized initialization vectors produce distinct encrypted results.
  * Added checks for failures caused by incorrect keys and tampered ciphertext.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->