### PR TITLE
Prevent duplicate no-location stock rows under concurrent first insert

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.inventoryTransaction;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,28 @@ public interface CurrentStockRepository extends JpaRepository<CurrentStock, Long
 
     Optional<CurrentStock> findByMaterialIdAndProjectIdAndStorageLocationId(
             Long materialId, Long projectId, Long storageLocationId);
+
+    /**
+     * Inserts a zero-quantity stock row if one does not already exist for this
+     * material/project/location, doing nothing on conflict. Called before taking the
+     * pessimistic lock so the lock always has a row to hold: two events racing to
+     * create the first record for the same key cannot both insert (which for a null
+     * location the composite unique constraint would not catch, since NULLs are
+     * distinct). Native because {@code ON CONFLICT DO NOTHING} has no JPQL form.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query(value = """
+            INSERT INTO current_stock
+                (material_id, project_id, storage_location_id, organization_id,
+                 current_quantity, stock_value, created_at, updated_at)
+            VALUES (:materialId, :projectId, :storageLocationId, :organizationId,
+                    0.0, 0, current_timestamp, current_timestamp)
+            ON CONFLICT DO NOTHING
+            """, nativeQuery = true)
+    void seedZeroStockRow(@Param("materialId") Long materialId,
+                          @Param("projectId") Long projectId,
+                          @Param("storageLocationId") Long storageLocationId,
+                          @Param("organizationId") Long organizationId);
 
     @Query("SELECT cs FROM CurrentStock cs WHERE cs.material.id = :materialId AND cs.project.id = :projectId AND cs.storageLocation IS NULL")
     Optional<CurrentStock> findByMaterialIdAndProjectIdAndStorageLocationIsNull(

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
@@ -244,34 +244,25 @@ public class InventoryService {
     @Transactional
     public CurrentStock updateCurrentStock(Material material, Project project, StorageLocation storageLocation,
                                            Organization organization, Double quantityChanged, BigDecimal unitCost) {
-        CurrentStock stock;
-        if (storageLocation != null) {
-            stock = currentStockRepository
-                    .lockByMaterialProjectAndLocation(
-                            material.getId(), project.getId(), storageLocation.getId())
-                    .orElseGet(() -> {
-                        CurrentStock newStock = new CurrentStock();
-                        newStock.setMaterial(material);
-                        newStock.setProject(project);
-                        newStock.setStorageLocation(storageLocation);
-                        newStock.setOrganization(organization);
-                        newStock.setCurrentQuantity(0.0);
-                        newStock.setStockValue(BigDecimal.ZERO);
-                        return newStock;
-                    });
-        } else {
-            stock = currentStockRepository
-                    .lockByMaterialProjectAndNoLocation(material.getId(), project.getId())
-                    .orElseGet(() -> {
-                        CurrentStock newStock = new CurrentStock();
-                        newStock.setMaterial(material);
-                        newStock.setProject(project);
-                        newStock.setOrganization(organization);
-                        newStock.setCurrentQuantity(0.0);
-                        newStock.setStockValue(BigDecimal.ZERO);
-                        return newStock;
-                    });
-        }
+        Long storageLocationId = storageLocation != null ? storageLocation.getId() : null;
+
+        // Guarantee the row exists before locking. A plain "lock or else create" loses the
+        // race when two events create the first record for the same key at once: both find
+        // no row to lock and both insert. For a located row the composite unique constraint
+        // rejects the second insert, but for a no-location row NULLs are distinct so both
+        // would succeed and split the stock across duplicate rows. Seeding a zero row (a
+        // no-op on conflict) means the lock below always finds exactly one row to serialize on.
+        currentStockRepository.seedZeroStockRow(material.getId(), project.getId(),
+                storageLocationId, organization != null ? organization.getId() : null);
+
+        CurrentStock stock = (storageLocation != null
+                ? currentStockRepository.lockByMaterialProjectAndLocation(
+                        material.getId(), project.getId(), storageLocationId)
+                : currentStockRepository.lockByMaterialProjectAndNoLocation(
+                        material.getId(), project.getId()))
+                .orElseThrow(() -> new IllegalStateException(
+                        "Current stock row missing after seed for material " + material.getId()
+                                + " project " + project.getId()));
 
         // Update stock value
         if (quantityChanged > 0 && unitCost != null) {

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -244,5 +244,6 @@
     <!-- v4.0 - Subcontract module -->
     <include file="db/changelog/v4.0/031-create-sub-contracts.xml"/>
     <include file="db/changelog/v4.0/032-create-contract-milestones.xml"/>
+    <include file="db/changelog/v4.0/033-current-stock-null-location-unique.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/033-current-stock-null-location-unique.xml
+++ b/src/main/resources/db/changelog/v4.0/033-current-stock-null-location-unique.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="033-current-stock-null-location-unique" author="echno">
+        <comment>
+            The composite unique constraint on (material_id, project_id, storage_location_id)
+            does not stop duplicate no-location stock rows: SQL treats each NULL as distinct,
+            so two rows with the same material and project and a NULL storage location satisfy
+            it. Add a partial unique index so at most one no-location row can exist per
+            material and project, matching the guarantee already in force for located rows.
+            Auditing confirmed no such duplicates exist, so the index applies cleanly.
+        </comment>
+        <sql>
+            CREATE UNIQUE INDEX IF NOT EXISTS uk_current_stock_material_project_no_location
+            ON current_stock (material_id, project_id)
+            WHERE storage_location_id IS NULL;
+        </sql>
+        <rollback>
+            DROP INDEX IF EXISTS current_stock@uk_current_stock_material_project_no_location;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryFirstInsertConcurrencyIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryFirstInsertConcurrencyIT.java
@@ -1,0 +1,118 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency test for the FIRST insert of a no-location stock row against a real
+ * CockroachDB. Two threads increment a material/project that has no stock row yet, so
+ * both race to create it. Without the seed-then-lock path (and the partial unique index
+ * behind it) both would insert a separate no-location row: the total would still sum
+ * correctly but the stock would be split across duplicates that later locks each miss.
+ * With the fix exactly one row exists and the quantity is exact.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(InventoryService.class)
+class InventoryFirstInsertConcurrencyIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @Autowired
+    private CurrentStockRepository currentStockRepository;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentFirstInserts_createOneRow_andDoNotLoseUpdates() throws Exception {
+        // Seed only the organization, material and project - deliberately NO stock row,
+        // so the worker threads exercise the first-insert path.
+        long[] ids = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("First Insert Org");
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail("first-insert@example.test");
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+
+            Material material = new Material();
+            material.setMaterialName("Cement");
+            material.setUnit("bag");
+            material.setOrganization(org);
+            entityManager.persist(material);
+
+            Project project = new Project();
+            project.setProjectName("Project 1");
+            project.setOrganization(org);
+            entityManager.persist(project);
+
+            entityManager.flush();
+            return new long[] {org.getId(), material.getId(), project.getId()};
+        });
+
+        Organization org = new Organization();
+        org.setId(ids[0]);
+        Material material = new Material();
+        material.setId(ids[1]);
+        Project project = new Project();
+        project.setId(ids[2]);
+
+        int threads = 2;
+        double increment = 10.0;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                startGate.await();
+                inventoryService.updateCurrentStock(material, project, null, org, increment, BigDecimal.ONE);
+                return null;
+            }));
+        }
+        startGate.countDown();
+        for (Future<?> future : futures) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        Double finalQuantity = currentStockRepository.sumCurrentQuantityByMaterialAndProject(ids[1], ids[2]);
+        assertThat(finalQuantity).isEqualTo(threads * increment);
+
+        long rowCount = currentStockRepository.findAll().stream()
+                .filter(cs -> cs.getMaterial().getId().equals(ids[1])
+                        && cs.getProject().getId().equals(ids[2])
+                        && cs.getStorageLocation() == null)
+                .count();
+        assertThat(rowCount).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Completes the stock data-integrity work (Part B of the audit's stock findings; #328 added the pessimistic lock for existing rows).

## Problem
`InventoryService.updateCurrentStock` did a "lock the row or create it if absent" upsert. When two inventory events create the *first* record for the same material/project/location simultaneously, both find no row to lock and both insert. For a located row the composite unique constraint `(material_id, project_id, storage_location_id)` rejects the second insert, but for a **no-location** row SQL treats each NULL as distinct, so both inserts succeed and the stock is split across duplicate rows that subsequent locks each miss (drift / lost updates).

## Fix
- **Seed-then-lock**: `updateCurrentStock` now seeds a zero row (`INSERT ... ON CONFLICT DO NOTHING`) before taking the pessimistic lock, so the lock always finds exactly one row to serialize on. The insert is a no-op when the row exists.
- **Partial unique index** (migration `033`) over `(material_id, project_id) WHERE storage_location_id IS NULL`, matching the guarantee the composite constraint already gives located rows. A read-only audit of staging confirmed **zero** existing duplicates, so it applies cleanly.

## Tests
- New `InventoryFirstInsertConcurrencyIT` (real CockroachDB): 2 threads first-insert the same no-location key -> exactly **one** row, quantity exact. Fails without the fix.
- Existing `InventoryServiceConcurrencyIT` (4 threads on a pre-seeded row) still green (no regression), which also confirms `ON CONFLICT DO NOTHING` selects the partial index as arbiter on CockroachDB.

## Not included (deferred, per scope decision)
- Wiring stock-adjustment approval to actually post to CurrentStock: it needs an approval workflow that the document-only module does not have yet.