### PR TITLE
Validate JWT audience and issuer on the resource server

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/JwtDecoderConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/JwtDecoderConfig.java
@@ -1,0 +1,126 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the resource-server {@link JwtDecoder} so it does more than the default
+ * signature + expiry check. Spring's auto-configured decoder (built from
+ * {@code jwk-set-uri} alone) accepts any token the realm signed, regardless of who
+ * it was minted for; this adds:
+ *
+ * <ul>
+ *   <li><b>Audience</b> - the token's {@code aud} must contain the backend client id.
+ *       Every request's token is first exchanged for an RPT scoped to exactly this
+ *       client (see {@link RPTExchangeFilter}), so legitimate tokens always match while
+ *       a token minted for a different client in the same realm is rejected.</li>
+ *   <li><b>Issuer</b> - optional. When {@code echno.security.jwt.accepted-issuers} is
+ *       set, the {@code iss} claim must be one of the listed values. Keycloak stamps the
+ *       realm's canonical (frontend) issuer, which can differ from the internal URL the
+ *       backend dials, so the property takes a list.</li>
+ * </ul>
+ */
+@Configuration
+@Slf4j
+public class JwtDecoderConfig {
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
+    private String jwkSetUri;
+
+    @Value("${jwt.auth.converter.resource-id}")
+    private String resourceId;
+
+    @Value("${echno.security.jwt.require-audience:true}")
+    private boolean requireAudience;
+
+    @Value("${echno.security.jwt.accepted-issuers:}")
+    private List<String> acceptedIssuers;
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+
+        List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
+        validators.add(new JwtTimestampValidator());
+
+        if (requireAudience) {
+            validators.add(new AudienceValidator(resourceId));
+            log.info("JWT audience validation enabled (required audience: {})", resourceId);
+        } else {
+            log.warn("JWT audience validation is DISABLED");
+        }
+
+        Set<String> issuers = acceptedIssuers == null ? Set.of()
+                : acceptedIssuers.stream()
+                        .filter(s -> s != null && !s.isBlank())
+                        .map(String::trim)
+                        .collect(Collectors.toSet());
+        if (!issuers.isEmpty()) {
+            validators.add(new IssuerValidator(issuers));
+            log.info("JWT issuer validation enabled (accepted issuers: {})", issuers);
+        } else {
+            log.warn("JWT issuer validation is DISABLED (echno.security.jwt.accepted-issuers is empty)");
+        }
+
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
+        return decoder;
+    }
+
+    /** Fails a token whose {@code aud} claim does not contain the required audience. */
+    static class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+        private final String requiredAudience;
+
+        AudienceValidator(String requiredAudience) {
+            this.requiredAudience = requiredAudience;
+        }
+
+        @Override
+        public OAuth2TokenValidatorResult validate(Jwt token) {
+            if (token.getAudience() != null && token.getAudience().contains(requiredAudience)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(new OAuth2Error(
+                    "invalid_token",
+                    "The required audience '" + requiredAudience + "' is missing",
+                    null));
+        }
+    }
+
+    /** Fails a token whose {@code iss} claim is not one of the accepted issuers. */
+    static class IssuerValidator implements OAuth2TokenValidator<Jwt> {
+
+        private final Set<String> acceptedIssuers;
+
+        IssuerValidator(Set<String> acceptedIssuers) {
+            this.acceptedIssuers = acceptedIssuers;
+        }
+
+        @Override
+        public OAuth2TokenValidatorResult validate(Jwt token) {
+            String issuer = token.getIssuer() == null ? null : token.getIssuer().toString();
+            if (issuer != null && acceptedIssuers.contains(issuer)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(new OAuth2Error(
+                    "invalid_token",
+                    "The issuer '" + issuer + "' is not accepted",
+                    null));
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,19 @@ keycloak:
     output-path: src/main/resources/config
 
 
+echno:
+  security:
+    jwt:
+      # Reject any access token whose audience does not include the backend client
+      # (the RPT is minted for exactly this client, so legitimate tokens always match).
+      require-audience: ${ECHNO_JWT_REQUIRE_AUDIENCE:true}
+      # Comma-separated list of issuers the token's `iss` claim must match. Empty
+      # disables the check. Keycloak stamps the realm's canonical (frontend) issuer,
+      # which can differ from the internal URL the backend dials, so list every URL
+      # the same realm may present.
+      accepted-issuers: ${ECHNO_JWT_ACCEPTED_ISSUERS:}
+
+
 spring:
   cache:
     cache-names:

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/JwtDecoderConfigTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/JwtDecoderConfigTest.java
@@ -1,0 +1,82 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the JWT audience and issuer validators. No Spring context: the
+ * validators are exercised directly against hand-built {@link Jwt} tokens.
+ */
+class JwtDecoderConfigTest {
+
+    private static final String BACKEND_CLIENT = "echno-backend-client";
+    private static final String PUBLIC_ISSUER = "https://auth.echno.in/realms/echno-realm";
+    private static final String INTERNAL_ISSUER = "http://echno-keycloak:8080/realms/echno-realm";
+
+    private Jwt.Builder token() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300));
+    }
+
+    // --- Audience ---------------------------------------------------------
+
+    @Test
+    void audienceValidator_acceptsTokenWithRequiredAudience() {
+        var validator = new JwtDecoderConfig.AudienceValidator(BACKEND_CLIENT);
+        Jwt jwt = token().audience(List.of(BACKEND_CLIENT, "account")).build();
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void audienceValidator_rejectsTokenMintedForAnotherClient() {
+        var validator = new JwtDecoderConfig.AudienceValidator(BACKEND_CLIENT);
+        Jwt jwt = token().audience(List.of("some-other-client")).build();
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertTrue(result.hasErrors());
+    }
+
+    @Test
+    void audienceValidator_rejectsTokenWithNoAudience() {
+        var validator = new JwtDecoderConfig.AudienceValidator(BACKEND_CLIENT);
+        Jwt jwt = token().claim("sub", "user").build();
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertTrue(result.hasErrors());
+    }
+
+    // --- Issuer -----------------------------------------------------------
+
+    @Test
+    void issuerValidator_acceptsEitherRealmUrlForTheSameRealm() {
+        var validator = new JwtDecoderConfig.IssuerValidator(Set.of(PUBLIC_ISSUER, INTERNAL_ISSUER));
+
+        assertFalse(validator.validate(token().issuer(PUBLIC_ISSUER).build()).hasErrors());
+        assertFalse(validator.validate(token().issuer(INTERNAL_ISSUER).build()).hasErrors());
+    }
+
+    @Test
+    void issuerValidator_rejectsForeignIssuer() {
+        var validator = new JwtDecoderConfig.IssuerValidator(Set.of(PUBLIC_ISSUER));
+        Jwt jwt = token().issuer("https://evil.example.com/realms/echno-realm").build();
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertTrue(result.hasErrors());
+    }
+}


### PR DESCRIPTION
Closes the audit finding that the backend validated neither `aud` nor `iss` on incoming tokens (jwk-set-uri only), so any token the realm signed was accepted regardless of the client it was minted for.

## What
- New `JwtDecoderConfig` supplies a custom `JwtDecoder` (built from the same `jwk-set-uri`) with a delegating validator chain: timestamp (default) + **audience** + optional **issuer**.
- **Audience** (`echno.security.jwt.require-audience`, default **true**): the token's `aud` must contain the backend client (`jwt.auth.converter.resource-id`). Safe to enforce: every request's access token is already exchanged for an RPT scoped to exactly this client (`RPTExchangeFilter`), and `JwtAuthConverter` already reads `resource_access[resource-id]` for roles, so working authorization proves the claim is always present.
- **Issuer** (`echno.security.jwt.accepted-issuers`, default **empty = off**): when set, `iss` must be one of the listed values. Left opt-in because Keycloak stamps the realm's canonical (frontend) issuer, which differs from the internal URL the backend dials, so the accepted set is environment-specific. Enabling it on staging is a follow-up env change (`ECHNO_JWT_ACCEPTED_ISSUERS`) in echno-deployment.

## Tests
- `JwtDecoderConfigTest` (plain JUnit): audience accepts the backend client, rejects another client and a no-audience token; issuer accepts either realm URL, rejects a foreign issuer.
- Existing `UserControllerAuthzTest` still green (the new decoder bean does not disturb the security web slice).

## Follow-up
- After deploy, confirm a page still loads on echno.in (audience enforcement), then set `ECHNO_JWT_ACCEPTED_ISSUERS` to the realm's public + internal issuer URLs to turn on issuer validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable JWT audience and issuer validation.
  * Tokens now undergo timestamp, audience, and issuer checks when enabled.
  * Invalid tokens are rejected with clear `invalid_token` errors.
  * Added environment-backed settings for accepted audiences and issuers.

* **Tests**
  * Added coverage for valid and invalid audiences, missing audience claims, and accepted or rejected issuers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->