### PR TITLE
fix: construction invoice update returns lines with ids (false-failure on edit)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -134,8 +134,9 @@ public class ConstructionInvoiceService {
         inv.getLines().clear();
         applyLinesAndTotals(inv, req.lines());
 
-        log.info("Updated construction invoice {}", inv.getInvoiceNumber());
-        return mapper.toDto(inv);
+        ConstructionInvoice saved = invoiceRepo.saveAndFlush(inv);
+        log.info("Updated construction invoice {}", saved.getInvoiceNumber());
+        return mapper.toDto(saved);
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -201,6 +201,9 @@ class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
         ConstructionInvoiceDto updated = service.update(id, updateReq);
         assertThat(updated.status()).isEqualTo(ConstructionInvoiceStatus.SENT);
         assertThat(updated.lines()).hasSize(1);
+        // The replaced line must be flushed so it carries a generated id; otherwise
+        // the client-side parser rejects the null id and the update looks failed.
+        assertThat(updated.lines().getFirst().id()).isNotNull();
         assertThat(updated.subtotal()).isEqualByComparingTo(bd("300"));
         assertThat(updated.taxAmount()).isEqualByComparingTo(bd("54"));
         assertThat(updated.discountAmount()).isEqualByComparingTo(BigDecimal.ZERO);


### PR DESCRIPTION
Smoke-testing the live staging app surfaced this: editing a construction invoice showed a "Failed to update invoice / Failed to process construction invoice data" error, **even though the PUT returned 200 and the change persisted**.

Cause: `ConstructionInvoiceService.update` clears and re-adds the line items, then maps to the DTO **before flushing**, so the replaced lines have null ids. The `@tornotron/echno-core` parser runs `parseUuid` on each line id and throws on null, so the (successful) response is reported as a failure. Create was unaffected because `save()` on the new entity persists the lines and assigns their ids.

Fix: `saveAndFlush` before mapping in `update`, mirroring the create path and the inspection service. Adds a test assertion that the updated line carries a non-null id (the backend DTO tolerates a null id, so only this assertion or the client parser catches it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Construction invoice updates now reliably save and refresh replacement line items.
  * Updated invoices display accurate generated identifiers after saving.

* **Tests**
  * Added integration coverage to verify identifiers are assigned to replacement invoice lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->