### PR TITLE
Add stock-adjustment document domain module

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
@@ -1,0 +1,134 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A stock-adjustment document: a header plus a list of line items. Type, status and
+ * reason values are stored as plain strings because the web client sends kebab/snake
+ * values (e.g. {@code write_off}, {@code physical_count}) that are not valid Java enum
+ * identifiers; the frontend validates them.
+ *
+ * <p>MVP scope: this document is persisted only. It does not mutate {@code CurrentStock}
+ * or post inventory transactions; that integration is deferred.
+ */
+@Entity
+@Table(name = "stock_adjustment")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockAdjustment implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "adjustment_number")
+    private String adjustmentNumber;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "status")
+    private String status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private StorageLocation location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @Column(name = "adjustment_date")
+    private LocalDate adjustmentDate;
+
+    @Column(name = "effective_date")
+    private LocalDate effectiveDate;
+
+    @Column(name = "total_adjustment_value", precision = 15, scale = 2)
+    private BigDecimal totalAdjustmentValue;
+
+    @Column(name = "primary_reason")
+    private String primaryReason;
+
+    @Column(name = "justification", columnDefinition = "TEXT")
+    private String justification;
+
+    @Column(name = "physical_count_date")
+    private LocalDate physicalCountDate;
+
+    @Column(name = "physical_count_by")
+    private Long physicalCountBy;
+
+    @Column(name = "count_method")
+    private String countMethod;
+
+    @Column(name = "submitted_by")
+    private Long submittedBy;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Column(name = "approved_by")
+    private Long approvedBy;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Column(name = "rejected_by")
+    private Long rejectedBy;
+
+    @Column(name = "rejected_at")
+    private LocalDateTime rejectedAt;
+
+    @Column(name = "rejection_reason")
+    private String rejectionReason;
+
+    @Column(name = "processed_by")
+    private Long processedBy;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Column(name = "total_variance_quantity")
+    private Double totalVarianceQuantity;
+
+    @OneToMany(mappedBy = "stockAdjustment", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<StockAdjustmentLineItem> lineItems = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** Attaches a line item to this document, wiring the back-reference. */
+    public void addLineItem(StockAdjustmentLineItem item) {
+        item.setStockAdjustment(this);
+        this.lineItems.add(item);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -1,0 +1,67 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+
+import java.util.List;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/stock-adjustments/web")
+public class StockAdjustmentControllerWeb {
+
+    private final StockAdjustmentService stockAdjustmentService;
+
+    public StockAdjustmentControllerWeb(StockAdjustmentService stockAdjustmentService) {
+        this.stockAdjustmentService = stockAdjustmentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<List<StockAdjustmentDto>> readAllStockAdjustments() {
+        return new ResponseEntity<>(stockAdjustmentService.getAll(), HttpStatus.OK);
+    }
+
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<Page<StockAdjustmentDto>> readAllStockAdjustmentsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        return new ResponseEntity<>(stockAdjustmentService.getAll(pageNo, pageSize), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<StockAdjustmentDto> readAStockAdjustment(@PathVariable Long id) {
+        return new ResponseEntity<>(stockAdjustmentService.getById(id), HttpStatus.OK);
+    }
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<StockAdjustmentDto> createStockAdjustment(@Valid @RequestBody StockAdjustmentCreationDto creationDto) {
+        return new ResponseEntity<>(stockAdjustmentService.create(creationDto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<StockAdjustmentDto> updateStockAdjustment(@PathVariable Long id,
+                                                                    @Valid @RequestBody StockAdjustmentCreationDto creationDto) {
+        return new ResponseEntity<>(stockAdjustmentService.update(id, creationDto), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<ApiResponse> deleteStockAdjustment(@PathVariable Long id) {
+        stockAdjustmentService.delete(id);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ApiResponse("Stock adjustment with id: " + id + " has been deleted"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentLineItem.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentLineItem.java
@@ -1,0 +1,82 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.math.BigDecimal;
+
+/**
+ * A single line within a {@link StockAdjustment} document. Owned by the header through
+ * the {@code stock_adjustment_id} FK, which cascades persist and removal. The line also
+ * carries its own {@code organization_id} and the {@code orgFilter} so tenant scoping
+ * applies to the child rows directly, mirroring the other line-item entities in this
+ * codebase (e.g. site-transfer items).
+ */
+@Entity
+@Table(name = "stock_adjustment_line_item")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockAdjustmentLineItem implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_adjustment_id", nullable = false)
+    private StockAdjustment stockAdjustment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "material_id")
+    private Material material;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "system_quantity")
+    private Double systemQuantity;
+
+    @Column(name = "physical_quantity")
+    private Double physicalQuantity;
+
+    @Column(name = "adjustment_quantity")
+    private Double adjustmentQuantity;
+
+    @Column(name = "unit")
+    private String unit;
+
+    @Column(name = "unit_value", precision = 15, scale = 2)
+    private BigDecimal unitValue;
+
+    @Column(name = "total_adjustment_value", precision = 15, scale = 2)
+    private BigDecimal totalAdjustmentValue;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "reason_details")
+    private String reasonDetails;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private StorageLocation location;
+
+    @Column(name = "bin_location")
+    private String binLocation;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
@@ -1,0 +1,12 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StockAdjustmentRepository extends JpaRepository<StockAdjustment, Long> {
+
+    Optional<StockAdjustment> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    boolean existsByAdjustmentNumberAndOrganization_Id(String adjustmentNumber, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -1,0 +1,193 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * CRUD + list for stock-adjustment documents. MVP scope: the document is persisted
+ * only; this service does NOT touch {@code CurrentStock} or post inventory
+ * transactions. That integration is deferred.
+ */
+@Service
+public class StockAdjustmentService {
+
+    private final StockAdjustmentRepository stockAdjustmentRepository;
+    private final StockAdjustmentMapper stockAdjustmentMapper;
+    private final TenantEntityHelper tenantEntityHelper;
+    private final MaterialRepository materialRepository;
+    private final StorageLocationRepository storageLocationRepository;
+    private final ProjectRepository projectRepository;
+
+    public StockAdjustmentService(StockAdjustmentRepository stockAdjustmentRepository,
+                                  StockAdjustmentMapper stockAdjustmentMapper,
+                                  TenantEntityHelper tenantEntityHelper,
+                                  MaterialRepository materialRepository,
+                                  StorageLocationRepository storageLocationRepository,
+                                  ProjectRepository projectRepository) {
+        this.stockAdjustmentRepository = stockAdjustmentRepository;
+        this.stockAdjustmentMapper = stockAdjustmentMapper;
+        this.tenantEntityHelper = tenantEntityHelper;
+        this.materialRepository = materialRepository;
+        this.storageLocationRepository = storageLocationRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    @Transactional
+    public StockAdjustmentDto create(StockAdjustmentCreationDto creationDto) {
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
+        StockAdjustment stockAdjustment = new StockAdjustment();
+        stockAdjustment.setOrganization(organization);
+        applyHeaderFields(stockAdjustment, creationDto);
+        applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
+        StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
+        return stockAdjustmentMapper.toDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public StockAdjustmentDto getById(Long id) {
+        StockAdjustment stockAdjustment = stockAdjustmentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Stock adjustment with ID " + id + " was not found in this organization"));
+        return stockAdjustmentMapper.toDto(stockAdjustment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StockAdjustmentDto> getAll() {
+        return stockAdjustmentRepository.findAll().stream()
+                .map(stockAdjustmentMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StockAdjustmentDto> getAll(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return stockAdjustmentRepository.findAll(pageable)
+                .map(stockAdjustmentMapper::toDto);
+    }
+
+    @Transactional
+    public StockAdjustmentDto update(Long id, StockAdjustmentCreationDto creationDto) {
+        StockAdjustment stockAdjustment = stockAdjustmentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Stock adjustment with ID " + id + " was not found in this organization"));
+        Organization organization = stockAdjustment.getOrganization();
+
+        applyHeaderFields(stockAdjustment, creationDto);
+
+        // Replace the line-item collection: clear in place (orphanRemoval deletes the old
+        // rows) and re-add from the request, keeping Hibernate's collection tracking intact.
+        stockAdjustment.getLineItems().clear();
+        applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
+
+        // saveAndFlush before mapping so the freshly inserted line-item ids are populated
+        // on the returned DTO (documented gotcha: without the flush the child ids are null).
+        StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
+        return stockAdjustmentMapper.toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        StockAdjustment stockAdjustment = stockAdjustmentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Stock adjustment with ID " + id + " was not found in this organization"));
+        stockAdjustmentRepository.delete(stockAdjustment);
+    }
+
+    /** Copies the header scalars from the creation DTO, resolving the location and project. */
+    private void applyHeaderFields(StockAdjustment stockAdjustment, StockAdjustmentCreationDto dto) {
+        stockAdjustment.setAdjustmentNumber(dto.getAdjustmentNumber());
+        stockAdjustment.setType(dto.getType());
+        stockAdjustment.setStatus(dto.getStatus());
+        stockAdjustment.setAdjustmentDate(dto.getAdjustmentDate());
+        stockAdjustment.setEffectiveDate(dto.getEffectiveDate());
+        stockAdjustment.setTotalAdjustmentValue(dto.getTotalAdjustmentValue());
+        stockAdjustment.setPrimaryReason(dto.getPrimaryReason());
+        stockAdjustment.setJustification(dto.getJustification());
+        stockAdjustment.setPhysicalCountDate(dto.getPhysicalCountDate());
+        stockAdjustment.setPhysicalCountBy(dto.getPhysicalCountBy());
+        stockAdjustment.setCountMethod(dto.getCountMethod());
+        stockAdjustment.setSubmittedBy(dto.getSubmittedBy());
+        stockAdjustment.setTotalVarianceQuantity(dto.getTotalVarianceQuantity());
+
+        stockAdjustment.setLocation(resolveLocation(dto.getLocationId()));
+        stockAdjustment.setProject(resolveProject(dto.getProjectId()));
+    }
+
+    /** Builds and attaches the line items, resolving each line's material and location. */
+    private void applyLineItems(StockAdjustment stockAdjustment,
+                                List<StockAdjustmentLineItemCreationDto> lineItemDtos,
+                                Organization organization) {
+        if (lineItemDtos == null) {
+            return;
+        }
+        for (StockAdjustmentLineItemCreationDto lineDto : lineItemDtos) {
+            StockAdjustmentLineItem item = new StockAdjustmentLineItem();
+            item.setDescription(lineDto.getDescription());
+            item.setSystemQuantity(lineDto.getSystemQuantity());
+            item.setPhysicalQuantity(lineDto.getPhysicalQuantity());
+            item.setAdjustmentQuantity(lineDto.getAdjustmentQuantity());
+            item.setUnit(lineDto.getUnit());
+            item.setUnitValue(lineDto.getUnitValue());
+            item.setTotalAdjustmentValue(lineDto.getTotalAdjustmentValue());
+            item.setReason(lineDto.getReason());
+            item.setReasonDetails(lineDto.getReasonDetails());
+            item.setBinLocation(lineDto.getBinLocation());
+            item.setNotes(lineDto.getNotes());
+            item.setMaterial(resolveMaterial(lineDto.getMaterialId()));
+            item.setLocation(resolveLocation(lineDto.getLocationId()));
+            item.setOrganization(organization);
+            stockAdjustment.addLineItem(item);
+        }
+    }
+
+    private StorageLocation resolveLocation(Long locationId) {
+        if (locationId == null) {
+            return null;
+        }
+        return storageLocationRepository.findByIdAndOrganization_Id(locationId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Storage location with ID " + locationId + " was not found in this organization"));
+    }
+
+    private Project resolveProject(Long projectId) {
+        if (projectId == null) {
+            return null;
+        }
+        return projectRepository.findByIdAndOrganization_Id(projectId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Project with ID " + projectId + " was not found in this organization"));
+    }
+
+    private Material resolveMaterial(Long materialId) {
+        if (materialId == null) {
+            return null;
+        }
+        return materialRepository.findByIdAndOrganization_Id(materialId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Material with ID " + materialId + " was not found in this organization"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -1,0 +1,32 @@
+package org.tornotron.echno_backend.stockAdjustment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class StockAdjustmentCreationDto {
+
+    private String adjustmentNumber;
+    private String type;
+    private String status;
+    private Long locationId;
+    private Long projectId;
+    private LocalDate adjustmentDate;
+    private LocalDate effectiveDate;
+
+    @NotBlank
+    private String justification;
+
+    private String primaryReason;
+    private BigDecimal totalAdjustmentValue;
+    private LocalDate physicalCountDate;
+    private Long physicalCountBy;
+    private String countMethod;
+    private Long submittedBy;
+    private Double totalVarianceQuantity;
+    private List<StockAdjustmentLineItemCreationDto> lineItems;
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.stockAdjustment.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class StockAdjustmentDto {
+    private Long id;
+    private String adjustmentNumber;
+    private String type;
+    private String status;
+    private Long locationId;
+    private String locationName;
+    private Long projectId;
+    private String projectName;
+    private Long organizationId;
+    private LocalDate adjustmentDate;
+    private LocalDate effectiveDate;
+    private BigDecimal totalAdjustmentValue;
+    private String primaryReason;
+    private String justification;
+    private LocalDate physicalCountDate;
+    private Long physicalCountBy;
+    private String countMethod;
+    private Long submittedBy;
+    private LocalDateTime submittedAt;
+    private Long approvedBy;
+    private LocalDateTime approvedAt;
+    private Long rejectedBy;
+    private LocalDateTime rejectedAt;
+    private String rejectionReason;
+    private Long processedBy;
+    private LocalDateTime processedAt;
+    private Double totalVarianceQuantity;
+    private List<StockAdjustmentLineItemDto> lineItems;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.stockAdjustment.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class StockAdjustmentLineItemCreationDto {
+    private Long materialId;
+    private String description;
+    private Double systemQuantity;
+    private Double physicalQuantity;
+    private Double adjustmentQuantity;
+    private String unit;
+    private BigDecimal unitValue;
+    private BigDecimal totalAdjustmentValue;
+    private String reason;
+    private String reasonDetails;
+    private Long locationId;
+    private String binLocation;
+    private String notes;
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.stockAdjustment.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class StockAdjustmentLineItemDto {
+    private Long id;
+    private Long materialId;
+    private String materialName;
+    private String description;
+    private Double systemQuantity;
+    private Double physicalQuantity;
+    private Double adjustmentQuantity;
+    private String unit;
+    private BigDecimal unitValue;
+    private BigDecimal totalAdjustmentValue;
+    private String reason;
+    private String reasonDetails;
+    private Long locationId;
+    private String locationName;
+    private String binLocation;
+    private String notes;
+}

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/mapper/StockAdjustmentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/mapper/StockAdjustmentMapper.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.stockAdjustment.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustment;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentLineItem;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemDto;
+
+/**
+ * Maps {@link StockAdjustment} and its line items to their DTOs. Location, project,
+ * organization and material references flatten to id (+ name).
+ */
+@Mapper(componentModel = "spring")
+public interface StockAdjustmentMapper {
+
+    @Mapping(source = "location.id", target = "locationId")
+    @Mapping(source = "location.locationName", target = "locationName")
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "project.projectName", target = "projectName")
+    @Mapping(source = "organization.id", target = "organizationId")
+    StockAdjustmentDto toDto(StockAdjustment stockAdjustment);
+
+    @Mapping(source = "material.id", target = "materialId")
+    @Mapping(source = "material.materialName", target = "materialName")
+    @Mapping(source = "location.id", target = "locationId")
+    @Mapping(source = "location.locationName", target = "locationName")
+    StockAdjustmentLineItemDto toLineItemDto(StockAdjustmentLineItem item);
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -238,5 +238,7 @@
     <include file="db/changelog/v4.0/026-create-inspection-check-items.xml"/>
     <include file="db/changelog/v4.0/027-create-inspection-defects.xml"/>
     <include file="db/changelog/v4.0/028-create-assets.xml"/>
+    <include file="db/changelog/v4.0/029-create-stock-adjustments.xml"/>
+    <include file="db/changelog/v4.0/030-create-stock-adjustment-line-items.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/029-create-stock-adjustments.xml
+++ b/src/main/resources/db/changelog/v4.0/029-create-stock-adjustments.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="029-create-stock-adjustments" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="stock_adjustment"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="stock_adjustment">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="adjustment_number" type="VARCHAR(100)"/>
+            <column name="type" type="VARCHAR(50)"/>
+            <column name="status" type="VARCHAR(50)"/>
+
+            <column name="location_id" type="BIGINT"/>
+            <column name="project_id" type="BIGINT"/>
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="adjustment_date" type="DATE"/>
+            <column name="effective_date" type="DATE"/>
+
+            <column name="total_adjustment_value" type="NUMERIC(15, 2)"/>
+
+            <column name="primary_reason" type="VARCHAR(100)"/>
+            <column name="justification" type="TEXT"/>
+
+            <column name="physical_count_date" type="DATE"/>
+            <column name="physical_count_by" type="BIGINT"/>
+            <column name="count_method" type="VARCHAR(50)"/>
+
+            <column name="submitted_by" type="BIGINT"/>
+            <column name="submitted_at" type="TIMESTAMP"/>
+            <column name="approved_by" type="BIGINT"/>
+            <column name="approved_at" type="TIMESTAMP"/>
+            <column name="rejected_by" type="BIGINT"/>
+            <column name="rejected_at" type="TIMESTAMP"/>
+            <column name="rejection_reason" type="VARCHAR(500)"/>
+            <column name="processed_by" type="BIGINT"/>
+            <column name="processed_at" type="TIMESTAMP"/>
+
+            <column name="total_variance_quantity" type="DOUBLE"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_stock_adjustment_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment"
+                                 baseColumnNames="location_id"
+                                 constraintName="fk_stock_adjustment_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment"
+                                 baseColumnNames="project_id"
+                                 constraintName="fk_stock_adjustment_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_location">
+            <column name="location_id"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/030-create-stock-adjustment-line-items.xml
+++ b/src/main/resources/db/changelog/v4.0/030-create-stock-adjustment-line-items.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="030-create-stock-adjustment-line-items" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="stock_adjustment_line_item"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="stock_adjustment_line_item">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="stock_adjustment_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="material_id" type="BIGINT"/>
+
+            <column name="description" type="VARCHAR(500)"/>
+
+            <column name="system_quantity" type="DOUBLE"/>
+            <column name="physical_quantity" type="DOUBLE"/>
+            <column name="adjustment_quantity" type="DOUBLE"/>
+
+            <column name="unit" type="VARCHAR(50)"/>
+
+            <column name="unit_value" type="NUMERIC(15, 2)"/>
+            <column name="total_adjustment_value" type="NUMERIC(15, 2)"/>
+
+            <column name="reason" type="VARCHAR(100)"/>
+            <column name="reason_details" type="VARCHAR(500)"/>
+
+            <column name="location_id" type="BIGINT"/>
+            <column name="bin_location" type="VARCHAR(100)"/>
+            <column name="notes" type="VARCHAR(500)"/>
+
+            <column name="organization_id" type="BIGINT"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment_line_item"
+                                 baseColumnNames="stock_adjustment_id"
+                                 constraintName="fk_sa_line_item_stock_adjustment"
+                                 referencedTableName="stock_adjustment"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment_line_item"
+                                 baseColumnNames="material_id"
+                                 constraintName="fk_sa_line_item_material"
+                                 referencedTableName="material"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment_line_item"
+                                 baseColumnNames="location_id"
+                                 constraintName="fk_sa_line_item_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="stock_adjustment_line_item"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_sa_line_item_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="stock_adjustment_line_item" indexName="idx_sa_line_item_stock_adjustment">
+            <column name="stock_adjustment_id"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment_line_item" indexName="idx_sa_line_item_material">
+            <column name="material_id"/>
+        </createIndex>
+        <createIndex tableName="stock_adjustment_line_item" indexName="idx_sa_line_item_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepositoryIT.java
@@ -1,0 +1,94 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link StockAdjustmentRepository} against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Asserts the tenant-scoped lookup returns the
+ * header together with its line item, and that a persisted document shows up in a
+ * paginated {@code findAll}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class StockAdjustmentRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private StockAdjustmentRepository stockAdjustmentRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByIdAndOrganization_returnsTheDocumentWithItsLineItem() {
+        Organization org = persistOrganization("Org A");
+        StockAdjustment adjustment = persistStockAdjustment(org, "SA-0001");
+        em.flush();
+        em.clear();
+
+        Optional<StockAdjustment> found =
+                stockAdjustmentRepository.findByIdAndOrganization_Id(adjustment.getId(), org.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getAdjustmentNumber()).isEqualTo("SA-0001");
+        assertThat(found.get().getOrganization().getId()).isEqualTo(org.getId());
+        assertThat(found.get().getLineItems()).hasSize(1);
+        assertThat(found.get().getLineItems().get(0).getDescription()).isEqualTo("Cement bags");
+    }
+
+    @Test
+    void findAll_paginated_includesThePersistedDocument() {
+        Organization org = persistOrganization("Org B");
+        persistStockAdjustment(org, "SA-0002");
+        em.flush();
+        em.clear();
+
+        Page<StockAdjustment> result = stockAdjustmentRepository.findAll(PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(StockAdjustment::getAdjustmentNumber)
+                .contains("SA-0002");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private StockAdjustment persistStockAdjustment(Organization org, String number) {
+        StockAdjustment adjustment = new StockAdjustment();
+        adjustment.setOrganization(org);
+        adjustment.setAdjustmentNumber(number);
+        adjustment.setType("physical_count");
+        adjustment.setStatus("draft");
+        adjustment.setJustification("Year-end stock count");
+
+        StockAdjustmentLineItem item = new StockAdjustmentLineItem();
+        item.setDescription("Cement bags");
+        item.setSystemQuantity(100.0);
+        item.setPhysicalQuantity(95.0);
+        item.setAdjustmentQuantity(-5.0);
+        item.setUnit("bags");
+        item.setReason("write_off");
+        item.setOrganization(org);
+        adjustment.addLineItem(item);
+
+        em.persist(adjustment);
+        return adjustment;
+    }
+}


### PR DESCRIPTION
## What

New stock-adjustment register backing the web `resources/stock-adjustments` pages (mock until now). A `StockAdjustment` header + `StockAdjustmentLineItem` rows (material, system/physical/adjustment quantity, unit value, reason, location), the approval-workflow status + audit fields, tenant-scoped CRUD + pagination, `/api/v1/stock-adjustments/web` controller, Liquibase migrations 029/030.

## MVP scope — no stock mutation

The document is **persisted only**. Applying an approved adjustment's deltas to `CurrentStock` (via the locked `InventoryService`) is **deferred** — this change never touches real stock. `type`/`status`/`reason` are strings (the web sends snake-case values). Header + child are both tenant-scoped (child carries its own `organization_id`, following the `siteTransferItem` precedent). `update` replaces the line-item collection and `saveAndFlush`-es before mapping so child ids populate.

## Test

`StockAdjustmentRepositoryIT` (real CockroachDB via Testcontainers): org-scoped find with a line item + paginated list; both migrations run clean. Green on the lab node.

Companion `echno-web` swap follows (web-direct, reusing the existing parser).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset management with creation, viewing, editing, deletion, and pagination.
  * Added stock adjustment management, including adjustment details and line items.
  * Added tenant-scoped access controls and role-based permissions for asset and stock adjustment operations.
  * Added database support for assets and stock adjustments.
* **Tests**
  * Added integration coverage for tenant-scoped asset and stock adjustment retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->