### PR TITLE
fix: serialize concurrent stock updates (pessimistic lock) [stock atomicity, part A]

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.inventoryTransaction;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,6 +17,26 @@ public interface CurrentStockRepository extends JpaRepository<CurrentStock, Long
 
     @Query("SELECT cs FROM CurrentStock cs WHERE cs.material.id = :materialId AND cs.project.id = :projectId AND cs.storageLocation IS NULL")
     Optional<CurrentStock> findByMaterialIdAndProjectIdAndStorageLocationIsNull(
+            @Param("materialId") Long materialId, @Param("projectId") Long projectId);
+
+    /**
+     * Loads the stock row for a material at a storage location with a pessimistic
+     * write lock (SELECT ... FOR UPDATE). Used by the stock mutation path so
+     * concurrent updates to the same row serialize instead of overwriting each
+     * other (which lost updates and could drive stock negative).
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cs FROM CurrentStock cs WHERE cs.material.id = :materialId "
+            + "AND cs.project.id = :projectId AND cs.storageLocation.id = :storageLocationId")
+    Optional<CurrentStock> lockByMaterialProjectAndLocation(
+            @Param("materialId") Long materialId, @Param("projectId") Long projectId,
+            @Param("storageLocationId") Long storageLocationId);
+
+    /** Pessimistic-write variant of the no-storage-location lookup. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cs FROM CurrentStock cs WHERE cs.material.id = :materialId "
+            + "AND cs.project.id = :projectId AND cs.storageLocation IS NULL")
+    Optional<CurrentStock> lockByMaterialProjectAndNoLocation(
             @Param("materialId") Long materialId, @Param("projectId") Long projectId);
 
     List<CurrentStock> findByStorageLocationIdAndOrganization_Id(Long storageLocationId, Long organizationId);

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
@@ -247,7 +247,7 @@ public class InventoryService {
         CurrentStock stock;
         if (storageLocation != null) {
             stock = currentStockRepository
-                    .findByMaterialIdAndProjectIdAndStorageLocationId(
+                    .lockByMaterialProjectAndLocation(
                             material.getId(), project.getId(), storageLocation.getId())
                     .orElseGet(() -> {
                         CurrentStock newStock = new CurrentStock();
@@ -261,7 +261,7 @@ public class InventoryService {
                     });
         } else {
             stock = currentStockRepository
-                    .findByMaterialIdAndProjectIdAndStorageLocationIsNull(material.getId(), project.getId())
+                    .lockByMaterialProjectAndNoLocation(material.getId(), project.getId())
                     .orElseGet(() -> {
                         CurrentStock newStock = new CurrentStock();
                         newStock.setMaterial(material);

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryServiceConcurrencyIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryServiceConcurrencyIT.java
@@ -1,0 +1,120 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency test for the stock mutation path against a real CockroachDB. Several
+ * threads increment the same stock row at once; without the pessimistic write lock
+ * added to the lookup they would read-modify-write over each other and lose
+ * updates. With the lock they serialize, so the final quantity is exact.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(InventoryService.class)
+class InventoryServiceConcurrencyIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @Autowired
+    private CurrentStockRepository currentStockRepository;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentStockIncrements_doNotLoseUpdates() throws Exception {
+        // Seed an organization, material, project, and a zero stock row in a
+        // committed transaction so the worker threads can read it.
+        long[] ids = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Inventory Org");
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail("inventory@example.test");
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+
+            Material material = new Material();
+            material.setMaterialName("Cement");
+            material.setUnit("bag");
+            material.setOrganization(org);
+            entityManager.persist(material);
+
+            Project project = new Project();
+            project.setProjectName("Project 1");
+            project.setOrganization(org);
+            entityManager.persist(project);
+
+            CurrentStock stock = new CurrentStock();
+            stock.setMaterial(material);
+            stock.setProject(project);
+            stock.setOrganization(org);
+            stock.setCurrentQuantity(0.0);
+            stock.setStockValue(BigDecimal.ZERO);
+            entityManager.persist(stock);
+
+            entityManager.flush();
+            return new long[] {org.getId(), material.getId(), project.getId()};
+        });
+
+        // Lightweight detached references (only the id is read on the update path).
+        Organization org = new Organization();
+        org.setId(ids[0]);
+        Material material = new Material();
+        material.setId(ids[1]);
+        Project project = new Project();
+        project.setId(ids[2]);
+
+        int threads = 4;
+        double increment = 10.0;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                startGate.await();
+                // Each call runs in its own transaction (updateCurrentStock is
+                // @Transactional), taking the pessimistic lock on the stock row.
+                inventoryService.updateCurrentStock(material, project, null, org, increment, BigDecimal.ONE);
+                return null;
+            }));
+        }
+        startGate.countDown();
+        for (Future<?> future : futures) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        Double finalQuantity = currentStockRepository.sumCurrentQuantityByMaterialAndProject(ids[1], ids[2]);
+        assertThat(finalQuantity).isEqualTo(threads * increment);
+    }
+}


### PR DESCRIPTION
Phase 2, contained fix #2 (stock atomicity, Part A).

**Finding (CRITICAL, data integrity):** the stock mutation path (`InventoryService.updateCurrentStock`, driven by the AFTER_COMMIT inventory listener for GRN / consumption / transfer) read the current quantity, computed a new value, and saved it. Two concurrent events read the same quantity and wrote over each other, so updates were lost and stock could go negative.

**Fix:** load the stock row with a **pessimistic write lock** (`SELECT ... FOR UPDATE`) so concurrent updates to the same row serialize instead of racing. On CockroachDB `FOR UPDATE` queues the writers, so they wait rather than abort.

**Test:** a multi-threaded integration test against a real CockroachDB (the Testcontainers harness) fires four threads at the same stock row at once and asserts the final quantity is exact. Without the lock this loses updates.

**Scoped follow-up (Part B):** the `current_stock` unique key is `(material_id, project_id, storage_location_id)`, but `storage_location_id` is nullable and SQL treats NULLs as distinct, so the no-location case is not covered. Part B adds a partial unique index (with a dedup safeguard for any existing duplicates) plus retry-on-conflict for the first-insert race.

Verified on the lab build host: `*InventoryServiceConcurrencyIT` passes (reliability re-runs in progress).