### PR TITLE
fix: gate the Loki push appender behind a profile

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,25 +19,35 @@
 
     <springProperty scope="local" name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
 
-    <!-- Loki Appender Configuration -->
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>${LOKI_URL}</url>
-        </http>
-        <format>
-            <label>
-                <pattern>app=echno_backend,host=${HOSTNAME},level=%level</pattern>
-            </label>
-            <message>
-                <pattern>%msg %ex{full}</pattern>
-            </message>
-        </format>
-    </appender>
+    <!--
+      Direct Loki push is opt-in via the "loki" Spring profile, enabled where a
+      reachable Loki lives (the deployed stack sets SPRING_PROFILES_ACTIVE=loki).
+      Off by default, so local dev and tests do not spam connection errors trying
+      to reach a Loki that is not there. Console logging to stdout is always on, so
+      a stdout log shipper still collects everything even when this is disabled.
+    -->
+    <springProfile name="loki">
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>${LOKI_URL}</url>
+            </http>
+            <format>
+                <label>
+                    <pattern>app=echno_backend,host=${HOSTNAME},level=%level</pattern>
+                </label>
+                <message>
+                    <pattern>%msg %ex{full}</pattern>
+                </message>
+            </format>
+        </appender>
+    </springProfile>
 
     <!-- Root Logger Configuration -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="LOKI"/>
+        <springProfile name="loki">
+            <appender-ref ref="LOKI"/>
+        </springProfile>
     </root>
 
     <!-- Specific Logger Configurations -->


### PR DESCRIPTION
The Loki4j appender was attached to the root logger unconditionally, so it spammed `ConnectException` stack traces wherever Loki was not reachable at the configured URL, notably local development and every test run (the noise seen throughout the Testcontainers IT logs).

**Change:** move the appender and its root reference behind a `loki` Spring profile, off by default. Console logging to stdout is untouched, so a stdout log shipper (the deployed stack's Grafana Alloy scrapes container stdout) still collects everything even when the direct push is off.

**Deployment:** the deployed backend runs the default profile, so a companion change to `echno-deployment` (`backend.env.j2`) sets `SPRING_PROFILES_ACTIVE=loki` to keep pushing directly to `echno-loki` exactly as before. The two must land together for the deployed push to continue; the env change is already committed so any future deploy picks it up.

**Verified on .116:** InventoryValuationIT green under the default profile with zero `loki`/`ConnectException` lines in the run log (previously present on every run). No `@Profile` beans exist, so activating an explicit profile deactivates nothing.