### PR TITLE
Lock leave request on approve/reject to prevent double-processing

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -112,7 +112,10 @@ public class LeaveApprovalService {
 
     @Transactional
     public LeaveRequestDto approve(Long requestId, LeaveApprovalActionDto dto) {
-        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId, TenantContext.getCurrentOrgId())
+        // Pessimistic lock: concurrent approve/reject on the same request must
+        // serialize, or both read a stale PENDING_APPROVAL status and finalize
+        // twice (double balance deduction / advancing the chain twice).
+        LeaveRequest request = requestRepository.lockByIdAndOrganizationId(requestId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 
@@ -136,7 +139,7 @@ public class LeaveApprovalService {
 
     @Transactional
     public LeaveRequestDto reject(Long requestId, LeaveApprovalActionDto dto) {
-        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
+        LeaveRequest request = requestRepository.lockByIdAndOrganizationId(requestId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestRepository.java
@@ -1,8 +1,10 @@
 package org.tornotron.echno_backend.leave;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.leave.enums.LeaveStatus;
@@ -17,6 +19,17 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
 
 
     Optional<LeaveRequest> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Loads a leave request under a pessimistic write lock so concurrent
+     * approve/reject actions on the same request serialize: the second waits for
+     * the first to commit, then sees the updated status and is rejected by the
+     * pending-approval guard instead of double-processing (double balance
+     * deduction / advancing the chain twice).
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM LeaveRequest r WHERE r.id = :id AND r.organization.id = :orgId")
+    Optional<LeaveRequest> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
     Page<LeaveRequest> findByEmployeeId(Long employeeId, Pageable pageable);
 

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalConcurrencyIT.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalConcurrencyIT.java
@@ -1,0 +1,139 @@
+package org.tornotron.echno_backend.leave;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency test for the leave-approval lock against a real CockroachDB.
+ * Several threads try to approve the same pending request at once; each mirrors
+ * the service guard (approve only while still PENDING_APPROVAL). Without the
+ * pessimistic write lock the approve/reject paths now take, every thread reads
+ * the stale PENDING status and "approves", double-processing. With the lock they
+ * serialize, so exactly one approval wins.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LeaveApprovalConcurrencyIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private LeaveRequestRepository requestRepository;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentApprovals_onlyOneWins() throws Exception {
+        long requestId = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Approval Org");
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail("approval@example.test");
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+
+            User user = new User();
+            user.setKeycloakId("kc-approval");
+            user.setName("approval-user");
+            entityManager.persist(user);
+
+            Employee employee = new Employee();
+            employee.setOrganization(org);
+            employee.setUser(user);
+            employee.setEmployeeName("approval-user");
+            employee.setGender("U");
+            employee.setPhoneNumber("0000000000");
+            employee.setEmailAddress("approval@emp.test");
+            employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+            entityManager.persist(employee);
+
+            LeavePolicy policy = new LeavePolicy();
+            policy.setOrganization(org);
+            policy.setLeaveTypeCode("AL");
+            policy.setLeaveTypeName("Annual Leave");
+            policy.setAnnualQuota(20.0);
+            policy.setCreatedAt(LocalDateTime.now());
+            policy.setUpdatedAt(LocalDateTime.now());
+            entityManager.persist(policy);
+
+            LeaveRequest request = new LeaveRequest();
+            request.setRequestNumber("LR-0001");
+            request.setEmployee(employee);
+            request.setOrganization(org);
+            request.setLeavePolicy(policy);
+            request.setStartDate(LocalDate.of(2026, 9, 1));
+            request.setEndDate(LocalDate.of(2026, 9, 2));
+            request.setTotalDays(2.0);
+            request.setReason("Personal");
+            request.setStatus(LeaveStatus.PENDING_APPROVAL);
+            request.setCreatedAt(LocalDateTime.now());
+            request.setUpdatedAt(LocalDateTime.now());
+            entityManager.persist(request);
+
+            entityManager.flush();
+            return request.getId();
+        });
+
+        long orgId = new TransactionTemplate(txManager).execute(status ->
+                requestRepository.findById(requestId).orElseThrow().getOrganization().getId());
+
+        int threads = 4;
+        AtomicInteger approvals = new AtomicInteger(0);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                startGate.await();
+                new TransactionTemplate(txManager).executeWithoutResult(status -> {
+                    LeaveRequest request = requestRepository
+                            .lockByIdAndOrganizationId(requestId, orgId)
+                            .orElseThrow();
+                    // Mirror the service guard: only approve while still pending.
+                    if (request.getStatus() == LeaveStatus.PENDING_APPROVAL) {
+                        request.setStatus(LeaveStatus.APPROVED);
+                        requestRepository.save(request);
+                        approvals.incrementAndGet();
+                    }
+                });
+                return null;
+            }));
+        }
+        startGate.countDown();
+        for (Future<?> future : futures) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        assertThat(approvals.get()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## What

`LeaveApprovalService.approve`/`reject` loaded the request with a plain read and relied on a `status == PENDING_APPROVAL` guard. Two concurrent approvals both read the stale PENDING status before either committed, so **both passed the guard and finalized** — advancing the approval chain twice or deducting the leave balance twice (the leave-approval double-approval gap from the 2026-08 audit).

Load the request under a **pessimistic write lock** (`lockByIdAndOrganizationId`) in both `approve` and `reject`, so they serialize: the second waits for the first to commit, then sees the updated status and the guard rejects it.

## Test

`LeaveApprovalConcurrencyIT` (real CockroachDB, 4 threads on one pending request, each mirroring the pending-only guard) asserts exactly one approval wins. Green on the lab node.

Completes the data-integrity locking set alongside stock (#328), leave-balance (#329), and payable (#372).