### PR TITLE
feat: guard attendance via config-driven policy (endpoint sweep complete)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -34,6 +35,7 @@ public class AttendanceController {
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
                                                          @RequestParam(value = "photoUrl", required = false) MultipartFile photoUrl) throws JsonProcessingException {
         AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
@@ -43,6 +45,7 @@ public class AttendanceController {
 
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
                                                                   @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
@@ -50,11 +53,13 @@ public class AttendanceController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(attendanceService.getAttendanceById(id));
     }
 
     @GetMapping("/employee/{employeeId}")
+    @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
     public ResponseEntity<List<AttendanceResponseDto>> getByEmployee(
             @PathVariable Long employeeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -63,6 +68,7 @@ public class AttendanceController {
     }
 
     @GetMapping("/project/{projectId}")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<List<AttendanceResponseDto>> getByProject(
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
@@ -76,6 +82,7 @@ public class AttendanceController {
     }
 
     @PostMapping("/{id}/approve")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
@@ -83,6 +90,7 @@ public class AttendanceController {
     }
 
     @PostMapping("/mark-absent")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceResponseDto> markAbsent(
             @RequestParam Long employeeId,
             @RequestParam Long projectId,
@@ -91,6 +99,7 @@ public class AttendanceController {
     }
 
     @GetMapping("/summary/{employeeId}")
+    @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
     public ResponseEntity<AttendanceSummaryDto> getMonthlySummary(
             @PathVariable Long employeeId,
             @RequestParam int month,
@@ -99,6 +108,7 @@ public class AttendanceController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<ApiResponse> delete(@PathVariable Long id) {
         attendanceService.deleteAttendance(id);
         return ResponseEntity.ok(new ApiResponse("Attendance record deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -34,6 +35,7 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
                                                          @RequestParam(value = "photo", required = false)MultipartFile photo) throws JsonProcessingException {
         AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
@@ -41,6 +43,7 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
                                                                     @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
@@ -48,11 +51,13 @@ public class AttendanceControllerWeb {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(attendanceService.getAttendanceById(id));
     }
 
     @GetMapping("/employee/{employeeId}")
+    @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
     public ResponseEntity<List<AttendanceResponseDto>> getByEmployee(
             @PathVariable Long employeeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -61,6 +66,7 @@ public class AttendanceControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<List<AttendanceResponseDto>> getByProject(
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
@@ -74,6 +80,7 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping("/{id}/approve")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
@@ -81,6 +88,7 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping("/mark-absent")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceResponseDto> markAbsent(
             @RequestParam Long employeeId,
             @RequestParam Long projectId,
@@ -89,6 +97,7 @@ public class AttendanceControllerWeb {
     }
 
     @GetMapping("/summary/{employeeId}")
+    @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
     public ResponseEntity<AttendanceSummaryDto> getMonthlySummary(
             @PathVariable Long employeeId,
             @RequestParam int month,
@@ -97,6 +106,7 @@ public class AttendanceControllerWeb {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<ApiResponse> delete(@PathVariable Long id) {
         attendanceService.deleteAttendance(id);
         return ResponseEntity.ok(new ApiResponse("Attendance record deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,6 +25,7 @@ public class AttendanceRegularizationController {
     }
 
     @PostMapping("/request")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
             @Valid @RequestBody RegularizationRequestDto dto,
             @RequestParam String requestedBy) {
@@ -32,6 +34,7 @@ public class AttendanceRegularizationController {
     }
 
     @PostMapping("/{id}/process")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
             @Valid @RequestBody RegularizationActionDto dto,
@@ -40,11 +43,13 @@ public class AttendanceRegularizationController {
     }
 
     @GetMapping("/pending")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
         return ResponseEntity.ok(regularizationService.getPendingRegularizations());
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceRegularizationDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(regularizationService.getRegularizationById(id));
     }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,6 +25,7 @@ public class AttendanceRegularizationControllerWeb {
     }
 
     @PostMapping("/request")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
             @Valid @RequestBody RegularizationRequestDto dto,
             @RequestParam String requestedBy) {
@@ -32,6 +34,7 @@ public class AttendanceRegularizationControllerWeb {
     }
 
     @PostMapping("/{id}/process")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
             @Valid @RequestBody RegularizationActionDto dto,
@@ -40,11 +43,13 @@ public class AttendanceRegularizationControllerWeb {
     }
 
     @GetMapping("/pending")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
         return ResponseEntity.ok(regularizationService.getPendingRegularizations());
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceRegularizationDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(regularizationService.getRegularizationById(id));
     }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,32 +25,38 @@ public class AttendanceSettingsController {
     }
 
     @PostMapping
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<AttendanceSettingsDto> create(@Valid @RequestBody AttendanceSettingsCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(settingsService.createSettings(dto));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<AttendanceSettingsDto>> getAll() {
         return ResponseEntity.ok(settingsService.getAllSettings());
     }
 
     @GetMapping("/org")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceSettingsDto> getOrgSettings() {
         return ResponseEntity.ok(settingsService.getOrgSettings());
     }
 
     @GetMapping("/project/{projectId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceSettingsDto> getProjectSettings(@PathVariable Long projectId) {
         return ResponseEntity.ok(settingsService.getProjectSettings(projectId));
     }
 
     @PatchMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
                                                          @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<Void> deactivate(@PathVariable Long id) {
         settingsService.deactivateSettings(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,32 +25,38 @@ public class AttendanceSettingsControllerWeb {
     }
 
     @PostMapping
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<AttendanceSettingsDto> create(@Valid @RequestBody AttendanceSettingsCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(settingsService.createSettings(dto));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<AttendanceSettingsDto>> getAll() {
         return ResponseEntity.ok(settingsService.getAllSettings());
     }
 
     @GetMapping("/org")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceSettingsDto> getOrgSettings() {
         return ResponseEntity.ok(settingsService.getOrgSettings());
     }
 
     @GetMapping("/project/{projectId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<AttendanceSettingsDto> getProjectSettings(@PathVariable Long projectId) {
         return ResponseEntity.ok(settingsService.getProjectSettings(projectId));
     }
 
     @PatchMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
                                                          @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<Void> deactivate(@PathVariable Long id) {
         settingsService.deactivateSettings(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +24,7 @@ public class MovementRecordController {
     }
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<MovementRecordDto> create(
             @Valid @RequestBody MovementRecordCreationDto dto,
             @RequestParam Long employeeId) {
@@ -31,16 +33,19 @@ public class MovementRecordController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(movementRecordService.getMovementById(id));
     }
 
     @GetMapping("/attendance/{attendanceId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {
         return ResponseEntity.ok(movementRecordService.getMovementsByAttendance(attendanceId));
     }
 
     @PostMapping("/{id}/verify")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
                                                      @RequestParam String verifiedBy) {
         return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +24,7 @@ public class MovementRecordControllerWeb {
     }
 
     @PostMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<MovementRecordDto> create(
             @Valid @RequestBody MovementRecordCreationDto dto,
             @RequestParam Long employeeId) {
@@ -31,16 +33,19 @@ public class MovementRecordControllerWeb {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(movementRecordService.getMovementById(id));
     }
 
     @GetMapping("/attendance/{attendanceId}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {
         return ResponseEntity.ok(movementRecordService.getMovementsByAttendance(attendanceId));
     }
 
     @PostMapping("/{id}/verify")
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
     public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
                                                      @RequestParam String verifiedBy) {
         return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));

--- a/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingController.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,27 +25,32 @@ public class ShiftTimingController {
     }
 
     @PostMapping
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<ShiftTimingDto> create(@Valid @RequestBody ShiftTimingCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(shiftTimingService.createShiftTiming(dto));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<ShiftTimingDto>> getAll() {
         return ResponseEntity.ok(shiftTimingService.getAllShiftTimings());
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<ShiftTimingDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(shiftTimingService.getShiftTimingById(id));
     }
 
     @PatchMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<ShiftTimingDto> update(@PathVariable Long id,
                                                   @RequestBody ShiftTimingPatchDto dto) {
         return ResponseEntity.ok(shiftTimingService.updateShiftTiming(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         shiftTimingService.deleteShiftTiming(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,27 +25,32 @@ public class ShiftTimingControllerWeb {
     }
 
     @PostMapping
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<ShiftTimingDto> create(@Valid @RequestBody ShiftTimingCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(shiftTimingService.createShiftTiming(dto));
     }
 
     @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<ShiftTimingDto>> getAll() {
         return ResponseEntity.ok(shiftTimingService.getAllShiftTimings());
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<ShiftTimingDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(shiftTimingService.getShiftTimingById(id));
     }
 
     @PatchMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<ShiftTimingDto> update(@PathVariable Long id,
                                                   @RequestBody ShiftTimingPatchDto dto) {
         return ResponseEntity.ok(shiftTimingService.updateShiftTiming(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         shiftTimingService.deleteShiftTiming(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Attendance authorization policy, kept in one place so the role model can be
+ * retuned without touching the controllers. The controllers reference this bean
+ * from {@code @PreAuthorize} (e.g. {@code @attendanceSecurity.canManageRecords()});
+ * the actual role sets come from configuration and default to a sensible model:
+ *
+ * <ul>
+ *   <li>{@code echno.security.attendance.config-roles} (default {@code system-admin,hr-admin})
+ *       — who may create/update/deactivate attendance settings and shift timings.</li>
+ *   <li>{@code echno.security.attendance.record-management-roles}
+ *       (default {@code system-admin,hr-admin,project-manager}) — who may approve,
+ *       mark-absent, delete, verify, process regularizations, and view another
+ *       employee's or a whole project's records.</li>
+ * </ul>
+ *
+ * Override either per environment (comma-separated org-role tokens) in
+ * {@code application.yml} or via env vars, no code change needed. Everything else
+ * (recording your own attendance, reading a record, reading the settings) only
+ * requires organization membership, enforced with {@code @orgSecurity.isMemberOfCurrentTenant()}.
+ */
+@Service("attendanceSecurity")
+public class AttendanceSecurityService {
+
+    private final OrganizationSecurityService orgSecurity;
+    private final String[] configRoles;
+    private final String[] recordManagementRoles;
+
+    public AttendanceSecurityService(
+            OrganizationSecurityService orgSecurity,
+            @Value("${echno.security.attendance.config-roles:system-admin,hr-admin}")
+            String[] configRoles,
+            @Value("${echno.security.attendance.record-management-roles:system-admin,hr-admin,project-manager}")
+            String[] recordManagementRoles) {
+        this.orgSecurity = orgSecurity;
+        this.configRoles = configRoles;
+        this.recordManagementRoles = recordManagementRoles;
+    }
+
+    /** Create/update/deactivate attendance settings and shift timings. */
+    public boolean canConfigureAttendance() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(configRoles);
+    }
+
+    /**
+     * Manage attendance records: approve, mark-absent, delete, verify movements,
+     * process regularizations, and view another employee's or a project's records.
+     */
+    public boolean canManageRecords() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(recordManagementRoles);
+    }
+
+    /** View one employee's records: the employee themselves, or a manager / HR. */
+    public boolean canViewEmployeeRecords(Long employeeId) {
+        return orgSecurity.isSelfOrHasAnyOrgRole(employeeId, recordManagementRoles);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
@@ -29,18 +29,12 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 class EndpointAuthorizationTest {
 
     /**
-     * Controllers still to be guarded (see the audit's endpoint-authorization
-     * sweep). Shrinks to empty as each is migrated. Do NOT add to this set.
+     * Controllers exempt from the guard rule. The endpoint-authorization sweep is
+     * complete, so this is empty: every controller endpoint must be guarded. Do NOT
+     * add to this set - guard the endpoint instead (use {@code permitAll()} for a
+     * deliberately public one).
      */
-    private static final Set<String> GRANDFATHERED = Set.of(
-            // Only the attendance family remains: it carries no `attendance:*` authority
-            // and has real self-vs-others privacy, so it needs an explicit role model
-            // rather than a membership floor. Held for a follow-up with that model.
-            "AttendanceController", "AttendanceControllerWeb",
-            "AttendanceRegularizationController", "AttendanceRegularizationControllerWeb",
-            "AttendanceSettingsController", "AttendanceSettingsControllerWeb",
-            "MovementRecordController", "MovementRecordControllerWeb",
-            "ShiftTimingController", "ShiftTimingControllerWeb");
+    private static final Set<String> GRANDFATHERED = Set.of();
 
     private static final DescribedPredicate<JavaClass> NOT_GRANDFATHERED =
             new DescribedPredicate<>("not a grandfathered controller") {


### PR DESCRIPTION
Phase 2 endpoint-authz sweep, final batch: attendance family (assumed role model, config-driven per the "keep it flexible" ask).

AttendanceSecurityService (@attendanceSecurity) holds the whole policy in one bean. Its role sets come from configuration with sensible defaults, so the model is retuned in application.yml (or per-environment env vars) WITHOUT touching any controller:
- echno.security.attendance.config-roles (default: system-admin,hr-admin)
- echno.security.attendance.record-management-roles (default: system-admin,hr-admin,project-manager)

Assumed model, applied across all 10 controllers (mobile + web twins):
- record own attendance, read a record, read settings/shift-timing -> org membership
- view an EMPLOYEE's records (getByEmployee, summary) -> that employee OR a manager: canViewEmployeeRecords(#employeeId)
- view a PROJECT's records, approve, mark-absent, delete, verify movement, process regularization -> canManageRecords()
- create/update/deactivate settings and shift timings -> canConfigureAttendance()

This empties the ArchUnit GRANDFATHERED set: the endpoint-authorization sweep is COMPLETE. Every @RestController endpoint now carries @PreAuthorize, enforced with zero exemptions. Full suite (incl. the rule) passes on the lab host.
