### PR TITLE
Batch-fetch lazy associations to cut the list N+1

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,13 @@ spring:
     show-sql: false
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        # Batch-load lazy associations and collections in IN-clause groups instead of
+        # one query per parent row. Turns the N+1 on list endpoints (each row pulling
+        # its own to-one/to-many) into a handful of batched queries. No effect on the
+        # response shape, and unlike a collection JOIN FETCH it composes with pagination.
+        default_batch_fetch_size: 100
   servlet:
     multipart:
       enabled: true


### PR DESCRIPTION
Sets `hibernate.default_batch_fetch_size=100` in `application.yml`.

The audit flagged a probable N+1 across DTO conversion (~225 lazy associations): a list endpoint that maps each row through a mapper touching a lazy `@ManyToOne` or `@OneToMany` issues one extra query per row. Concrete example: `ConstructionInvoiceService.findAll(...).map(mapper::toDto)` returns invoices whose DTO includes `lines`, but `lines` is lazy and the list query does not fetch it, so a page of N invoices runs N extra line-item queries.

Global batch fetching is the right lever here rather than per-query fetch-joins:
- It applies to the whole lazy-association surface in one place, not one repository method at a time.
- It has zero effect on response shape.
- Unlike a collection `JOIN FETCH`, it composes with pagination (a collection join plus `Pageable` forces Hibernate to paginate in memory).

Hibernate loads the deferred associations for up to 100 parents in a single `IN (...)` query, so a page turns from `1 + N` queries into `1 + few`. The Testcontainers integration tests exercise the full context and the construction-invoice list path, so CI validates the config loads and behaviour is unchanged.