### PR TITLE
Add GRN/Payable/PurchaseOrder mappers, migrate their services (Vendor subtree 1/2)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
@@ -7,13 +7,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.tornotron.echno_backend.DtoConversions.GoodsReceivedNoteDtoConvertor;
+import org.tornotron.echno_backend.goodsReceivedNote.mapper.GoodsReceivedNoteMapper;
 import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
@@ -48,7 +47,7 @@ public class GoodsReceivedNoteService {
     private final VendorRepository vendorRepository;
     private final MaterialRepository materialRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final FileStorageService fileStorageService;
+    private final GoodsReceivedNoteMapper goodsReceivedNoteMapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final EmployeeRepository employeeRepository;
     private final ProjectRepository projectRepository;
@@ -61,7 +60,7 @@ public class GoodsReceivedNoteService {
                                     UserRepository userRepository,
                                     MaterialRepository materialRepository,
                                     ApplicationEventPublisher eventPublisher,
-                                    FileStorageService fileStorageService,
+                                    GoodsReceivedNoteMapper goodsReceivedNoteMapper,
                                     TenantEntityHelper tenantEntityHelper,
                                     EmployeeRepository employeeRepository,
                                     ProjectRepository projectRepository,
@@ -71,7 +70,7 @@ public class GoodsReceivedNoteService {
         this.vendorRepository = vendorRepository;
         this.materialRepository = materialRepository;
         this.eventPublisher = eventPublisher;
-        this.fileStorageService = fileStorageService;
+        this.goodsReceivedNoteMapper = goodsReceivedNoteMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
@@ -151,7 +150,7 @@ public class GoodsReceivedNoteService {
         // Publish GrnCreatedEvent for automatic inventory update
         eventPublisher.publishEvent(new GrnCreatedEvent(this, grn));
 
-        return GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService);
+        return goodsReceivedNoteMapper.toDto(grn);
     }
 
     @Transactional
@@ -190,20 +189,20 @@ public class GoodsReceivedNoteService {
         }
 
         grn = goodsReceivedNoteRepository.save(grn);
-        return GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService);
+        return goodsReceivedNoteMapper.toDto(grn);
     }
 
     @Transactional(readOnly = true)
     public GoodsReceivedNoteDto getGrnById(Long id) {
         GoodsReceivedNote grn = goodsReceivedNoteRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("GRN with ID " + id + " was not found in this organization"));
-        return GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService);
+        return goodsReceivedNoteMapper.toDto(grn);
     }
 
     @Transactional(readOnly = true)
     public List<GoodsReceivedNoteDto> getAllGrns() {
         return goodsReceivedNoteRepository.findAll().stream()
-                .map(grn -> GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService))
+                .map(grn -> goodsReceivedNoteMapper.toDto(grn))
                 .collect(Collectors.toList());
     }
 
@@ -211,20 +210,20 @@ public class GoodsReceivedNoteService {
     public Page<GoodsReceivedNoteDto> getAllGrns(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "receivedOn"));
         return goodsReceivedNoteRepository.findAll(pageable)
-                .map(grn -> GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService));
+                .map(grn -> goodsReceivedNoteMapper.toDto(grn));
     }
 
     @Transactional(readOnly = true)
     public List<GoodsReceivedNoteDto> getGrnsByVendor(Long vendorId) {
         return goodsReceivedNoteRepository.findByVendorId(vendorId).stream()
-                .map(grn -> GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService))
+                .map(grn -> goodsReceivedNoteMapper.toDto(grn))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<GoodsReceivedNoteDto> getGrnsByDateRange(LocalDateTime startDate, LocalDateTime endDate) {
         return goodsReceivedNoteRepository.findByReceivedOnBetween(startDate, endDate).stream()
-                .map(grn -> GoodsReceivedNoteDtoConvertor.convertToDto(grn, fileStorageService))
+                .map(grn -> goodsReceivedNoteMapper.toDto(grn))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/mapper/GoodsReceivedNoteMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/mapper/GoodsReceivedNoteMapper.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.goodsReceivedNote.mapper;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GrnItemDto;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+
+/**
+ * Maps {@link GoodsReceivedNote} to its DTO. receivedBy maps through {@link EmployeeMapper};
+ * vendor/purchase-order/project/storage-location flatten to id + name; item lines via
+ * {@link #toItemDto}. The old converter left items null when there were none, so
+ * {@link #nullifyEmptyItems} restores that.
+ */
+@Mapper(componentModel = "spring", uses = EmployeeMapper.class)
+public interface GoodsReceivedNoteMapper {
+
+    @Mapping(source = "vendor.id", target = "vendorId")
+    @Mapping(source = "vendor.vendorName", target = "vendorName")
+    @Mapping(source = "purchaseOrder.id", target = "purchaseOrderId")
+    @Mapping(source = "purchaseOrder.poNumber", target = "purchaseOrderNumber")
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "project.projectName", target = "projectName")
+    @Mapping(source = "storageLocation.id", target = "storageLocationId")
+    @Mapping(source = "storageLocation.locationName", target = "storageLocationName")
+    GoodsReceivedNoteDto toDto(GoodsReceivedNote grn);
+
+    @Mapping(source = "material.id", target = "materialId")
+    @Mapping(source = "material.materialName", target = "materialName")
+    GrnItemDto toItemDto(GrnItem item);
+
+    @AfterMapping
+    default void nullifyEmptyItems(@MappingTarget GoodsReceivedNoteDto dto) {
+        if (dto.getItems() != null && dto.getItems().isEmpty()) {
+            dto.setItems(null);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
@@ -6,12 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.tornotron.echno_backend.DtoConversions.PayableDtoConvertor;
+import org.tornotron.echno_backend.payable.mapper.PayableMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
@@ -37,7 +36,7 @@ public class PayableService {
     private final VendorRepository vendorRepository;
     private final GoodsReceivedNoteRepository goodsReceivedNoteRepository;
     private final UserRepository userRepository;
-    private final FileStorageService fileStorageService;
+    private final PayableMapper payableMapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final EmployeeRepository employeeRepository;
     private final ProjectRepository projectRepository;
@@ -46,7 +45,7 @@ public class PayableService {
                           VendorRepository vendorRepository,
                           GoodsReceivedNoteRepository goodsReceivedNoteRepository,
                           UserRepository userRepository,
-                          FileStorageService fileStorageService,
+                          PayableMapper payableMapper,
                           TenantEntityHelper tenantEntityHelper,
                           EmployeeRepository employeeRepository,
                           ProjectRepository projectRepository) {
@@ -54,7 +53,7 @@ public class PayableService {
         this.vendorRepository = vendorRepository;
         this.goodsReceivedNoteRepository = goodsReceivedNoteRepository;
         this.userRepository = userRepository;
-        this.fileStorageService = fileStorageService;
+        this.payableMapper = payableMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
@@ -102,7 +101,7 @@ public class PayableService {
         payable.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         payable = payableRepository.save(payable);
-        return PayableDtoConvertor.convertToDto(payable, fileStorageService);
+        return payableMapper.toDto(payable);
     }
 
     @Transactional
@@ -114,20 +113,20 @@ public class PayableService {
         payable.setAmountPaid(currentPaid.add(paymentAmount));
 
         payable = payableRepository.save(payable);
-        return PayableDtoConvertor.convertToDto(payable, fileStorageService);
+        return payableMapper.toDto(payable);
     }
 
     @Transactional(readOnly = true)
     public PayableDto getPayableById(Long id) {
         Payable payable = payableRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Payable with ID " + id + " was not found in this organization"));
-        return PayableDtoConvertor.convertToDto(payable, fileStorageService);
+        return payableMapper.toDto(payable);
     }
 
     @Transactional(readOnly = true)
     public List<PayableDto> getAllPayables() {
         return payableRepository.findAll().stream()
-                .map(payable -> PayableDtoConvertor.convertToDto(payable, fileStorageService))
+                .map(payable -> payableMapper.toDto(payable))
                 .collect(Collectors.toList());
     }
 
@@ -135,20 +134,20 @@ public class PayableService {
     public Page<PayableDto> getAllPayables(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
         return payableRepository.findAll(pageable)
-                .map(payable -> PayableDtoConvertor.convertToDto(payable, fileStorageService));
+                .map(payable -> payableMapper.toDto(payable));
     }
 
     @Transactional(readOnly = true)
     public List<PayableDto> getPayablesByVendor(Long vendorId) {
         return payableRepository.findByVendorIdAndOrganization_id(vendorId,TenantContext.getCurrentOrgId()).stream()
-                .map(payable -> PayableDtoConvertor.convertToDto(payable, fileStorageService))
+                .map(payable -> payableMapper.toDto(payable))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<PayableDto> getOutstandingPayables() {
         return payableRepository.findOutstandingPayables().stream()
-                .map(payable -> PayableDtoConvertor.convertToDto(payable, fileStorageService))
+                .map(payable -> payableMapper.toDto(payable))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/payable/mapper/PayableMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/mapper/PayableMapper.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.payable.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.payable.Payable;
+import org.tornotron.echno_backend.payable.dto.PayableDto;
+
+/** Maps {@link Payable} to its DTO. Vendor/GRN/project flatten to id + name; createdBy via {@link EmployeeMapper}. */
+@Mapper(componentModel = "spring", uses = EmployeeMapper.class)
+public interface PayableMapper {
+
+    @Mapping(source = "vendor.id", target = "vendorId")
+    @Mapping(source = "vendor.vendorName", target = "vendorName")
+    @Mapping(source = "goodsReceivedNote.id", target = "goodsReceivedNoteId")
+    @Mapping(source = "goodsReceivedNote.grnNumber", target = "grnNumber")
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "project.projectName", target = "projectName")
+    PayableDto toDto(Payable payable);
+}

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
@@ -6,12 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.tornotron.echno_backend.DtoConversions.PurchaseOrderDtoConvertor;
+import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.indent.Indent;
@@ -42,7 +41,7 @@ public class PurchaseOrderService {
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final VendorRepository vendorRepository;
     private final IndentRepository indentRepository;
-    private final FileStorageService fileStorageService;
+    private final PurchaseOrderMapper purchaseOrderMapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final EmployeeRepository employeeRepository;
     private final ProjectRepository projectRepository;
@@ -53,7 +52,7 @@ public class PurchaseOrderService {
     public PurchaseOrderService(PurchaseOrderRepository purchaseOrderRepository,
                                 VendorRepository vendorRepository,
                                 IndentRepository indentRepository,
-                                FileStorageService fileStorageService,
+                                PurchaseOrderMapper purchaseOrderMapper,
                                 TenantEntityHelper tenantEntityHelper,
                                 EmployeeRepository employeeRepository,
                                 ProjectRepository projectRepository,
@@ -63,7 +62,7 @@ public class PurchaseOrderService {
         this.purchaseOrderRepository = purchaseOrderRepository;
         this.vendorRepository = vendorRepository;
         this.indentRepository = indentRepository;
-        this.fileStorageService = fileStorageService;
+        this.purchaseOrderMapper = purchaseOrderMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
@@ -120,7 +119,7 @@ public class PurchaseOrderService {
         }
 
         purchaseOrder = purchaseOrderRepository.save(purchaseOrder);
-        return PurchaseOrderDtoConvertor.convertToDto(purchaseOrder, fileStorageService);
+        return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
     @Transactional
@@ -141,13 +140,13 @@ public class PurchaseOrderService {
     public PurchaseOrderDto getPurchaseOrderById(Long id) {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Purchase order with ID " + id + " was not found in this organization"));
-        return PurchaseOrderDtoConvertor.convertToDto(purchaseOrder, fileStorageService);
+        return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto> getAllPurchaseOrders() {
         return purchaseOrderRepository.findAll().stream()
-                .map(po -> PurchaseOrderDtoConvertor.convertToDto(po, fileStorageService))
+                .map(po -> purchaseOrderMapper.toDto(po))
                 .collect(Collectors.toList());
     }
 
@@ -155,27 +154,27 @@ public class PurchaseOrderService {
     public Page<PurchaseOrderDto> getAllPurchaseOrders(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
         return purchaseOrderRepository.findAll(pageable)
-                .map(po -> PurchaseOrderDtoConvertor.convertToDto(po, fileStorageService));
+                .map(po -> purchaseOrderMapper.toDto(po));
     }
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto> getPurchaseOrdersByVendor(Long vendorId) {
         return purchaseOrderRepository.findByVendorId(vendorId).stream()
-                .map(po -> PurchaseOrderDtoConvertor.convertToDto(po, fileStorageService))
+                .map(po -> purchaseOrderMapper.toDto(po))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto> getPurchaseOrdersByIndent(Long indentId) {
         return purchaseOrderRepository.findByIndentId(indentId).stream()
-                .map(po -> PurchaseOrderDtoConvertor.convertToDto(po, fileStorageService))
+                .map(po -> purchaseOrderMapper.toDto(po))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto> getPurchaseOrdersByStatus(PurchaseOrderStatus status) {
         return purchaseOrderRepository.findByStatus(status).stream()
-                .map(po -> PurchaseOrderDtoConvertor.convertToDto(po, fileStorageService))
+                .map(po -> purchaseOrderMapper.toDto(po))
                 .collect(Collectors.toList());
     }
 
@@ -197,7 +196,7 @@ public class PurchaseOrderService {
         }
 
         purchaseOrder = purchaseOrderRepository.save(purchaseOrder);
-        return PurchaseOrderDtoConvertor.convertToDto(purchaseOrder, fileStorageService);
+        return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
     @Transactional

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/mapper/PurchaseOrderMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/mapper/PurchaseOrderMapper.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.purchaseOrder.mapper;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderItemDto;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
+
+/**
+ * Maps {@link PurchaseOrder} to its DTO. createdBy maps through {@link EmployeeMapper};
+ * vendor/indent/project flatten to id + name; item lines via {@link #toItemDto}. The old
+ * converter left items null when there were none, restored by {@link #nullifyEmptyItems}.
+ */
+@Mapper(componentModel = "spring", uses = EmployeeMapper.class)
+public interface PurchaseOrderMapper {
+
+    @Mapping(source = "vendor.id", target = "vendorId")
+    @Mapping(source = "vendor.vendorName", target = "vendorName")
+    @Mapping(source = "indent.id", target = "indentId")
+    @Mapping(source = "indent.indentNumber", target = "indentNumber")
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "project.projectName", target = "projectName")
+    PurchaseOrderDto toDto(PurchaseOrder purchaseOrder);
+
+    @Mapping(source = "material.id", target = "materialId")
+    @Mapping(source = "material.materialName", target = "materialName")
+    @Mapping(source = "indentItem.id", target = "indentItemId")
+    PurchaseOrderItemDto toItemDto(PurchaseOrderItem item);
+
+    @AfterMapping
+    default void nullifyEmptyItems(@MappingTarget PurchaseOrderDto dto) {
+        if (dto.getItems() != null && dto.getItems().isEmpty()) {
+            dto.setItems(null);
+        }
+    }
+}


### PR DESCRIPTION
Vendor-subtree prerequisites. `PayableMapper` (uses EmployeeMapper) flattens vendor/GRN/project; `GoodsReceivedNoteMapper` + `PurchaseOrderMapper` flatten their associations and map item lines, with `@AfterMapping` restoring items-null-when-empty. The three services migrate (dropping now-unused `FileStorageService`). Converters kept because VendorDtoConvertor still nests them (deleted in the Vendor PR). Verified impls: Payable 15, GRN 22 (16+6), PO 24 (15+9).