### PR TITLE
Add a member employee lookup and restrict full reads to management

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
 import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
 import org.tornotron.echno_backend.employee.dto.OrgRoleAssignmentDto;
@@ -64,14 +65,24 @@ public class EmployeeControllerWeb {
      *
      * @return A {@link ResponseEntity} containing the list of employee DTOs and HTTP status 200 (OK).
      */
-    @GetMapping
+    /**
+     * Minimal, non-sensitive employee list for populating pickers. Readable by any
+     * tenant member; the full employee reads below are restricted to management roles.
+     */
+    @GetMapping("/lookup")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    public ResponseEntity<List<EmployeeLookupDto>> lookupEmployees() {
+        return new ResponseEntity<>(employeeService.lookupEmployees(), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return new ResponseEntity<>(employeeService.displayAllEmployees(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<Page<EmployeeDto>> readAllEmployeesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
@@ -88,7 +99,7 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing the employee DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
         EmployeeDto employee = employeeService.displayAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(employee);

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
 import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
 import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
@@ -198,6 +199,23 @@ public class EmployeeService {
     public List<EmployeeDto> displayAllEmployees() {
         return employeeRepository.findAll().stream()
                 .map(employee -> employeeMapper.toDto(employee))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves every employee as a minimal, non-sensitive lookup projection for
+     * dropdowns. Unlike {@link #displayAllEmployees()} this exposes no contact
+     * details, salary or personal data, so it can be read by any tenant member.
+     */
+    @Transactional(readOnly = true)
+    public List<EmployeeLookupDto> lookupEmployees() {
+        return employeeRepository.findAll().stream()
+                .map(employee -> new EmployeeLookupDto(
+                        employee.getId(),
+                        employee.getEmployeeId(),
+                        employee.getEmployeeName(),
+                        employee.getDesignation(),
+                        employee.getOrganization() != null ? employee.getOrganization().getId() : null))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeLookupDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeLookupDto.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.employee.dto;
+
+/**
+ * A minimal, non-sensitive projection of an employee for populating pickers
+ * (assignee, inspector, payee, ...). It carries only what a dropdown needs to
+ * display and identify an employee, so it can stay readable by any tenant member
+ * while the full {@link EmployeeDto} (contact details, salary, personal data) is
+ * restricted to management roles.
+ */
+public record EmployeeLookupDto(
+        Long id,
+        String employeeId,
+        String employeeName,
+        String designation,
+        Long organizationId
+) {
+}


### PR DESCRIPTION
Completes the fine-grained RBAC item deferred from #379: tighten employee reads without breaking member workflows.

## Problem
`GET /employee/web` (and `/paginated`, `/{id}`) return the full `EmployeeDto` (contact, salary, personal data) but were on the tenant-membership floor, because the app's assignee/inspector/payee pickers across ~15 pages call the full list just for id+name.

## Change
- New **`GET /employee/web/lookup`** → `EmployeeLookupDto` (id, employeeId, employeeName, designation, organizationId) - no PII, **member** floor. This is what the pickers need.
- Full reads **`GET /employee/web`**, **`/paginated`**, **`/{id}`** → **management** roles (`system-admin`, `hr-admin`, `project-manager`).
- Self lookups are unaffected: `useCurrentUserEmployee`/`useUserEmployees` resolve through `/user/web/employees`, not these endpoints (verified in echno-web/echno-core).

## Follow-up (this PR is step 1 of 3)
- **echno-core**: add `employeeService.getLookup()` + `useEmployeeLookup()`, publish.
- **echno-web**: repoint the ~15 picker sites from `useEmployees()` to `useEmployeeLookup()`, bump core. Until that lands, member users hit the pickers via the now-restricted full list, so the two follow-ups should ship close behind. HR management pages (employee table/detail/edit) keep using the full read and are management-gated already in practice.
- `/managers` and `/subordinates` were left on the member floor for now (hierarchy pickers); a later pass can give them the same lookup treatment.

Endpoint-authorization ArchUnit ratchet stays green (the new endpoint is guarded).