### PR TITLE
Restrict employee hierarchy reads to management

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -189,19 +189,19 @@ public class EmployeeControllerWeb {
      * @return A {@link ResponseEntity} containing a list of employee DTOs who report to the manager and HTTP status 200 (OK).
      */
     @GetMapping("/managerId/{managerId}/subordinates")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<List<EmployeeDto>> getDirectSubordinates(@PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getDirectSubordinates(managerId));
     }
 
     @GetMapping("/managers")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<List<EmployeeDto>> getAllTheManagers() {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagers());
     }
 
     @GetMapping("/managers/organizationId/{organizationId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     public ResponseEntity<List<EmployeeDto>> getAllManagersForAnOrganization(@PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagersByOrganizationId(organizationId));
     }


### PR DESCRIPTION
Follow-up to the employee-read RBAC split (#381): the manager/subordinate reads were left on the member floor and are the same class of intra-org PII exposure.

## What
Moved to `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')`:
- `GET /employee/web/managers`
- `GET /employee/web/managers/organizationId/{organizationId}`
- `GET /employee/web/managerId/{managerId}/subordinates`

All three return the full `EmployeeDto`. Verified their only web callers are management screens (leave-request approval, employee-management detail, the invitation form's manager picker) whose users hold these roles, so no member workflow breaks; this also backstops the frontend at the API level.

## Left on the member floor (intentionally)
- `GET /employee/web/lookup` (the minimal picker projection).
- `GET /employee/web/{employeeId}/roles`: `useEmployeeRoles` (sidebar / `use-authorization`) sources roles from `useCurrentUserEmployee` (`/user/web/employees`), not this endpoint, and it returns roles rather than PII.

Backend-only (no core/web change). ArchUnit endpoint-authorization ratchet stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access controls for employee hierarchy endpoints.
  * Restricted subordinate and manager listings to authorized administrative and management roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->