### PR TITLE
feat: Keycloak admin guards + ArchUnit endpoint-authz ratchet (batch 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:cockroachdb'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.common.controller;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -32,6 +33,7 @@ public class KeycloakGroupController {
         this.employeeRepository = employeeRepository;
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/assign")
     public ResponseEntity<ApiResponse> assignUserToKeycloakOrg(
             @RequestParam Long userId
@@ -48,6 +50,7 @@ public class KeycloakGroupController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User added to keycloak Org"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/assignRole")
     public ResponseEntity<ApiResponse> assignOrgRole(
             @RequestParam Long employeeId,
@@ -65,6 +68,7 @@ public class KeycloakGroupController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User assigned a role"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/unassignRole")
     public ResponseEntity<ApiResponse> unassignOrgRole(
             @RequestParam Long employeeId,

--- a/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
+++ b/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.keycloak;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import io.prometheus.metrics.shaded.com_google_protobuf_4_28_3.Api;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ public class KeycloakManagementController {
         this.keycloakManagementService = keycloakManagementService;
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients")
     public ResponseEntity<ApiResponse> createClient(@Valid @RequestBody ClientCreationDto dto) {
         String id = keycloakManagementService.createClient(dto);
@@ -29,6 +31,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Client created with ID: " + id));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/roles")
     public ResponseEntity<ApiResponse> addClientRole(@PathVariable String clientId, @Valid @RequestBody RoleCreationDto dto) {
         keycloakManagementService.addClientRole(clientId, dto);
@@ -36,6 +39,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Role added successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/authorization")
     public ResponseEntity<ApiResponse> enableAuthorization(@PathVariable String clientId, @RequestParam boolean enabled) {
         keycloakManagementService.enableAuthorizationServices(clientId, enabled);
@@ -43,6 +47,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Authorization services updated"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/users/{userId}/roles")
     public ResponseEntity<ApiResponse> assignRoleToUser(@PathVariable String userId,@PathVariable String clientId, @RequestParam String roleName) {
         keycloakManagementService.assignClientRoleToUser(userId, clientId, roleName);
@@ -51,6 +56,7 @@ public class KeycloakManagementController {
 
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/resources")
     public ResponseEntity<ApiResponse> addResource(@PathVariable String clientId,@Valid @RequestBody ResourceDefinitionDto dto) {
         keycloakManagementService.createResource(clientId,dto);
@@ -58,6 +64,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Resource created successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/policies")
     public ResponseEntity<ApiResponse> addPolicy(@PathVariable String clientId,@Valid @RequestBody RolePolicyDefinitionDto dto) {
         keycloakManagementService.createRolePolicy(clientId,dto);
@@ -65,6 +72,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Policy created successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/policies/js")
     public ResponseEntity<ApiResponse> addJsPolicy(@PathVariable String clientId, @Valid @RequestBody JsPolicyDefinitionDto dto) {
         keycloakManagementService.createJsPolicy(clientId, dto);
@@ -72,6 +80,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("JS policy created successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/permissions")
     public ResponseEntity<ApiResponse> addPermission(@PathVariable String clientId, @Valid @RequestBody PermissionDefinitionDto dto) {
         keycloakManagementService.createPermission(clientId,dto);
@@ -79,6 +88,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Permission created successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/authorization-setup")
     public ResponseEntity<ApiResponse> createWholeAuthorizationSetup(@PathVariable String clientId,@Valid @RequestBody AuthorizationSetupDto dto) {
         keycloakManagementService.configureAuthorization(clientId,dto);
@@ -86,6 +96,7 @@ public class KeycloakManagementController {
                 .body(new ApiResponse("Authorization setup created successfully"));
     }
 
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/roles")
     public ResponseEntity<ApiResponse> addRealmRoles(@RequestBody Map<String, String> roles) {
         keycloakManagementService.addRealmRoles(roles);

--- a/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
@@ -1,0 +1,73 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Set;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * Ratchet for the endpoint-authorization sweep: every request-mapped method in a
+ * {@code @RestController} must carry a {@code @PreAuthorize} (on the method or the
+ * class), so a new endpoint cannot ship without an explicit authorization decision.
+ *
+ * <p>{@link #GRANDFATHERED} lists controllers that predate this rule and are still
+ * unguarded. They are being migrated batch by batch; as a controller is fully
+ * guarded it is removed from this set. The rule keeps the gap from growing and
+ * forces every new controller to be guarded. A deliberately public endpoint must
+ * use {@code @PreAuthorize("permitAll()")} rather than be left un-annotated.
+ */
+class EndpointAuthorizationTest {
+
+    /**
+     * Controllers still to be guarded (see the audit's endpoint-authorization
+     * sweep). Shrinks to empty as each is migrated. Do NOT add to this set.
+     */
+    private static final Set<String> GRANDFATHERED = Set.of(
+            "AttendanceController", "AttendanceControllerWeb",
+            "AttendanceRegularizationController", "AttendanceRegularizationControllerWeb",
+            "AttendanceSettingsController", "AttendanceSettingsControllerWeb",
+            "MovementRecordController", "MovementRecordControllerWeb",
+            "ShiftTimingController", "ShiftTimingControllerWeb",
+            "AuthController",
+            "FeatureController", "PlanController", "SubscriptionController",
+            "EmployeeControllerWeb",
+            "LeaveApprovalController", "LeaveBalanceController",
+            "LeavePolicyController", "LeaveRequestController",
+            "OrganizationWebController",
+            "ReportController",
+            "TaskControllerWeb");
+
+    private static final DescribedPredicate<JavaClass> NOT_GRANDFATHERED =
+            new DescribedPredicate<>("not a grandfathered controller") {
+                @Override
+                public boolean test(JavaClass javaClass) {
+                    return !GRANDFATHERED.contains(javaClass.getSimpleName());
+                }
+            };
+
+    private static final JavaClasses PRODUCTION_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("org.tornotron.echno_backend");
+
+    @Test
+    void everyControllerEndpointHasAnAuthorizationGuard() {
+        ArchRule rule = methods()
+                .that().areDeclaredInClassesThat().areAnnotatedWith(RestController.class)
+                .and().areDeclaredInClassesThat(NOT_GRANDFATHERED)
+                .and().areMetaAnnotatedWith(RequestMapping.class)
+                .should().beAnnotatedWith(PreAuthorize.class)
+                .orShould().beDeclaredInClassesThat().areAnnotatedWith(PreAuthorize.class);
+
+        rule.check(PRODUCTION_CLASSES);
+    }
+}


### PR DESCRIPTION
Phase 2 — `@PreAuthorize` endpoint sweep, **batch 2**.

The audit found ~140 request-mapped methods with no `@PreAuthorize` (my earlier grep undercounted; some files carry `@PreAuthorize` only in *javadoc*, which ArchUnit correctly ignores). This batch does two things:

1. **Guards the Keycloak admin controllers** (`KeycloakManagementController`, `KeycloakGroupController`) with `hasAnyOrgRoleForCurrentTenant(system-admin)` — unambiguously admin operations (13 endpoints).

2. **Adds an ArchUnit ratchet** (`EndpointAuthorizationTest`): every `@RestController` endpoint must carry `@PreAuthorize`. A `GRANDFATHERED` set lists the ~20 controllers still to migrate (attendance family, billing, leave, employee/task/org/report, auth). The rule **prevents the gap from growing** and forces every *new* controller to be guarded; controllers leave the set as they are migrated.

The remaining controllers need the domain RBAC model (which role/authority each operation requires) — they will be migrated in follow-up batches by mirroring their guarded twins and the `<resource>:action` authority convention; the attendance family has no such authority yet, so it will take a membership floor / admin-for-config baseline.

Full suite incl. the ArchUnit rule passes on the lab host.