### PR TITLE
Add paginated web endpoints for issues and employees

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.employee;
 
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -66,7 +67,15 @@ public class EmployeeControllerWeb {
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
-        return new ResponseEntity<>(employeeService.displayAllEmployees(),HttpStatus.OK);
+        return new ResponseEntity<>(employeeService.displayAllEmployees(), HttpStatus.OK);
+    }
+
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<Page<EmployeeDto>> readAllEmployeesPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        return new ResponseEntity<>(employeeService.displayAllEmployees(pageNo, pageSize), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -1,6 +1,10 @@
 package org.tornotron.echno_backend.employee;
 
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -192,6 +196,20 @@ public class EmployeeService {
         return employeeRepository.findAll().stream()
                 .map(employee -> employeeMapper.toDto(employee))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves a page of employees, ordered alphabetically by name.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Number of employees per page.
+     * @return A page of employee DTOs.
+     */
+    @Transactional(readOnly = true)
+    public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "employeeName"));
+        return employeeRepository.findAll(pageable)
+                .map(employee -> employeeMapper.toDto(employee));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -39,6 +39,15 @@ public class IssueControllerWeb {
         return new ResponseEntity<>(issues, HttpStatus.OK);
     }
 
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<Page<IssueDto>> readAllIssuesPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize);
+        return new ResponseEntity<>(issues, HttpStatus.OK);
+    }
+
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<List<IssueDto>> readAllIssuesOfProject(@PathVariable Long projectId){

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -88,6 +88,13 @@ public class IssueService {
     }
 
     @Transactional(readOnly = true)
+    public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return issueRepository.findAll(pageable)
+                .map(issue -> issueMapper.toDto(issue));
+    }
+
+    @Transactional(readOnly = true)
     public List<IssueDto> getAllIssuesByTaskId(Long taskId) {
         return issueRepository.findAllByTask_IdAndOrganization_Id(taskId,TenantContext.getCurrentOrgId()).stream()
                 .map(issue -> issueMapper.toDto(issue))


### PR DESCRIPTION
## What

The issue and employee web list endpoints (`GET /issues/web`, `GET /employees/web`) return unbounded `List<Dto>` responses. But these same endpoints back the app's **global lookups** — employee dropdowns, the issue-count badge in the app layout, client-side creator/assignee name resolution — which need the full set. So rather than converting them in place, this adds sibling paginated endpoints for the table views:

- `GET /api/v1/issues/web/paginated` → `Page<IssueDto>`, sorted `createdAt` desc.
- `GET /api/v1/employees/web/paginated` → `Page<EmployeeDto>`, sorted by `employeeName` asc.

Both take `pageNo` (default 0) and `pageSize` (default 10), matching the convention already used by the material-consumption, indent and GRN web controllers.

## Why additive, not in-place

Converting the existing endpoints to `Page` would break every consumer that relies on the full list: employee `<Select>` dropdowns across finance/attendance/inspections, the dashboard and app-layout issue counts, and issue name resolution. The unbounded endpoints are left untouched; only the issue and employee **tables** move to the paginated variant (in the companion `echno-core`/`echno-web` PRs).

## Notes

- The tenant `orgFilter` applies to `findAll(pageable)`, so org isolation is unchanged.
- Mobile `EmployeeController` is untouched.

## Test

`./gradlew compileJava` clean on lab node.