### PR TITLE
feat: fail-closed tenant isolation on entity loads

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -48,6 +48,18 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(TenantAccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CustomErrorResponse handleTenantAccessDeniedException(TenantAccessDeniedException ex, WebRequest request) {
+        logger.warn("Tenant access denied: {}", ex.getMessage());
+        return new CustomErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                "Access to this resource is not permitted for your organization",
+                request.getDescription(false),
+                LocalDateTime.now()
+        );
+    }
+
     @ExceptionHandler(UnbalancedEntryException.class)
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     public CustomErrorResponse handleUnbalancedEntryException(UnbalancedEntryException ex, WebRequest request) {

--- a/src/main/java/org/tornotron/echno_backend/common/exception/TenantAccessDeniedException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/TenantAccessDeniedException.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.common.exception;
+
+/**
+ * Thrown when a tenant-scoped entity belonging to a different organization is
+ * loaded while a tenant context is active. This is the fail-closed backstop for
+ * cross-tenant reads that the Hibernate org filter cannot cover (primary-key
+ * loads, and any path where the filter was not enabled).
+ */
+public class TenantAccessDeniedException extends RuntimeException {
+
+    public TenantAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationListenerRegistrar.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationListenerRegistrar.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers {@link TenantIsolationLoadListener} with Hibernate's event system once
+ * the SessionFactory is built, so tenant isolation is enforced on every entity load.
+ */
+@Component
+@RequiredArgsConstructor
+public class TenantIsolationListenerRegistrar {
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    @PostConstruct
+    public void registerListener() {
+        SessionFactoryImplementor sessionFactory =
+                entityManagerFactory.unwrap(SessionFactoryImplementor.class);
+        EventListenerRegistry registry =
+                sessionFactory.getServiceRegistry().getService(EventListenerRegistry.class);
+        registry.appendListeners(EventType.POST_LOAD, new TenantIsolationLoadListener());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
@@ -1,0 +1,48 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.hibernate.event.spi.PostLoadEvent;
+import org.hibernate.event.spi.PostLoadEventListener;
+import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.organization.Organization;
+
+/**
+ * Enforces tenant isolation at the ORM load boundary. The Hibernate {@code orgFilter}
+ * scopes queries, but it never applies to primary-key loads ({@code findById}) and
+ * only runs where the filter was enabled, so a caller can still read another
+ * organization's row by id. This listener runs on every entity load and, when a
+ * tenant context is active and not bypassed, rejects any {@link TenantScopedEntity}
+ * that belongs to a different organization.
+ *
+ * <p>Legitimate cross-tenant work (seeding, startup, system-admin operations) runs
+ * under {@code @BypassTenantFilter}, which sets the bypass flag this listener honors.
+ * Rows with no organization (legacy data pending backfill) are left alone: isolation
+ * cannot be enforced on them here.
+ */
+public class TenantIsolationLoadListener implements PostLoadEventListener {
+
+    @Override
+    public void onPostLoad(PostLoadEvent event) {
+        if (!(event.getEntity() instanceof TenantScopedEntity scoped)) {
+            return;
+        }
+
+        Long contextOrgId = TenantContext.getCurrentOrgId();
+        if (contextOrgId == null || TenantContext.isBypassed()) {
+            return;
+        }
+
+        Organization organization = scoped.getOrganization();
+        if (organization == null) {
+            return;
+        }
+
+        // Reading the id off a lazy proxy does not initialize it.
+        Long entityOrgId = organization.getId();
+        if (entityOrgId != null && !entityOrgId.equals(contextOrgId)) {
+            throw new TenantAccessDeniedException(
+                    "Cross-tenant access denied: " + event.getEntity().getClass().getSimpleName()
+                            + " belongs to organization " + entityOrgId
+                            + " but the request is scoped to organization " + contextOrgId);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
@@ -1,0 +1,101 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.category.Category;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Proves that tenant isolation is fail-closed for reads. A category belongs to
+ * organization B; loading it by primary key (which the Hibernate org filter never
+ * covers) is rejected when the request is scoped to organization A, allowed for
+ * organization B, and allowed when the tenant filter is explicitly bypassed.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TenantIsolationListenerRegistrar.class)
+class TenantIsolationIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long categoryId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        Organization orgA = persistOrganization("Org A");
+        Organization orgB = persistOrganization("Org B");
+
+        Category category = new Category();
+        category.setName("Concrete");
+        category.setOrganization(orgB);
+        entityManager.persist(category);
+
+        entityManager.flush();
+        orgAId = orgA.getId();
+        orgBId = orgB.getId();
+        categoryId = category.getId();
+        // Detach so findById reloads from the database and triggers the load listener.
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void clearContext() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void findById_forTheOwningOrganization_returnsTheEntity() {
+        TenantContext.setCurrentOrgId(orgBId);
+
+        assertThat(categoryRepository.findById(categoryId)).isPresent();
+    }
+
+    @Test
+    void findById_forAnotherOrganization_isRejected() {
+        TenantContext.setCurrentOrgId(orgAId);
+
+        assertThatThrownBy(() -> categoryRepository.findById(categoryId))
+                .isInstanceOf(TenantAccessDeniedException.class);
+    }
+
+    @Test
+    void findById_forAnotherOrganization_whenBypassed_returnsTheEntity() {
+        TenantContext.setCurrentOrgId(orgAId);
+        TenantContext.setBypass(true);
+        try {
+            assertThat(categoryRepository.findById(categoryId)).isPresent();
+        } finally {
+            TenantContext.setBypass(false);
+        }
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+}


### PR DESCRIPTION
Phase 2 — the tenant-isolation redesign (the audit's #1 correctness risk).

## The gap
Multi-tenancy was **opt-in and failed open**. The Hibernate `orgFilter` scopes queries, but:
- it **never applies to primary-key loads** (`findById`), and
- it only ran inside `@Transactional` methods where the aspect enabled it.

So a caller could read (and, combined with the now-fixed authz gaps, mutate) another organization's row by id. ~118 endpoints had no `@PreAuthorize` backstop, so this was systemic.

## The fix
A Hibernate **`PostLoad` event listener** (`TenantIsolationLoadListener`) that runs on **every entity load** and rejects any `TenantScopedEntity` whose `organization` differs from the current `TenantContext`, when a context is active and not bypassed. Registered on the SessionFactory by `TenantIsolationListenerRegistrar`. This closes the cross-tenant read for **every load path** — `findById`, lazy loads, and un-filtered queries — not just the filtered ones. Cross-tenant access now returns **403**.

- Legitimate cross-tenant work (seeding, startup, system-admin) already runs under `@BypassTenantFilter`, which the listener honors.
- Rows with no organization (legacy data pending backfill) are left alone — isolation cannot be enforced on them here.
- `Organization` is the tenant root (not a `TenantScopedEntity`), so it is not checked; reading `organization.getId()` off the lazy proxy does not trigger a load.

## Test
`TenantIsolationIT` against a real CockroachDB: a category owned by org B is **rejected** for org A, **allowed** for org B, and **allowed** when bypassed. The full existing suite still passes with the listener active (14 tests, 0 failures) — the other ITs set no tenant context, so the listener no-ops for them.

## Deploy risk (read before the staging cutover)
This changes data access app-wide. **Any legitimate flow that loads cross-org data without `@BypassTenantFilter` will now 403.** Merging to `development` does not deploy; the staging cutover is the review point. Before deploying, exercise the app on staging and add `@BypassTenantFilter` to any legit cross-org path that surfaces. Scope note: the null-tenant-context case (a query with no context set) is unchanged here — authenticated requests always have a context, so it is a system-path concern, not the user-facing exploit.

Verified on the lab build host (JDK 21 + Docker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tenant isolation enforcement when loading organization-scoped data.
  - Cross-organization access is now rejected with a clear HTTP 403 response.
  - Tenant isolation can still be bypassed where explicitly permitted.

- **Bug Fixes**
  - Prevented tenant-scoped entities from being accessed across organization boundaries.

- **Tests**
  - Added integration coverage for allowed access, denied access, and bypass scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->