### PR TITLE
Add subcontract module (header + milestones)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/subcontract/ContractMilestone.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/ContractMilestone.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.subcontract;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * A single milestone within a {@link SubContract}. Owned by the header through the
+ * {@code sub_contract_id} FK, which cascades persist and removal. The milestone also
+ * carries its own {@code organization_id} and the {@code orgFilter} so tenant scoping
+ * applies to the child rows directly, mirroring the other line-item entities in this
+ * codebase (e.g. stock-adjustment line items). Status is a plain string; the frontend
+ * validates it.
+ */
+@Entity
+@Table(name = "contract_milestone")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ContractMilestone implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sub_contract_id", nullable = false)
+    private SubContract subContract;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(name = "completion_date")
+    private LocalDate completionDate;
+
+    @Column(name = "payment_percentage", precision = 15, scale = 2)
+    private BigDecimal paymentPercentage;
+
+    @Column(name = "amount", precision = 15, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "status")
+    private String status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContract.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContract.java
@@ -1,0 +1,188 @@
+package org.tornotron.echno_backend.subcontract;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A subcontract: a header plus a list of milestones. Type and status values are
+ * stored as plain strings because the web client sends kebab/camel values (e.g.
+ * {@code on-hold}, {@code inProgress}) that are not valid Java enum identifiers;
+ * the frontend validates them.
+ *
+ * <p>{@code projectId}/{@code projectName} are kept as plain columns rather than a
+ * JPA relationship to keep the module self-contained; supervisor/account-manager
+ * ids are likewise plain columns.
+ */
+@Entity
+@Table(name = "sub_contract")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SubContract implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "contract_id")
+    private String contractId;
+
+    @Column(name = "contract_name", nullable = false)
+    private String contractName;
+
+    @Column(name = "work_description", columnDefinition = "TEXT")
+    private String workDescription;
+
+    @Column(name = "scope_of_work", columnDefinition = "TEXT")
+    private String scopeOfWork;
+
+    @Column(name = "contractor_name", nullable = false)
+    private String contractorName;
+
+    @Column(name = "contractor_contact_person")
+    private String contractorContactPerson;
+
+    @Column(name = "contractor_phone")
+    private String contractorPhone;
+
+    @Column(name = "contractor_email")
+    private String contractorEmail;
+
+    @Column(name = "contractor_address", columnDefinition = "TEXT")
+    private String contractorAddress;
+
+    @Column(name = "contractor_gst")
+    private String contractorGst;
+
+    @Column(name = "contractor_pan")
+    private String contractorPan;
+
+    @Column(name = "contractor_license")
+    private String contractorLicense;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "contract_value", precision = 15, scale = 2)
+    private BigDecimal contractValue;
+
+    @Column(name = "currency")
+    private String currency = "INR";
+
+    @Column(name = "mobilization_advance", precision = 15, scale = 2)
+    private BigDecimal mobilizationAdvance;
+
+    @Column(name = "retention_percentage", precision = 15, scale = 2)
+    private BigDecimal retentionPercentage;
+
+    @Column(name = "total_paid", precision = 15, scale = 2)
+    private BigDecimal totalPaid;
+
+    @Column(name = "total_due", precision = 15, scale = 2)
+    private BigDecimal totalDue;
+
+    @Column(name = "payment_terms", columnDefinition = "TEXT")
+    private String paymentTerms;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "actual_completion_date")
+    private LocalDate actualCompletionDate;
+
+    @Column(name = "completion_percentage", precision = 15, scale = 2)
+    private BigDecimal completionPercentage;
+
+    @Column(name = "project_id")
+    private Long projectId;
+
+    @Column(name = "project_name")
+    private String projectName;
+
+    @Column(name = "quality_rating", precision = 15, scale = 2)
+    private BigDecimal qualityRating;
+
+    @Column(name = "timeliness_rating", precision = 15, scale = 2)
+    private BigDecimal timelinessRating;
+
+    @Column(name = "safety_rating", precision = 15, scale = 2)
+    private BigDecimal safetyRating;
+
+    @Column(name = "overall_rating", precision = 15, scale = 2)
+    private BigDecimal overallRating;
+
+    @Column(name = "insurance_provider")
+    private String insuranceProvider;
+
+    @Column(name = "insurance_policy_number")
+    private String insurancePolicyNumber;
+
+    @Column(name = "insurance_expiry")
+    private LocalDate insuranceExpiry;
+
+    @Column(name = "bank_name")
+    private String bankName;
+
+    @Column(name = "bank_account_number")
+    private String bankAccountNumber;
+
+    @Column(name = "bank_ifsc")
+    private String bankIfsc;
+
+    @Column(name = "supervisor_id")
+    private Long supervisorId;
+
+    @Column(name = "account_manager_id")
+    private Long accountManagerId;
+
+    @Column(name = "penalty_clause", columnDefinition = "TEXT")
+    private String penaltyClause;
+
+    @Column(name = "warranty_period")
+    private String warrantyPeriod;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @OneToMany(mappedBy = "subContract", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<ContractMilestone> milestones = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** Attaches a milestone to this contract, wiring the back-reference. */
+    public void addMilestone(ContractMilestone milestone) {
+        milestone.setSubContract(this);
+        this.milestones.add(milestone);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.subcontract;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.subcontract.dto.SubContractCreationDto;
+import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
+
+import java.util.List;
+
+@RestController
+@Validated
+@RequestMapping("/api/v1/sub-contracts/web")
+public class SubContractControllerWeb {
+
+    private final SubContractService subContractService;
+
+    public SubContractControllerWeb(SubContractService subContractService) {
+        this.subContractService = subContractService;
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<List<SubContractDto>> readAllSubContracts() {
+        return new ResponseEntity<>(subContractService.getAll(), HttpStatus.OK);
+    }
+
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<Page<SubContractDto>> readAllSubContractsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String type) {
+        return new ResponseEntity<>(subContractService.getPaginated(pageNo, pageSize, search, status, type), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<SubContractDto> readASubContract(@PathVariable Long id) {
+        return new ResponseEntity<>(subContractService.getById(id), HttpStatus.OK);
+    }
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<SubContractDto> createSubContract(@Valid @RequestBody SubContractCreationDto creationDto) {
+        return new ResponseEntity<>(subContractService.create(creationDto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<SubContractDto> updateSubContract(@PathVariable Long id,
+                                                            @Valid @RequestBody SubContractCreationDto creationDto) {
+        return new ResponseEntity<>(subContractService.update(id, creationDto), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    public ResponseEntity<ApiResponse> deleteSubContract(@PathVariable Long id) {
+        subContractService.delete(id);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ApiResponse("Subcontract with id: " + id + " has been deleted"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractRepository.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.subcontract;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SubContractRepository extends JpaRepository<SubContract, Long> {
+
+    Optional<SubContract> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    boolean existsByContractIdAndOrganization_Id(String contractId, Long organizationId);
+
+    /**
+     * Paginated subcontract search. Every filter is optional (a null argument disables
+     * that clause); the tenant orgFilter still applies. {@code search} matches the
+     * contract name, contractor name, or business contract id, case-insensitively.
+     * Type and status match the plain string columns.
+     */
+    @Query("""
+            SELECT s FROM SubContract s WHERE
+              (:search IS NULL
+                 OR LOWER(s.contractName) LIKE :search
+                 OR LOWER(s.contractorName) LIKE :search
+                 OR LOWER(s.contractId) LIKE :search) AND
+              (:status IS NULL OR s.status = :status) AND
+              (:type IS NULL OR s.type = :type)
+            """)
+    Page<SubContract> search(
+            @Param("search") String search,
+            @Param("status") String status,
+            @Param("type") String type,
+            Pageable pageable);
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
@@ -1,0 +1,196 @@
+package org.tornotron.echno_backend.subcontract;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.subcontract.dto.ContractMilestoneDto;
+import org.tornotron.echno_backend.subcontract.dto.SubContractCreationDto;
+import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
+import org.tornotron.echno_backend.subcontract.mapper.SubContractMapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * CRUD + list for subcontracts. The subcontract is a header plus a list of
+ * milestones; each milestone carries its own organization so tenant scoping
+ * applies to the child rows directly.
+ */
+@Service
+public class SubContractService {
+
+    private final SubContractRepository subContractRepository;
+    private final SubContractMapper subContractMapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    public SubContractService(SubContractRepository subContractRepository,
+                              SubContractMapper subContractMapper,
+                              TenantEntityHelper tenantEntityHelper) {
+        this.subContractRepository = subContractRepository;
+        this.subContractMapper = subContractMapper;
+        this.tenantEntityHelper = tenantEntityHelper;
+    }
+
+    @Transactional
+    public SubContractDto create(SubContractCreationDto creationDto) {
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
+        SubContract subContract = new SubContract();
+        subContract.setOrganization(organization);
+        applyHeaderFields(subContract, creationDto);
+        applyMilestones(subContract, creationDto.getMilestones(), organization);
+        SubContract saved = subContractRepository.saveAndFlush(subContract);
+        return subContractMapper.toDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public SubContractDto getById(Long id) {
+        SubContract subContract = subContractRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Subcontract with ID " + id + " was not found in this organization"));
+        return subContractMapper.toDto(subContract);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SubContractDto> getAll() {
+        return subContractRepository.findAll().stream()
+                .map(subContractMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SubContractDto> getPaginated(int pageNo, int pageSize, String search, String status, String type) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return subContractRepository.search(searchPattern(search), blankToNull(status), blankToNull(type), pageable)
+                .map(subContractMapper::toDto);
+    }
+
+    @Transactional
+    public SubContractDto update(Long id, SubContractCreationDto creationDto) {
+        SubContract subContract = subContractRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Subcontract with ID " + id + " was not found in this organization"));
+        Organization organization = subContract.getOrganization();
+
+        applyHeaderFields(subContract, creationDto);
+
+        // Replace the milestone collection: clear in place (orphanRemoval deletes the old
+        // rows) and re-add from the request, keeping Hibernate's collection tracking intact.
+        subContract.getMilestones().clear();
+        applyMilestones(subContract, creationDto.getMilestones(), organization);
+
+        // saveAndFlush before mapping so the freshly inserted milestone ids are populated
+        // on the returned DTO (without the flush the child ids are null).
+        SubContract saved = subContractRepository.saveAndFlush(subContract);
+        return subContractMapper.toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        SubContract subContract = subContractRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Subcontract with ID " + id + " was not found in this organization"));
+        subContractRepository.delete(subContract);
+    }
+
+    /** Copies the header scalars from the creation DTO. Project/supervisor/account-manager stay plain ids. */
+    private void applyHeaderFields(SubContract subContract, SubContractCreationDto dto) {
+        subContract.setContractId(dto.getContractId());
+        subContract.setContractName(dto.getContractName());
+        subContract.setWorkDescription(dto.getWorkDescription());
+        subContract.setScopeOfWork(dto.getScopeOfWork());
+
+        subContract.setContractorName(dto.getContractorName());
+        subContract.setContractorContactPerson(dto.getContractorContactPerson());
+        subContract.setContractorPhone(dto.getContractorPhone());
+        subContract.setContractorEmail(dto.getContractorEmail());
+        subContract.setContractorAddress(dto.getContractorAddress());
+        subContract.setContractorGst(dto.getContractorGst());
+        subContract.setContractorPan(dto.getContractorPan());
+        subContract.setContractorLicense(dto.getContractorLicense());
+
+        subContract.setType(dto.getType());
+        subContract.setStatus(dto.getStatus());
+
+        subContract.setContractValue(dto.getContractValue());
+        if (dto.getCurrency() != null) {
+            subContract.setCurrency(dto.getCurrency());
+        }
+        subContract.setMobilizationAdvance(dto.getMobilizationAdvance());
+        subContract.setRetentionPercentage(dto.getRetentionPercentage());
+        subContract.setTotalPaid(dto.getTotalPaid());
+        subContract.setTotalDue(dto.getTotalDue());
+        subContract.setPaymentTerms(dto.getPaymentTerms());
+
+        subContract.setStartDate(dto.getStartDate());
+        subContract.setEndDate(dto.getEndDate());
+        subContract.setActualCompletionDate(dto.getActualCompletionDate());
+        subContract.setCompletionPercentage(dto.getCompletionPercentage());
+
+        subContract.setProjectId(dto.getProjectId());
+        subContract.setProjectName(dto.getProjectName());
+
+        subContract.setQualityRating(dto.getQualityRating());
+        subContract.setTimelinessRating(dto.getTimelinessRating());
+        subContract.setSafetyRating(dto.getSafetyRating());
+        subContract.setOverallRating(dto.getOverallRating());
+
+        subContract.setInsuranceProvider(dto.getInsuranceProvider());
+        subContract.setInsurancePolicyNumber(dto.getInsurancePolicyNumber());
+        subContract.setInsuranceExpiry(dto.getInsuranceExpiry());
+
+        subContract.setBankName(dto.getBankName());
+        subContract.setBankAccountNumber(dto.getBankAccountNumber());
+        subContract.setBankIfsc(dto.getBankIfsc());
+
+        subContract.setSupervisorId(dto.getSupervisorId());
+        subContract.setAccountManagerId(dto.getAccountManagerId());
+
+        subContract.setPenaltyClause(dto.getPenaltyClause());
+        subContract.setWarrantyPeriod(dto.getWarrantyPeriod());
+        subContract.setNotes(dto.getNotes());
+    }
+
+    /** Builds and attaches the milestones, wiring each child's back-reference and organization. */
+    private void applyMilestones(SubContract subContract,
+                                 List<ContractMilestoneDto> milestoneDtos,
+                                 Organization organization) {
+        if (milestoneDtos == null) {
+            return;
+        }
+        for (ContractMilestoneDto milestoneDto : milestoneDtos) {
+            ContractMilestone milestone = new ContractMilestone();
+            milestone.setName(milestoneDto.getName());
+            milestone.setDescription(milestoneDto.getDescription());
+            milestone.setTargetDate(milestoneDto.getTargetDate());
+            milestone.setCompletionDate(milestoneDto.getCompletionDate());
+            milestone.setPaymentPercentage(milestoneDto.getPaymentPercentage());
+            milestone.setAmount(milestoneDto.getAmount());
+            milestone.setStatus(milestoneDto.getStatus());
+            milestone.setOrganization(organization);
+            subContract.addMilestone(milestone);
+        }
+    }
+
+    /**
+     * Builds a lower-cased {@code %...%} LIKE pattern for the search term, or null
+     * when blank. The pattern is assembled here rather than with SQL {@code CONCAT}
+     * so no null bind lands inside a {@code ||}, which CockroachDB mistypes as bytes.
+     */
+    private static String searchPattern(String value) {
+        return (value == null || value.isBlank()) ? null : "%" + value.trim().toLowerCase() + "%";
+    }
+
+    private static String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/ContractMilestoneDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/ContractMilestoneDto.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.subcontract.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class ContractMilestoneDto {
+    private Long id;
+    private String name;
+    private String description;
+    private LocalDate targetDate;
+    private LocalDate completionDate;
+    private BigDecimal paymentPercentage;
+    private BigDecimal amount;
+    private String status;
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractCreationDto.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.subcontract.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class SubContractCreationDto {
+
+    private String contractId;
+
+    @NotBlank
+    private String contractName;
+
+    private String workDescription;
+    private String scopeOfWork;
+
+    @NotBlank
+    private String contractorName;
+
+    private String contractorContactPerson;
+    private String contractorPhone;
+    private String contractorEmail;
+    private String contractorAddress;
+    private String contractorGst;
+    private String contractorPan;
+    private String contractorLicense;
+
+    private String type;
+    private String status;
+
+    private BigDecimal contractValue;
+    private String currency;
+    private BigDecimal mobilizationAdvance;
+    private BigDecimal retentionPercentage;
+    private BigDecimal totalPaid;
+    private BigDecimal totalDue;
+    private String paymentTerms;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate actualCompletionDate;
+    private BigDecimal completionPercentage;
+
+    private Long projectId;
+    private String projectName;
+
+    private BigDecimal qualityRating;
+    private BigDecimal timelinessRating;
+    private BigDecimal safetyRating;
+    private BigDecimal overallRating;
+
+    private String insuranceProvider;
+    private String insurancePolicyNumber;
+    private LocalDate insuranceExpiry;
+
+    private String bankName;
+    private String bankAccountNumber;
+    private String bankIfsc;
+
+    private Long supervisorId;
+    private Long accountManagerId;
+
+    private String penaltyClause;
+    private String warrantyPeriod;
+    private String notes;
+
+    private List<ContractMilestoneDto> milestones;
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractDto.java
@@ -1,0 +1,71 @@
+package org.tornotron.echno_backend.subcontract.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class SubContractDto {
+    private Long id;
+    private String contractId;
+    private String contractName;
+    private String workDescription;
+    private String scopeOfWork;
+
+    private String contractorName;
+    private String contractorContactPerson;
+    private String contractorPhone;
+    private String contractorEmail;
+    private String contractorAddress;
+    private String contractorGst;
+    private String contractorPan;
+    private String contractorLicense;
+
+    private String type;
+    private String status;
+
+    private BigDecimal contractValue;
+    private String currency;
+    private BigDecimal mobilizationAdvance;
+    private BigDecimal retentionPercentage;
+    private BigDecimal totalPaid;
+    private BigDecimal totalDue;
+    private String paymentTerms;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate actualCompletionDate;
+    private BigDecimal completionPercentage;
+
+    private Long projectId;
+    private String projectName;
+
+    private BigDecimal qualityRating;
+    private BigDecimal timelinessRating;
+    private BigDecimal safetyRating;
+    private BigDecimal overallRating;
+
+    private String insuranceProvider;
+    private String insurancePolicyNumber;
+    private LocalDate insuranceExpiry;
+
+    private String bankName;
+    private String bankAccountNumber;
+    private String bankIfsc;
+
+    private Long supervisorId;
+    private Long accountManagerId;
+
+    private String penaltyClause;
+    private String warrantyPeriod;
+    private String notes;
+
+    private Long organizationId;
+    private List<ContractMilestoneDto> milestones;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/subcontract/mapper/SubContractMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/mapper/SubContractMapper.java
@@ -1,0 +1,21 @@
+package org.tornotron.echno_backend.subcontract.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.subcontract.ContractMilestone;
+import org.tornotron.echno_backend.subcontract.SubContract;
+import org.tornotron.echno_backend.subcontract.dto.ContractMilestoneDto;
+import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
+
+/**
+ * Maps {@link SubContract} and its milestones to their DTOs. Organization flattens
+ * to id; the milestone collection maps element-wise via {@link #toMilestoneDto}.
+ */
+@Mapper(componentModel = "spring")
+public interface SubContractMapper {
+
+    @Mapping(source = "organization.id", target = "organizationId")
+    SubContractDto toDto(SubContract subContract);
+
+    ContractMilestoneDto toMilestoneDto(ContractMilestone milestone);
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -241,4 +241,8 @@
     <include file="db/changelog/v4.0/029-create-stock-adjustments.xml"/>
     <include file="db/changelog/v4.0/030-create-stock-adjustment-line-items.xml"/>
 
+    <!-- v4.0 - Subcontract module -->
+    <include file="db/changelog/v4.0/031-create-sub-contracts.xml"/>
+    <include file="db/changelog/v4.0/032-create-contract-milestones.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/031-create-sub-contracts.xml
+++ b/src/main/resources/db/changelog/v4.0/031-create-sub-contracts.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="031-create-sub-contracts" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="sub_contract"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="sub_contract">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="contract_id" type="VARCHAR(100)"/>
+            <column name="contract_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="work_description" type="TEXT"/>
+            <column name="scope_of_work" type="TEXT"/>
+
+            <column name="contractor_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="contractor_contact_person" type="VARCHAR(200)"/>
+            <column name="contractor_phone" type="VARCHAR(50)"/>
+            <column name="contractor_email" type="VARCHAR(200)"/>
+            <column name="contractor_address" type="TEXT"/>
+            <column name="contractor_gst" type="VARCHAR(50)"/>
+            <column name="contractor_pan" type="VARCHAR(50)"/>
+            <column name="contractor_license" type="VARCHAR(100)"/>
+
+            <column name="type" type="VARCHAR(50)"/>
+            <column name="status" type="VARCHAR(50)"/>
+
+            <column name="contract_value" type="NUMERIC(15, 2)"/>
+            <column name="currency" type="VARCHAR(10)"/>
+            <column name="mobilization_advance" type="NUMERIC(15, 2)"/>
+            <column name="retention_percentage" type="NUMERIC(15, 2)"/>
+            <column name="total_paid" type="NUMERIC(15, 2)"/>
+            <column name="total_due" type="NUMERIC(15, 2)"/>
+            <column name="payment_terms" type="TEXT"/>
+
+            <column name="start_date" type="DATE"/>
+            <column name="end_date" type="DATE"/>
+            <column name="actual_completion_date" type="DATE"/>
+            <column name="completion_percentage" type="NUMERIC(15, 2)"/>
+
+            <column name="project_id" type="BIGINT"/>
+            <column name="project_name" type="VARCHAR(255)"/>
+
+            <column name="quality_rating" type="NUMERIC(15, 2)"/>
+            <column name="timeliness_rating" type="NUMERIC(15, 2)"/>
+            <column name="safety_rating" type="NUMERIC(15, 2)"/>
+            <column name="overall_rating" type="NUMERIC(15, 2)"/>
+
+            <column name="insurance_provider" type="VARCHAR(200)"/>
+            <column name="insurance_policy_number" type="VARCHAR(100)"/>
+            <column name="insurance_expiry" type="DATE"/>
+
+            <column name="bank_name" type="VARCHAR(200)"/>
+            <column name="bank_account_number" type="VARCHAR(100)"/>
+            <column name="bank_ifsc" type="VARCHAR(50)"/>
+
+            <column name="supervisor_id" type="BIGINT"/>
+            <column name="account_manager_id" type="BIGINT"/>
+
+            <column name="penalty_clause" type="TEXT"/>
+            <column name="warranty_period" type="VARCHAR(200)"/>
+            <column name="notes" type="TEXT"/>
+
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="sub_contract"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_sub_contract_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="sub_contract" indexName="idx_sub_contract_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="sub_contract" indexName="idx_sub_contract_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="sub_contract" indexName="idx_sub_contract_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="sub_contract" indexName="idx_sub_contract_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/032-create-contract-milestones.xml
+++ b/src/main/resources/db/changelog/v4.0/032-create-contract-milestones.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="032-create-contract-milestones" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="contract_milestone"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="contract_milestone">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="sub_contract_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+
+            <column name="target_date" type="DATE"/>
+            <column name="completion_date" type="DATE"/>
+
+            <column name="payment_percentage" type="NUMERIC(15, 2)"/>
+            <column name="amount" type="NUMERIC(15, 2)"/>
+
+            <column name="status" type="VARCHAR(50)"/>
+
+            <column name="organization_id" type="BIGINT"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="contract_milestone"
+                                 baseColumnNames="sub_contract_id"
+                                 constraintName="fk_contract_milestone_sub_contract"
+                                 referencedTableName="sub_contract"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="contract_milestone"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_contract_milestone_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="contract_milestone" indexName="idx_contract_milestone_sub_contract">
+            <column name="sub_contract_id"/>
+        </createIndex>
+        <createIndex tableName="contract_milestone" indexName="idx_contract_milestone_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/subcontract/SubContractRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/subcontract/SubContractRepositoryIT.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.subcontract;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link SubContractRepository} against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Asserts the tenant-scoped lookup and that
+ * a persisted subcontract cascades its milestone and shows up in {@code findAll}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SubContractRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private SubContractRepository subContractRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByIdAndOrganization_returnsTheSubContractWithItsMilestone() {
+        Organization org = persistOrganization("Org A");
+        SubContract subContract = persistSubContract(org, "Foundation Works", "BuildCo");
+        em.flush();
+        em.clear();
+
+        Optional<SubContract> found = subContractRepository.findByIdAndOrganization_Id(subContract.getId(), org.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getContractName()).isEqualTo("Foundation Works");
+        assertThat(found.get().getOrganization().getId()).isEqualTo(org.getId());
+        assertThat(found.get().getMilestones()).hasSize(1);
+        assertThat(found.get().getMilestones().get(0).getName()).isEqualTo("Slab casting");
+        assertThat(found.get().getMilestones().get(0).getOrganization().getId()).isEqualTo(org.getId());
+    }
+
+    @Test
+    void findByIdAndOrganization_doesNotReturnAcrossTenants() {
+        Organization orgA = persistOrganization("Org A2");
+        Organization orgB = persistOrganization("Org B2");
+        SubContract subContract = persistSubContract(orgA, "Plumbing", "PipeCo");
+        em.flush();
+        em.clear();
+
+        Optional<SubContract> found = subContractRepository.findByIdAndOrganization_Id(subContract.getId(), orgB.getId());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void findAll_paginated_includesThePersistedSubContract() {
+        Organization org = persistOrganization("Org C");
+        persistSubContract(org, "Electrical Fit-out", "SparkCo");
+        em.flush();
+        em.clear();
+
+        Page<SubContract> result = subContractRepository.findAll(PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(SubContract::getContractName)
+                .contains("Electrical Fit-out");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private SubContract persistSubContract(Organization org, String contractName, String contractorName) {
+        SubContract subContract = new SubContract();
+        subContract.setOrganization(org);
+        subContract.setContractName(contractName);
+        subContract.setContractorName(contractorName);
+        subContract.setStatus("active");
+        subContract.setType("labor");
+
+        ContractMilestone milestone = new ContractMilestone();
+        milestone.setName("Slab casting");
+        milestone.setStatus("pending");
+        milestone.setOrganization(org);
+        subContract.addMilestone(milestone);
+
+        em.persist(subContract);
+        return subContract;
+    }
+}


### PR DESCRIPTION
Adds a self-contained `subcontract` domain backing the third-party sub-contracts web feature (previously mock-only).

## What
- `SubContract` header entity + `ContractMilestone` child, both tenant-scoped (`TenantScopedEntity` + `orgFilter`); the child carries its own `organization_id`.
- `SubContractControllerWeb` at `/api/v1/sub-contracts/web`: list, `/paginated` (search over name/contractor/contract-id + optional status/type), get, create, update, delete. Reads require tenant membership; writes require `system-admin`/`project-manager` (mirrors the asset module).
- MapStruct mapper, DTOs, repository with a null-safe search (LIKE pattern built in Java to avoid the CockroachDB CONCAT-null typing issue).
- Liquibase `031-create-sub-contracts` + `032-create-contract-milestones`.
- `SubContractRepositoryIT` (Testcontainers CockroachDB) covering persist, tenant filter and milestone cascade.

## Notes
- Type/status stored as plain strings (the web client sends its own vocabulary; the frontend validates).
- Milestones replace-in-place on update (orphanRemoval), `saveAndFlush` before mapping so child ids populate on the response.
- Financial id-links (invoice/payment/advance) and document urls are deferred; project/supervisor/account-manager kept as plain id columns.