### PR TITLE
Include status in the employee lookup

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -215,6 +215,7 @@ public class EmployeeService {
                         employee.getEmployeeId(),
                         employee.getEmployeeName(),
                         employee.getDesignation(),
+                        employee.getStatus(),
                         employee.getOrganization() != null ? employee.getOrganization().getId() : null))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeLookupDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeLookupDto.java
@@ -1,17 +1,20 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
+
 /**
  * A minimal, non-sensitive projection of an employee for populating pickers
  * (assignee, inspector, payee, ...). It carries only what a dropdown needs to
- * display and identify an employee, so it can stay readable by any tenant member
- * while the full {@link EmployeeDto} (contact details, salary, personal data) is
- * restricted to management roles.
+ * display, identify and filter an employee (including active/inactive status), so
+ * it can stay readable by any tenant member while the full {@link EmployeeDto}
+ * (contact details, salary, personal data) is restricted to management roles.
  */
 public record EmployeeLookupDto(
         Long id,
         String employeeId,
         String employeeName,
         String designation,
+        EmployeeStatus status,
         Long organizationId
 ) {
 }


### PR DESCRIPTION
Follow-up to #381: add `status` to `EmployeeLookupDto` (and the service mapping). A member-facing dashboard counts active employees and pickers want to filter to active ones, and status is not sensitive, so it belongs in the lookup rather than forcing the management-only full read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employee search results now display each employee’s active or inactive status.
  * Employee status is available for identifying and filtering employees in lookup views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->