### PR TITLE
chore: tenant-filter log hygiene + fix flaky encryption test

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfig.java
@@ -24,14 +24,14 @@ public class HibernateFilterConfig {
     @Around("within(org.tornotron.echno_backend..*) && @annotation(transactional)")
     public Object enableOrgFilter(ProceedingJoinPoint joinPoint, Transactional transactional) throws Throwable {
         Long orgId = TenantContext.getCurrentOrgId();
-        log.info("[HibernateFilter] Aspect triggered for {}, orgId={}, bypassed={}",
+        log.debug("[HibernateFilter] Aspect triggered for {}, orgId={}, bypassed={}",
                 joinPoint.getSignature().toShortString(), orgId, TenantContext.isBypassed());
         if (orgId != null && !TenantContext.isBypassed()) {
             Session session = entityManager.unwrap(Session.class);
             session.enableFilter("orgFilter").setParameter("organizationId", orgId);
-            log.info("[HibernateFilter] orgFilter ENABLED for organization {}", orgId);
+            log.debug("[HibernateFilter] orgFilter ENABLED for organization {}", orgId);
         } else {
-            log.info("[HibernateFilter] orgFilter NOT enabled (orgId={}, bypassed={})", orgId, TenantContext.isBypassed());
+            log.debug("[HibernateFilter] orgFilter NOT enabled (orgId={}, bypassed={})", orgId, TenantContext.isBypassed());
         }
         return joinPoint.proceed();
     }

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/EncryptionServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/EncryptionServiceTest.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.common.configuration;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,11 +52,13 @@ class EncryptionServiceTest {
     @Test
     void tamperedCiphertextFailsAuthentication() {
         String encrypted = encryptionService.encrypt("secret");
-        char[] chars = encrypted.toCharArray();
-        int i = chars.length - 3; // flip a character inside the ciphertext/tag
-        chars[i] = (chars[i] == 'A') ? 'B' : 'A';
+        // Decode to the raw IV+ciphertext+tag bytes and flip a bit in the last
+        // byte (the GCM tag). Corrupting a base64 character instead is unreliable:
+        // near the padding it can decode to the same bytes and decrypt succeeds.
+        byte[] bytes = Base64.getDecoder().decode(encrypted);
+        bytes[bytes.length - 1] ^= 0x01;
+        String tampered = Base64.getEncoder().encodeToString(bytes);
 
-        assertThrows(RuntimeException.class,
-                () -> encryptionService.decrypt(new String(chars)));
+        assertThrows(RuntimeException.class, () -> encryptionService.decrypt(tampered));
     }
 }


### PR DESCRIPTION
Two small backend hygiene fixes.

1. **Log noise / minor info leak:** `HibernateFilterConfig` (the aspect that enables the Hibernate org filter) logged at **INFO on every transactional method**, printing the org id and bypass state per request (same class as the `TenantFilter` fix in #323). Dropped the three lines to `debug`.

2. **Flaky test:** `EncryptionServiceTest.tamperedCiphertextFailsAuthentication` (added in #324) flipped a single base64 character near the padding, which can decode to the same bytes so decryption still succeeds. It failed intermittently in CI (it caught this PR). Now it decodes to the raw IV+ciphertext+tag bytes and flips a bit in the GCM tag, which always fails authentication. **Verified 10/10 runs green on the lab host.**