### PR TITLE
Lock payable recordPayment; reject overpayment

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/payable/PayableRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableRepository.java
@@ -1,7 +1,10 @@
 package org.tornotron.echno_backend.payable;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +12,16 @@ import java.util.Optional;
 public interface PayableRepository extends JpaRepository<Payable, Long> {
 
     Optional<Payable> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Loads a payable for a read-modify-write on {@code amountPaid} under a
+     * pessimistic write lock, so concurrent {@code recordPayment} calls serialize
+     * instead of losing updates. On CockroachDB {@code SELECT … FOR UPDATE} queues
+     * writers rather than aborting them.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payable p WHERE p.id = :id AND p.organization.id = :orgId")
+    Optional<Payable> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
     Optional<Payable> findByPayableNumber(String payableNumber);
 

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.payable.mapper.PayableMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -106,11 +107,26 @@ public class PayableService {
 
     @Transactional
     public PayableDto recordPayment(Long id, BigDecimal paymentAmount) {
-        Payable payable = payableRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
+        if (paymentAmount == null || paymentAmount.signum() <= 0) {
+            throw new InvalidRequestException("Payment amount must be greater than zero");
+        }
+
+        // Pessimistic lock so concurrent payments against the same payable
+        // serialize their read-modify-write on amountPaid (no lost updates).
+        Payable payable = payableRepository.lockByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Payable with ID " + id + " was not found in this organization"));
 
         BigDecimal currentPaid = payable.getAmountPaid() != null ? payable.getAmountPaid() : BigDecimal.ZERO;
-        payable.setAmountPaid(currentPaid.add(paymentAmount));
+        BigDecimal newPaid = currentPaid.add(paymentAmount);
+
+        BigDecimal total = payable.getAmountRecorded();
+        if (total != null && newPaid.compareTo(total) > 0) {
+            throw new InvalidRequestException(
+                    "Payment of " + paymentAmount + " would overpay payable " + id +
+                    " (recorded " + total + ", already paid " + currentPaid + ")");
+        }
+
+        payable.setAmountPaid(newPaid);
 
         payable = payableRepository.save(payable);
         return payableMapper.toDto(payable);

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableConcurrencyIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableConcurrencyIT.java
@@ -1,0 +1,108 @@
+package org.tornotron.echno_backend.payable;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency test for the payable payment lock against a real CockroachDB.
+ * Several threads record a payment against the same payable at once; without the
+ * pessimistic write lock that {@code recordPayment} now takes on the lookup, they
+ * read the same {@code amountPaid} and write over each other, losing payments.
+ * With the lock they serialize, so the recorded total is exact.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PayableConcurrencyIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private PayableRepository payableRepository;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentPayments_doNotLoseUpdates() throws Exception {
+        long[] ids = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Payable Org");
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail("payable@example.test");
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+
+            Project project = new Project();
+            project.setProjectName("Project 1");
+            project.setOrganization(org);
+            entityManager.persist(project);
+
+            Payable payable = new Payable();
+            payable.setPayableNumber("PAY-0001");
+            payable.setContractorName("ACME Contractors");
+            payable.setProject(project);
+            payable.setOrganization(org);
+            payable.setAmountRecorded(new BigDecimal("1000.00"));
+            payable.setAmountPaid(BigDecimal.ZERO);
+            entityManager.persist(payable);
+
+            entityManager.flush();
+            return new long[] {org.getId(), payable.getId()};
+        });
+
+        long orgId = ids[0];
+        long payableId = ids[1];
+        int threads = 4;
+        BigDecimal increment = new BigDecimal("10.00");
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                startGate.await();
+                new TransactionTemplate(txManager).executeWithoutResult(status -> {
+                    Payable payable = payableRepository
+                            .lockByIdAndOrganizationId(payableId, orgId)
+                            .orElseThrow();
+                    BigDecimal current = payable.getAmountPaid() == null ? BigDecimal.ZERO : payable.getAmountPaid();
+                    payable.setAmountPaid(current.add(increment));
+                    payableRepository.save(payable);
+                });
+                return null;
+            }));
+        }
+        startGate.countDown();
+        for (Future<?> future : futures) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        Payable finalPayable = payableRepository.findByIdAndOrganization_Id(payableId, orgId).orElseThrow();
+        assertThat(finalPayable.getAmountPaid()).isEqualByComparingTo(increment.multiply(BigDecimal.valueOf(threads)));
+    }
+}


### PR DESCRIPTION
## What

`PayableService.recordPayment` did an **unlocked read-modify-write** on `amountPaid` — two concurrent payments against the same payable read the same value and wrote over each other, losing a payment (the payable-concurrency gap flagged in the 2026-08 audit, same class as the stock #328 / leave-balance #329 locks).

- Load the payable under a **pessimistic write lock** (`lockByIdAndOrganizationId`), so concurrent `recordPayment` calls serialize. On CockroachDB `SELECT … FOR UPDATE` queues writers rather than aborting.
- Reject a **non-positive** payment (400) and a payment that would push `amountPaid` **past `amountRecorded`** (overpayment) — previously it silently overpaid.

## Test

`PayableConcurrencyIT` (real CockroachDB via Testcontainers, 4 threads recording payments on one payable) asserts the recorded total is exact. Green on the lab node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure payments are positive.
  * Prevented payments from exceeding the remaining payable balance.
  * Improved payment processing reliability during concurrent updates.

* **Tests**
  * Added integration coverage verifying that simultaneous payments are recorded accurately without lost updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->