### PR TITLE
test: Testcontainers (CockroachDB) integration harness + first DB test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:cockroachdb'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -74,4 +77,9 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.named('test') {
     useJUnitPlatform()
+    // Testcontainers' bundled docker-java pings the daemon with API 1.32, which
+    // modern Docker Engines reject (they require >= 1.40). docker-java reads the
+    // pinned version from the 'api.version' system property (not DOCKER_API_VERSION,
+    // which is a docker-CLI variable). 1.44 is accepted by both CI and the lab host.
+    systemProperty 'api.version', '1.44'
 }

--- a/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
@@ -1,0 +1,30 @@
+package org.tornotron.echno_backend.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Base class for integration tests that need a real database. Starts a single
+ * CockroachDB container (the engine staging and production run) once for the
+ * whole test JVM and shares it across every subclass; the Testcontainers reaper
+ * removes it at the end. The application's Liquibase changelog builds the schema,
+ * so subclasses exercise real SQL against the same database the app uses.
+ */
+public abstract class AbstractIntegrationTest {
+
+    private static final CockroachContainer COCKROACH =
+            new CockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v26.2.4"));
+
+    static {
+        COCKROACH.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", COCKROACH::getJdbcUrl);
+        registry.add("spring.datasource.username", COCKROACH::getUsername);
+        registry.add("spring.datasource.password", COCKROACH::getPassword);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
@@ -1,0 +1,32 @@
+package org.tornotron.echno_backend.user;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test proving the Testcontainers + Liquibase + JPA stack end to end:
+ * a real CockroachDB is provisioned, the changelog builds the schema, and the
+ * org-scoped user query (added to close the cross-tenant user dump) runs as real
+ * SQL. Subsequent tenant-isolation tests build on this harness.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findUsersByOrganizationId_executesAndReturnsEmpty_forAnUnknownOrg() {
+        Page<User> result = userRepository.findUsersByOrganizationId(999_999L, PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+}


### PR DESCRIPTION
Phase 1 (echno-backend), increment 3: the integration-test foundation.

Adds an `AbstractIntegrationTest` base that starts a single CockroachDB container (the same engine staging and production run) once per JVM and shares it across subclasses; the app's Liquibase changelog builds the schema, so subclasses exercise **real SQL**. The first test runs the org-scoped user query added to close the cross-tenant user dump.

This is what the risky Phase 2 fixes need to be proven against: tenant isolation, stock/leave/payable data-integrity locking, etc. all require a real database.

Build changes:
- adds the Testcontainers `junit-jupiter` + `cockroachdb` modules (test scope);
- pins docker-java's client API version via the `api.version` system property, because its 1.32 default is rejected by modern Docker Engines (minimum 1.40).

Verified on the lab build host (JDK 21 + Docker): full `./gradlew test` is green: 8 tests (EncryptionService 4, UserControllerAuthz 3, UserRepositoryIT 1), 0 failures. CI runs on `ubuntu-latest`, which provides Docker; the container adds a couple of minutes for the image pull and boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration testing with a real CockroachDB instance running in Docker.
  * Added coverage confirming user searches for unknown organizations return an empty paginated result.
  * Configured the test environment to connect reliably to the database container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->