### PR TITLE
Add Category/Issue mappers, migrate their services (Portfolio 1/2)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.tornotron.echno_backend.DtoConversions.CategoryDtoConvertor;
+import org.tornotron.echno_backend.category.mapper.CategoryMapper;
 import org.tornotron.echno_backend.category.dto.CategoryCreationDto;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.category.dto.CategorySimpleDto;
@@ -25,6 +25,7 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final TenantEntityHelper tenantEntityHelper;
+    private final CategoryMapper categoryMapper;
 
     /**
      * Constructs a CategoryService with the given CategoryRepository.
@@ -32,9 +33,10 @@ public class CategoryService {
      * @param categoryRepository The repository for category data access.
      * @param tenantEntityHelper The helper for resolving the current organization.
      */
-    public CategoryService(CategoryRepository categoryRepository, TenantEntityHelper tenantEntityHelper) {
+    public CategoryService(CategoryRepository categoryRepository, TenantEntityHelper tenantEntityHelper, CategoryMapper categoryMapper) {
         this.categoryRepository = categoryRepository;
         this.tenantEntityHelper = tenantEntityHelper;
+        this.categoryMapper = categoryMapper;
     }
 
     /**
@@ -56,7 +58,7 @@ public class CategoryService {
         category.setDescription(categoryCreationDto.getDescription());
         category.setIcon(categoryCreationDto.getIcon());
         category.setImage(categoryCreationDto.getImage());
-        return CategoryDtoConvertor.convertCategoryToSimpleDto(categoryRepository.save(category));
+        return categoryMapper.toSimpleDto(categoryRepository.save(category));
     }
 
     /**
@@ -70,7 +72,7 @@ public class CategoryService {
     public Page<CategoryDto> getAllCategories(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "id"));
         return categoryRepository.findAll(pageable)
-                .map(CategoryDtoConvertor::convertCategoryToDto);
+                .map(categoryMapper::toDto);
     }
 
     /**
@@ -83,7 +85,7 @@ public class CategoryService {
     @Transactional(readOnly = true)
     public CategoryDto getACategory(Long id) {
         CategoryDto categoryDto = categoryRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
-                .map(CategoryDtoConvertor::convertCategoryToDto)
+                .map(categoryMapper::toDto)
                 .orElse(null);
 
         if(categoryDto == null) {

--- a/src/main/java/org/tornotron/echno_backend/category/mapper/CategoryMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/category/mapper/CategoryMapper.java
@@ -1,0 +1,13 @@
+package org.tornotron.echno_backend.category.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.category.Category;
+import org.tornotron.echno_backend.category.dto.CategoryDto;
+import org.tornotron.echno_backend.category.dto.CategorySimpleDto;
+
+/** Maps {@link Category} to its full and simple DTOs. All fields by name. */
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+    CategorySimpleDto toSimpleDto(Category category);
+}

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -7,12 +7,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.tornotron.echno_backend.DtoConversions.IssueDtoConvertor;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
@@ -36,14 +35,14 @@ public class IssueService {
     private final IssueRepository issueRepository;
     private final TaskRepository taskRepository;
     private final AttachmentService attachmentService;
-    private final FileStorageService fileStorageService;
+    private final IssueMapper issueMapper;
     private final EmployeeRepository employeeRepository;
 
-    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, FileStorageService fileStorageService, EmployeeRepository employeeRepository) {
+    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository) {
         this.issueRepository = issueRepository;
         this.taskRepository = taskRepository;
         this.attachmentService = attachmentService;
-        this.fileStorageService = fileStorageService;
+        this.issueMapper = issueMapper;
         this.employeeRepository = employeeRepository;
     }
 
@@ -78,34 +77,34 @@ public class IssueService {
             savedIssue = issueRepository.save(savedIssue);
         }
 
-        return IssueDtoConvertor.convertIssueToSimpleDto(savedIssue);
+        return issueMapper.toSimpleDto(savedIssue);
     }
 
     @Transactional(readOnly = true)
     public List<IssueDto> getAllIssues() {
         return issueRepository.findAll().stream()
-                .map(issue -> IssueDtoConvertor.convertIssueToDto(issue,fileStorageService))
+                .map(issue -> issueMapper.toDto(issue))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<IssueDto> getAllIssuesByTaskId(Long taskId) {
         return issueRepository.findAllByTask_IdAndOrganization_Id(taskId,TenantContext.getCurrentOrgId()).stream()
-                .map(issue -> IssueDtoConvertor.convertIssueToDto(issue,fileStorageService))
+                .map(issue -> issueMapper.toDto(issue))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<IssueDto> getAllIssuesByProjectId(Long projectId) {
         return issueRepository.findAllByTask_Project_IdAndOrganization_Id(projectId,TenantContext.getCurrentOrgId()).stream()
-                .map(issue -> IssueDtoConvertor.convertIssueToDto(issue,fileStorageService))
+                .map(issue -> issueMapper.toDto(issue))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public IssueDto getAnIssue(Long id) {
         IssueDto issueDto = issueRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
-                .map(issue -> IssueDtoConvertor.convertIssueToDto(issue, fileStorageService))
+                .map(issue -> issueMapper.toDto(issue))
                 .orElse(null);
         if (issueDto == null) {
             throw new ResourceNotFoundException("Issue with ID " + id + " was not found in this organization");
@@ -125,7 +124,7 @@ public class IssueService {
                 issue.addAttachment(attachment);
             }
         }
-        return IssueDtoConvertor.convertIssueToSimpleDto(issueRepository.save(issue));
+        return issueMapper.toSimpleDto(issueRepository.save(issue));
     }
 
     private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue) {

--- a/src/main/java/org/tornotron/echno_backend/issue/mapper/IssueMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/mapper/IssueMapper.java
@@ -1,0 +1,35 @@
+package org.tornotron.echno_backend.issue.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.IssueComment.IssueComment;
+import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.issue.Issue;
+import org.tornotron.echno_backend.issue.dto.IssueDto;
+import org.tornotron.echno_backend.issue.dto.IssueSimpleDto;
+
+/**
+ * Maps {@link Issue} to its DTOs. The creator/assignee employees and the task are
+ * flattened to id + name (the DTO carries names, not full employee objects); comments
+ * map through {@link #toCommentDto}; attachments through {@link AttachmentMapper}.
+ */
+@Mapper(componentModel = "spring", uses = AttachmentMapper.class)
+public interface IssueMapper {
+
+    @Mapping(source = "task.id", target = "taskId")
+    @Mapping(source = "task.title", target = "taskName")
+    @Mapping(source = "createdBy.id", target = "createdById")
+    @Mapping(source = "createdBy.employeeName", target = "createdByName")
+    @Mapping(source = "assignedTo.id", target = "assignedToId")
+    @Mapping(source = "assignedTo.employeeName", target = "assignedToName")
+    IssueDto toDto(Issue issue);
+
+    @Mapping(source = "createdBy.id", target = "createdById")
+    @Mapping(source = "createdBy.employeeName", target = "createdByName")
+    @Mapping(source = "assignedTo.id", target = "assignedToId")
+    @Mapping(source = "assignedTo.employeeName", target = "assignedToName")
+    IssueSimpleDto toSimpleDto(Issue issue);
+
+    IssueCommentDto toCommentDto(IssueComment comment);
+}


### PR DESCRIPTION
Portfolio-subtree leaves. `CategoryMapper` (toDto + toSimpleDto) and `IssueMapper` (toDto, toSimpleDto, toCommentDto; uses AttachmentMapper) replace the converters in CategoryService and IssueService. Issue flattens the creator/assignee employees and the task to id + name (the DTO carries names, not full objects). Converters kept because TaskDtoConvertor still nests both (deleted in the Task/Project/Organization PR). Verified: Category 10 setters (5+5), Issue 30 (15+11+4).