### PR TITLE
fix: scope batch user update to the caller's organization

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
@@ -40,6 +40,21 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Page<User> findUsersByOrganizationId(@Param("organizationId") Long organizationId, Pageable pageable);
 
     /**
+     * Finds the users among the given ids that belong to the organization (via an
+     * Employee record). Used to scope batch operations so a caller can only touch
+     * users in their own tenant: ids outside the organization simply do not come
+     * back, letting the caller reject them.
+     *
+     * @param organizationId The organization to scope by.
+     * @param userIds        The candidate user ids.
+     * @return The subset of those users that are members of the organization.
+     */
+    @Query("SELECT DISTINCT e.user FROM Employee e "
+            + "WHERE e.organization.id = :organizationId AND e.user.id IN :userIds")
+    List<User> findUsersByOrganizationIdAndIdIn(@Param("organizationId") Long organizationId,
+                                                @Param("userIds") List<Long> userIds);
+
+    /**
      * Finds a user by their name.
      *
      * @param name The name of the user to find. Must not be blank and must be between 3 and 50 characters.

--- a/src/main/java/org/tornotron/echno_backend/user/UserService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserService.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -397,8 +398,21 @@ public class UserService {
      */
     @Transactional
     public void batchUpdateUser(List<UserPatchDto> updates) {
+        Long organizationId = TenantContext.getCurrentOrgId();
+        if (organizationId == null) {
+            throw new AccessDeniedException("No organization context; cannot batch update users");
+        }
+
         List<Long> userIds = updates.stream().map(UserPatchDto::getId).collect(Collectors.toList());
-        List<User> users = userRepository.findAllById(userIds);
+        // Scope the load to the caller's organization (findAllById would load users
+        // from any tenant by primary key, which the org filter never covers).
+        List<User> users = userRepository.findUsersByOrganizationIdAndIdIn(organizationId, userIds);
+
+        Set<Long> foundIds = users.stream().map(User::getId).collect(Collectors.toSet());
+        List<Long> outsideOrg = userIds.stream().filter(id -> !foundIds.contains(id)).collect(Collectors.toList());
+        if (!outsideOrg.isEmpty()) {
+            throw new AccessDeniedException("Cannot update users outside your organization: " + outsideOrg);
+        }
 
         Map<Long, User> userMap = users.stream().collect(Collectors.toMap(User::getId, user -> user));
 

--- a/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
@@ -4,17 +4,23 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test proving the Testcontainers + Liquibase + JPA stack end to end:
- * a real CockroachDB is provisioned, the changelog builds the schema, and the
- * org-scoped user query (added to close the cross-tenant user dump) runs as real
- * SQL. Subsequent tenant-isolation tests build on this harness.
+ * Integration tests for the org-scoped user queries against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). These queries are the mechanism that
+ * scopes user reads and batch updates to a tenant, so they are covered with real
+ * SQL rather than mocks.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -23,10 +29,67 @@ class UserRepositoryIT extends AbstractIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private TestEntityManager em;
+
     @Test
     void findUsersByOrganizationId_executesAndReturnsEmpty_forAnUnknownOrg() {
         Page<User> result = userRepository.findUsersByOrganizationId(999_999L, PageRequest.of(0, 20));
 
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void findUsersByOrganizationIdAndIdIn_returnsOnlyMembersOfThatOrganization() {
+        Organization orgA = persistOrganization("Org A");
+        Organization orgB = persistOrganization("Org B");
+
+        User a1 = persistUser("a1");
+        User a2 = persistUser("a2");
+        User b1 = persistUser("b1");
+        persistEmployee(orgA, a1);
+        persistEmployee(orgA, a2);
+        persistEmployee(orgB, b1);
+        em.flush();
+        em.clear();
+
+        List<User> found = userRepository.findUsersByOrganizationIdAndIdIn(
+                orgA.getId(), List.of(a1.getId(), a2.getId(), b1.getId()));
+
+        // b1 belongs to Org B: even though its id was requested, it must not come
+        // back, so the batch-update caller rejects it instead of editing it.
+        assertThat(found).extracting(User::getId)
+                .containsExactlyInAnyOrder(a1.getId(), a2.getId());
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private User persistUser(String tag) {
+        User user = new User();
+        user.setKeycloakId("kc-" + tag);
+        user.setName(tag);
+        em.persist(user);
+        return user;
+    }
+
+    private Employee persistEmployee(Organization org, User user) {
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(user.getName());
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(user.getName() + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+        return employee;
     }
 }


### PR DESCRIPTION
Phase 2, contained fix #1.

**Finding (HIGH, cross-tenant write):** `UserService.batchUpdateUser` loaded users with `findAllById(ids)` — a primary-key load, which the Hibernate org filter never applies to. Combined with the system-admin guard from #321, a system-admin of org A could still edit users in org B by passing their ids in the batch body.

**Fix:** load only the users that belong to the caller's organization via a new org-scoped query (`findUsersByOrganizationIdAndIdIn`, mirroring the #322 pattern), and **reject** the whole request if any requested id is outside the org. Also fail closed when there is no tenant context.

**Test:** an integration test against a real CockroachDB (the new Testcontainers harness) builds two organizations with their own users and asserts a user from the other org is not returned even when its id is requested.

Verified on the lab build host: `*UserRepositoryIT` -> 2 passing.