### PR TITLE
feat: inspection module (CRUD + list)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inspection/CheckItemStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/CheckItemStatus.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Per-check-point outcome within an inspection. The wire value is the hyphenated
+ * form from {@link #getValue()}; the constant name is the database representation.
+ * The passed and failed counts on an inspection are derived from these statuses.
+ */
+public enum CheckItemStatus {
+    PASSED("passed"),
+    FAILED("failed"),
+    NOT_APPLICABLE("not-applicable"),
+    PENDING("pending");
+
+    private final String value;
+
+    CheckItemStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static CheckItemStatus fromValue(String value) {
+        for (CheckItemStatus status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown check item status: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionResult.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionResult.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Outcome of a completed inspection. Nullable on the entity until the inspection
+ * is concluded. The wire value is the hyphenated form from {@link #getValue()};
+ * the constant name is the database representation.
+ */
+public enum InspectionResult {
+    PASSED("passed"),
+    FAILED("failed"),
+    PASSED_WITH_REMARKS("passed-with-remarks"),
+    PENDING("pending");
+
+    private final String value;
+
+    InspectionResult(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionResult fromValue(String value) {
+        for (InspectionResult result : values()) {
+            if (result.value.equalsIgnoreCase(value)) {
+                return result;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection result: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Lifecycle state of an inspection. The wire value is the hyphenated form from
+ * {@link #getValue()}; the constant name is the database representation stored
+ * by {@code @Enumerated(STRING)}.
+ */
+public enum InspectionStatus {
+    SCHEDULED("scheduled"),
+    IN_PROGRESS("in-progress"),
+    COMPLETED("completed"),
+    FAILED("failed"),
+    PASSED("passed"),
+    PASSED_WITH_REMARKS("passed-with-remarks"),
+    CANCELLED("cancelled");
+
+    private final String value;
+
+    InspectionStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionStatus fromValue(String value) {
+        for (InspectionStatus status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection status: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionType.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionType.java
@@ -1,0 +1,44 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The kind of site inspection being carried out. The wire value (what the API
+ * emits and accepts) is the lowercase form supplied by {@link #getValue()}; the
+ * constant name is what {@code @Enumerated(STRING)} stores in the database. A
+ * distinct wire value is required because one member ({@code FINAL}) collides
+ * with a Java reserved word and several inspection statuses use hyphenated forms.
+ */
+public enum InspectionType {
+    SAFETY("safety"),
+    QUALITY("quality"),
+    PROGRESS("progress"),
+    FINAL("final"),
+    STRUCTURAL("structural"),
+    ELECTRICAL("electrical"),
+    PLUMBING("plumbing"),
+    FINISHING("finishing"),
+    COMPLIANCE("compliance");
+
+    private final String value;
+
+    InspectionType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionType fromValue(String value) {
+        for (InspectionType type : values()) {
+            if (type.value.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection type: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionResultConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionResultConverter.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+
+/**
+ * Binds the hyphenated wire value of {@link InspectionResult} (e.g.
+ * {@code passed-with-remarks}) when it arrives as a query parameter on the
+ * list endpoint.
+ */
+@Component
+public class StringToInspectionResultConverter implements Converter<String, InspectionResult> {
+
+    @Override
+    public InspectionResult convert(String source) {
+        return InspectionResult.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionStatusConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionStatusConverter.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+
+/**
+ * Binds the hyphenated wire value of {@link InspectionStatus} (e.g.
+ * {@code in-progress}) when it arrives as a query parameter on the list endpoint.
+ */
+@Component
+public class StringToInspectionStatusConverter implements Converter<String, InspectionStatus> {
+
+    @Override
+    public InspectionStatus convert(String source) {
+        return InspectionStatus.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionTypeConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionTypeConverter.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.InspectionType;
+
+/**
+ * Binds the hyphenated wire value of {@link InspectionType} (e.g. {@code final},
+ * {@code safety}) when it arrives as a query parameter on the list endpoint.
+ * Spring's default enum binding matches the constant name, not the wire value,
+ * so an explicit converter is registered.
+ */
+@Component
+public class StringToInspectionTypeConverter implements Converter<String, InspectionType> {
+
+    @Override
+    public InspectionType convert(String source) {
+        return InspectionType.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
@@ -1,0 +1,166 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A site quality or safety inspection. Tenant-scoped through the Hibernate
+ * {@code orgFilter}; created and updated timestamps are managed by Hibernate
+ * ({@code @CreationTimestamp}/{@code @UpdateTimestamp}), mirroring the portfolio
+ * domains (issue, task, project) rather than the finance auditing base class.
+ * Cross-domain references (project, inspector, contractor) are plain scalar ids
+ * with no FK, keeping this module additive and decoupled.
+ */
+@Entity
+@Table(name = "inspections",
+        uniqueConstraints = @UniqueConstraint(name = "uk_inspection_number",
+                columnNames = {"organization_id", "inspection_number"}),
+        indexes = {
+                @Index(name = "idx_insp_project", columnList = "project_id"),
+                @Index(name = "idx_insp_status", columnList = "status"),
+                @Index(name = "idx_insp_type", columnList = "type"),
+                @Index(name = "idx_insp_result", columnList = "result"),
+                @Index(name = "idx_insp_scheduled_date", columnList = "scheduled_date"),
+                @Index(name = "idx_insp_inspector", columnList = "inspector_id")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter @Setter
+@NoArgsConstructor
+public class Inspection implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "inspection_number", nullable = false, length = 30)
+    private String inspectionNumber;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private InspectionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private InspectionStatus status = InspectionStatus.SCHEDULED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private InspectionResult result;
+
+    // Scalar references to core-domain records. Kept as plain ids (no cross-module FK)
+    // so this module stays additive and decoupled; a later increment can wire them up.
+    @Column(name = "project_id")
+    private Long projectId;
+
+    @Column(length = 300)
+    private String location;
+
+    @Column(name = "area_inspected", length = 300)
+    private String areaInspected;
+
+    @Column(name = "drawing_reference", length = 200)
+    private String drawingReference;
+
+    @Column(name = "scheduled_date", nullable = false)
+    private LocalDate scheduledDate;
+
+    @Column(name = "scheduled_time", length = 20)
+    private String scheduledTime;
+
+    @Column(name = "actual_start_time")
+    private LocalDateTime actualStartTime;
+
+    @Column(name = "actual_end_time")
+    private LocalDateTime actualEndTime;
+
+    // Duration in minutes.
+    @Column(name = "duration")
+    private Integer duration;
+
+    @Column(name = "inspector_id", nullable = false)
+    private Long inspectorId;
+
+    @Column(name = "contractor_id")
+    private Long contractorId;
+
+    @Column(name = "client_representative", length = 200)
+    private String clientRepresentative;
+
+    @ElementCollection
+    @CollectionTable(name = "inspection_attendees",
+            joinColumns = @JoinColumn(name = "inspection_id"))
+    @Column(name = "attendee", length = 200)
+    private List<String> attendees = new ArrayList<>();
+
+    @Column(name = "weather_conditions", length = 200)
+    private String weatherConditions;
+
+    @Column(length = 50)
+    private String temperature;
+
+    // Summary counts recomputed from the check items and defects on every save.
+    @Column(name = "total_check_points", nullable = false)
+    private int totalCheckPoints;
+
+    @Column(name = "passed_check_points", nullable = false)
+    private int passedCheckPoints;
+
+    @Column(name = "failed_check_points", nullable = false)
+    private int failedCheckPoints;
+
+    @Column(name = "defects_found", nullable = false)
+    private int defectsFound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @OneToMany(mappedBy = "inspection", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @OrderBy("lineOrder ASC")
+    private List<InspectionCheckItem> checkItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "inspection", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @OrderBy("lineOrder ASC")
+    private List<InspectionDefect> defects = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void addCheckItem(InspectionCheckItem item) {
+        item.setInspection(this);
+        item.setLineOrder(this.checkItems.size());
+        this.checkItems.add(item);
+    }
+
+    public void addDefect(InspectionDefect defect) {
+        defect.setInspection(this);
+        defect.setLineOrder(this.defects.size());
+        this.defects.add(defect);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionCheckItem.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionCheckItem.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.tornotron.echno_backend.inspection.CheckItemStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A single check point within an inspection. Owned by {@link Inspection} through
+ * the {@code inspection_id} FK; the parent cascades persist and removal. Tenant
+ * scoping is inherited from the owning inspection, which carries the org filter.
+ */
+@Entity
+@Table(name = "inspection_check_items",
+        indexes = @Index(name = "idx_insp_check_item_inspection", columnList = "inspection_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class InspectionCheckItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "inspection_id", nullable = false)
+    private Inspection inspection;
+
+    @Column(nullable = false, length = 200)
+    private String category;
+
+    @Column(name = "check_point", nullable = false, length = 500)
+    private String checkPoint;
+
+    @Column(length = 1000)
+    private String specification;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private CheckItemStatus status = CheckItemStatus.PENDING;
+
+    @Column(length = 1000)
+    private String remarks;
+
+    @Column(name = "photos_required", nullable = false)
+    private boolean photosRequired;
+
+    @ElementCollection
+    @CollectionTable(name = "inspection_check_item_photos",
+            joinColumns = @JoinColumn(name = "check_item_id"))
+    @Column(name = "photo", length = 500)
+    private List<String> photos = new ArrayList<>();
+
+    @Column(length = 200)
+    private String measurement;
+
+    @Column(name = "expected_value", length = 200)
+    private String expectedValue;
+
+    // Free-form priority ('high' | 'medium' | 'low'), kept as text to match the
+    // web contract's inline string union.
+    @Column(length = 20)
+    private String priority = "medium";
+
+    @Column(name = "line_order", nullable = false)
+    private int lineOrder;
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A defect raised during an inspection. Owned by {@link Inspection} through the
+ * {@code inspection_id} FK; the parent cascades persist and removal. The severity
+ * and status are kept as text to match the web contract's inline string unions
+ * ('critical' | 'major' | 'minor' and 'open' | 'in-progress' | 'resolved' | 'verified').
+ */
+@Entity
+@Table(name = "inspection_defects",
+        indexes = @Index(name = "idx_insp_defect_inspection", columnList = "inspection_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class InspectionDefect {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "inspection_id", nullable = false)
+    private Inspection inspection;
+
+    @Column(length = 200)
+    private String category;
+
+    @Column(nullable = false, length = 1000)
+    private String description;
+
+    @Column(length = 20)
+    private String severity;
+
+    @Column(length = 300)
+    private String location;
+
+    @ElementCollection
+    @CollectionTable(name = "inspection_defect_photos",
+            joinColumns = @JoinColumn(name = "defect_id"))
+    @Column(name = "photo", length = 500)
+    private List<String> photos = new ArrayList<>();
+
+    @Column(name = "corrective_action", nullable = false, length = 1000)
+    private String correctiveAction;
+
+    @Column(name = "responsible_party", length = 200)
+    private String responsibleParty;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(length = 20)
+    private String status = "open";
+
+    @Column(name = "resolved_date")
+    private LocalDate resolvedDate;
+
+    @Column(name = "line_order", nullable = false)
+    private int lineOrder;
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.InspectionType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Creates a new inspection. Status is forced to {@code SCHEDULED} and the result
+ * stays unset until the inspection is concluded through an update; neither is
+ * accepted here. The summary counts are computed from the supplied check items
+ * and defects.
+ */
+public record CreateInspectionRequest(
+        @NotBlank @Size(max = 200) String title,
+        @NotNull InspectionType type,
+        Long projectId,
+        @Size(max = 300) String location,
+        @Size(max = 300) String areaInspected,
+        @Size(max = 200) String drawingReference,
+        @NotNull LocalDate scheduledDate,
+        @Size(max = 20) String scheduledTime,
+        LocalDateTime actualStartTime,
+        LocalDateTime actualEndTime,
+        @PositiveOrZero Integer duration,
+        @NotNull Long inspectorId,
+        Long contractorId,
+        @Size(max = 200) String clientRepresentative,
+        List<@Size(max = 200) String> attendees,
+        @Size(max = 200) String weatherConditions,
+        @Size(max = 50) String temperature,
+        @Valid List<InspectionCheckItemRequest> checkItems,
+        @Valid List<InspectionDefectRequest> defects
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import org.tornotron.echno_backend.inspection.CheckItemStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InspectionCheckItemDto(
+        UUID id,
+        String category,
+        String checkPoint,
+        String specification,
+        CheckItemStatus status,
+        String remarks,
+        boolean photosRequired,
+        List<String> photos,
+        String measurement,
+        String expectedValue,
+        String priority
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
@@ -1,0 +1,26 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.CheckItemStatus;
+
+import java.util.List;
+
+/**
+ * Check-point payload shared by the create and update requests. The inspection's
+ * passed, failed and total counts are derived server-side from the supplied
+ * check items; the client does not set them.
+ */
+public record InspectionCheckItemRequest(
+        @NotBlank @Size(max = 200) String category,
+        @NotBlank @Size(max = 500) String checkPoint,
+        @Size(max = 1000) String specification,
+        @NotNull CheckItemStatus status,
+        @Size(max = 1000) String remarks,
+        boolean photosRequired,
+        List<@Size(max = 500) String> photos,
+        @Size(max = 200) String measurement,
+        @Size(max = 200) String expectedValue,
+        @Size(max = 20) String priority
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record InspectionDefectDto(
+        UUID id,
+        String category,
+        String description,
+        String severity,
+        String location,
+        List<String> photos,
+        String correctiveAction,
+        String responsibleParty,
+        LocalDate targetDate,
+        String status,
+        LocalDate resolvedDate
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Defect payload shared by the create and update requests. The number of defects
+ * recorded feeds the inspection's {@code defectsFound} count, computed server-side.
+ */
+public record InspectionDefectRequest(
+        @Size(max = 200) String category,
+        @NotBlank @Size(max = 1000) String description,
+        @Size(max = 20) String severity,
+        @Size(max = 300) String location,
+        List<@Size(max = 500) String> photos,
+        @NotBlank @Size(max = 1000) String correctiveAction,
+        @Size(max = 200) String responsibleParty,
+        LocalDate targetDate,
+        @Size(max = 20) String status,
+        LocalDate resolvedDate
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record InspectionDto(
+        UUID id,
+        String inspectionNumber,
+        String title,
+        InspectionType type,
+        InspectionStatus status,
+        InspectionResult result,
+        Long projectId,
+        String location,
+        String areaInspected,
+        String drawingReference,
+        LocalDate scheduledDate,
+        String scheduledTime,
+        LocalDateTime actualStartTime,
+        LocalDateTime actualEndTime,
+        Integer duration,
+        Long inspectorId,
+        Long contractorId,
+        String clientRepresentative,
+        List<String> attendees,
+        String weatherConditions,
+        String temperature,
+        int totalCheckPoints,
+        int passedCheckPoints,
+        int failedCheckPoints,
+        int defectsFound,
+        List<InspectionCheckItemDto> checkItems,
+        List<InspectionDefectDto> defects,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Full replacement of an inspection. Status is set directly and the result is
+ * optional (set once the inspection is concluded). The check items and defects
+ * are rebuilt from the payload and the summary counts recomputed from them.
+ */
+public record UpdateInspectionRequest(
+        @NotBlank @Size(max = 200) String title,
+        @NotNull InspectionType type,
+        @NotNull InspectionStatus status,
+        InspectionResult result,
+        Long projectId,
+        @Size(max = 300) String location,
+        @Size(max = 300) String areaInspected,
+        @Size(max = 200) String drawingReference,
+        @NotNull LocalDate scheduledDate,
+        @Size(max = 20) String scheduledTime,
+        LocalDateTime actualStartTime,
+        LocalDateTime actualEndTime,
+        @PositiveOrZero Integer duration,
+        @NotNull Long inspectorId,
+        Long contractorId,
+        @Size(max = 200) String clientRepresentative,
+        List<@Size(max = 200) String> attendees,
+        @Size(max = 200) String weatherConditions,
+        @Size(max = 50) String temperature,
+        @Valid List<InspectionCheckItemRequest> checkItems,
+        @Valid List<InspectionDefectRequest> defects
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/mapper/InspectionMapper.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.inspection.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.domain.InspectionCheckItem;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemDto;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDefectDto;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+
+@Mapper(componentModel = "spring")
+public interface InspectionMapper {
+
+    InspectionDto toDto(Inspection inspection);
+
+    InspectionCheckItemDto toCheckItemDto(InspectionCheckItem item);
+
+    InspectionDefectDto toDefectDto(InspectionDefect defect);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionRepository.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface InspectionRepository
+        extends JpaRepository<Inspection, UUID>, JpaSpecificationExecutor<Inspection> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads. The
+     * check items and defects load lazily while the transaction is still open.
+     */
+    @Query("SELECT i FROM Inspection i WHERE i.id = :id")
+    Optional<Inspection> findByIdScoped(@Param("id") UUID id);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionSpecifications.java
@@ -1,0 +1,44 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the optional list filters as a JPA {@link Specification}. Only non-null
+ * arguments become predicates, which avoids binding null-typed parameters on the
+ * Postgres wire protocol. Organization scoping is handled separately by the
+ * Hibernate {@code orgFilter} enabled per request.
+ */
+public final class InspectionSpecifications {
+
+    private InspectionSpecifications() {}
+
+    public static Specification<Inspection> withFilters(Long projectId,
+                                                        InspectionStatus status,
+                                                        InspectionType type,
+                                                        InspectionResult result) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (projectId != null) {
+                predicates.add(cb.equal(root.get("projectId"), projectId));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            if (result != null) {
+                predicates.add(cb.equal(root.get("result"), result));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
@@ -1,0 +1,204 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.CheckItemStatus;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.domain.InspectionCheckItem;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDefectRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.repositories.InspectionSpecifications;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * CRUD + list for site inspections. This increment does no workflow beyond the
+ * status field: status and result are set directly from the request, and the
+ * summary counts (total, passed, failed check points and defects found) are
+ * recomputed from the supplied check items and defects on every save.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InspectionService {
+
+    private static final String DOC_TYPE = "INSP";
+
+    private final InspectionRepository inspectionRepo;
+    private final EntryNumberGenerator numberGen;
+    private final InspectionMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public InspectionDto findById(UUID id) {
+        return mapper.toDto(inspectionRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Inspection with ID " + id + " was not found")));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<InspectionDto> findAll(Long projectId,
+                                       InspectionStatus status,
+                                       InspectionType type,
+                                       InspectionResult result,
+                                       Pageable pageable) {
+        return inspectionRepo.findAll(
+                        InspectionSpecifications.withFilters(projectId, status, type, result),
+                        pageable)
+                .map(mapper::toDto);
+    }
+
+    @Transactional
+    public InspectionDto create(CreateInspectionRequest req) {
+        Inspection inspection = new Inspection();
+        inspection.setInspectionNumber(numberGen.next(DOC_TYPE));
+        inspection.setTitle(req.title());
+        inspection.setType(req.type());
+        inspection.setStatus(InspectionStatus.SCHEDULED);
+        inspection.setProjectId(req.projectId());
+        inspection.setLocation(req.location());
+        inspection.setAreaInspected(req.areaInspected());
+        inspection.setDrawingReference(req.drawingReference());
+        inspection.setScheduledDate(req.scheduledDate());
+        inspection.setScheduledTime(req.scheduledTime());
+        inspection.setActualStartTime(req.actualStartTime());
+        inspection.setActualEndTime(req.actualEndTime());
+        inspection.setDuration(req.duration());
+        inspection.setInspectorId(req.inspectorId());
+        inspection.setContractorId(req.contractorId());
+        inspection.setClientRepresentative(req.clientRepresentative());
+        replaceAll(inspection.getAttendees(), req.attendees());
+        inspection.setWeatherConditions(req.weatherConditions());
+        inspection.setTemperature(req.temperature());
+        inspection.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+
+        applyChildrenAndCounts(inspection, req.checkItems(), req.defects());
+
+        Inspection saved = inspectionRepo.saveAndFlush(inspection);
+        log.info("Created inspection {}", saved.getInspectionNumber());
+        return mapper.toDto(saved);
+    }
+
+    @Transactional
+    public InspectionDto update(UUID id, UpdateInspectionRequest req) {
+        Inspection inspection = inspectionRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Inspection with ID " + id + " was not found"));
+
+        inspection.setTitle(req.title());
+        inspection.setType(req.type());
+        inspection.setStatus(req.status());
+        inspection.setResult(req.result());
+        inspection.setProjectId(req.projectId());
+        inspection.setLocation(req.location());
+        inspection.setAreaInspected(req.areaInspected());
+        inspection.setDrawingReference(req.drawingReference());
+        inspection.setScheduledDate(req.scheduledDate());
+        inspection.setScheduledTime(req.scheduledTime());
+        inspection.setActualStartTime(req.actualStartTime());
+        inspection.setActualEndTime(req.actualEndTime());
+        inspection.setDuration(req.duration());
+        inspection.setInspectorId(req.inspectorId());
+        inspection.setContractorId(req.contractorId());
+        inspection.setClientRepresentative(req.clientRepresentative());
+        replaceAll(inspection.getAttendees(), req.attendees());
+        inspection.setWeatherConditions(req.weatherConditions());
+        inspection.setTemperature(req.temperature());
+
+        inspection.getCheckItems().clear();
+        inspection.getDefects().clear();
+        applyChildrenAndCounts(inspection, req.checkItems(), req.defects());
+
+        Inspection saved = inspectionRepo.saveAndFlush(inspection);
+        log.info("Updated inspection {}", saved.getInspectionNumber());
+        return mapper.toDto(saved);
+    }
+
+    /**
+     * Rebuilds the check items and defects from the request and derives the four
+     * summary counts: total check points is the number of check items, passed and
+     * failed are counted from their statuses, and defects found is the number of
+     * defects.
+     */
+    private void applyChildrenAndCounts(Inspection inspection,
+                                        List<InspectionCheckItemRequest> checkItemReqs,
+                                        List<InspectionDefectRequest> defectReqs) {
+        int passed = 0;
+        int failed = 0;
+
+        if (checkItemReqs != null) {
+            for (InspectionCheckItemRequest cr : checkItemReqs) {
+                InspectionCheckItem item = new InspectionCheckItem();
+                item.setCategory(cr.category());
+                item.setCheckPoint(cr.checkPoint());
+                item.setSpecification(cr.specification());
+                item.setStatus(cr.status());
+                item.setRemarks(cr.remarks());
+                item.setPhotosRequired(cr.photosRequired());
+                replaceAll(item.getPhotos(), cr.photos());
+                item.setMeasurement(cr.measurement());
+                item.setExpectedValue(cr.expectedValue());
+                item.setPriority(cr.priority() != null ? cr.priority() : "medium");
+                inspection.addCheckItem(item);
+
+                if (cr.status() == CheckItemStatus.PASSED) {
+                    passed++;
+                } else if (cr.status() == CheckItemStatus.FAILED) {
+                    failed++;
+                }
+            }
+        }
+
+        int defectCount = 0;
+        if (defectReqs != null) {
+            for (InspectionDefectRequest dr : defectReqs) {
+                InspectionDefect defect = new InspectionDefect();
+                defect.setCategory(dr.category());
+                defect.setDescription(dr.description());
+                defect.setSeverity(dr.severity());
+                defect.setLocation(dr.location());
+                replaceAll(defect.getPhotos(), dr.photos());
+                defect.setCorrectiveAction(dr.correctiveAction());
+                defect.setResponsibleParty(dr.responsibleParty());
+                defect.setTargetDate(dr.targetDate());
+                defect.setStatus(dr.status() != null ? dr.status() : "open");
+                defect.setResolvedDate(dr.resolvedDate());
+                inspection.addDefect(defect);
+                defectCount++;
+            }
+        }
+
+        inspection.setTotalCheckPoints(checkItemReqs != null ? checkItemReqs.size() : 0);
+        inspection.setPassedCheckPoints(passed);
+        inspection.setFailedCheckPoints(failed);
+        inspection.setDefectsFound(defectCount);
+    }
+
+    /**
+     * Replaces the contents of a managed collection in place rather than swapping
+     * the reference, which keeps Hibernate's element-collection tracking intact.
+     */
+    private static void replaceAll(List<String> target, List<String> source) {
+        target.clear();
+        if (source != null) {
+            target.addAll(source);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.inspection.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.inspection.InspectionResult;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/inspections/web")
+@RequiredArgsConstructor
+public class InspectionControllerWeb {
+
+    private final InspectionService service;
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ResponseEntity<InspectionDto> create(@Valid @RequestBody CreateInspectionRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public InspectionDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public Page<InspectionDto> list(@RequestParam(required = false) Long projectId,
+                                    @RequestParam(required = false) InspectionStatus status,
+                                    @RequestParam(required = false) InspectionType type,
+                                    @RequestParam(required = false) InspectionResult result,
+                                    Pageable pageable) {
+        return service.findAll(projectId, status, type, result, pageable);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public InspectionDto update(@PathVariable UUID id,
+                                @Valid @RequestBody UpdateInspectionRequest req) {
+        return service.update(id, req);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -233,4 +233,9 @@
     <!-- v4.0 - Construction payment module -->
     <include file="db/changelog/v4.0/024-create-construction-payments.xml"/>
 
+    <!-- v4.0 - Inspection module -->
+    <include file="db/changelog/v4.0/025-create-inspections.xml"/>
+    <include file="db/changelog/v4.0/026-create-inspection-check-items.xml"/>
+    <include file="db/changelog/v4.0/027-create-inspection-defects.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/025-create-inspections.xml
+++ b/src/main/resources/db/changelog/v4.0/025-create-inspections.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="025-create-inspections" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspections"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspections">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="inspection_number" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="title" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(30)" defaultValue="SCHEDULED">
+                <constraints nullable="false"/>
+            </column>
+            <column name="result" type="VARCHAR(30)"/>
+
+            <column name="project_id" type="BIGINT"/>
+
+            <column name="location" type="VARCHAR(300)"/>
+            <column name="area_inspected" type="VARCHAR(300)"/>
+            <column name="drawing_reference" type="VARCHAR(200)"/>
+
+            <column name="scheduled_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="scheduled_time" type="VARCHAR(20)"/>
+            <column name="actual_start_time" type="TIMESTAMP"/>
+            <column name="actual_end_time" type="TIMESTAMP"/>
+            <column name="duration" type="INT"/>
+
+            <column name="inspector_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="contractor_id" type="BIGINT"/>
+            <column name="client_representative" type="VARCHAR(200)"/>
+
+            <column name="weather_conditions" type="VARCHAR(200)"/>
+            <column name="temperature" type="VARCHAR(50)"/>
+
+            <column name="total_check_points" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="passed_check_points" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="failed_check_points" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="defects_found" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspections"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_inspections_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="inspections"
+                             columnNames="organization_id, inspection_number"
+                             constraintName="uk_inspection_number"/>
+
+        <createIndex tableName="inspections" indexName="idx_insp_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_insp_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_insp_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_insp_result">
+            <column name="result"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_insp_scheduled_date">
+            <column name="scheduled_date"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_insp_inspector">
+            <column name="inspector_id"/>
+        </createIndex>
+        <createIndex tableName="inspections" indexName="idx_inspections_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="025-create-inspection-attendees" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspection_attendees"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspection_attendees">
+            <column name="inspection_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attendee" type="VARCHAR(200)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspection_attendees"
+                                 baseColumnNames="inspection_id"
+                                 constraintName="fk_insp_attendees_inspection"
+                                 referencedTableName="inspections"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="inspection_attendees" indexName="idx_insp_attendees_inspection">
+            <column name="inspection_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/026-create-inspection-check-items.xml
+++ b/src/main/resources/db/changelog/v4.0/026-create-inspection-check-items.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="026-create-inspection-check-items" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspection_check_items"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspection_check_items">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="inspection_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="check_point" type="VARCHAR(500)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="specification" type="VARCHAR(1000)"/>
+            <column name="status" type="VARCHAR(30)" defaultValue="PENDING">
+                <constraints nullable="false"/>
+            </column>
+            <column name="remarks" type="VARCHAR(1000)"/>
+            <column name="photos_required" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="measurement" type="VARCHAR(200)"/>
+            <column name="expected_value" type="VARCHAR(200)"/>
+            <column name="priority" type="VARCHAR(20)" defaultValue="medium"/>
+            <column name="line_order" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspection_check_items"
+                                 baseColumnNames="inspection_id"
+                                 constraintName="fk_insp_check_items_inspection"
+                                 referencedTableName="inspections"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="inspection_check_items" indexName="idx_insp_check_item_inspection">
+            <column name="inspection_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="026-create-inspection-check-item-photos" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspection_check_item_photos"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspection_check_item_photos">
+            <column name="check_item_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="photo" type="VARCHAR(500)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspection_check_item_photos"
+                                 baseColumnNames="check_item_id"
+                                 constraintName="fk_insp_check_item_photos_item"
+                                 referencedTableName="inspection_check_items"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="inspection_check_item_photos"
+                     indexName="idx_insp_check_item_photos_item">
+            <column name="check_item_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/027-create-inspection-defects.xml
+++ b/src/main/resources/db/changelog/v4.0/027-create-inspection-defects.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="027-create-inspection-defects" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspection_defects"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspection_defects">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="inspection_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="VARCHAR(200)"/>
+            <column name="description" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="severity" type="VARCHAR(20)"/>
+            <column name="location" type="VARCHAR(300)"/>
+            <column name="corrective_action" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="responsible_party" type="VARCHAR(200)"/>
+            <column name="target_date" type="DATE"/>
+            <column name="status" type="VARCHAR(20)" defaultValue="open"/>
+            <column name="resolved_date" type="DATE"/>
+            <column name="line_order" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspection_defects"
+                                 baseColumnNames="inspection_id"
+                                 constraintName="fk_insp_defects_inspection"
+                                 referencedTableName="inspections"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="inspection_defects" indexName="idx_insp_defect_inspection">
+            <column name="inspection_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="027-create-inspection-defect-photos" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inspection_defect_photos"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="inspection_defect_photos">
+            <column name="defect_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="photo" type="VARCHAR(500)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="inspection_defect_photos"
+                                 baseColumnNames="defect_id"
+                                 constraintName="fk_insp_defect_photos_defect"
+                                 referencedTableName="inspection_defects"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="inspection_defect_photos" indexName="idx_insp_defect_photos_defect">
+            <column name="defect_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
@@ -1,0 +1,274 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDefectRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end exercise of the inspection CRUD path against a real CockroachDB:
+ * create derives the summary counts from the check items and defects, get and
+ * list return them, update rebuilds the children and recomputes the counts, and
+ * the org filter keeps one tenant's inspections invisible to another.
+ *
+ * <p>No {@code JpaAuditingConfig} import is needed: the created and updated
+ * timestamps are populated by Hibernate's {@code @CreationTimestamp}/{@code
+ * @UpdateTimestamp} at persist time, not by Spring Data auditing.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class InspectionServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private InspectionService service;
+
+    @Autowired
+    private InspectionRepository inspectionRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long projectId;
+
+    // The tenant seed (orgs + project) must be committed, not held in the test's
+    // rolled-back transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW, so
+    // the document_sequence insert commits in a separate transaction that only sees
+    // committed rows. The inspection itself stays in the rolled-back test transaction.
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("Org A");
+            Organization orgB = persistOrganization("Org B");
+
+            Project project = new Project();
+            project.setProjectName("Tower A");
+            project.setOrganization(orgA);
+            entityManager.persist(project);
+
+            entityManager.flush();
+            orgAId = orgA.getId();
+            orgBId = orgB.getId();
+            projectId = project.getId();
+        });
+
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgAId == null && orgBId == null) {
+            return;
+        }
+        // Committed seed rows survive the test rollback, so remove them by hand in
+        // FK-safe order (also clears the committed document_sequence rows).
+        inCommittedTx(() -> {
+            deleteForOrgs("DELETE FROM inspection_defect_photos WHERE defect_id IN "
+                    + "(SELECT d.id FROM inspection_defects d JOIN inspections i ON d.inspection_id = i.id "
+                    + "WHERE i.organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspection_check_item_photos WHERE check_item_id IN "
+                    + "(SELECT c.id FROM inspection_check_items c JOIN inspections i ON c.inspection_id = i.id "
+                    + "WHERE i.organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspection_attendees WHERE inspection_id IN "
+                    + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspection_defects WHERE inspection_id IN "
+                    + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspection_check_items WHERE inspection_id IN "
+                    + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspections WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM document_sequence WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM project WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
+        });
+    }
+
+    private void deleteForOrgs(String sql) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("a", orgAId)
+                .setParameter("b", orgBId)
+                .executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    @Test
+    void create_get_list_update_derivesCountsAndScopesByTenant() {
+        CreateInspectionRequest createReq = new CreateInspectionRequest(
+                "Third floor slab check",
+                InspectionType.QUALITY,
+                projectId,
+                "Block A, Level 3",
+                "Slab and columns",
+                "STR-03-REV2",
+                LocalDate.of(2026, 8, 20),
+                "09:30",
+                null, null, 90,
+                100L,
+                200L,
+                "Client Rep",
+                List.of("Site Engineer", "Safety Officer"),
+                "Clear",
+                "32C",
+                List.of(
+                        new InspectionCheckItemRequest("Structural", "Column alignment",
+                                "Within 5mm", CheckItemStatus.PASSED, null, false, null,
+                                "3mm", "5mm", "high"),
+                        new InspectionCheckItemRequest("Structural", "Rebar spacing",
+                                "150mm c/c", CheckItemStatus.PASSED, null, false, null,
+                                null, null, "medium"),
+                        new InspectionCheckItemRequest("Finishing", "Surface level",
+                                "Level within tolerance", CheckItemStatus.FAILED, "Uneven patch",
+                                true, List.of("photo-1.jpg"), null, null, "low")
+                ),
+                List.of(
+                        new InspectionDefectRequest("Finishing", "Uneven surface near grid B2",
+                                "minor", "Grid B2", List.of("defect-1.jpg"),
+                                "Re-level and re-finish", "Contractor",
+                                LocalDate.of(2026, 8, 25), "open", null)
+                )
+        );
+
+        // create - counts derived from the children, status forced to SCHEDULED
+        InspectionDto created = service.create(createReq);
+        assertThat(created.status()).isEqualTo(InspectionStatus.SCHEDULED);
+        assertThat(created.result()).isNull();
+        assertThat(created.inspectionNumber()).startsWith("INSP-");
+        assertThat(created.checkItems()).hasSize(3);
+        assertThat(created.defects()).hasSize(1);
+        assertThat(created.attendees()).containsExactly("Site Engineer", "Safety Officer");
+        assertThat(created.totalCheckPoints()).isEqualTo(3);
+        assertThat(created.passedCheckPoints()).isEqualTo(2);
+        assertThat(created.failedCheckPoints()).isEqualTo(1);
+        assertThat(created.defectsFound()).isEqualTo(1);
+        assertThat(created.createdAt()).isNotNull();
+
+        UUID id = created.id();
+
+        // get
+        InspectionDto fetched = service.findById(id);
+        assertThat(fetched.id()).isEqualTo(id);
+        assertThat(fetched.checkItems()).hasSize(3);
+        assertThat(fetched.defects()).hasSize(1);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // tenant scoping - invisible to another organization
+        enableOrgFilter(orgBId);
+        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isZero();
+        assertThat(inspectionRepo.findByIdScoped(id)).isEmpty();
+
+        // visible and listable to the owning organization
+        disableOrgFilter();
+        enableOrgFilter(orgAId);
+        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(service.findAll(projectId, InspectionStatus.SCHEDULED,
+                InspectionType.QUALITY, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(inspectionRepo.findByIdScoped(id)).isPresent();
+        disableOrgFilter();
+
+        // update - status and result set directly, children rebuilt, counts recomputed
+        UpdateInspectionRequest updateReq = new UpdateInspectionRequest(
+                "Third floor slab check",
+                InspectionType.QUALITY,
+                InspectionStatus.COMPLETED,
+                InspectionResult.PASSED,
+                projectId,
+                "Block A, Level 3",
+                "Slab and columns",
+                "STR-03-REV2",
+                LocalDate.of(2026, 8, 20),
+                "09:30",
+                null, null, 60,
+                100L,
+                200L,
+                "Client Rep",
+                List.of("Site Engineer"),
+                "Clear",
+                "30C",
+                List.of(
+                        new InspectionCheckItemRequest("Structural", "Column alignment",
+                                "Within 5mm", CheckItemStatus.PASSED, null, false, null,
+                                null, null, "high")
+                ),
+                List.of()
+        );
+
+        InspectionDto updated = service.update(id, updateReq);
+        assertThat(updated.status()).isEqualTo(InspectionStatus.COMPLETED);
+        assertThat(updated.result()).isEqualTo(InspectionResult.PASSED);
+        assertThat(updated.checkItems()).hasSize(1);
+        assertThat(updated.defects()).isEmpty();
+        assertThat(updated.attendees()).containsExactly("Site Engineer");
+        assertThat(updated.totalCheckPoints()).isEqualTo(1);
+        assertThat(updated.passedCheckPoints()).isEqualTo(1);
+        assertThat(updated.failedCheckPoints()).isZero();
+        assertThat(updated.defectsFound()).isZero();
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+}


### PR DESCRIPTION
Recommendation-2 first domain: unblocks the site **inspection** domain (was web-mock-only). A new `inspection` module mirroring the construction module structure, for quality/safety inspections with check items, defects, and attendees.

## Adds
- `Inspection` (+ `InspectionCheckItem`, `InspectionDefect` child tables, and element-collection tables for attendees/photos), enums `InspectionType`/`InspectionStatus`/`InspectionResult`/`CheckItemStatus`, DTOs + MapStruct mapper, repository (+ Specifications), service (create/update/findById/findAll), and `InspectionControllerWeb` at `/api/v1/inspections/web` (tenant-guarded). Migrations `v4.0/025-027`. Number prefix `INSP`.
- Counts (total/passed/failed check points, defects found) are computed server-side from the children on every save.
- Uses the portfolio domains inline Hibernate `@CreationTimestamp` pattern (not the finance BaseEntity); `create`/`update` `saveAndFlush` so the response carries the timestamps and persisted children.

## Note for frontend/Abin
The web enum values are kebab-case (`in-progress`, `passed-with-remarks`) and one is the reserved word `final`, which conflicts with the backend house style (constant-name == wire value). Honored the web contract via `@JsonValue`/`@JsonCreator` + query-param converter beans. If wed rather the backend dictate camelCase values (like `IssueStatus`), the web enums change and these drop.

## Verified
Compiled and `InspectionServiceIT` (create/get/list/update + tenant scoping + derived counts) green on the lab box against real CockroachDB.

Next: core types + web service swap (its list table is already on the shared DataTable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inspection management with creation, viewing, updating, and paginated listing.
  - Added inspection types, lifecycle statuses, results, and filtering options.
  - Added checklist items with statuses, measurements, priorities, remarks, and photos.
  - Added defect tracking with descriptions, classifications, corrective actions, responsibilities, dates, and photos.
  - Added validation for inspection details and nested checklist and defect data.
  - Added tenant-scoped access controls for authorized inspection management roles.
- **Bug Fixes**
  - Added automatic calculation of inspection checklist and defect summary counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->