### PR TITLE
Align the flat-scope /web controller twins to @orgSecurity

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -26,14 +26,14 @@ public class IssueCommentControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("hasAuthority('issue-comment:create') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueCommentService.addIssueComment(issueCommentCreationDto));
     }
 
     @GetMapping
-    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
                                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
@@ -41,19 +41,19 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<IssueCommentDto> getAnIssueComment(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAnIssueComment(id));
     }
 
     @GetMapping("/issueId/{issueId}")
-    @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<IssueCommentDto>> getAllIssueCommentsByIssueId(@PathVariable Long issueId) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAllIssueCommentsByIssueId(issueId));
     }
 
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('issue-comment:delete') or hasAuthority('issue-comment:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<ApiResponse> deleteAnIssueComment(@PathVariable Long id) {
         issueCommentService.deleteAnIssueComment(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("IssueComment with id: "+id+" deleted successfully with"));

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -39,7 +39,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 201 (Created).
      */
     @PostMapping
-    @PreAuthorize("hasAuthority('category:create') or hasAuthority('category:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<CategorySimpleDto> createCategory(@Valid @RequestBody CategoryCreationDto categoryCreationDto) {
         logger.info("Category Added Successfully");
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -54,7 +54,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
@@ -70,7 +70,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the category DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<?> readACategory(@PathVariable Long id) {
         CategoryDto categoryDto = categoryService.getACategory(id);
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
@@ -83,7 +83,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} with a success message and HTTP status 200 (OK).
      */
     @DeleteMapping("{id}")
-    @PreAuthorize("hasAuthority('category:delete') or hasAuthority('category:admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<ApiResponse> deleteACategory(@PathVariable Long id) {
         categoryService.deleteACategory(id);
         return ResponseEntity.status(HttpStatus.OK)


### PR DESCRIPTION
Closes out the last flat-scope `/web` endpoints. `CategoryControllerWeb` (4) and `IssueCommentControllerWeb` (5) were still guarding endpoints with the pre-tenant `hasAuthority('x:read')` scopes while every other `/web` controller had moved to the tenant-aware `@orgSecurity` checks. After this change, no `*ControllerWeb` has an active flat scope.

## Mapping

I mirrored the operational-data pattern used by the sibling Project / Task / Issue `/web` controllers (member-level reads, admin/PM writes) rather than the reference-data pattern (Vendor / Material, which are `system-admin` throughout), because categories and issue comments are read by ordinary members in normal flows:

| Endpoint | Was | Now |
| --- | --- | --- |
| Category create / delete | `category:create` / `category:delete` (+`:admin`) | `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')` |
| Category read (list, by id) | `category:read` (+`:admin`) | `@orgSecurity.isMemberOfCurrentTenant()` |
| Issue-comment create | `issue-comment:create` (+`:admin`) | `@orgSecurity.isMemberOfCurrentTenant()` (mirrors issue creation) |
| Issue-comment read (list, by id, by issueId) | `issue-comment:read` (+`:admin`) | `@orgSecurity.isMemberOfCurrentTenant()` |
| Issue-comment delete | `issue-comment:delete` (+`:admin`) | `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')` |

Reads are kept open to any tenant member so member-facing flows (category dropdowns, reading issue comments) do not regress; writes are restricted to the same roles the parent domains use.

## Notes

- `EmployeeControllerWeb` was already fully migrated; its only `hasAuthority` lines are commented-out dead code, so it is not touched here.
- The changes are entirely inside `@PreAuthorize` string literals; both SpEL methods (`isMemberOfCurrentTenant`, `hasAnyOrgRoleForCurrentTenant`) and both roles are already used across the codebase.
- The row-level tenant filter from the fail-closed redesign already scopes these endpoints by org, so this is a role-consistency fix, not a data-isolation fix. No tests referenced the old authorities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated issue comment and category access controls to use current-tenant membership.
  - Restricted issue comment and category creation and deletion to tenant system administrators or project managers.
  - Maintained tenant-based access for viewing and retrieving issue comments and categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->