### PR TITLE
test: web-slice authorization tests for UserController guards

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/user/UserControllerAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserControllerAuthzTest.java
@@ -1,0 +1,87 @@
+package org.tornotron.echno_backend.user;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization tests locking in the phase-0 @PreAuthorize guards on
+ * UserController (the fixes that closed the open-registration cross-tenant chain).
+ * Method security is enabled by a minimal test security config; @orgSecurity is
+ * mocked so a caller lacking the required org role is forbidden and one with it
+ * is allowed. Regression guard: if a @PreAuthorize is ever dropped, these fail.
+ */
+@WebMvcTest(UserController.class)
+@Import(UserControllerAuthzTest.TestSecurityConfig.class)
+class UserControllerAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @Test
+    void readAllUsers_isForbidden_forANonAdminCaller() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/user/all").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void readAllUsers_isOk_forAnAdminCaller() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
+        when(userService.getAllUsers(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/user/all").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteUser_isForbidden_forANonAdminCaller() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/user/5").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+# Test-only property values so slice tests (e.g. @WebMvcTest) can build a context
+# without the runtime environment variables. The JWT decoder built from this URI is
+# lazy and never contacted: web-slice authz tests authenticate via SecurityMockMvc
+# (.with(jwt(...))), which sets the authentication directly and bypasses decoding.
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_JWK_SET_URI=http://localhost:0/protocol/openid-connect/certs


### PR DESCRIPTION
Phase 1 (echno-backend), increment 2.

Adds a \`@WebMvcTest\` security slice that verifies the \`@PreAuthorize\` guards added in the phase-0 lockdown (#321) actually deny unauthorized callers:
- \`GET /user/all\` is **403** for a caller without an org admin role, **200** for one with it
- \`DELETE /user/{id}\` is **403** for a non-admin

Method security is enabled by a minimal test config; \`@orgSecurity\` is mocked so the assertions turn purely on the annotation. If a guard is ever dropped, these fail the build, so the fix cannot silently regress.

Also adds \`src/test/resources/application.properties\` (test-only) so slice tests can build a context without the runtime environment variables; the JWT decoder it configures is lazy and bypassed by \`SecurityMockMvc\` (\`.with(jwt())\`).

Verified on the lab build host (JDK 21): \`./gradlew test --tests "*UserControllerAuthzTest"\` -> 3 passing, 0 skipped.