### PR TITLE
feat: construction payment module (CRUD + list, no ledger posting)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPayeeType.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPayeeType.java
@@ -1,0 +1,16 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionPayeeType {
+    EMPLOYEE,
+    VENDOR,
+    SUB_CONTRACTOR,
+    LABOUR,
+    CONSULTANT,
+    UTILITY,
+    GOVERNMENT,
+    INSURANCE,
+    BANK,
+    LEGAL,
+    RENTAL,
+    OTHER
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentMethod.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentMethod.java
@@ -1,0 +1,13 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionPaymentMethod {
+    CASH,
+    CHEQUE,
+    BANK_TRANSFER,
+    UPI,
+    CARD,
+    NEFT,
+    RTGS,
+    IMPS,
+    OTHER
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentType.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentType.java
@@ -1,0 +1,10 @@
+package org.tornotron.echno_backend.finance.construction;
+
+public enum ConstructionPaymentType {
+    INVOICE,
+    ADVANCE,
+    REFUND,
+    EXPENSE,
+    SALARY,
+    OTHER
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentVoucherStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentVoucherStatus.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.finance.construction;
+
+/**
+ * Processing status of a construction payment voucher. Named with the "Voucher"
+ * qualifier because {@link ConstructionPaymentStatus} is already taken by the
+ * construction invoice's payment-progress field (UNPAID / PARTIALLY_PAID / PAID).
+ * In this increment the status is set directly on create and update; no ledger
+ * journal entry is posted on any transition.
+ */
+public enum ConstructionPaymentVoucherStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED,
+    CANCELLED,
+    REFUNDED
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
@@ -1,0 +1,137 @@
+package org.tornotron.echno_backend.finance.construction.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * A construction payment voucher: a single outgoing (or refund) payment record.
+ * Distinct from the AR customer-receipt Payment in the ledger module. Unlike the
+ * construction invoice it carries no line items. This increment does NO ledger or
+ * journal posting: the status is set directly and no JournalEntry is created.
+ */
+@Entity
+@Table(name = "construction_payments",
+        uniqueConstraints = @UniqueConstraint(name = "uk_construction_payment_number",
+                columnNames = {"organization_id", "payment_number"}),
+        indexes = {
+                @Index(name = "idx_cpmt_project", columnList = "project_id"),
+                @Index(name = "idx_cpmt_vendor", columnList = "vendor_id"),
+                @Index(name = "idx_cpmt_status", columnList = "status"),
+                @Index(name = "idx_cpmt_type", columnList = "type"),
+                @Index(name = "idx_cpmt_payee_type", columnList = "payee_type"),
+                @Index(name = "idx_cpmt_payment_date", columnList = "payment_date")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter @Setter
+@NoArgsConstructor
+public class ConstructionPayment extends BaseEntity implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "payment_number", nullable = false, length = 30)
+    private String paymentNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ConstructionPaymentType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ConstructionPaymentVoucherStatus status = ConstructionPaymentVoucherStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ConstructionPaymentMethod method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payee_type", length = 20)
+    private ConstructionPayeeType payeeType;
+
+    // Scalar references to other domains. Kept as plain ids (no cross-module FK) so
+    // this module stays additive and decoupled; a later increment can wire them up.
+    // project/vendor/purchase-order/employee/labour are core-domain Long ids; the
+    // invoice ref points at a construction invoice, whose id is a UUID.
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
+    @Column(name = "invoice_id")
+    private UUID invoiceId;
+
+    @Column(name = "purchase_order_id")
+    private Long purchaseOrderId;
+
+    @Column(name = "vendor_id")
+    private Long vendorId;
+
+    @Column(name = "employee_id")
+    private Long employeeId;
+
+    @Column(name = "sub_contract_id")
+    private Long subContractId;
+
+    @Column(name = "labour_id")
+    private Long labourId;
+
+    @Column(name = "payee_name", length = 200)
+    private String payeeName;
+
+    @Column(name = "payee_details", length = 500)
+    private String payeeDetails;
+
+    @Column(precision = 19, scale = 4, nullable = false)
+    private BigDecimal amount = BigDecimal.ZERO;
+
+    @Column(nullable = false, length = 10)
+    private String currency = "INR";
+
+    @Column(name = "payment_date", nullable = false)
+    private LocalDate paymentDate;
+
+    @Column(name = "transaction_id", length = 100)
+    private String transactionId;
+
+    @Column(name = "reference_number", length = 100)
+    private String referenceNumber;
+
+    @Column(name = "bank_name", length = 100)
+    private String bankName;
+
+    @Column(name = "account_number", length = 50)
+    private String accountNumber;
+
+    @Column(name = "ifsc_code", length = 20)
+    private String ifscCode;
+
+    @Column(name = "verified_by")
+    private Long verifiedBy;
+
+    @Column(name = "verified_at")
+    private Instant verifiedAt;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 1000)
+    private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -1,0 +1,41 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record ConstructionPaymentDto(
+        UUID id,
+        String paymentNumber,
+        ConstructionPaymentType type,
+        ConstructionPaymentVoucherStatus status,
+        ConstructionPaymentMethod method,
+        ConstructionPayeeType payeeType,
+        Long projectId,
+        UUID invoiceId,
+        Long purchaseOrderId,
+        Long vendorId,
+        Long employeeId,
+        Long subContractId,
+        Long labourId,
+        String payeeName,
+        String payeeDetails,
+        BigDecimal amount,
+        String currency,
+        LocalDate paymentDate,
+        String transactionId,
+        String referenceNumber,
+        String bankName,
+        String accountNumber,
+        String ifscCode,
+        Long verifiedBy,
+        Instant verifiedAt,
+        String description,
+        String notes
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import jakarta.validation.constraints.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Creates a construction payment voucher. The status is not accepted here: a new
+ * voucher always starts PENDING (no ledger posting in this increment). The payment
+ * number is generated server-side with the CPMT sequence.
+ */
+public record CreateConstructionPaymentRequest(
+        @NotNull ConstructionPaymentType type,
+        @NotNull ConstructionPaymentMethod method,
+        ConstructionPayeeType payeeType,
+        @NotNull Long projectId,
+        UUID invoiceId,
+        Long purchaseOrderId,
+        Long vendorId,
+        Long employeeId,
+        Long subContractId,
+        Long labourId,
+        @Size(max = 200) String payeeName,
+        @Size(max = 500) String payeeDetails,
+        @NotNull @Positive BigDecimal amount,
+        @Size(max = 10) String currency,
+        @NotNull LocalDate paymentDate,
+        @Size(max = 100) String transactionId,
+        @Size(max = 100) String referenceNumber,
+        @Size(max = 100) String bankName,
+        @Size(max = 50) String accountNumber,
+        @Size(max = 20) String ifscCode,
+        Long verifiedBy,
+        Instant verifiedAt,
+        @Size(max = 1000) String description,
+        @Size(max = 1000) String notes
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
@@ -1,0 +1,45 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import jakarta.validation.constraints.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Full replacement of an editable construction payment voucher. The status is set
+ * directly (no ledger posting in this increment); no JournalEntry is created on any
+ * status transition.
+ */
+public record UpdateConstructionPaymentRequest(
+        @NotNull ConstructionPaymentType type,
+        @NotNull ConstructionPaymentVoucherStatus status,
+        @NotNull ConstructionPaymentMethod method,
+        ConstructionPayeeType payeeType,
+        @NotNull Long projectId,
+        UUID invoiceId,
+        Long purchaseOrderId,
+        Long vendorId,
+        Long employeeId,
+        Long subContractId,
+        Long labourId,
+        @Size(max = 200) String payeeName,
+        @Size(max = 500) String payeeDetails,
+        @NotNull @Positive BigDecimal amount,
+        @Size(max = 10) String currency,
+        @NotNull LocalDate paymentDate,
+        @Size(max = 100) String transactionId,
+        @Size(max = 100) String referenceNumber,
+        @Size(max = 100) String bankName,
+        @Size(max = 50) String accountNumber,
+        @Size(max = 20) String ifscCode,
+        Long verifiedBy,
+        Instant verifiedAt,
+        @Size(max = 1000) String description,
+        @Size(max = 1000) String notes
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
@@ -1,0 +1,11 @@
+package org.tornotron.echno_backend.finance.construction.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+
+@Mapper(componentModel = "spring")
+public interface ConstructionPaymentMapper {
+
+    ConstructionPaymentDto toDto(ConstructionPayment payment);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentRepository.java
@@ -1,0 +1,23 @@
+package org.tornotron.echno_backend.finance.construction.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ConstructionPaymentRepository
+        extends JpaRepository<ConstructionPayment, UUID>, JpaSpecificationExecutor<ConstructionPayment> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT cp FROM ConstructionPayment cp WHERE cp.id = :id")
+    Optional<ConstructionPayment> findByIdScoped(@Param("id") UUID id);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
@@ -1,0 +1,48 @@
+package org.tornotron.echno_backend.finance.construction.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the optional list filters as a JPA {@link Specification}. Only non-null
+ * arguments become predicates, which avoids binding null-typed parameters on the
+ * Postgres wire protocol. Organization scoping is handled separately by the
+ * Hibernate {@code orgFilter} enabled per request.
+ */
+public final class ConstructionPaymentSpecifications {
+
+    private ConstructionPaymentSpecifications() {}
+
+    public static Specification<ConstructionPayment> withFilters(Long projectId,
+                                                                 Long vendorId,
+                                                                 ConstructionPaymentVoucherStatus status,
+                                                                 ConstructionPaymentType type,
+                                                                 ConstructionPayeeType payeeType) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (projectId != null) {
+                predicates.add(cb.equal(root.get("projectId"), projectId));
+            }
+            if (vendorId != null) {
+                predicates.add(cb.equal(root.get("vendorId"), vendorId));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            if (payeeType != null) {
+                predicates.add(cb.equal(root.get("payeeType"), payeeType));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -1,0 +1,147 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentSpecifications;
+
+import java.util.UUID;
+
+/**
+ * CRUD + list for construction payment vouchers. This increment deliberately does
+ * NO ledger or journal posting: the status is set directly and no JournalEntry is
+ * created. A later increment will add the ledger-posting hooks (post the cash/bank
+ * and payable movement on completion, reverse on cancel/refund).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConstructionPaymentService {
+
+    private static final String DOC_TYPE = "CPMT";
+    private static final String DEFAULT_CURRENCY = "INR";
+
+    private final ConstructionPaymentRepository paymentRepo;
+    private final EntryNumberGenerator numberGen;
+    private final ConstructionPaymentMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public ConstructionPaymentDto findById(UUID id) {
+        return mapper.toDto(paymentRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction payment with ID " + id + " was not found")));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ConstructionPaymentDto> findAll(Long projectId,
+                                                Long vendorId,
+                                                ConstructionPaymentVoucherStatus status,
+                                                ConstructionPaymentType type,
+                                                ConstructionPayeeType payeeType,
+                                                Pageable pageable) {
+        return paymentRepo.findAll(
+                        ConstructionPaymentSpecifications.withFilters(projectId, vendorId, status, type, payeeType),
+                        pageable)
+                .map(mapper::toDto);
+    }
+
+    @Transactional
+    public ConstructionPaymentDto create(CreateConstructionPaymentRequest req) {
+        ConstructionPayment payment = new ConstructionPayment();
+        payment.setPaymentNumber(numberGen.next(DOC_TYPE));
+        payment.setType(req.type());
+        payment.setStatus(ConstructionPaymentVoucherStatus.PENDING);
+        payment.setMethod(req.method());
+        payment.setPayeeType(req.payeeType());
+        payment.setProjectId(req.projectId());
+        payment.setInvoiceId(req.invoiceId());
+        payment.setPurchaseOrderId(req.purchaseOrderId());
+        payment.setVendorId(req.vendorId());
+        payment.setEmployeeId(req.employeeId());
+        payment.setSubContractId(req.subContractId());
+        payment.setLabourId(req.labourId());
+        payment.setPayeeName(req.payeeName());
+        payment.setPayeeDetails(req.payeeDetails());
+        payment.setAmount(MoneyUtils.normalize(req.amount()));
+        payment.setCurrency(resolveCurrency(req.currency()));
+        payment.setPaymentDate(req.paymentDate());
+        payment.setTransactionId(req.transactionId());
+        payment.setReferenceNumber(req.referenceNumber());
+        payment.setBankName(req.bankName());
+        payment.setAccountNumber(req.accountNumber());
+        payment.setIfscCode(req.ifscCode());
+        payment.setVerifiedBy(req.verifiedBy());
+        payment.setVerifiedAt(req.verifiedAt());
+        payment.setDescription(req.description());
+        payment.setNotes(req.notes());
+        payment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+
+        ConstructionPayment saved = paymentRepo.save(payment);
+        log.info("Created construction payment {}", saved.getPaymentNumber());
+        return mapper.toDto(saved);
+    }
+
+    @Transactional
+    public ConstructionPaymentDto update(UUID id, UpdateConstructionPaymentRequest req) {
+        ConstructionPayment payment = paymentRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction payment with ID " + id + " was not found"));
+
+        if (payment.getStatus() == ConstructionPaymentVoucherStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber()
+                            + " is cancelled and cannot be updated");
+        }
+
+        payment.setType(req.type());
+        payment.setStatus(req.status());
+        payment.setMethod(req.method());
+        payment.setPayeeType(req.payeeType());
+        payment.setProjectId(req.projectId());
+        payment.setInvoiceId(req.invoiceId());
+        payment.setPurchaseOrderId(req.purchaseOrderId());
+        payment.setVendorId(req.vendorId());
+        payment.setEmployeeId(req.employeeId());
+        payment.setSubContractId(req.subContractId());
+        payment.setLabourId(req.labourId());
+        payment.setPayeeName(req.payeeName());
+        payment.setPayeeDetails(req.payeeDetails());
+        payment.setAmount(MoneyUtils.normalize(req.amount()));
+        payment.setCurrency(resolveCurrency(req.currency()));
+        payment.setPaymentDate(req.paymentDate());
+        payment.setTransactionId(req.transactionId());
+        payment.setReferenceNumber(req.referenceNumber());
+        payment.setBankName(req.bankName());
+        payment.setAccountNumber(req.accountNumber());
+        payment.setIfscCode(req.ifscCode());
+        payment.setVerifiedBy(req.verifiedBy());
+        payment.setVerifiedAt(req.verifiedAt());
+        payment.setDescription(req.description());
+        payment.setNotes(req.notes());
+
+        log.info("Updated construction payment {}", payment.getPaymentNumber());
+        return mapper.toDto(payment);
+    }
+
+    private String resolveCurrency(String currency) {
+        return (currency == null || currency.isBlank()) ? DEFAULT_CURRENCY : currency;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -1,0 +1,57 @@
+package org.tornotron.echno_backend.finance.construction.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionPaymentService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/finance/construction-payments/web")
+@RequiredArgsConstructor
+public class ConstructionPaymentControllerWeb {
+
+    private final ConstructionPaymentService service;
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ResponseEntity<ConstructionPaymentDto> create(@Valid @RequestBody CreateConstructionPaymentRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionPaymentDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public Page<ConstructionPaymentDto> list(@RequestParam(required = false) Long projectId,
+                                             @RequestParam(required = false) Long vendorId,
+                                             @RequestParam(required = false) ConstructionPaymentVoucherStatus status,
+                                             @RequestParam(required = false) ConstructionPaymentType type,
+                                             @RequestParam(required = false) ConstructionPayeeType payeeType,
+                                             Pageable pageable) {
+        return service.findAll(projectId, vendorId, status, type, payeeType, pageable);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionPaymentDto update(@PathVariable UUID id,
+                                         @Valid @RequestBody UpdateConstructionPaymentRequest req) {
+        return service.update(id, req);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -230,4 +230,7 @@
     <include file="db/changelog/v4.0/022-create-construction-invoices.xml"/>
     <include file="db/changelog/v4.0/023-create-construction-invoice-lines.xml"/>
 
+    <!-- v4.0 - Construction payment module -->
+    <include file="db/changelog/v4.0/024-create-construction-payments.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/024-create-construction-payments.xml
+++ b/src/main/resources/db/changelog/v4.0/024-create-construction-payments.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="024-create-construction-payments" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="construction_payments"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="construction_payments">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="payment_number" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(20)" defaultValue="PENDING">
+                <constraints nullable="false"/>
+            </column>
+            <column name="method" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="payee_type" type="VARCHAR(20)"/>
+
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="invoice_id" type="UUID"/>
+            <column name="purchase_order_id" type="BIGINT"/>
+            <column name="vendor_id" type="BIGINT"/>
+            <column name="employee_id" type="BIGINT"/>
+            <column name="sub_contract_id" type="BIGINT"/>
+            <column name="labour_id" type="BIGINT"/>
+
+            <column name="payee_name" type="VARCHAR(200)"/>
+            <column name="payee_details" type="VARCHAR(500)"/>
+
+            <column name="amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="currency" type="VARCHAR(10)" defaultValue="INR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="payment_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="transaction_id" type="VARCHAR(100)"/>
+            <column name="reference_number" type="VARCHAR(100)"/>
+            <column name="bank_name" type="VARCHAR(100)"/>
+            <column name="account_number" type="VARCHAR(50)"/>
+            <column name="ifsc_code" type="VARCHAR(20)"/>
+
+            <column name="verified_by" type="BIGINT"/>
+            <column name="verified_at" type="TIMESTAMP"/>
+
+            <column name="description" type="VARCHAR(1000)"/>
+            <column name="notes" type="VARCHAR(1000)"/>
+
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(100)"/>
+            <column name="updated_by" type="VARCHAR(100)"/>
+            <column name="version" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="construction_payments"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_construction_payments_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="construction_payments"
+                             columnNames="organization_id, payment_number"
+                             constraintName="uk_construction_payment_number"/>
+
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_vendor">
+            <column name="vendor_id"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_payee_type">
+            <column name="payee_type"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_payment_date">
+            <column name="payment_date"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_construction_payments_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -1,0 +1,228 @@
+package org.tornotron.echno_backend.finance.construction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionPaymentService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end exercise of the construction payment CRUD path against a real
+ * CockroachDB: create stores the voucher and generates a CPMT number, get and list
+ * return it, update replaces its fields and sets the status directly, and the org
+ * filter keeps one tenant's payments invisible to another.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ConstructionPaymentService.class, ConstructionPaymentMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class})
+class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ConstructionPaymentService service;
+
+    @Autowired
+    private ConstructionPaymentRepository paymentRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long projectId;
+
+    // The tenant seed (orgs + project) must be committed, not held in the test's
+    // rolled-back transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW, so
+    // the document_sequence insert commits in a separate transaction that only sees
+    // committed rows. The payment itself stays in the rolled-back test transaction.
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("Org A");
+            Organization orgB = persistOrganization("Org B");
+
+            Project project = new Project();
+            project.setProjectName("Tower A");
+            project.setOrganization(orgA);
+            entityManager.persist(project);
+
+            entityManager.flush();
+            orgAId = orgA.getId();
+            orgBId = orgB.getId();
+            projectId = project.getId();
+        });
+
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgAId == null && orgBId == null) {
+            return;
+        }
+        // Committed seed rows survive the test rollback, so remove them by hand in
+        // FK-safe order (also clears the committed document_sequence rows).
+        inCommittedTx(() -> {
+            deleteForOrgs("DELETE FROM construction_payments WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM document_sequence WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM project WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
+        });
+    }
+
+    private void deleteForOrgs(String sql) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("a", orgAId)
+                .setParameter("b", orgBId)
+                .executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    @Test
+    void create_get_list_update_persistsVoucherAndScopesByTenant() {
+        CreateConstructionPaymentRequest createReq = new CreateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                ConstructionPaymentMethod.BANK_TRANSFER,
+                ConstructionPayeeType.VENDOR,
+                projectId,
+                null, null,
+                42L,
+                null, null, null,
+                "Acme Supplies", "Consumer No: 123456",
+                bd("15000.50"),
+                "INR",
+                LocalDate.of(2026, 8, 1),
+                "TXN-0001", "REF-0001", "State Bank", "0001112223", "SBIN0000001",
+                7L, null,
+                "First running payment", "Approved by PM"
+        );
+
+        // create - status forced to PENDING, number generated, amount stored
+        ConstructionPaymentDto created = service.create(createReq);
+        assertThat(created.status()).isEqualTo(ConstructionPaymentVoucherStatus.PENDING);
+        assertThat(created.paymentNumber()).startsWith("CPMT-");
+        assertThat(created.amount()).isEqualByComparingTo(bd("15000.50"));
+        assertThat(created.currency()).isEqualTo("INR");
+        assertThat(created.type()).isEqualTo(ConstructionPaymentType.INVOICE);
+        assertThat(created.method()).isEqualTo(ConstructionPaymentMethod.BANK_TRANSFER);
+        assertThat(created.payeeType()).isEqualTo(ConstructionPayeeType.VENDOR);
+        assertThat(created.vendorId()).isEqualTo(42L);
+
+        UUID id = created.id();
+
+        // get
+        ConstructionPaymentDto fetched = service.findById(id);
+        assertThat(fetched.id()).isEqualTo(id);
+        assertThat(fetched.amount()).isEqualByComparingTo(bd("15000.50"));
+        assertThat(fetched.payeeName()).isEqualTo("Acme Supplies");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // tenant scoping - invisible to another organization
+        enableOrgFilter(orgBId);
+        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements()).isZero();
+        assertThat(paymentRepo.findByIdScoped(id)).isEmpty();
+
+        // visible and listable to the owning organization, including the filters
+        disableOrgFilter();
+        enableOrgFilter(orgAId);
+        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(service.findAll(projectId, 42L, ConstructionPaymentVoucherStatus.PENDING,
+                ConstructionPaymentType.INVOICE, ConstructionPayeeType.VENDOR, pageable)
+                .getTotalElements()).isEqualTo(1);
+        assertThat(paymentRepo.findByIdScoped(id)).isPresent();
+        disableOrgFilter();
+
+        // update - status set directly, fields replaced
+        UpdateConstructionPaymentRequest updateReq = new UpdateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                ConstructionPaymentVoucherStatus.COMPLETED,
+                ConstructionPaymentMethod.UPI,
+                ConstructionPayeeType.VENDOR,
+                projectId,
+                null, null,
+                42L,
+                null, null, null,
+                "Acme Supplies", "Consumer No: 123456",
+                bd("16000"),
+                "INR",
+                LocalDate.of(2026, 8, 2),
+                "TXN-0002", "REF-0002", "State Bank", "0001112223", "SBIN0000001",
+                7L, null,
+                "Revised running payment", "Settled"
+        );
+
+        ConstructionPaymentDto updated = service.update(id, updateReq);
+        assertThat(updated.status()).isEqualTo(ConstructionPaymentVoucherStatus.COMPLETED);
+        assertThat(updated.method()).isEqualTo(ConstructionPaymentMethod.UPI);
+        assertThat(updated.amount()).isEqualByComparingTo(bd("16000"));
+        assertThat(updated.paymentDate()).isEqualTo(LocalDate.of(2026, 8, 2));
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private static BigDecimal bd(String value) {
+        return new BigDecimal(value);
+    }
+}


### PR DESCRIPTION
Increment 2 of the construction finance build (per `docs/specs/2026-08-12-construction-finance-design.md`): the **construction payment voucher** as a new module under `finance/construction`, mirroring the construction invoice module. **CRUD + paginated/filtered list only, no ledger posting** (a later increment).

The construction payment is a single voucher (no line items): project-scoped, typed by `type` (invoice/advance/refund/expense/salary/other), `method`, `status`, and `payeeType` (12 payee kinds), referencing invoices/POs/vendors/employees/labour as scalar ids. Distinct from the AR customer-receipt Payment.

## Adds
- `ConstructionPayment` entity (tenant-scoped, `finance.ledger.domain.BaseEntity`), 4 enums (voucher status named `ConstructionPaymentVoucherStatus` to avoid colliding with the invoice `ConstructionPaymentStatus` progress enum), DTOs + MapStruct mapper, repository (+ Specifications), service (create/update/findById/findAll), controller at `/api/v1/finance/construction-payments/web` guarded with `@orgSecurity.hasAnyOrgRoleForCurrentTenant(system-admin,project-manager)`.
- Migration `v4.0/024`, registered in the master changelog. Document numbers prefixed `CPMT`.

## Verified
Compiled and `ConstructionPaymentServiceIT` run on the lab box against real CockroachDB (create/get/list-with-filters/update + tenant scoping): green.

## Flagged for later
- `invoiceId` is stored as `UUID` (construction invoice id) but the web types it as `number` — web reconciliation needed.
- `subContractId` kept as an unenforced scalar (no `SubContract` entity exists yet).
- `attachments` omitted (would need a child table); ledger posting + invoice paid-amount rollups are the posting increment.