### PR TITLE
feat: construction invoice module (CRUD + list, no ledger posting)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceStatus.java
@@ -1,0 +1,12 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionInvoiceStatus {
+    DRAFT,
+    PENDING,
+    SENT,
+    PARTIALLY_PAID,
+    PAID,
+    OVERDUE,
+    CANCELLED,
+    DISPUTED
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceType.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceType.java
@@ -1,0 +1,8 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionInvoiceType {
+    PURCHASE,
+    SALES,
+    EXPENSE,
+    SERVICE
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentStatus.java
@@ -1,0 +1,9 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionPaymentStatus {
+    UNPAID,
+    PARTIALLY_PAID,
+    PAID,
+    REFUNDED,
+    CANCELLED
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
@@ -1,0 +1,129 @@
+package org.tornotron.echno_backend.finance.construction.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "construction_invoices",
+        uniqueConstraints = @UniqueConstraint(name = "uk_construction_invoice_number",
+                columnNames = {"organization_id", "invoice_number"}),
+        indexes = {
+                @Index(name = "idx_cinv_project", columnList = "project_id"),
+                @Index(name = "idx_cinv_vendor", columnList = "vendor_id"),
+                @Index(name = "idx_cinv_status", columnList = "status"),
+                @Index(name = "idx_cinv_type", columnList = "type"),
+                @Index(name = "idx_cinv_issue_date", columnList = "issue_date")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter @Setter
+@NoArgsConstructor
+public class ConstructionInvoice extends BaseEntity implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "invoice_number", nullable = false, length = 30)
+    private String invoiceNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ConstructionInvoiceType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ConstructionInvoiceStatus status = ConstructionInvoiceStatus.DRAFT;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status", nullable = false, length = 20)
+    private ConstructionPaymentStatus paymentStatus = ConstructionPaymentStatus.UNPAID;
+
+    // Scalar references to core-domain records. Kept as plain ids (no cross-module FK)
+    // so this module stays additive and decoupled; a later increment can wire them up.
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
+    @Column(name = "vendor_id")
+    private Long vendorId;
+
+    @Column(name = "purchase_order_id")
+    private Long purchaseOrderId;
+
+    @Column(name = "goods_receipt_id")
+    private Long goodsReceiptId;
+
+    @Column(name = "issue_date", nullable = false)
+    private LocalDate issueDate;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Column(name = "payment_date")
+    private LocalDate paymentDate;
+
+    @Column(precision = 19, scale = 4, nullable = false)
+    private BigDecimal subtotal = BigDecimal.ZERO;
+
+    @Column(name = "tax_amount", precision = 19, scale = 4, nullable = false)
+    private BigDecimal taxAmount = BigDecimal.ZERO;
+
+    @Column(name = "discount_amount", precision = 19, scale = 4, nullable = false)
+    private BigDecimal discountAmount = BigDecimal.ZERO;
+
+    @Column(name = "total_amount", precision = 19, scale = 4, nullable = false)
+    private BigDecimal totalAmount = BigDecimal.ZERO;
+
+    @Column(name = "paid_amount", precision = 19, scale = 4, nullable = false)
+    private BigDecimal paidAmount = BigDecimal.ZERO;
+
+    @Column(name = "balance_amount", precision = 19, scale = 4, nullable = false)
+    private BigDecimal balanceAmount = BigDecimal.ZERO;
+
+    @Column(name = "payment_terms", length = 100)
+    private String paymentTerms;
+
+    @Column(name = "payment_method", length = 50)
+    private String paymentMethod;
+
+    @Column(name = "gst_number", length = 30)
+    private String gstNumber;
+
+    @Column(name = "tax_type", length = 20)
+    private String taxType;
+
+    @Column(length = 1000)
+    private String notes;
+
+    @Column(name = "terms_and_conditions", length = 2000)
+    private String termsAndConditions;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @OneToMany(mappedBy = "invoice", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @OrderBy("lineOrder ASC")
+    private List<ConstructionInvoiceLine> lines = new ArrayList<>();
+
+    public void addLine(ConstructionInvoiceLine line) {
+        line.setInvoice(this);
+        line.setLineOrder(this.lines.size());
+        this.lines.add(line);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoiceLine.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoiceLine.java
@@ -1,0 +1,69 @@
+package org.tornotron.echno_backend.finance.construction.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "construction_invoice_lines",
+        indexes = @Index(name = "idx_cinvl_invoice", columnList = "invoice_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class ConstructionInvoiceLine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "invoice_id", nullable = false)
+    private ConstructionInvoice invoice;
+
+    @Column(nullable = false, length = 500)
+    private String description;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantity;
+
+    @Column(nullable = false, length = 50)
+    private String unit;
+
+    @Column(name = "unit_price", nullable = false, precision = 19, scale = 4)
+    private BigDecimal unitPrice;
+
+    @Column(name = "tax_rate", nullable = false, precision = 7, scale = 4)
+    private BigDecimal taxRate = BigDecimal.ZERO;          // e.g. 18.0000 for 18% GST
+
+    @Column(name = "tax_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxAmount = BigDecimal.ZERO;
+
+    @Column(name = "discount_rate", nullable = false, precision = 7, scale = 4)
+    private BigDecimal discountRate = BigDecimal.ZERO;     // e.g. 5.0000 for 5%
+
+    @Column(name = "discount_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal discountAmount = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal subtotal;                           // quantity * unitPrice
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal total;                              // subtotal + tax - discount
+
+    // Nullable scalar references to core-domain records (no cross-module FK).
+    @Column(name = "inventory_item_id")
+    private Long inventoryItemId;
+
+    @Column(name = "asset_id")
+    private Long assetId;
+
+    @Column(name = "task_id")
+    private Long taskId;
+
+    @Column(name = "line_order", nullable = false)
+    private int lineOrder;                                 // zero-based position within the invoice
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -1,0 +1,38 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record ConstructionInvoiceDto(
+        UUID id,
+        String invoiceNumber,
+        ConstructionInvoiceType type,
+        ConstructionInvoiceStatus status,
+        ConstructionPaymentStatus paymentStatus,
+        Long projectId,
+        Long vendorId,
+        Long purchaseOrderId,
+        Long goodsReceiptId,
+        LocalDate issueDate,
+        LocalDate dueDate,
+        LocalDate paymentDate,
+        BigDecimal subtotal,
+        BigDecimal taxAmount,
+        BigDecimal discountAmount,
+        BigDecimal totalAmount,
+        BigDecimal paidAmount,
+        BigDecimal balanceAmount,
+        String paymentTerms,
+        String paymentMethod,
+        String gstNumber,
+        String taxType,
+        String notes,
+        String termsAndConditions,
+        List<ConstructionInvoiceLineDto> lines
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
@@ -1,0 +1,21 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record ConstructionInvoiceLineDto(
+        UUID id,
+        String description,
+        BigDecimal quantity,
+        String unit,
+        BigDecimal unitPrice,
+        BigDecimal taxRate,
+        BigDecimal taxAmount,
+        BigDecimal discountRate,
+        BigDecimal discountAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        Long inventoryItemId,
+        Long assetId,
+        Long taskId
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+
+/**
+ * Line payload shared by the create and update requests. Amounts (subtotal, tax,
+ * discount, total) are computed server-side from quantity, unit price and the
+ * percentage rates; the client only supplies the inputs.
+ */
+public record ConstructionInvoiceLineRequest(
+        @NotBlank @Size(max = 500) String description,
+        @NotNull @DecimalMin(value = "0.0001") BigDecimal quantity,
+        @NotBlank @Size(max = 50) String unit,
+        @NotNull @DecimalMin(value = "0.0") BigDecimal unitPrice,
+        @DecimalMin(value = "0.0") @DecimalMax(value = "100.0") BigDecimal taxRate,
+        @DecimalMin(value = "0.0") @DecimalMax(value = "100.0") BigDecimal discountRate,
+        Long inventoryItemId,
+        Long assetId,
+        Long taskId
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionInvoiceRequest.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateConstructionInvoiceRequest(
+        @NotNull ConstructionInvoiceType type,
+        @NotNull Long projectId,
+        Long vendorId,
+        Long purchaseOrderId,
+        Long goodsReceiptId,
+        @NotNull LocalDate issueDate,
+        @NotNull LocalDate dueDate,
+        @Size(max = 100) String paymentTerms,
+        @Size(max = 50) String paymentMethod,
+        @Size(max = 30) String gstNumber,
+        @Size(max = 20) String taxType,
+        @Size(max = 1000) String notes,
+        @Size(max = 2000) String termsAndConditions,
+        @NotNull @Size(min = 1) @Valid List<ConstructionInvoiceLineRequest> lines
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionInvoiceRequest.java
@@ -1,0 +1,35 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Full replacement of an editable construction invoice. Status and payment status
+ * are set directly (no ledger posting in this increment); money totals are always
+ * recomputed from the supplied lines.
+ */
+public record UpdateConstructionInvoiceRequest(
+        @NotNull ConstructionInvoiceType type,
+        @NotNull ConstructionInvoiceStatus status,
+        @NotNull ConstructionPaymentStatus paymentStatus,
+        @NotNull Long projectId,
+        Long vendorId,
+        Long purchaseOrderId,
+        Long goodsReceiptId,
+        @NotNull LocalDate issueDate,
+        @NotNull LocalDate dueDate,
+        LocalDate paymentDate,
+        @Size(max = 100) String paymentTerms,
+        @Size(max = 50) String paymentMethod,
+        @Size(max = 30) String gstNumber,
+        @Size(max = 20) String taxType,
+        @Size(max = 1000) String notes,
+        @Size(max = 2000) String termsAndConditions,
+        @NotNull @Size(min = 1) @Valid List<ConstructionInvoiceLineRequest> lines
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
@@ -1,0 +1,15 @@
+package org.tornotron.echno_backend.finance.construction.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineDto;
+
+@Mapper(componentModel = "spring")
+public interface ConstructionInvoiceMapper {
+
+    ConstructionInvoiceDto toDto(ConstructionInvoice invoice);
+
+    ConstructionInvoiceLineDto toLineDto(ConstructionInvoiceLine line);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceRepository.java
@@ -1,0 +1,26 @@
+package org.tornotron.echno_backend.finance.construction.repositories;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ConstructionInvoiceRepository
+        extends JpaRepository<ConstructionInvoice, UUID>, JpaSpecificationExecutor<ConstructionInvoice> {
+
+    /**
+     * Org-scoped lookup by id with its lines eagerly fetched. Uses JPQL (not
+     * {@code find()} by primary key) so the Hibernate {@code orgFilter} is applied,
+     * preventing cross-tenant reads.
+     */
+    @EntityGraph(attributePaths = {"lines"})
+    @Query("SELECT ci FROM ConstructionInvoice ci WHERE ci.id = :id")
+    Optional<ConstructionInvoice> findByIdWithLines(@Param("id") UUID id);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceSpecifications.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.finance.construction.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the optional list filters as a JPA {@link Specification}. Only non-null
+ * arguments become predicates, which avoids binding null-typed parameters on the
+ * Postgres wire protocol. Organization scoping is handled separately by the
+ * Hibernate {@code orgFilter} enabled per request.
+ */
+public final class ConstructionInvoiceSpecifications {
+
+    private ConstructionInvoiceSpecifications() {}
+
+    public static Specification<ConstructionInvoice> withFilters(Long projectId,
+                                                                 Long vendorId,
+                                                                 ConstructionInvoiceStatus status,
+                                                                 ConstructionInvoiceType type) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (projectId != null) {
+                predicates.add(cb.equal(root.get("projectId"), projectId));
+            }
+            if (vendorId != null) {
+                predicates.add(cb.equal(root.get("vendorId"), vendorId));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -1,0 +1,198 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceSpecifications;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * CRUD + list for construction invoices. This increment deliberately does NO ledger
+ * or journal posting: money totals are computed arithmetically from the line items
+ * and status is set directly. A later increment will add the ledger-posting hooks
+ * (create the receivable/payable journal entry on issue, reverse it on cancel) that
+ * the AR invoice module already has.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConstructionInvoiceService {
+
+    private static final String DOC_TYPE = "CINV";
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    private final ConstructionInvoiceRepository invoiceRepo;
+    private final EntryNumberGenerator numberGen;
+    private final ConstructionInvoiceMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public ConstructionInvoiceDto findById(UUID id) {
+        return mapper.toDto(invoiceRepo.findByIdWithLines(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction invoice with ID " + id + " was not found")));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ConstructionInvoiceDto> findAll(Long projectId,
+                                                Long vendorId,
+                                                ConstructionInvoiceStatus status,
+                                                ConstructionInvoiceType type,
+                                                Pageable pageable) {
+        return invoiceRepo.findAll(
+                        ConstructionInvoiceSpecifications.withFilters(projectId, vendorId, status, type),
+                        pageable)
+                .map(mapper::toDto);
+    }
+
+    @Transactional
+    public ConstructionInvoiceDto create(CreateConstructionInvoiceRequest req) {
+        if (req.dueDate().isBefore(req.issueDate())) {
+            throw new InvalidRequestException("Due date cannot be before issue date");
+        }
+
+        ConstructionInvoice inv = new ConstructionInvoice();
+        inv.setInvoiceNumber(numberGen.next(DOC_TYPE));
+        inv.setType(req.type());
+        inv.setStatus(ConstructionInvoiceStatus.DRAFT);
+        inv.setPaymentStatus(ConstructionPaymentStatus.UNPAID);
+        inv.setProjectId(req.projectId());
+        inv.setVendorId(req.vendorId());
+        inv.setPurchaseOrderId(req.purchaseOrderId());
+        inv.setGoodsReceiptId(req.goodsReceiptId());
+        inv.setIssueDate(req.issueDate());
+        inv.setDueDate(req.dueDate());
+        inv.setPaymentTerms(req.paymentTerms());
+        inv.setPaymentMethod(req.paymentMethod());
+        inv.setGstNumber(req.gstNumber());
+        inv.setTaxType(req.taxType());
+        inv.setNotes(req.notes());
+        inv.setTermsAndConditions(req.termsAndConditions());
+        inv.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+
+        applyLinesAndTotals(inv, req.lines());
+
+        ConstructionInvoice saved = invoiceRepo.save(inv);
+        log.info("Created construction invoice {}", saved.getInvoiceNumber());
+        return mapper.toDto(saved);
+    }
+
+    @Transactional
+    public ConstructionInvoiceDto update(UUID id, UpdateConstructionInvoiceRequest req) {
+        if (req.dueDate().isBefore(req.issueDate())) {
+            throw new InvalidRequestException("Due date cannot be before issue date");
+        }
+
+        ConstructionInvoice inv = invoiceRepo.findByIdWithLines(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction invoice with ID " + id + " was not found"));
+
+        if (inv.getStatus() == ConstructionInvoiceStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction invoice " + inv.getInvoiceNumber() + " is cancelled and cannot be updated");
+        }
+
+        inv.setType(req.type());
+        inv.setStatus(req.status());
+        inv.setPaymentStatus(req.paymentStatus());
+        inv.setProjectId(req.projectId());
+        inv.setVendorId(req.vendorId());
+        inv.setPurchaseOrderId(req.purchaseOrderId());
+        inv.setGoodsReceiptId(req.goodsReceiptId());
+        inv.setIssueDate(req.issueDate());
+        inv.setDueDate(req.dueDate());
+        inv.setPaymentDate(req.paymentDate());
+        inv.setPaymentTerms(req.paymentTerms());
+        inv.setPaymentMethod(req.paymentMethod());
+        inv.setGstNumber(req.gstNumber());
+        inv.setTaxType(req.taxType());
+        inv.setNotes(req.notes());
+        inv.setTermsAndConditions(req.termsAndConditions());
+
+        inv.getLines().clear();
+        applyLinesAndTotals(inv, req.lines());
+
+        log.info("Updated construction invoice {}", inv.getInvoiceNumber());
+        return mapper.toDto(inv);
+    }
+
+    /**
+     * Rebuilds the invoice lines from the request and recomputes every money total.
+     * Per line: subtotal = quantity * unitPrice; discount = subtotal * discountRate%;
+     * tax = (subtotal - discount) * taxRate% (tax charged on the net-of-discount base);
+     * total = subtotal + tax - discount. The invoice header sums the line values;
+     * balance = total - paid (paid is always zero in this increment).
+     */
+    private void applyLinesAndTotals(ConstructionInvoice inv, List<ConstructionInvoiceLineRequest> lineReqs) {
+        BigDecimal subtotal = BigDecimal.ZERO;
+        BigDecimal taxTotal = BigDecimal.ZERO;
+        BigDecimal discountTotal = BigDecimal.ZERO;
+
+        for (ConstructionInvoiceLineRequest lr : lineReqs) {
+            BigDecimal qty = MoneyUtils.normalize(lr.quantity());
+            BigDecimal price = MoneyUtils.normalize(lr.unitPrice());
+            BigDecimal lineSub = MoneyUtils.normalize(qty.multiply(price));
+
+            BigDecimal discRate = MoneyUtils.normalize(lr.discountRate());
+            BigDecimal discAmt = MoneyUtils.normalize(lineSub.multiply(discRate).divide(HUNDRED));
+
+            BigDecimal taxRate = MoneyUtils.normalize(lr.taxRate());
+            BigDecimal taxableBase = MoneyUtils.normalize(lineSub.subtract(discAmt));
+            BigDecimal taxAmt = MoneyUtils.normalize(taxableBase.multiply(taxRate).divide(HUNDRED));
+
+            BigDecimal lineTotal = MoneyUtils.normalize(lineSub.add(taxAmt).subtract(discAmt));
+
+            ConstructionInvoiceLine line = new ConstructionInvoiceLine();
+            line.setDescription(lr.description());
+            line.setQuantity(qty);
+            line.setUnit(lr.unit());
+            line.setUnitPrice(price);
+            line.setTaxRate(taxRate);
+            line.setTaxAmount(taxAmt);
+            line.setDiscountRate(discRate);
+            line.setDiscountAmount(discAmt);
+            line.setSubtotal(lineSub);
+            line.setTotal(lineTotal);
+            line.setInventoryItemId(lr.inventoryItemId());
+            line.setAssetId(lr.assetId());
+            line.setTaskId(lr.taskId());
+            inv.addLine(line);
+
+            subtotal = subtotal.add(lineSub);
+            taxTotal = taxTotal.add(taxAmt);
+            discountTotal = discountTotal.add(discAmt);
+        }
+
+        BigDecimal total = MoneyUtils.normalize(subtotal.add(taxTotal).subtract(discountTotal));
+        BigDecimal paid = MoneyUtils.normalize(inv.getPaidAmount());
+
+        inv.setSubtotal(MoneyUtils.normalize(subtotal));
+        inv.setTaxAmount(MoneyUtils.normalize(taxTotal));
+        inv.setDiscountAmount(MoneyUtils.normalize(discountTotal));
+        inv.setTotalAmount(total);
+        inv.setPaidAmount(paid);
+        inv.setBalanceAmount(MoneyUtils.normalize(total.subtract(paid)));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.finance.construction.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/finance/construction-invoices/web")
+@RequiredArgsConstructor
+public class ConstructionInvoiceControllerWeb {
+
+    private final ConstructionInvoiceService service;
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ResponseEntity<ConstructionInvoiceDto> create(@Valid @RequestBody CreateConstructionInvoiceRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public Page<ConstructionInvoiceDto> list(@RequestParam(required = false) Long projectId,
+                                             @RequestParam(required = false) Long vendorId,
+                                             @RequestParam(required = false) ConstructionInvoiceStatus status,
+                                             @RequestParam(required = false) ConstructionInvoiceType type,
+                                             Pageable pageable) {
+        return service.findAll(projectId, vendorId, status, type, pageable);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto update(@PathVariable UUID id,
+                                         @Valid @RequestBody UpdateConstructionInvoiceRequest req) {
+        return service.update(id, req);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -226,4 +226,8 @@
     <!-- v4.0 - Finance multi-tenancy (organization scoping) -->
     <include file="db/changelog/v4.0/021-add-org-scope-to-finance.xml"/>
 
+    <!-- v4.0 - Construction invoice module -->
+    <include file="db/changelog/v4.0/022-create-construction-invoices.xml"/>
+    <include file="db/changelog/v4.0/023-create-construction-invoice-lines.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/022-create-construction-invoices.xml
+++ b/src/main/resources/db/changelog/v4.0/022-create-construction-invoices.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="022-create-construction-invoices" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="construction_invoices"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="construction_invoices">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="invoice_number" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(20)" defaultValue="DRAFT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="payment_status" type="VARCHAR(20)" defaultValue="UNPAID">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="vendor_id" type="BIGINT"/>
+            <column name="purchase_order_id" type="BIGINT"/>
+            <column name="goods_receipt_id" type="BIGINT"/>
+
+            <column name="issue_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="due_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="payment_date" type="DATE"/>
+
+            <column name="subtotal" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tax_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="discount_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="total_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="paid_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="balance_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="payment_terms" type="VARCHAR(100)"/>
+            <column name="payment_method" type="VARCHAR(50)"/>
+            <column name="gst_number" type="VARCHAR(30)"/>
+            <column name="tax_type" type="VARCHAR(20)"/>
+            <column name="notes" type="VARCHAR(1000)"/>
+            <column name="terms_and_conditions" type="VARCHAR(2000)"/>
+
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(100)"/>
+            <column name="updated_by" type="VARCHAR(100)"/>
+            <column name="version" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="construction_invoices"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_construction_invoices_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="construction_invoices"
+                             columnNames="organization_id, invoice_number"
+                             constraintName="uk_construction_invoice_number"/>
+
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_vendor">
+            <column name="vendor_id"/>
+        </createIndex>
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_issue_date">
+            <column name="issue_date"/>
+        </createIndex>
+        <createIndex tableName="construction_invoices" indexName="idx_construction_invoices_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/023-create-construction-invoice-lines.xml
+++ b/src/main/resources/db/changelog/v4.0/023-create-construction-invoice-lines.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="023-create-construction-invoice-lines" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="construction_invoice_lines"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="construction_invoice_lines">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="invoice_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(500)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="quantity" type="NUMERIC(19, 4)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="unit" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="unit_price" type="NUMERIC(19, 4)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tax_rate" type="NUMERIC(7, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tax_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="discount_rate" type="NUMERIC(7, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="discount_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="subtotal" type="NUMERIC(19, 4)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="total" type="NUMERIC(19, 4)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="inventory_item_id" type="BIGINT"/>
+            <column name="asset_id" type="BIGINT"/>
+            <column name="task_id" type="BIGINT"/>
+            <column name="line_order" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="construction_invoice_lines"
+                                 baseColumnNames="invoice_id"
+                                 constraintName="fk_cinvl_invoice"
+                                 referencedTableName="construction_invoices"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="construction_invoice_lines" indexName="idx_cinvl_invoice">
+            <column name="invoice_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -1,0 +1,234 @@
+package org.tornotron.echno_backend.finance.construction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end exercise of the construction invoice CRUD path against a real
+ * CockroachDB: create computes the money totals from the line items, get and list
+ * return them, update recomputes them, and the org filter keeps one tenant's
+ * invoices invisible to another.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class})
+class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ConstructionInvoiceService service;
+
+    @Autowired
+    private ConstructionInvoiceRepository invoiceRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long projectId;
+
+    // The tenant seed (orgs + project) must be committed, not held in the test's
+    // rolled-back transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW, so
+    // the document_sequence insert commits in a separate transaction that only sees
+    // committed rows. The invoice itself stays in the rolled-back test transaction.
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("Org A");
+            Organization orgB = persistOrganization("Org B");
+
+            Project project = new Project();
+            project.setProjectName("Tower A");
+            project.setOrganization(orgA);
+            entityManager.persist(project);
+
+            entityManager.flush();
+            orgAId = orgA.getId();
+            orgBId = orgB.getId();
+            projectId = project.getId();
+        });
+
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgAId == null && orgBId == null) {
+            return;
+        }
+        // Committed seed rows survive the test rollback, so remove them by hand in
+        // FK-safe order (also clears the committed document_sequence rows).
+        inCommittedTx(() -> {
+            deleteForOrgs("DELETE FROM construction_invoice_lines WHERE invoice_id IN "
+                    + "(SELECT id FROM construction_invoices WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM construction_invoices WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM document_sequence WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM project WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
+        });
+    }
+
+    private void deleteForOrgs(String sql) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("a", orgAId)
+                .setParameter("b", orgBId)
+                .executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    @Test
+    void create_get_list_update_computesTotalsAndScopesByTenant() {
+        CreateConstructionInvoiceRequest createReq = new CreateConstructionInvoiceRequest(
+                ConstructionInvoiceType.SALES,
+                projectId,
+                null, null, null,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31),
+                "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
+                "First running bill", "Standard terms apply",
+                List.of(
+                        new ConstructionInvoiceLineRequest("Cement supply", bd("2"), "nos",
+                                bd("100"), bd("18"), null, null, null, null),
+                        new ConstructionInvoiceLineRequest("Steel supply", bd("1"), "lot",
+                                bd("50"), bd("18"), bd("10"), null, null, null)
+                )
+        );
+
+        // create - totals computed from the lines, status forced to DRAFT/UNPAID
+        ConstructionInvoiceDto created = service.create(createReq);
+        assertThat(created.status()).isEqualTo(ConstructionInvoiceStatus.DRAFT);
+        assertThat(created.paymentStatus()).isEqualTo(ConstructionPaymentStatus.UNPAID);
+        assertThat(created.invoiceNumber()).startsWith("CINV-");
+        assertThat(created.lines()).hasSize(2);
+        assertThat(created.subtotal()).isEqualByComparingTo(bd("250"));
+        assertThat(created.discountAmount()).isEqualByComparingTo(bd("5"));
+        assertThat(created.taxAmount()).isEqualByComparingTo(bd("44.1"));
+        assertThat(created.totalAmount()).isEqualByComparingTo(bd("289.1"));
+        assertThat(created.paidAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(created.balanceAmount()).isEqualByComparingTo(bd("289.1"));
+
+        UUID id = created.id();
+
+        // get
+        ConstructionInvoiceDto fetched = service.findById(id);
+        assertThat(fetched.id()).isEqualTo(id);
+        assertThat(fetched.totalAmount()).isEqualByComparingTo(bd("289.1"));
+        assertThat(fetched.lines()).hasSize(2);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // tenant scoping - invisible to another organization
+        enableOrgFilter(orgBId);
+        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isZero();
+        assertThat(invoiceRepo.findByIdWithLines(id)).isEmpty();
+
+        // visible and listable to the owning organization
+        disableOrgFilter();
+        enableOrgFilter(orgAId);
+        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(service.findAll(projectId, null, ConstructionInvoiceStatus.DRAFT,
+                ConstructionInvoiceType.SALES, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(invoiceRepo.findByIdWithLines(id)).isPresent();
+        disableOrgFilter();
+
+        // update - status set directly, totals recomputed from the new single line
+        UpdateConstructionInvoiceRequest updateReq = new UpdateConstructionInvoiceRequest(
+                ConstructionInvoiceType.SALES,
+                ConstructionInvoiceStatus.SENT,
+                ConstructionPaymentStatus.UNPAID,
+                projectId,
+                null, null, null,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31),
+                null,
+                "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
+                "Revised running bill", "Standard terms apply",
+                List.of(
+                        new ConstructionInvoiceLineRequest("Cement supply", bd("3"), "nos",
+                                bd("100"), bd("18"), null, null, null, null)
+                )
+        );
+
+        ConstructionInvoiceDto updated = service.update(id, updateReq);
+        assertThat(updated.status()).isEqualTo(ConstructionInvoiceStatus.SENT);
+        assertThat(updated.lines()).hasSize(1);
+        assertThat(updated.subtotal()).isEqualByComparingTo(bd("300"));
+        assertThat(updated.taxAmount()).isEqualByComparingTo(bd("54"));
+        assertThat(updated.discountAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(updated.totalAmount()).isEqualByComparingTo(bd("354"));
+        assertThat(updated.balanceAmount()).isEqualByComparingTo(bd("354"));
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private static BigDecimal bd(String value) {
+        return new BigDecimal(value);
+    }
+}


### PR DESCRIPTION
## Summary

First increment of the construction finance build (per `docs/specs/2026-08-12-construction-finance-design.md`): the **construction invoice** document as its own module, mirroring the AR invoice module's structure. **CRUD + paginated/filtered list only, no ledger posting** (posting is a deliberate later increment, since it is the financially sensitive part that needs the real chart-of-accounts codes first).

This is the operational construction document: invoices tied to a project and optional vendor, typed (purchase/sales/expense/service), with line items carrying discount and inventory/asset/task references, and an 8-state lifecycle. It is a new entity/table, additive, decoupled from the AR module (cross-domain references stored as scalar ids to avoid coupling).

## What it adds

- `finance/construction/` module: `ConstructionInvoice` + `ConstructionInvoiceLine` entities (tenant-scoped via `orgFilter`, `finance.ledger.domain.BaseEntity` auditing), 3 enums, DTOs + MapStruct mapper, repository (+ Specifications for filtered list), service (create/update/findById/findAll, totals computed from lines), and `ConstructionInvoiceControllerWeb` at `/api/v1/finance/construction-invoices/web`.
- Endpoints: `POST` (create, 201), `GET /{id}`, `GET` (list, paginated + `projectId`/`vendorId`/`status`/`type` filters), `PUT /{id}`. Every endpoint guarded with the same tenant role model the AR invoice controller uses (`@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')`).
- Two Liquibase migrations (v4.0/022, 023), registered in the master changelog.
- Money math: discount on line subtotal, tax on the net-of-discount base, `total = subtotal + tax - discount`; header totals are line sums; `balance = total - paid`. All via the shared `MoneyUtils` (scale 4, HALF_UP).
- Document numbers prefixed `CINV`, org+type+fiscal-year scoped (distinct sequence from AR `INV`).

## Verification

Compiled and the integration test run on the lab build box against a real CockroachDB (Testcontainers): create -> get -> list -> update, asserting computed totals and tenant scoping (one org's invoices invisible to another). `compileJava compileTestJava` clean, `ConstructionInvoiceServiceIT` green.

## Not in this increment (follow-ups)

Ledger posting (issue -> journal entry; sales/service materialize an AR invoice, purchase/expense post AP entries via a config-driven bean), construction payment, and the AR list endpoints. Tracked in the design spec's build sequence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added construction invoice creation, viewing, updating, and paginated listing.
  - Added invoice line-item support with quantities, pricing, taxes, discounts, and related references.
  - Added invoice types and payment statuses, including overdue, paid, refunded, cancelled, and disputed states.
  - Added filtering by project, vendor, invoice type, and status.
  - Added automatic calculation of subtotals, discounts, taxes, totals, payments, and balances.
  - Added validation for invoice dates, details, and required line items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->