### PR TITLE
Add asset register domain module

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/asset/Asset.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/Asset.java
@@ -1,0 +1,136 @@
+package org.tornotron.echno_backend.asset;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.vendor.Vendor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * A fixed asset in the organization's asset register. Type/status/condition are stored as
+ * plain strings because the web client sends kebab-case values (e.g. {@code heavy-equipment})
+ * that are not valid Java enum identifiers; the frontend validates them.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+public class Asset implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "asset_id")
+    private String assetId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "asset_condition")
+    private String assetCondition;
+
+    @Column(name = "purchase_date")
+    private LocalDate purchaseDate;
+
+    @Column(name = "purchase_price", precision = 15, scale = 2)
+    private BigDecimal purchasePrice;
+
+    @Column(name = "current_value", precision = 15, scale = 2)
+    private BigDecimal currentValue;
+
+    @Column(name = "depreciation_rate")
+    private Double depreciationRate;
+
+    @Column(name = "assigned_to")
+    private String assignedTo;
+
+    @Column(name = "assigned_project")
+    private String assignedProject;
+
+    @Column(name = "manufacturer")
+    private String manufacturer;
+
+    @Column(name = "model")
+    private String model;
+
+    @Column(name = "serial_number")
+    private String serialNumber;
+
+    @Column(name = "registration_number")
+    private String registrationNumber;
+
+    @Column(name = "warranty_expiry")
+    private LocalDate warrantyExpiry;
+
+    @Column(name = "last_maintenance_date")
+    private LocalDate lastMaintenanceDate;
+
+    @Column(name = "next_maintenance_date")
+    private LocalDate nextMaintenanceDate;
+
+    @Column(name = "insurance_expiry")
+    private LocalDate insuranceExpiry;
+
+    @Column(name = "maintenance_schedule")
+    private String maintenanceSchedule;
+
+    @Column(name = "usage_hours")
+    private Double usageHours;
+
+    @Column(name = "max_usage_hours")
+    private Double maxUsageHours;
+
+    @Column(name = "fuel_type")
+    private String fuelType;
+
+    @Column(name = "insurance_provider")
+    private String insuranceProvider;
+
+    @Column(name = "policy_number")
+    private String policyNumber;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vendor_id")
+    private Vendor vendor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private StorageLocation location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -1,0 +1,65 @@
+package org.tornotron.echno_backend.asset;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
+import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.common.response.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/assets/web")
+public class AssetControllerWeb {
+
+    private final AssetService assetService;
+
+    public AssetControllerWeb(AssetService assetService) {
+        this.assetService = assetService;
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<List<AssetDto>> readAllAssets() {
+        return new ResponseEntity<>(assetService.getAllAssets(), HttpStatus.OK);
+    }
+
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<Page<AssetDto>> readAllAssetsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        return new ResponseEntity<>(assetService.getAllAssets(pageNo, pageSize), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<AssetDto> readAnAsset(@PathVariable Long id) {
+        return new ResponseEntity<>(assetService.getAssetById(id), HttpStatus.OK);
+    }
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<AssetDto> createAsset(@Valid @RequestBody AssetCreationDto creationDto) {
+        return new ResponseEntity<>(assetService.createAsset(creationDto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<AssetDto> updateAsset(@PathVariable Long id, @Valid @RequestBody AssetCreationDto creationDto) {
+        return new ResponseEntity<>(assetService.updateAsset(id, creationDto), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<ApiResponse> deleteAsset(@PathVariable Long id) {
+        assetService.deleteAsset(id);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Asset with id: " + id + " has been deleted"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetRepository.java
@@ -1,0 +1,12 @@
+package org.tornotron.echno_backend.asset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AssetRepository extends JpaRepository<Asset, Long> {
+
+    Optional<Asset> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    boolean existsByAssetIdAndOrganization_Id(String assetId, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
@@ -1,0 +1,133 @@
+package org.tornotron.echno_backend.asset;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
+import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.asset.mapper.AssetMapper;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.vendor.Vendor;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AssetService {
+
+    private final AssetRepository assetRepository;
+    private final AssetMapper assetMapper;
+    private final TenantEntityHelper tenantEntityHelper;
+    private final VendorRepository vendorRepository;
+    private final StorageLocationRepository storageLocationRepository;
+
+    public AssetService(AssetRepository assetRepository,
+                        AssetMapper assetMapper,
+                        TenantEntityHelper tenantEntityHelper,
+                        VendorRepository vendorRepository,
+                        StorageLocationRepository storageLocationRepository) {
+        this.assetRepository = assetRepository;
+        this.assetMapper = assetMapper;
+        this.tenantEntityHelper = tenantEntityHelper;
+        this.vendorRepository = vendorRepository;
+        this.storageLocationRepository = storageLocationRepository;
+    }
+
+    @Transactional
+    public AssetDto createAsset(AssetCreationDto creationDto) {
+        Asset asset = new Asset();
+        applyFields(asset, creationDto);
+        asset.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        return assetMapper.toDto(assetRepository.save(asset));
+    }
+
+    @Transactional(readOnly = true)
+    public AssetDto getAssetById(Long id) {
+        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+        return assetMapper.toDto(asset);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AssetDto> getAllAssets() {
+        return assetRepository.findAll().stream()
+                .map(asset -> assetMapper.toDto(asset))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AssetDto> getAllAssets(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return assetRepository.findAll(pageable)
+                .map(asset -> assetMapper.toDto(asset));
+    }
+
+    @Transactional
+    public AssetDto updateAsset(Long id, AssetCreationDto creationDto) {
+        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+        applyFields(asset, creationDto);
+        return assetMapper.toDto(assetRepository.save(asset));
+    }
+
+    @Transactional
+    public void deleteAsset(Long id) {
+        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+        assetRepository.delete(asset);
+    }
+
+    /** Copies the mutable fields from the creation DTO onto the asset, resolving the vendor and location. */
+    private void applyFields(Asset asset, AssetCreationDto dto) {
+        asset.setAssetId(dto.getAssetId());
+        asset.setName(dto.getName());
+        asset.setDescription(dto.getDescription());
+        asset.setType(dto.getType());
+        asset.setCategory(dto.getCategory());
+        asset.setStatus(dto.getStatus());
+        asset.setAssetCondition(dto.getAssetCondition());
+        asset.setPurchaseDate(dto.getPurchaseDate());
+        asset.setPurchasePrice(dto.getPurchasePrice());
+        asset.setCurrentValue(dto.getCurrentValue());
+        asset.setDepreciationRate(dto.getDepreciationRate());
+        asset.setAssignedTo(dto.getAssignedTo());
+        asset.setAssignedProject(dto.getAssignedProject());
+        asset.setManufacturer(dto.getManufacturer());
+        asset.setModel(dto.getModel());
+        asset.setSerialNumber(dto.getSerialNumber());
+        asset.setRegistrationNumber(dto.getRegistrationNumber());
+        asset.setWarrantyExpiry(dto.getWarrantyExpiry());
+        asset.setLastMaintenanceDate(dto.getLastMaintenanceDate());
+        asset.setNextMaintenanceDate(dto.getNextMaintenanceDate());
+        asset.setInsuranceExpiry(dto.getInsuranceExpiry());
+        asset.setMaintenanceSchedule(dto.getMaintenanceSchedule());
+        asset.setUsageHours(dto.getUsageHours());
+        asset.setMaxUsageHours(dto.getMaxUsageHours());
+        asset.setFuelType(dto.getFuelType());
+        asset.setInsuranceProvider(dto.getInsuranceProvider());
+        asset.setPolicyNumber(dto.getPolicyNumber());
+        asset.setNotes(dto.getNotes());
+
+        Vendor vendor = null;
+        if (dto.getVendorId() != null) {
+            vendor = vendorRepository.findByIdAndOrganization_Id(dto.getVendorId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Vendor with ID " + dto.getVendorId() + " was not found in this organization"));
+        }
+        asset.setVendor(vendor);
+
+        StorageLocation location = null;
+        if (dto.getLocationId() != null) {
+            location = storageLocationRepository.findByIdAndOrganization_Id(dto.getLocationId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID " + dto.getLocationId() + " was not found in this organization"));
+        }
+        asset.setLocation(location);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
@@ -1,0 +1,49 @@
+package org.tornotron.echno_backend.asset.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class AssetCreationDto {
+
+    private String assetId;
+
+    @NotBlank
+    private String name;
+
+    private String description;
+    private String type;
+    private String category;
+    private String status;
+    // The web sends the field as "condition"; the entity column is
+    // "asset_condition" (condition is a SQL reserved word). Accept both.
+    @JsonAlias("condition")
+    private String assetCondition;
+    private LocalDate purchaseDate;
+    private BigDecimal purchasePrice;
+    private BigDecimal currentValue;
+    private Double depreciationRate;
+    private String assignedTo;
+    private String assignedProject;
+    private String manufacturer;
+    private String model;
+    private String serialNumber;
+    private String registrationNumber;
+    private LocalDate warrantyExpiry;
+    private LocalDate lastMaintenanceDate;
+    private LocalDate nextMaintenanceDate;
+    private LocalDate insuranceExpiry;
+    private String maintenanceSchedule;
+    private Double usageHours;
+    private Double maxUsageHours;
+    private String fuelType;
+    private String insuranceProvider;
+    private String policyNumber;
+    private String notes;
+    private Long vendorId;
+    private Long locationId;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
@@ -1,0 +1,47 @@
+package org.tornotron.echno_backend.asset.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+public class AssetDto {
+    private Long id;
+    private String assetId;
+    private String name;
+    private String description;
+    private String type;
+    private String category;
+    private String status;
+    private String assetCondition;
+    private LocalDate purchaseDate;
+    private BigDecimal purchasePrice;
+    private BigDecimal currentValue;
+    private Double depreciationRate;
+    private String assignedTo;
+    private String assignedProject;
+    private String manufacturer;
+    private String model;
+    private String serialNumber;
+    private String registrationNumber;
+    private LocalDate warrantyExpiry;
+    private LocalDate lastMaintenanceDate;
+    private LocalDate nextMaintenanceDate;
+    private LocalDate insuranceExpiry;
+    private String maintenanceSchedule;
+    private Double usageHours;
+    private Double maxUsageHours;
+    private String fuelType;
+    private String insuranceProvider;
+    private String policyNumber;
+    private String notes;
+    private Long vendorId;
+    private String vendorName;
+    private Long locationId;
+    private String locationName;
+    private Long organizationId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMapper.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.asset.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.asset.Asset;
+import org.tornotron.echno_backend.asset.dto.AssetDto;
+
+/** Maps {@link Asset} to its DTO. Vendor/location/organization flatten to id (+ name). */
+@Mapper(componentModel = "spring")
+public interface AssetMapper {
+
+    @Mapping(source = "vendor.id", target = "vendorId")
+    @Mapping(source = "vendor.vendorName", target = "vendorName")
+    @Mapping(source = "location.id", target = "locationId")
+    @Mapping(source = "location.locationName", target = "locationName")
+    @Mapping(source = "organization.id", target = "organizationId")
+    AssetDto toDto(Asset asset);
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -237,5 +237,6 @@
     <include file="db/changelog/v4.0/025-create-inspections.xml"/>
     <include file="db/changelog/v4.0/026-create-inspection-check-items.xml"/>
     <include file="db/changelog/v4.0/027-create-inspection-defects.xml"/>
+    <include file="db/changelog/v4.0/028-create-assets.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/028-create-assets.xml
+++ b/src/main/resources/db/changelog/v4.0/028-create-assets.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="028-create-assets" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="asset"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="asset">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="asset_id" type="VARCHAR(100)"/>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="type" type="VARCHAR(50)"/>
+            <column name="category" type="VARCHAR(100)"/>
+            <column name="status" type="VARCHAR(50)"/>
+            <column name="asset_condition" type="VARCHAR(50)"/>
+
+            <column name="purchase_date" type="DATE"/>
+            <column name="purchase_price" type="NUMERIC(15, 2)"/>
+            <column name="current_value" type="NUMERIC(15, 2)"/>
+            <column name="depreciation_rate" type="DOUBLE"/>
+
+            <column name="assigned_to" type="VARCHAR(200)"/>
+            <column name="assigned_project" type="VARCHAR(200)"/>
+
+            <column name="manufacturer" type="VARCHAR(200)"/>
+            <column name="model" type="VARCHAR(200)"/>
+            <column name="serial_number" type="VARCHAR(200)"/>
+            <column name="registration_number" type="VARCHAR(200)"/>
+
+            <column name="warranty_expiry" type="DATE"/>
+            <column name="last_maintenance_date" type="DATE"/>
+            <column name="next_maintenance_date" type="DATE"/>
+            <column name="insurance_expiry" type="DATE"/>
+            <column name="maintenance_schedule" type="VARCHAR(200)"/>
+
+            <column name="usage_hours" type="DOUBLE"/>
+            <column name="max_usage_hours" type="DOUBLE"/>
+
+            <column name="fuel_type" type="VARCHAR(50)"/>
+            <column name="insurance_provider" type="VARCHAR(200)"/>
+            <column name="policy_number" type="VARCHAR(100)"/>
+
+            <column name="notes" type="TEXT"/>
+
+            <column name="vendor_id" type="BIGINT"/>
+            <column name="location_id" type="BIGINT"/>
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="asset"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_asset_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="asset"
+                                 baseColumnNames="vendor_id"
+                                 constraintName="fk_asset_vendor"
+                                 referencedTableName="vendor"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="asset"
+                                 baseColumnNames="location_id"
+                                 constraintName="fk_asset_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="asset" indexName="idx_asset_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="asset" indexName="idx_asset_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="asset" indexName="idx_asset_vendor">
+            <column name="vendor_id"/>
+        </createIndex>
+        <createIndex tableName="asset" indexName="idx_asset_location">
+            <column name="location_id"/>
+        </createIndex>
+        <createIndex tableName="asset" indexName="idx_asset_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetRepositoryIT.java
@@ -1,0 +1,78 @@
+package org.tornotron.echno_backend.asset;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AssetRepository} against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Asserts the tenant-scoped lookup and
+ * that a persisted asset shows up in a paginated {@code findAll}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AssetRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByIdAndOrganization_returnsTheAssetForItsOrganization() {
+        Organization org = persistOrganization("Org A");
+        Asset asset = persistAsset(org, "Excavator");
+        em.flush();
+        em.clear();
+
+        Optional<Asset> found = assetRepository.findByIdAndOrganization_Id(asset.getId(), org.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Excavator");
+        assertThat(found.get().getOrganization().getId()).isEqualTo(org.getId());
+    }
+
+    @Test
+    void findAll_paginated_includesThePersistedAsset() {
+        Organization org = persistOrganization("Org B");
+        persistAsset(org, "Concrete Mixer");
+        em.flush();
+        em.clear();
+
+        Page<Asset> result = assetRepository.findAll(PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Asset::getName)
+                .contains("Concrete Mixer");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Asset persistAsset(Organization org, String name) {
+        Asset asset = new Asset();
+        asset.setOrganization(org);
+        asset.setName(name);
+        asset.setStatus("available");
+        asset.setType("heavy-equipment");
+        em.persist(asset);
+        return asset;
+    }
+}


### PR DESCRIPTION
## What

New fixed-asset register backing the web `resources/assets` pages, which until now rendered **mock data as real numbers** (the last HIGH-severity item of that class from the 2026-08 audit).

- `Asset` entity (tenant-scoped, `@Filter` orgFilter), `AssetDto` / `AssetCreationDto`, MapStruct `AssetMapper`, `AssetRepository`, tenant-scoped `AssetService` (CRUD + list + paginated), `AssetControllerWeb` at `/api/v1/assets/web`, Liquibase migration `028-create-assets`.
- **MVP scope:** the core register — identity, `type`/`status`/`condition` as strings (the web sends kebab-case values), purchase/current-value/depreciation, assignment, maintenance/insurance/warranty dates, and `vendor` + `storage-location` FKs. The location-transfer history table and the Expense links are **deferred** (Expense has no backend yet).

## Notes

- Auth mirrors `IssueControllerWeb`: reads → tenant membership; writes → `system-admin`/`project-manager`.
- `AssetCreationDto` accepts the web's `condition` field via `@JsonAlias` onto `assetCondition` (the column name avoids the SQL reserved word).

## Test

`AssetRepositoryIT` (real CockroachDB via Testcontainers) covers the org-scoped find + paginated list; the migration runs clean. Green on the lab node.

Companion `echno-core` types/service + `echno-web` swap follow.