### PR TITLE
Stamp uploaded attachments with the current tenant organization

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -11,6 +11,7 @@ import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.repository.AttachmentRepository;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.attendance.AttendanceRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
@@ -43,8 +44,9 @@ public class AttachmentService {
     private final IssueRepository issueRepository;
     private final UserRepository userRepository;
     private final AttendanceRepository attendanceRepository;
+    private final TenantEntityHelper tenantEntityHelper;
 
-    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, OrganizationRepository organizationRepository, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository) {
+    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, OrganizationRepository organizationRepository, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository, TenantEntityHelper tenantEntityHelper) {
         this.attachmentRepository = attachmentRepository;
         this.fileStorageService = fileStorageService;
         this.organizationRepository = organizationRepository;
@@ -53,6 +55,7 @@ public class AttachmentService {
         this.issueRepository = issueRepository;
         this.userRepository = userRepository;
         this.attendanceRepository = attendanceRepository;
+        this.tenantEntityHelper = tenantEntityHelper;
     }
 
     /**
@@ -88,6 +91,7 @@ public class AttachmentService {
             attachment.setFileSize(storedFile.size());
             attachment.setOriginalFilename(originalFile.getOriginalFilename());
             linkToEntity(attachment, folder, entityId);
+            attachment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
             attachments.add(attachmentRepository.save(attachment));
         }
 
@@ -116,6 +120,8 @@ public class AttachmentService {
         attachment.setContentType(storedFile.contentType());
         attachment.setFileSize(storedFile.size());
         attachment.setOriginalFilename(file.getOriginalFilename());
+        linkToEntity(attachment, folder, entityId);
+        attachment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         return attachmentRepository.save(attachment);
     }
@@ -292,6 +298,7 @@ public class AttachmentService {
             attachment.setFileSize(request.fileSize());
             attachment.setOriginalFilename(request.filename());
             linkToEntity(attachment, folder, entityId);
+            attachment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
             attachments.add(attachmentRepository.save(attachment));
         }
         return attachments;

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.common.dto.StoredFile;
+import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.repository.AttachmentRepository;
+import org.tornotron.echno_backend.issue.IssueRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.TaskRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies uploaded attachments are stamped with the current tenant's organization.
+ * Without it the row's organization_id stays null and the entity's orgFilter (and the
+ * fail-closed load listener) skip the row, leaving it outside tenant scoping.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttachmentServiceTenancyTest {
+
+    @Mock private AttachmentRepository attachmentRepository;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private IssueRepository issueRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MultipartFile file;
+
+    private AttachmentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AttachmentService(attachmentRepository, fileStorageService, organizationRepository,
+                projectRepository, taskRepository, issueRepository, userRepository, attendanceRepository,
+                tenantEntityHelper);
+    }
+
+    @Test
+    void uploadAttachment_stampsCurrentTenantOrganization() {
+        Organization org = new Organization();
+        org.setId(7L);
+
+        when(file.getOriginalFilename()).thenReturn("photo.jpg");
+        when(file.getSize()).thenReturn(10L);
+        when(attachmentRepository.existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
+                "ISSUE", 1L, "photo.jpg", 10L)).thenReturn(false);
+        when(fileStorageService.uploadFile(eq(file), any())).thenReturn(new StoredFile("k", "image/jpeg", 10L));
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        when(attachmentRepository.save(any(Attachment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Folder that hits linkToEntity's default branch, so no parent lookup is needed.
+        Attachment result = service.uploadAttachment(file, "ISSUE", 1L, "misc");
+
+        assertThat(result.getOrganization()).isSameAs(org);
+    }
+}


### PR DESCRIPTION
Fixes a tenancy gap in attachment uploads (related to the audit's attachment findings).

## Problem
`Attachment` is a `TenantScopedEntity` (has `organization` + the `orgFilter`), but the upload code only set the **parent link** via `linkToEntity` (project/task/issue/user/attendance) and set `organization` **only** when the parent was itself an organization. So a project/task/issue attachment was saved with `organization_id = NULL`. A null-org row is skipped by the `orgFilter` and by the fail-closed load listener (#330), so it falls outside tenant scoping entirely. Staging currently has 9 such rows; every new non-org upload adds another.

## Fix
Set `organization` from the current tenant (`TenantEntityHelper.resolveCurrentOrganization()`) on all three create paths (multi-file upload, single-file upload, presigned-register). The single-file path also now calls `linkToEntity`, which it previously skipped, so it records its parent like the batch path.

## Test
`AttachmentServiceTenancyTest` (Mockito): an upload stamps the saved attachment with the current tenant's organization.

## Deferred
Backfilling the 9 pre-existing null-org rows on staging is a separate entity-type-specific data migration (they span PROJECT/TASK/ISSUE/ORGANIZATION with inconsistent `entity_type` naming). They are seed data, guarded from cross-tenant deletion by the controller `@PreAuthorize` (#321); production instances start clean now that the create path is fixed. Can follow up with a targeted backfill if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Attachments uploaded through streaming, single-file, and pre-signed upload flows are now associated with the current organization.
  - Improves attachment organization and tenant isolation across upload methods.

- **Tests**
  - Added coverage verifying that uploaded attachments reference the resolved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->