### PR TITLE
Fix CockroachDB error in paginated issue/employee search (no-search path)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -89,15 +89,18 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
      * Paginated employee search. Every filter is optional (a null argument
      * disables that clause); the tenant orgFilter still applies. {@code search}
      * matches name, email, phone, or the human-facing employee id,
-     * case-insensitively.
+     * case-insensitively. The caller passes {@code search} already lower-cased
+     * and wrapped in {@code %} wildcards (or null) — building the pattern in
+     * Java rather than with SQL {@code CONCAT} avoids a CockroachDB type error
+     * where a null bind inside {@code ||} is inferred as bytes.
      */
     @Query("""
             SELECT e FROM Employee e WHERE
               (:search IS NULL
-                 OR LOWER(e.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.emailAddress) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.phoneNumber) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.employeeId) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(e.employeeName) LIKE :search
+                 OR LOWER(e.emailAddress) LIKE :search
+                 OR LOWER(e.phoneNumber) LIKE :search
+                 OR LOWER(e.employeeId) LIKE :search) AND
               (:status IS NULL OR e.status = :status) AND
               (:department IS NULL OR e.department = :department)
             """)

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -211,7 +211,7 @@ public class EmployeeService {
     @Transactional(readOnly = true)
     public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize, String search, String status, String department) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "employeeName"));
-        String searchTerm = (search == null || search.isBlank()) ? null : search;
+        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
         String departmentTerm = (department == null || department.isBlank()) ? null : department;
         EmployeeStatus statusTerm = (status == null || status.isBlank()) ? null : EmployeeStatus.valueOf(status);
         return employeeRepository.search(searchTerm, statusTerm, departmentTerm, pageable)

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
@@ -32,9 +32,9 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             SELECT i FROM Issue i WHERE
               (:projectId IS NULL OR i.task.project.id = :projectId) AND
               (:search IS NULL
-                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(i.title) LIKE :search
+                 OR LOWER(i.description) LIKE :search
+                 OR LOWER(i.createdBy.employeeName) LIKE :search) AND
               (:status IS NULL OR i.status = :status) AND
               (:type IS NULL OR i.type = :type)
             """)
@@ -54,9 +54,9 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             SELECT i.status, COUNT(i) FROM Issue i WHERE
               (:projectId IS NULL OR i.task.project.id = :projectId) AND
               (:search IS NULL
-                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(i.title) LIKE :search
+                 OR LOWER(i.description) LIKE :search
+                 OR LOWER(i.createdBy.employeeName) LIKE :search) AND
               (:type IS NULL OR i.type = :type)
             GROUP BY i.status
             """)

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -92,7 +92,7 @@ public class IssueService {
     @Transactional(readOnly = true)
     public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return issueRepository.search(projectId, blankToNull(search), parseStatus(status), parseType(type), pageable)
+        return issueRepository.search(projectId, searchPattern(search), parseStatus(status), parseType(type), pageable)
                 .map(issue -> issueMapper.toDto(issue));
     }
 
@@ -100,7 +100,7 @@ public class IssueService {
     public IssueStatsDto getIssueStats(Long projectId, String search, String type) {
         Map<String, Long> byStatus = new LinkedHashMap<>();
         long total = 0;
-        for (Object[] row : issueRepository.countByStatus(projectId, blankToNull(search), parseType(type))) {
+        for (Object[] row : issueRepository.countByStatus(projectId, searchPattern(search), parseType(type))) {
             IssueStatus status = (IssueStatus) row[0];
             long count = (Long) row[1];
             byStatus.put(status.name(), count);
@@ -109,8 +109,13 @@ public class IssueService {
         return new IssueStatsDto(total, byStatus);
     }
 
-    private static String blankToNull(String value) {
-        return (value == null || value.isBlank()) ? null : value;
+    /**
+     * Builds a lower-cased {@code %...%} LIKE pattern for the search term, or null
+     * when blank. The pattern is assembled here rather than with SQL {@code CONCAT}
+     * so no null bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
+     */
+    private static String searchPattern(String value) {
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
     }
 
     private static IssueStatus parseStatus(String status) {

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeRepositoryIT.java
@@ -1,0 +1,92 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the paginated employee search against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). The no-filter case is a regression guard:
+ * a null search bound inside a SQL {@code CONCAT}/{@code ||} made CockroachDB
+ * reject the whole statement (SQLState 22023, "unsupported binary operator:
+ * <bytes> || <string>"), so every unfiltered page load 409'd. The pattern is now
+ * assembled in the service, so the query must run cleanly with every filter null.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class EmployeeRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void search_withEveryFilterNull_executesAndReturnsAll() {
+        Organization org = persistOrganization("Org A");
+        persistEmployee(org, "Alice");
+        persistEmployee(org, "Bob");
+        em.flush();
+        em.clear();
+
+        // The no-search path is what broke in staging: it must plan and run.
+        Page<Employee> result = employeeRepository.search(null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Employee::getEmployeeName)
+                .contains("Alice", "Bob");
+    }
+
+    @Test
+    void search_byNamePattern_matchesCaseInsensitively() {
+        Organization org = persistOrganization("Org B");
+        persistEmployee(org, "Charlotte");
+        persistEmployee(org, "Diego");
+        em.flush();
+        em.clear();
+
+        // Caller lower-cases and wraps the term in wildcards, as EmployeeService does.
+        Page<Employee> result = employeeRepository.search("%char%", null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Employee::getEmployeeName)
+                .containsExactly("Charlotte");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private void persistEmployee(Organization org, String name) {
+        User user = new User();
+        user.setKeycloakId("kc-" + name.toLowerCase());
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase() + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+    }
+}


### PR DESCRIPTION
## The bug (found in staging smoke-test)

`GET /employee/web/paginated`, `/issues/web/paginated`, and `/issues/web/stats` returned **409** on every initial (no-search) load. Backend log:

```
SQLState: 22023
ERROR: like_escape(): lower(): unsupported binary operator: <bytes> || <string>
```

The search filters built their LIKE pattern with SQL `CONCAT` (`LOWER(col) LIKE LOWER(CONCAT('%', :search, '%'))`). `CONCAT` compiles to `'%' || :search || '%'`, and when `:search` is null CockroachDB types the null bind as `bytes`, so `<bytes> || <string>` fails at planning. The employee table surfaced this as its error state; the issues page swallowed it and showed an empty list + zero stats (which is why the earlier smoke-test of the issues page looked "empty" rather than broken).

## Fix

Build the `%term%` pattern (lower-cased) in the service and match with a plain `LIKE :search` — no null ever lands inside a `||`. Applies to `EmployeeRepository.search`, `IssueRepository.search`, and `IssueRepository.countByStatus`. Enum/id equality filters were never affected.

## Test

New `EmployeeRepositoryIT` (real CockroachDB via Testcontainers): the no-filter case reproduces the original failure and now passes; a second case checks case-insensitive name matching. Ran green on the lab node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved employee and issue searches by trimming extra spaces and handling capitalization consistently.
  * Partial-match searches now work more reliably across employee names, email addresses, phone numbers, IDs, and issue fields.
  * Blank search terms are handled correctly without producing unexpected results.
* **Tests**
  * Added integration coverage for employee searches, including unfiltered and case-insensitive name searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->