### PR TITLE
Server-side search and filters for paginated issue and employee endpoints

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -74,8 +74,11 @@ public class EmployeeControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<Page<EmployeeDto>> readAllEmployeesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        return new ResponseEntity<>(employeeService.displayAllEmployees(pageNo, pageSize), HttpStatus.OK);
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String department) {
+        return new ResponseEntity<>(employeeService.displayAllEmployees(pageNo, pageSize, search, status, department), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -1,9 +1,12 @@
 package org.tornotron.echno_backend.employee;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.user.User;
 
@@ -81,4 +84,26 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     boolean existsByIdAndOrgRolesIn(@Param("employeeId") Long employeeId, @Param("roles") Set<OrgRole> roles);
 
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Paginated employee search. Every filter is optional (a null argument
+     * disables that clause); the tenant orgFilter still applies. {@code search}
+     * matches name, email, phone, or the human-facing employee id,
+     * case-insensitively.
+     */
+    @Query("""
+            SELECT e FROM Employee e WHERE
+              (:search IS NULL
+                 OR LOWER(e.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(e.emailAddress) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(e.phoneNumber) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(e.employeeId) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+              (:status IS NULL OR e.status = :status) AND
+              (:department IS NULL OR e.department = :department)
+            """)
+    Page<Employee> search(
+            @Param("search") String search,
+            @Param("status") EmployeeStatus status,
+            @Param("department") String department,
+            Pageable pageable);
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -206,9 +206,12 @@ public class EmployeeService {
      * @return A page of employee DTOs.
      */
     @Transactional(readOnly = true)
-    public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize) {
+    public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize, String search, String status, String department) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "employeeName"));
-        return employeeRepository.findAll(pageable)
+        String searchTerm = (search == null || search.isBlank()) ? null : search;
+        String departmentTerm = (department == null || department.isBlank()) ? null : department;
+        EmployeeStatus statusTerm = (status == null || status.isBlank()) ? null : EmployeeStatus.valueOf(status);
+        return employeeRepository.search(searchTerm, statusTerm, departmentTerm, pageable)
                 .map(employee -> employeeMapper.toDto(employee));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
 import org.tornotron.echno_backend.issue.dto.IssueDto;
 import org.tornotron.echno_backend.issue.dto.IssueSimpleDto;
+import org.tornotron.echno_backend.issue.dto.IssueStatsDto;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
@@ -43,9 +44,22 @@ public class IssueControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     public ResponseEntity<Page<IssueDto>> readAllIssuesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize);
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String type) {
+        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize, projectId, search, status, type);
         return new ResponseEntity<>(issues, HttpStatus.OK);
+    }
+
+    @GetMapping("/stats")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<IssueStatsDto> readIssueStats(
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String type) {
+        return new ResponseEntity<>(issueService.getIssueStats(projectId, search, type), HttpStatus.OK);
     }
 
     @GetMapping("/project/{projectId}")

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
@@ -1,6 +1,12 @@
 package org.tornotron.echno_backend.issue;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,5 +22,47 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
     List<Issue> findAllByTask_IdAndOrganization_Id(Long taskId, Long organizationId);
 
     List<Issue> findAllByTask_Project_IdAndOrganization_Id(Long projectId, Long organizationId);
+
+    /**
+     * Paginated issue search. Every filter is optional (a null argument disables
+     * that clause); the tenant orgFilter still applies. {@code search} matches
+     * title, description, or the creator's name, case-insensitively.
+     */
+    @Query("""
+            SELECT i FROM Issue i WHERE
+              (:projectId IS NULL OR i.task.project.id = :projectId) AND
+              (:search IS NULL
+                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+              (:status IS NULL OR i.status = :status) AND
+              (:type IS NULL OR i.type = :type)
+            """)
+    Page<Issue> search(
+            @Param("projectId") Long projectId,
+            @Param("search") String search,
+            @Param("status") IssueStatus status,
+            @Param("type") IssueType type,
+            Pageable pageable);
+
+    /**
+     * Counts issues per status under the same optional filters as {@link #search}
+     * (status itself excluded, so the breakdown always spans every status). Each
+     * row is {@code [IssueStatus, Long]}.
+     */
+    @Query("""
+            SELECT i.status, COUNT(i) FROM Issue i WHERE
+              (:projectId IS NULL OR i.task.project.id = :projectId) AND
+              (:search IS NULL
+                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
+                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+              (:type IS NULL OR i.type = :type)
+            GROUP BY i.status
+            """)
+    List<Object[]> countByStatus(
+            @Param("projectId") Long projectId,
+            @Param("search") String search,
+            @Param("type") IssueType type);
 
 }

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -17,11 +17,13 @@ import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
 import org.tornotron.echno_backend.issue.dto.IssueDto;
 import org.tornotron.echno_backend.issue.dto.IssueSimpleDto;
+import org.tornotron.echno_backend.issue.dto.IssueStatsDto;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 import org.tornotron.echno_backend.task.Task;
 import org.tornotron.echno_backend.task.TaskRepository;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -88,10 +90,35 @@ public class IssueService {
     }
 
     @Transactional(readOnly = true)
-    public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize) {
+    public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return issueRepository.findAll(pageable)
+        return issueRepository.search(projectId, blankToNull(search), parseStatus(status), parseType(type), pageable)
                 .map(issue -> issueMapper.toDto(issue));
+    }
+
+    @Transactional(readOnly = true)
+    public IssueStatsDto getIssueStats(Long projectId, String search, String type) {
+        Map<String, Long> byStatus = new LinkedHashMap<>();
+        long total = 0;
+        for (Object[] row : issueRepository.countByStatus(projectId, blankToNull(search), parseType(type))) {
+            IssueStatus status = (IssueStatus) row[0];
+            long count = (Long) row[1];
+            byStatus.put(status.name(), count);
+            total += count;
+        }
+        return new IssueStatsDto(total, byStatus);
+    }
+
+    private static String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
+    }
+
+    private static IssueStatus parseStatus(String status) {
+        return (status == null || status.isBlank()) ? null : IssueStatus.valueOf(status);
+    }
+
+    private static IssueType parseType(String type) {
+        return (type == null || type.isBlank()) ? null : IssueType.valueOf(type);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueStatsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueStatsDto.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.issue.dto;
+
+import java.util.Map;
+
+/**
+ * Aggregate issue counts for the issues dashboard, computed server-side over
+ * the active filters (project / search / type) so the stats stay accurate when
+ * the table is server-paginated.
+ *
+ * @param total    total matching issues across every status
+ * @param byStatus count per status, keyed by the {@code IssueStatus} name
+ *                 (e.g. {@code "open"}, {@code "inProgress"}); statuses with no
+ *                 matches are omitted, so consumers should default absent keys
+ *                 to zero
+ */
+public record IssueStatsDto(long total, Map<String, Long> byStatus) {
+}


### PR DESCRIPTION
## What

Builds on #363. The paginated web endpoints could only page a whole-org list, but the issue and employee tables search + filter client-side, which does not compose with server pagination. This pushes search and filters into the query:

- `GET /api/v1/issues/web/paginated` — now takes `projectId`, `search`, `status`, `type` (all optional).
- `GET /api/v1/issues/web/stats` — **new**: `{ total, byStatus }` per-status counts under the same `projectId`/`search`/`type` filters (status itself excluded), so the issues dashboard cards stay accurate when only one page is loaded.
- `GET /api/v1/employee/web/paginated` — now takes `search`, `status`, `department` (all optional).

Issue `search` matches title, description, or creator name; employee `search` matches name, email, phone, or employee id — matching what the tables filtered on client-side.

## Notes

- Every filter is optional and null-safe (`:param IS NULL OR …`); blanks normalize to null in the service.
- The tenant `orgFilter` scopes each JPQL query, same as the existing filter-reliant repository methods.
- The unbounded list endpoints and the previous no-filter paginated behavior are unchanged (defaults omit every filter).

## Test

`./gradlew compileJava` clean on lab node.