### PR TITLE
fix: guard the leave controllers (endpoint authz sweep, batch 3)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
@@ -25,6 +25,7 @@ public class LeaveApprovalController {
 
     @PostMapping("/requests/{requestId}/approve")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> approve(
             @PathVariable Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
@@ -26,6 +26,7 @@ public class LeaveBalanceController {
 
     @GetMapping("/employee/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -35,6 +36,7 @@ public class LeaveBalanceController {
 
     @GetMapping("/employee/{employeeId}/policy/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
             @PathVariable Long employeeId,
             @PathVariable Long policyId,
@@ -45,6 +47,7 @@ public class LeaveBalanceController {
 
     @GetMapping("/employee/{employeeId}/summary")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -54,6 +57,7 @@ public class LeaveBalanceController {
 
     @PostMapping("/employee/{employeeId}/recalculate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveBalanceDto>> recalculateBalances(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -63,6 +67,7 @@ public class LeaveBalanceController {
 
     @PostMapping("/adjust")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveTransactionDto> adjustBalance(
             @Valid @RequestBody LeaveBalanceAdjustmentDto dto) {
         return ResponseEntity.ok(balanceService.adjustBalance(dto));
@@ -70,6 +75,7 @@ public class LeaveBalanceController {
 
     @GetMapping("/employee/{employeeId}/transactions")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(
             @PathVariable Long employeeId) {
         return ResponseEntity.ok(balanceService.getTransactionHistory(employeeId));
@@ -77,6 +83,7 @@ public class LeaveBalanceController {
 
     @GetMapping("/{balanceId}/transactions")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionsByBalance(
             @PathVariable Long balanceId) {
         return ResponseEntity.ok(balanceService.getTransactionsByBalance(balanceId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -26,6 +26,7 @@ public class LeavePolicyController {
 
     @PostMapping
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     public ResponseEntity<LeavePolicyDto> createPolicy(
             @Valid @RequestBody LeavePolicyCreationDto dto) {
         LeavePolicyDto created = policyService.createPolicy(dto);
@@ -34,17 +35,19 @@ public class LeavePolicyController {
 
     @GetMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> getPolicy(@PathVariable Long policyId) {
         return ResponseEntity.ok(policyService.getPolicy(policyId));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeavePolicyDto>> getAllPolicies() {
         return ResponseEntity.status(HttpStatus.OK).body(policyService.getAllPolicies());
     }
 
     @GetMapping("/organization/{organizationId}")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeavePolicyDto>> getPoliciesByOrganization(
             @PathVariable Long organizationId,
             @RequestParam(required = false, defaultValue = "false") Boolean includeInactive) {
@@ -56,6 +59,7 @@ public class LeavePolicyController {
 
     @GetMapping("/employee/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(
             @PathVariable Long employeeId) {
         return ResponseEntity.ok(policyService.getApplicablePoliciesForEmployee(employeeId));
@@ -63,6 +67,7 @@ public class LeavePolicyController {
 
     @PatchMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @PathVariable Long policyId,
             @RequestBody Map<String, Object> updates) {
@@ -71,6 +76,7 @@ public class LeavePolicyController {
 
     @DeleteMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> deactivatePolicy(@PathVariable Long policyId) {
         policyService.deactivatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy deactivated successfully"));
@@ -78,6 +84,7 @@ public class LeavePolicyController {
 
     @PostMapping("/{policyId}/activate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<ApiResponse> activatePolicy(@PathVariable Long policyId) {
         policyService.activatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
@@ -85,6 +92,7 @@ public class LeavePolicyController {
 
     @PostMapping("/{policyId}/duplicate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @PathVariable Long policyId,
             @RequestParam Long targetOrganizationId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -30,6 +30,7 @@ public class LeaveRequestController {
 
     @PostMapping
 //    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<LeaveRequestDto> createRequest(
             @RequestParam Long employeeId,
             @Valid @RequestBody LeaveRequestCreationDto dto) {
@@ -39,12 +40,14 @@ public class LeaveRequestController {
 
     @GetMapping("/requestId/{requestId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<LeaveRequestDto> getRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.getRequest(requestId));
     }
 
     @GetMapping("/employeeId/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<Page<LeaveRequestDto>> getEmployeeRequests(
             @PathVariable Long employeeId,
             Pageable pageable) {
@@ -53,6 +56,7 @@ public class LeaveRequestController {
 
     @GetMapping("/employeeId/{employeeId}/status/{status}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequestsByStatus(
             @PathVariable Long employeeId,
             @PathVariable LeaveStatus status) {
@@ -61,12 +65,14 @@ public class LeaveRequestController {
 
     @GetMapping("/organizationId/{organizationId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
         return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
 
     @GetMapping("/pending-approvals")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
             @RequestParam Long approverId) {
         return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
@@ -74,6 +80,7 @@ public class LeaveRequestController {
 
     @GetMapping("/pending-approvals/count")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
             @RequestParam Long approverId) {
         long count = requestService.getPendingApprovalCount(approverId);
@@ -82,6 +89,7 @@ public class LeaveRequestController {
 
     @PatchMapping("requestId/{requestId}")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @PathVariable Long requestId,
             @RequestBody Map<String, Object> updates) {
@@ -90,12 +98,14 @@ public class LeaveRequestController {
 
     @PostMapping("/requestId/{requestId}/submit")
 //    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> submitRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.submitRequest(requestId));
     }
 
     @PostMapping("/requestId/{requestId}/cancel")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @PathVariable Long requestId,
             @RequestBody Map<String, String> body) {
@@ -105,12 +115,14 @@ public class LeaveRequestController {
 
     @PostMapping("/requestId/{requestId}/withdraw")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<LeaveRequestDto> withdrawRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.withdrawRequest(requestId));
     }
 
     @GetMapping("/conflicts")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
     public ResponseEntity<List<LocalDate>> getConflictingDates(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -120,6 +132,7 @@ public class LeaveRequestController {
 
     @PostMapping("/calculate-days")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<Map<String, Double>> calculateDays(
             @RequestBody Map<String, String> body) {
         LocalDate startDate = LocalDate.parse(body.get("startDate"));

--- a/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
@@ -41,8 +41,6 @@ class EndpointAuthorizationTest {
             "AuthController",
             "FeatureController", "PlanController", "SubscriptionController",
             "EmployeeControllerWeb",
-            "LeaveApprovalController", "LeaveBalanceController",
-            "LeavePolicyController", "LeaveRequestController",
             "OrganizationWebController",
             "ReportController",
             "TaskControllerWeb");


### PR DESCRIPTION
Phase 2 endpoint-authz sweep, **batch 3: leave controllers**.

Each mobile leave controller was fully unguarded while its `...Web` twin was fully guarded. Mirrored each twin's **per-method** `@PreAuthorize` (matched by method name) onto its mobile twin: `LeaveApprovalController`, `LeaveBalanceController`, `LeavePolicyController`, `LeaveRequestController`. Guards vary per operation (`system-admin` / `hr-admin` / `isSelfInCurrentTenant(#employeeId)` / `isMemberOfCurrentTenant`) exactly as the twins define them. One method whose twin endpoint is commented out (`getPoliciesByOrganization`) was guarded by hand to match the other org-level policy reads.

Removes the four leave controllers from the ArchUnit `GRANDFATHERED` set, so the rule now enforces them. Full suite (incl. the rule) passes on the lab host.