### PR TITLE
feat: guard billing/org/report/employee/task/auth (endpoint sweep batch 4)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/auth/AuthController.java
+++ b/src/main/java/org/tornotron/echno_backend/auth/AuthController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.auth;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
+    @PreAuthorize("permitAll()")
     public ResponseEntity<UserDto> registerUser(@Valid @RequestBody UserRegistrationDto userRegistrationDto) {
         UserDto createdUser = userService.registerUser(userRegistrationDto);
         return new ResponseEntity<>(createdUser, HttpStatus.CREATED);

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
@@ -30,6 +30,7 @@ public class FeatureController {
      *
      * @return List of active features
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     public ResponseEntity<List<FeatureDto>> getActiveFeatures() {
@@ -43,6 +44,7 @@ public class FeatureController {
      *
      * @return List of all features
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/all")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<List<FeatureDto>> getAllFeatures() {
@@ -56,6 +58,7 @@ public class FeatureController {
      * @param id Feature ID
      * @return Feature details
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     public ResponseEntity<FeatureDto> getFeatureById(@PathVariable Long id) {
@@ -69,6 +72,7 @@ public class FeatureController {
      * @param code Feature code
      * @return Feature details
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/code/{code}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     public ResponseEntity<FeatureDto> getFeatureByCode(@PathVariable String code) {
@@ -83,6 +87,7 @@ public class FeatureController {
      * @param dto Feature creation data
      * @return Created feature
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<FeatureDto> createFeature(@Valid @RequestBody FeatureCreateDto dto) {
@@ -98,6 +103,7 @@ public class FeatureController {
      * @param dto Feature update data
      * @return Updated feature
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<FeatureDto> updateFeature(@PathVariable Long id, @Valid @RequestBody FeatureCreateDto dto) {
@@ -112,6 +118,7 @@ public class FeatureController {
      * @param id Feature ID
      * @return Success message
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<ApiResponse> deactivateFeature(@PathVariable Long id) {
@@ -126,6 +133,7 @@ public class FeatureController {
      * @param id Feature ID
      * @return Success message
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{id}/activate")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<ApiResponse> activateFeature(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
@@ -28,6 +28,7 @@ public class PlanController {
      *
      * @return List of public plans
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/public")
     public ResponseEntity<List<PlanDto>> getPublicPlans() {
         List<Plan> plans = planService.getAllPublicPlans();
@@ -40,6 +41,7 @@ public class PlanController {
      *
      * @return List of all plans
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<List<PlanDto>> getAllPlans() {
@@ -53,6 +55,7 @@ public class PlanController {
      * @param id Plan ID
      * @return Plan details
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> getPlanById(@PathVariable Long id) {
@@ -66,6 +69,7 @@ public class PlanController {
      * @param code Plan code
      * @return Plan details
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/code/{code}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> getPlanByCode(@PathVariable String code) {
@@ -80,6 +84,7 @@ public class PlanController {
      * @param dto Plan creation data
      * @return Created plan
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> createPlan(@Valid @RequestBody PlanCreateDto dto) {
@@ -95,6 +100,7 @@ public class PlanController {
      * @param dto Plan update data
      * @return Updated plan
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> updatePlan(@PathVariable Long id, @Valid @RequestBody PlanCreateDto dto) {
@@ -109,6 +115,7 @@ public class PlanController {
      * @param id Plan ID
      * @return Success message
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<ApiResponse> deactivatePlan(@PathVariable Long id) {
@@ -123,6 +130,7 @@ public class PlanController {
      * @param id Plan ID
      * @return Success message
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{id}/activate")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<ApiResponse> activatePlan(@PathVariable Long id) {
@@ -138,6 +146,7 @@ public class PlanController {
      * @param dto    Feature assignment data
      * @return Updated plan
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{planId}/features")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> assignFeatureToPlan(
@@ -155,6 +164,7 @@ public class PlanController {
      * @param featureCode Feature code to remove
      * @return Updated plan
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{planId}/features/{featureCode}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<PlanDto> removeFeatureFromPlan(

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
@@ -33,6 +33,7 @@ public class SubscriptionController {
      *
      * @return Active subscription or empty if none
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/current")
     public ResponseEntity<SubscriptionDto> getCurrentSubscription() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -47,6 +48,7 @@ public class SubscriptionController {
      *
      * @return List of all subscriptions
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/history")
     public ResponseEntity<List<SubscriptionDto>> getSubscriptionHistory() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -60,6 +62,7 @@ public class SubscriptionController {
      * @param dto Subscription creation data with plan code
      * @return Created subscription
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping
     public ResponseEntity<SubscriptionDto> createSubscription(@Valid @RequestBody SubscriptionCreateDto dto)
             throws AuthenticationException {
@@ -74,6 +77,7 @@ public class SubscriptionController {
      * @param dto Plan change data
      * @return Updated subscription
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PutMapping("/change-plan")
     public ResponseEntity<SubscriptionDto> changeSubscription(@Valid @RequestBody SubscriptionChangeDto dto)
             throws AuthenticationException {
@@ -88,6 +92,7 @@ public class SubscriptionController {
      * @param dto Cancellation options
      * @return Success message
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/cancel")
     public ResponseEntity<ApiResponse> cancelSubscription(@RequestBody(required = false) SubscriptionCancelDto dto)
             throws AuthenticationException {
@@ -106,6 +111,7 @@ public class SubscriptionController {
      * @param featureCode The feature code to check
      * @return Feature access result
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/features/{featureCode}/access")
     public ResponseEntity<FeatureAccessResultDto> checkFeatureAccess(@PathVariable String featureCode)
             throws AuthenticationException {
@@ -120,6 +126,7 @@ public class SubscriptionController {
      * @param dto Usage record data
      * @return Success message
      */
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/usage")
     public ResponseEntity<ApiResponse> recordUsage(@Valid @RequestBody UsageRecordDto dto)
             throws AuthenticationException {
@@ -137,6 +144,7 @@ public class SubscriptionController {
      * @param userId User ID
      * @return Active subscription or empty
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/user/{userId}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<SubscriptionDto> getUserSubscription(@PathVariable Long userId) {
@@ -153,6 +161,7 @@ public class SubscriptionController {
      * @param userId User ID
      * @return List of subscriptions
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/user/{userId}/history")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<List<SubscriptionDto>> getUserSubscriptionHistory(@PathVariable Long userId) {
@@ -168,6 +177,7 @@ public class SubscriptionController {
      * @param dto    Subscription creation data
      * @return Created subscription
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/user/{userId}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<SubscriptionDto> createSubscriptionForUser(
@@ -185,6 +195,7 @@ public class SubscriptionController {
      * @param dto    Plan change data
      * @return Updated subscription
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/user/{userId}/change-plan")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<SubscriptionDto> changeSubscriptionForUser(
@@ -202,6 +213,7 @@ public class SubscriptionController {
      * @param dto    Cancellation options
      * @return Success message
      */
+    @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/user/{userId}/cancel")
 //    @PreAuthorize("hasAuthority('billing:admin')")
     public ResponseEntity<ApiResponse> cancelSubscriptionForUser(

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -64,6 +64,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the list of employee DTOs and HTTP status 200 (OK).
      */
     @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return new ResponseEntity<>(employeeService.displayAllEmployees(),HttpStatus.OK);
     }
@@ -75,6 +76,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the employee DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
         EmployeeDto employee = employeeService.displayAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(employee);
@@ -164,16 +166,19 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing a list of employee DTOs who report to the manager and HTTP status 200 (OK).
      */
     @GetMapping("/managerId/{managerId}/subordinates")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<EmployeeDto>> getDirectSubordinates(@PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getDirectSubordinates(managerId));
     }
 
     @GetMapping("/managers")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<EmployeeDto>> getAllTheManagers() {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagers());
     }
 
     @GetMapping("/managers/organizationId/{organizationId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<EmployeeDto>> getAllManagersForAnOrganization(@PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagersByOrganizationId(organizationId));
     }
@@ -191,6 +196,7 @@ public class EmployeeControllerWeb {
     }
 
     @GetMapping("/{employeeId}/roles")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<Set<OrgRole>> getOrgRoles(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getOrgRoles(employeeId));
     }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -40,6 +40,7 @@ public class OrganizationWebController {
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @RequireSubscription(feature = "CREATE_ORGANIZATION",recordUsage = true)
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
@@ -53,6 +54,7 @@ public class OrganizationWebController {
      * @return A {@link ResponseEntity} containing the list of organization DTOs and HTTP status 200 (OK).
      */
     @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     public ResponseEntity<List<OrganizationDto>> readAllOrganizations() {
         return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganization());
     }

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.pdfGeneration;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
@@ -64,6 +65,7 @@ public class ReportController {
         return ctx;
     }
 
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/pdf")
     public ResponseEntity<byte[]> pdfReport() {
         Context ctx = populateContext();

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -75,6 +75,7 @@ public class TaskControllerWeb {
     }
 
     @GetMapping("/projectId/{projectId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<TaskDto>> readAllTasksForProject(@PathVariable Long projectId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getTasksByProjectId(projectId));
     }

--- a/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
@@ -33,17 +33,14 @@ class EndpointAuthorizationTest {
      * sweep). Shrinks to empty as each is migrated. Do NOT add to this set.
      */
     private static final Set<String> GRANDFATHERED = Set.of(
+            // Only the attendance family remains: it carries no `attendance:*` authority
+            // and has real self-vs-others privacy, so it needs an explicit role model
+            // rather than a membership floor. Held for a follow-up with that model.
             "AttendanceController", "AttendanceControllerWeb",
             "AttendanceRegularizationController", "AttendanceRegularizationControllerWeb",
             "AttendanceSettingsController", "AttendanceSettingsControllerWeb",
             "MovementRecordController", "MovementRecordControllerWeb",
-            "ShiftTimingController", "ShiftTimingControllerWeb",
-            "AuthController",
-            "FeatureController", "PlanController", "SubscriptionController",
-            "EmployeeControllerWeb",
-            "OrganizationWebController",
-            "ReportController",
-            "TaskControllerWeb");
+            "ShiftTimingController", "ShiftTimingControllerWeb");
 
     private static final DescribedPredicate<JavaClass> NOT_GRANDFATHERED =
             new DescribedPredicate<>("not a grandfathered controller") {


### PR DESCRIPTION
Phase 2 endpoint-authz sweep, **batch 4 — conservative baselines** (per the "safe defaults" decision).

Guards every remaining non-attendance controller with defensible, **non-breaking** authorization:

| Controller | Guard |
|---|---|
| `FeatureController`, `PlanController` | `billing:admin` |
| `SubscriptionController` | path-split: self (`/current`, `/cancel`, …) = org membership; admin-for-user (`/user/{id}/…`) = `billing:admin` |
| `OrganizationWebController` | `createOrganization` stays `isAuthenticated()` (preserve signup); `readAllOrganizations` = `system-admin`; others were already guarded |
| `ReportController`, `EmployeeControllerWeb` reads, `TaskControllerWeb` | org membership floor |
| `AuthController.registerUser` | `permitAll()` (preserves public self-registration) |

Membership-floor guards are a conservative baseline (any org member; the #330 tenant-isolation listener still blocks cross-org reads) and can be tightened to fine-grained authorities later.

**The ArchUnit `GRANDFATHERED` set now contains only the attendance family (10 controllers)** — it carries no `attendance:*` authority and has real self-vs-others privacy, so it needs an explicit role model (records = self + hr-admin? settings = hr-admin?) rather than a membership floor. Held for a follow-up with that model; the ratchet keeps it from regressing.

Full suite incl. the ArchUnit rule passes on the lab host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened access controls across billing, subscriptions, employee records, organizations, reports, and tasks.
  * Restricted administrative actions to authorized billing administrators.
  * Limited tenant-specific information and operations to approved tenant members.
  * Required authenticated access for organization creation and elevated permissions for organization listings.
  * Kept user registration available without prior authentication.
  * Expanded authorization coverage across application endpoints for more consistent protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->