### PR TITLE
fix: guard unguarded controller twins (endpoint authz sweep, batch 1)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -26,12 +26,14 @@ public class IssueCommentControllerWeb {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('issue-comment:create') or hasAuthority('issue-comment:admin')")
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueCommentService.addIssueComment(issueCommentCreationDto));
     }
 
     @GetMapping
+    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
                                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
@@ -39,16 +41,19 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("{id}")
+    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
     public ResponseEntity<IssueCommentDto> getAnIssueComment(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAnIssueComment(id));
     }
 
     @GetMapping("/issueId/{issueId}")
+    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
     public ResponseEntity<List<IssueCommentDto>> getAllIssueCommentsByIssueId(@PathVariable Long issueId) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAllIssueCommentsByIssueId(issueId));
     }
 
     @DeleteMapping("{id}")
+    @PreAuthorize("hasAuthority('issue-comment:delete') or hasAuthority('issue-comment:admin')")
     public ResponseEntity<ApiResponse> deleteAnIssueComment(@PathVariable Long id) {
         issueCommentService.deleteAnIssueComment(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("IssueComment with id: "+id+" deleted successfully with"));

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -39,6 +39,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 201 (Created).
      */
     @PostMapping
+    @PreAuthorize("hasAuthority('category:create') or hasAuthority('category:admin')")
     public ResponseEntity<CategorySimpleDto> createCategory(@Valid @RequestBody CategoryCreationDto categoryCreationDto) {
         logger.info("Category Added Successfully");
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -53,6 +54,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
+    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
@@ -68,6 +70,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the category DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
+    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
     public ResponseEntity<?> readACategory(@PathVariable Long id) {
         CategoryDto categoryDto = categoryService.getACategory(id);
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
@@ -80,6 +83,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
+    @PreAuthorize("hasAuthority('category:delete') or hasAuthority('category:admin')")
     public ResponseEntity<ApiResponse> deleteACategory(@PathVariable Long id) {
         categoryService.deleteACategory(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrder;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -25,24 +26,28 @@ public class PurchaseOrderController {
         this.purchaseOrderService = purchaseOrderService;
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
     public ResponseEntity<PurchaseOrderDto> createPurchaseOrder(@Valid @RequestBody PurchaseOrderCreationDto creationDto) {
         PurchaseOrderDto created = purchaseOrderService.createPurchaseOrder(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{id}")
     public ResponseEntity<PurchaseOrderDto> getPurchaseOrderById(@PathVariable Long id) {
         PurchaseOrderDto purchaseOrder = purchaseOrderService.getPurchaseOrderById(id);
         return ResponseEntity.ok(purchaseOrder);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping
     public ResponseEntity<List<PurchaseOrderDto>> getAllPurchaseOrders() {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
         return ResponseEntity.ok(purchaseOrders);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/all")
     public ResponseEntity<Page<PurchaseOrderDto>> getAllPurchaseOrdersPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
@@ -52,30 +57,35 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(purchaseOrders);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/vendor/{vendorId}")
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByVendor(@PathVariable Long vendorId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByVendor(vendorId);
         return ResponseEntity.ok(purchaseOrders);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/indent/{indentId}")
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByIndent(@PathVariable Long indentId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByIndent(indentId);
         return ResponseEntity.ok(purchaseOrders);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/status/{status}")
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByStatus(@PathVariable PurchaseOrderStatus status) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByStatus(status);
         return ResponseEntity.ok(purchaseOrders);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping
     public ResponseEntity<PurchaseOrderDto> updatePurchaseOrder(@Valid @RequestBody PurchaseOrderUpdateDto updateDto) {
         PurchaseOrderDto updated = purchaseOrderService.updatePurchaseOrder(updateDto);
         return ResponseEntity.ok(updated);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/{id}/status")
     public ResponseEntity<ApiResponse> updatePurchaseOrderStatus(
             @PathVariable Long id,

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ public class PurchaseOrderItemController {
         this.purchaseOrderItemService = purchaseOrderItemService;
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
     public ResponseEntity<PurchaseOrderItemResponseDto> createPurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemCreationDto creationDto) {
@@ -30,18 +32,21 @@ public class PurchaseOrderItemController {
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{id}")
     public ResponseEntity<PurchaseOrderItemResponseDto> getPurchaseOrderItemById(@PathVariable Long id) {
         PurchaseOrderItemResponseDto item = purchaseOrderItemService.getPurchaseOrderItemById(id);
         return ResponseEntity.ok(item);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getAllPurchaseOrderItems();
         return ResponseEntity.ok(items);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/purchase-order/{purchaseOrderId}")
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByPurchaseOrderId(
             @PathVariable Long purchaseOrderId) {
@@ -49,12 +54,14 @@ public class PurchaseOrderItemController {
         return ResponseEntity.ok(items);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/material/{materialId}")
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByMaterialId(@PathVariable Long materialId) {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getItemsByMaterialId(materialId);
         return ResponseEntity.ok(items);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PutMapping
     public ResponseEntity<PurchaseOrderItemResponseDto> updatePurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemUpdateDto updateDto) {
@@ -62,6 +69,7 @@ public class PurchaseOrderItemController {
         return ResponseEntity.ok(updated);
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse> deletePurchaseOrderItem(@PathVariable Long id) {
         purchaseOrderItemService.deletePurchaseOrderItem(id);


### PR DESCRIPTION
Phase 2 — `@PreAuthorize` endpoint sweep, **batch 1: twin bypasses**.

Some controllers duplicate the endpoints of a fully-guarded twin but carried **no `@PreAuthorize` of their own**, so they were a live bypass of the twin's authorization (an attacker hits the unguarded twin instead of the guarded one). This batch mirrors each twin exactly:

- `PurchaseOrderController`, `PurchaseOrderItemController` -> `hasAnyOrgRoleForCurrentTenant(system-admin)` (matching their `...Web` twins)
- `CategoryControllerWeb`, `IssueCommentControllerWeb` -> the per-verb `<resource>:read/create/delete` (or `:admin`) authorities their mobile twins already use

Guards mirror **known-valid, in-use** authorities, so no legitimate caller loses access. Compiles; full suite passes on the lab host.

**Remaining sweep (subsequent PRs):** the attendance family (both twins unguarded -> membership floor / admin for config), the Keycloak-admin controllers (-> system-admin), the partial-gap controllers (LeavePolicy/Project/Task/User/Employee/Subscription -> targeted per-method), and finally an **ArchUnit rule** asserting every controller endpoint is guarded, which locks the sweep in and prevents regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added authorization checks for issue-comment and category actions, including creating, viewing, and deleting records.
  * Restricted purchase-order and purchase-order-item operations to system administrators within the current tenant.
  * Existing endpoint behavior remains unchanged for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->