### PR TITLE
Fix issue creation: accept web client's issueType field + 400 on bad type/status

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -89,15 +89,18 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
      * Paginated employee search. Every filter is optional (a null argument
      * disables that clause); the tenant orgFilter still applies. {@code search}
      * matches name, email, phone, or the human-facing employee id,
-     * case-insensitively.
+     * case-insensitively. The caller passes {@code search} already lower-cased
+     * and wrapped in {@code %} wildcards (or null) — building the pattern in
+     * Java rather than with SQL {@code CONCAT} avoids a CockroachDB type error
+     * where a null bind inside {@code ||} is inferred as bytes.
      */
     @Query("""
             SELECT e FROM Employee e WHERE
               (:search IS NULL
-                 OR LOWER(e.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.emailAddress) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.phoneNumber) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(e.employeeId) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(e.employeeName) LIKE :search
+                 OR LOWER(e.emailAddress) LIKE :search
+                 OR LOWER(e.phoneNumber) LIKE :search
+                 OR LOWER(e.employeeId) LIKE :search) AND
               (:status IS NULL OR e.status = :status) AND
               (:department IS NULL OR e.department = :department)
             """)

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -211,7 +211,7 @@ public class EmployeeService {
     @Transactional(readOnly = true)
     public Page<EmployeeDto> displayAllEmployees(int pageNo, int pageSize, String search, String status, String department) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "employeeName"));
-        String searchTerm = (search == null || search.isBlank()) ? null : search;
+        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
         String departmentTerm = (department == null || department.isBlank()) ? null : department;
         EmployeeStatus statusTerm = (status == null || status.isBlank()) ? null : EmployeeStatus.valueOf(status);
         return employeeRepository.search(searchTerm, statusTerm, departmentTerm, pageable)

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
@@ -32,9 +32,9 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             SELECT i FROM Issue i WHERE
               (:projectId IS NULL OR i.task.project.id = :projectId) AND
               (:search IS NULL
-                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(i.title) LIKE :search
+                 OR LOWER(i.description) LIKE :search
+                 OR LOWER(i.createdBy.employeeName) LIKE :search) AND
               (:status IS NULL OR i.status = :status) AND
               (:type IS NULL OR i.type = :type)
             """)
@@ -54,9 +54,9 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             SELECT i.status, COUNT(i) FROM Issue i WHERE
               (:projectId IS NULL OR i.task.project.id = :projectId) AND
               (:search IS NULL
-                 OR LOWER(i.title) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.description) LIKE LOWER(CONCAT('%', :search, '%'))
-                 OR LOWER(i.createdBy.employeeName) LIKE LOWER(CONCAT('%', :search, '%'))) AND
+                 OR LOWER(i.title) LIKE :search
+                 OR LOWER(i.description) LIKE :search
+                 OR LOWER(i.createdBy.employeeName) LIKE :search) AND
               (:type IS NULL OR i.type = :type)
             GROUP BY i.status
             """)

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.issue.mapper.IssueMapper;
 import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -57,8 +58,8 @@ public class IssueService {
         Issue issue = new Issue();
         issue.setTitle(issueCreationDto.getTitle());
         issue.setDescription(issueCreationDto.getDescription());
-        issue.setType(IssueType.valueOf(issueCreationDto.getType()));
-        issue.setStatus(IssueStatus.valueOf(issueCreationDto.getStatus()));
+        issue.setType(parseIssueType(issueCreationDto.getType()));
+        issue.setStatus(parseIssueStatus(issueCreationDto.getStatus()));
         issue.setCreatedBy(creator);
         issue.setTask(task);
         issue.setOrganization(task.getOrganization());
@@ -118,12 +119,42 @@ public class IssueService {
         return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
     }
 
+    // Optional filter parsers: a blank value means "no filter".
     private static IssueStatus parseStatus(String status) {
-        return (status == null || status.isBlank()) ? null : IssueStatus.valueOf(status);
+        return (status == null || status.isBlank()) ? null : parseIssueStatus(status);
     }
 
     private static IssueType parseType(String type) {
-        return (type == null || type.isBlank()) ? null : IssueType.valueOf(type);
+        return (type == null || type.isBlank()) ? null : parseIssueType(type);
+    }
+
+    /**
+     * Parses a required issue type. A missing or unknown value is a client error
+     * (400) rather than the {@code NullPointerException}/500 that a bare
+     * {@code IssueType.valueOf} would raise — the create/update DTOs are parsed
+     * from a multipart string part, so their {@code @NotNull} is not enforced.
+     */
+    private static IssueType parseIssueType(String type) {
+        if (type == null || type.isBlank()) {
+            throw new InvalidRequestException("Issue type is required");
+        }
+        try {
+            return IssueType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("'" + type + "' is not a valid issue type");
+        }
+    }
+
+    /** Parses a required issue status; see {@link #parseIssueType}. */
+    private static IssueStatus parseIssueStatus(String status) {
+        if (status == null || status.isBlank()) {
+            throw new InvalidRequestException("Issue status is required");
+        }
+        try {
+            return IssueStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("'" + status + "' is not a valid issue status");
+        }
     }
 
     @Transactional(readOnly = true)
@@ -176,10 +207,10 @@ public class IssueService {
                     issue.setDescription((String) value);
                     break;
                 case "type":
-                    issue.setType(IssueType.valueOf((String) value));
+                    issue.setType(parseIssueType((String) value));
                     break;
                 case "status":
-                    issue.setStatus(IssueStatus.valueOf((String) value));
+                    issue.setStatus(parseIssueStatus((String) value));
                     break;
                 case "assignedToId":
                     Long assigneeId = ((Number) value).longValue();

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -92,7 +92,7 @@ public class IssueService {
     @Transactional(readOnly = true)
     public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return issueRepository.search(projectId, blankToNull(search), parseStatus(status), parseType(type), pageable)
+        return issueRepository.search(projectId, searchPattern(search), parseStatus(status), parseType(type), pageable)
                 .map(issue -> issueMapper.toDto(issue));
     }
 
@@ -100,7 +100,7 @@ public class IssueService {
     public IssueStatsDto getIssueStats(Long projectId, String search, String type) {
         Map<String, Long> byStatus = new LinkedHashMap<>();
         long total = 0;
-        for (Object[] row : issueRepository.countByStatus(projectId, blankToNull(search), parseType(type))) {
+        for (Object[] row : issueRepository.countByStatus(projectId, searchPattern(search), parseType(type))) {
             IssueStatus status = (IssueStatus) row[0];
             long count = (Long) row[1];
             byStatus.put(status.name(), count);
@@ -109,8 +109,13 @@ public class IssueService {
         return new IssueStatsDto(total, byStatus);
     }
 
-    private static String blankToNull(String value) {
-        return (value == null || value.isBlank()) ? null : value;
+    /**
+     * Builds a lower-cased {@code %...%} LIKE pattern for the search term, or null
+     * when blank. The pattern is assembled here rather than with SQL {@code CONCAT}
+     * so no null bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
+     */
+    private static String searchPattern(String value) {
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
     }
 
     private static IssueStatus parseStatus(String status) {

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.issue.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
@@ -20,8 +21,11 @@ public class IssueCreationDto {
     @Size(min = 5, max = 500, message = "Description must be between 10 and 500 characters")
     private String description;
 
+    // The web client (echno-core) sends this field as "issueType"; accept both
+    // that and the canonical "type" so a create from the web populates it.
     @NotNull
     @Enumerated(EnumType.STRING)
+    @JsonAlias("issueType")
     private String type;
 
     @NotNull

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeRepositoryIT.java
@@ -1,0 +1,92 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the paginated employee search against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). The no-filter case is a regression guard:
+ * a null search bound inside a SQL {@code CONCAT}/{@code ||} made CockroachDB
+ * reject the whole statement (SQLState 22023, "unsupported binary operator:
+ * <bytes> || <string>"), so every unfiltered page load 409'd. The pattern is now
+ * assembled in the service, so the query must run cleanly with every filter null.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class EmployeeRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void search_withEveryFilterNull_executesAndReturnsAll() {
+        Organization org = persistOrganization("Org A");
+        persistEmployee(org, "Alice");
+        persistEmployee(org, "Bob");
+        em.flush();
+        em.clear();
+
+        // The no-search path is what broke in staging: it must plan and run.
+        Page<Employee> result = employeeRepository.search(null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Employee::getEmployeeName)
+                .contains("Alice", "Bob");
+    }
+
+    @Test
+    void search_byNamePattern_matchesCaseInsensitively() {
+        Organization org = persistOrganization("Org B");
+        persistEmployee(org, "Charlotte");
+        persistEmployee(org, "Diego");
+        em.flush();
+        em.clear();
+
+        // Caller lower-cases and wraps the term in wildcards, as EmployeeService does.
+        Page<Employee> result = employeeRepository.search("%char%", null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Employee::getEmployeeName)
+                .containsExactly("Charlotte");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private void persistEmployee(Organization org, String name) {
+        User user = new User();
+        user.setKeycloakId("kc-" + name.toLowerCase());
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase() + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
@@ -1,0 +1,38 @@
+package org.tornotron.echno_backend.issue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The create endpoint parses {@link IssueCreationDto} from a multipart string
+ * part, so its Jackson binding is exercised directly rather than through
+ * {@code @RequestBody}. The web client (echno-core) sends the domain category as
+ * {@code issueType}; these tests pin that it binds to {@code type} (a mismatch
+ * previously left {@code type} null and crashed create with a 500).
+ */
+class IssueCreationDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void bindsWebClientIssueTypeAliasOntoType() throws Exception {
+        IssueCreationDto dto = mapper.readValue(
+                "{\"title\":\"A title\",\"description\":\"A description\",\"issueType\":\"safety\",\"status\":\"open\"}",
+                IssueCreationDto.class);
+
+        assertThat(dto.getType()).isEqualTo("safety");
+        assertThat(dto.getStatus()).isEqualTo("open");
+    }
+
+    @Test
+    void bindsCanonicalTypeField() throws Exception {
+        IssueCreationDto dto = mapper.readValue(
+                "{\"title\":\"A title\",\"description\":\"A description\",\"type\":\"quality\",\"status\":\"open\"}",
+                IssueCreationDto.class);
+
+        assertThat(dto.getType()).isEqualTo("quality");
+    }
+}


### PR DESCRIPTION
## The bug (found while smoke-testing)

Creating an issue from the web returned **500** — `NullPointerException` in `IssueService.addIssue`: `IssueType.valueOf(dto.getType())` on a null `type`.

Two root causes:

1. **Field-name mismatch.** `echno-core` serializes the domain category on the wire as `issueType`, but `IssueCreationDto`'s field is `type` (no alias). The create endpoint parses the DTO from a **multipart string part** (`objectMapper.readValue`), so its `@NotNull` is never enforced — Jackson silently dropped the unmapped `issueType` and `type` stayed null. (Status matches, so only type broke.)
2. **500 instead of 400.** A genuinely missing/unknown enum crashed with an NPE rather than a client error.

## Fix

- `@JsonAlias("issueType")` on `IssueCreationDto.type` — the backend now accepts both the web field (`issueType`) and the canonical `type` (mobile/original contract). No core/web release needed.
- `parseIssueType` / `parseIssueStatus` raise a clean **400** (`InvalidRequestException`) for a missing or unknown value, on both create and the partial-update path, instead of a 500 NPE.

## Not part of the pagination/God-service work

This is a pre-existing defect surfaced by the smoke-test; `addIssue` and the create form are untouched by that work.

## Test

New `IssueCreationDtoTest` pins that `issueType` binds onto `type` (and canonical `type` still binds). Green on the lab node.

Follow-up worth noting: `echno-core` sends the non-canonical `issueType`; a future cleanup could align it to `type`, but the alias makes both work now.