### PR TITLE
Restrict subscription management and report reads to roles

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
@@ -33,7 +33,7 @@ public class SubscriptionController {
      *
      * @return Active subscription or empty if none
      */
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/current")
     public ResponseEntity<SubscriptionDto> getCurrentSubscription() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -48,7 +48,7 @@ public class SubscriptionController {
      *
      * @return List of all subscriptions
      */
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/history")
     public ResponseEntity<List<SubscriptionDto>> getSubscriptionHistory() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -62,7 +62,7 @@ public class SubscriptionController {
      * @param dto Subscription creation data with plan code
      * @return Created subscription
      */
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
     public ResponseEntity<SubscriptionDto> createSubscription(@Valid @RequestBody SubscriptionCreateDto dto)
             throws AuthenticationException {
@@ -77,7 +77,7 @@ public class SubscriptionController {
      * @param dto Plan change data
      * @return Updated subscription
      */
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PutMapping("/change-plan")
     public ResponseEntity<SubscriptionDto> changeSubscription(@Valid @RequestBody SubscriptionChangeDto dto)
             throws AuthenticationException {
@@ -92,7 +92,7 @@ public class SubscriptionController {
      * @param dto Cancellation options
      * @return Success message
      */
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/cancel")
     public ResponseEntity<ApiResponse> cancelSubscription(@RequestBody(required = false) SubscriptionCancelDto dto)
             throws AuthenticationException {

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
@@ -65,7 +65,7 @@ public class ReportController {
         return ctx;
     }
 
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @GetMapping("/pdf")
     public ResponseEntity<byte[]> pdfReport() {
         Context ctx = populateContext();


### PR DESCRIPTION
Fine-grained RBAC hardening of the intra-org read/action floor (writes were already role-gated; this tightens sensitive membership-floor endpoints).

## What
- **SubscriptionController**: `/current`, `/history`, create, `/change-plan`, `/cancel` moved from `isMemberOfCurrentTenant()` to `hasAnyOrgRoleForCurrentTenant('system-admin')`. This closes a real privilege gap: any org member could previously read the org's billing detail or **cancel the org's subscription**. The runtime `/features/{code}/access` check and `/usage` recording stay at the member floor (they gate normal in-app behaviour). The `/user/{userId}` endpoints already required `billing:admin` and are unchanged.
- **ReportController** `/pdf` moved to `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')` (aggregated report = a management view).

## Safe to enforce
The web app calls none of these endpoints (verified), so tightening them changes no current UI flow. The ArchUnit endpoint-authorization ratchet stays green (every endpoint remains guarded).

## Deferred (reported, not done here)
Tightening **employee reads** to roles was intentionally left out: `/employee/web` doubles as the app-wide assignee/name lookup (~15 dropdown call sites across finance/attendance/inspections), so restricting it to management roles would 403 ordinary members' forms. Doing it safely needs a lightweight member-accessible name-lookup endpoint first, then the full-detail read can be role-gated. Rows are already tenant-scoped by the fail-closed listener (#330), so this is an intra-org exposure, not a cross-tenant leak.