### PR TITLE
fix: serve company-bank-account and journal-entry web controllers under /api/v1

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/finance/company-bank-accounts/web")
+@RequestMapping("/api/v1/finance/company-bank-accounts/web")
 @RequiredArgsConstructor
 public class CompanyBankAccountControllerWeb {
 

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/finance/journal-entries/web")
+@RequestMapping("/api/v1/finance/journal-entries/web")
 @RequiredArgsConstructor
 public class JournalEntryControllerWeb {
 


### PR DESCRIPTION
Both web controllers were mapped at `/api/finance/.../web`, missing the `/v1` segment every other finance web controller uses. The `@tornotron/echno-core` client resolves these paths against its `/api/v1` base (the service docstrings even note "resolved against the `/api/v1` base"), so both endpoints returned 404 from the frontend, i.e. company-bank-accounts and journal-entries were unreachable in the UI.

Aligns the two outliers to the `/api/v1/finance/.../web` convention the six sibling finance web controllers already follow. No other code, test, or config references the old non-`/v1` paths. Mobile is unaffected (it consumes the base controllers, not the `/web` twins).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated company bank account and journal entry web API endpoints to use the `/api/v1` versioned path.
  * Existing functionality remains unchanged; clients should use the new versioned URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->