### PR TITLE
Extract KeycloakUserProvisioningService from UserService

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/user/KeycloakUserProvisioningService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/KeycloakUserProvisioningService.java
@@ -1,0 +1,113 @@
+package org.tornotron.echno_backend.user;
+
+import jakarta.ws.rs.core.Response;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provisions the Keycloak identity backing an application user: create (with an
+ * initial password and the default {@code user} realm role), delete, and an
+ * existence check.
+ *
+ * These are the low-level Keycloak primitives extracted from {@link UserService}.
+ * The registration saga (create Keycloak user, persist the local row, and on a
+ * database failure roll the Keycloak user back) stays in {@link UserService};
+ * this service only exposes the individual operations.
+ */
+@Service
+public class KeycloakUserProvisioningService {
+
+    private static final Logger logger = LoggerFactory.getLogger(KeycloakUserProvisioningService.class);
+
+    private final Keycloak keycloak;
+
+    @Value("${keycloak-initializer.application-realm}")
+    private String realm;
+
+    public KeycloakUserProvisioningService(Keycloak keycloak) {
+        this.keycloak = keycloak;
+    }
+
+    /**
+     * Creates a Keycloak user with the given credentials, sets a permanent
+     * password, and best-effort assigns the default {@code user} realm role.
+     *
+     * @return the new Keycloak user id.
+     * @throws DuplicateResourceException if a user with the email already exists.
+     */
+    public String createUser(String username, String email, String password) {
+        if (userExists(email)) {
+            throw new DuplicateResourceException("User with email '" + email + "' already exists in Keycloak");
+        }
+
+        UsersResource usersResource = keycloak.realm(realm).users();
+
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setUsername(username);
+        userRepresentation.setEmail(email);
+        userRepresentation.setEnabled(true);
+        userRepresentation.setEmailVerified(true);
+
+        String keycloakId;
+        try (Response response = usersResource.create(userRepresentation)) {
+            if (response.getStatus() != 201) {
+                throw new RuntimeException("Failed to create user '" + username + "' in Keycloak (status " + response.getStatus() + ")");
+            }
+            String location = response.getLocation().toString();
+            keycloakId = location.substring(location.lastIndexOf('/') + 1);
+        }
+
+        CredentialRepresentation credentialRepresentation = new CredentialRepresentation();
+        credentialRepresentation.setType(CredentialRepresentation.PASSWORD);
+        credentialRepresentation.setValue(password);
+        credentialRepresentation.setTemporary(false);
+
+        usersResource.get(keycloakId).resetPassword(credentialRepresentation);
+
+        try {
+            var userRole = keycloak.realm(realm).roles().get("user").toRepresentation();
+            usersResource.get(keycloakId).roles().realmLevel().add(Collections.singletonList(userRole));
+        } catch (Exception e) {
+            logger.warn("Failed to assign 'user' realm role to new user {}: {}", keycloakId, e.getMessage());
+        }
+
+        return keycloakId;
+    }
+
+    /**
+     * Removes a Keycloak user. Used as the compensating action when the local
+     * database write fails after the Keycloak user was created. Never throws;
+     * failures are logged for manual follow-up.
+     */
+    public void deleteUser(String keycloakId) {
+        try {
+            if (keycloakId != null) {
+                keycloak.realm(realm).users().get(keycloakId).remove();
+                logger.info("Rolled back Keycloak user creation for ID: {}", keycloakId);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to rollback Keycloak user creation for ID: {}. Manual intervention required.", keycloakId, e);
+        }
+    }
+
+    private boolean userExists(String email) {
+        try {
+            UsersResource usersResource = keycloak.realm(realm).users();
+            List<UserRepresentation> users = usersResource.search(email, true);
+            return !users.isEmpty();
+        } catch (Exception ex) {
+            throw new DatabaseOperationException("Failed to check whether user with email '" + email + "' exists in Keycloak: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/user/UserService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserService.java
@@ -1,13 +1,7 @@
 package org.tornotron.echno_backend.user;
 
-import jakarta.ws.rs.core.Response;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.representations.idm.CredentialRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +16,6 @@ import org.tornotron.echno_backend.user.mapper.UserMapper;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.service.AttachmentService;
-import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.service.FileStorageService;
@@ -33,7 +26,6 @@ import org.tornotron.echno_backend.user.dto.UserRegistrationDto;
 import org.tornotron.echno_backend.user.enums.UserRole;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,26 +44,23 @@ public class UserService {
     private static final String ATTACHMENT_TYPE_CV = "USER_CV";
 
     private final UserRepository userRepository;
-    private final Keycloak keycloak;
+    private final KeycloakUserProvisioningService keycloakUserProvisioningService;
     private final AttachmentService attachmentService;
     private final FileStorageService fileStorageService;
     private final EmployeeMapper employeeMapper;
     private final UserMapper userMapper;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
 
-    @Value("${keycloak-initializer.application-realm}")
-    private String realm;
-
     /**
      * Constructs a UserService with the given UserRepository.
      *
      * @param userRepository The repository for user data access.
-     * @param keycloak       The Keycloak client.
+     * @param keycloakUserProvisioningService The service that provisions the Keycloak identity.
      * @param attachmentService The service for attachment operations.
      */
-    public UserService(UserRepository userRepository, Keycloak keycloak, AttachmentService attachmentService,FileStorageService fileStorageService, EmployeeMapper employeeMapper, UserMapper userMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper) {
+    public UserService(UserRepository userRepository, KeycloakUserProvisioningService keycloakUserProvisioningService, AttachmentService attachmentService,FileStorageService fileStorageService, EmployeeMapper employeeMapper, UserMapper userMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper) {
         this.userRepository = userRepository;
-        this.keycloak = keycloak;
+        this.keycloakUserProvisioningService = keycloakUserProvisioningService;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
         this.employeeMapper = employeeMapper;
@@ -91,7 +80,7 @@ public class UserService {
             throw new DuplicateResourceException("User with email '" + userRegistrationDto.getEmail() + "' already exists");
         }
 
-        String keycloakId = createKeycloakUser(userRegistrationDto.getUserName(), userRegistrationDto.getEmail(), userRegistrationDto.getPassword());
+        String keycloakId = keycloakUserProvisioningService.createUser(userRegistrationDto.getUserName(), userRegistrationDto.getEmail(), userRegistrationDto.getPassword());
 
         try {
             User user = new User();
@@ -108,58 +97,8 @@ public class UserService {
             user.setKeycloakId(keycloakId);
             return userMapper.toDto(userRepository.save(user));
         } catch (Exception e) {
-            deleteKeycloakUser(keycloakId);
+            keycloakUserProvisioningService.deleteUser(keycloakId);
             throw e;
-        }
-    }
-
-    private String createKeycloakUser(String username, String email, String password) {
-        if (keycloakUserExists(email)) {
-            throw new DuplicateResourceException("User with email '" + email + "' already exists in Keycloak");
-        }
-
-        UsersResource usersResource = keycloak.realm(realm).users();
-
-        UserRepresentation userRepresentation = new UserRepresentation();
-        userRepresentation.setUsername(username);
-        userRepresentation.setEmail(email);
-        userRepresentation.setEnabled(true);
-        userRepresentation.setEmailVerified(true);
-
-        String keycloakId;
-        try (Response response = usersResource.create(userRepresentation)) {
-            if (response.getStatus() != 201) {
-                throw new RuntimeException("Failed to create user '" + username + "' in Keycloak (status " + response.getStatus() + ")");
-            }
-            String location = response.getLocation().toString();
-            keycloakId = location.substring(location.lastIndexOf('/') + 1);
-        }
-
-        CredentialRepresentation credentialRepresentation = new CredentialRepresentation();
-        credentialRepresentation.setType(CredentialRepresentation.PASSWORD);
-        credentialRepresentation.setValue(password);
-        credentialRepresentation.setTemporary(false);
-
-        usersResource.get(keycloakId).resetPassword(credentialRepresentation);
-
-        try {
-            var userRole = keycloak.realm(realm).roles().get("user").toRepresentation();
-            usersResource.get(keycloakId).roles().realmLevel().add(Collections.singletonList(userRole));
-        } catch (Exception e) {
-            logger.warn("Failed to assign 'user' realm role to new user {}: {}", keycloakId, e.getMessage());
-        }
-
-        return keycloakId;
-    }
-
-    private void deleteKeycloakUser(String keycloakId) {
-        try {
-            if (keycloakId != null) {
-                keycloak.realm(realm).users().get(keycloakId).remove();
-                logger.info("Rolled back Keycloak user creation for ID: {}", keycloakId);
-            }
-        } catch (Exception e) {
-            logger.error("Failed to rollback Keycloak user creation for ID: {}. Manual intervention required.", keycloakId, e);
         }
     }
 
@@ -443,16 +382,6 @@ public class UserService {
             throw new ResourceNotFoundException("User with ID " + id + " was not found");
         } else {
             userRepository.deleteById(id);
-        }
-    }
-
-    private boolean keycloakUserExists(String email) {
-        try {
-            UsersResource usersResource = keycloak.realm(realm).users();
-            List<UserRepresentation> users = usersResource.search(email, true);
-            return !users.isEmpty();
-        } catch (Exception ex) {
-            throw new DatabaseOperationException("Failed to check whether user with email '" + email + "' exists in Keycloak: " + ex.getMessage());
         }
     }
 


### PR DESCRIPTION
## What

First of the God-service extractions. `UserService` mixed local `User` CRUD with the raw Keycloak Admin-client calls. Move the three Keycloak identity primitives into a focused `KeycloakUserProvisioningService`:

- `createUser` (create + set permanent password + best-effort default `user` role)
- `deleteUser` (compensating rollback)
- a private existence check

`UserService` now injects it and no longer holds the `Keycloak` client or the realm value.

## No behaviour change

The registration saga stays in `UserService.registerUser` exactly as before: create the Keycloak user, persist the local row, and on a DB failure call `keycloakUserProvisioningService.deleteUser(...)` to roll back. No public method signatures change; no REST contract change.

## Test

`./gradlew compileJava` clean on lab node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized provisioning for user accounts, including duplicate-email checks, verified accounts, permanent passwords, and default role assignment.
  * Added rollback support to remove provisioned accounts when needed.

* **Improvements**
  * Streamlined user creation by consolidating account provisioning and rollback workflows.
  * Improved handling of account existence-check failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->