### PR TITLE
fix: authorize each id in the batch organization update

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -53,6 +53,7 @@ public class OrganizationService {
     private final UserContextService userContextService;
     private final EmployeeService employeeService;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
+    private final org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity;
 
     /**
      * Constructs an {@code OrganizationService} with the necessary dependencies.
@@ -62,7 +63,7 @@ public class OrganizationService {
      * @param keycloakGroupService The service for managing Keycloak groups.
      * @param subscriptionService The service for handling subscription billing.
      */
-    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper) {
+    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity) {
         this.repository = repository;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
@@ -71,6 +72,7 @@ public class OrganizationService {
         this.userContextService = userContextService;
         this.employeeService = employeeService;
         this.organizationMapper = organizationMapper;
+        this.orgSecurity = orgSecurity;
     }
 
     /**
@@ -210,6 +212,18 @@ public class OrganizationService {
      */
     @Transactional
     public void batchUpdateOrganization(List<OrganizationPatchDto> updates) {
+        // Organization is the tenant root, not a TenantScopedEntity, so neither the
+        // org filter nor the fail-closed load listener guards it. Authorize each id
+        // here: the caller must be a member of that organization (or a platform
+        // admin), mirroring the single-organization DELETE endpoint. Without this a
+        // member of one organization could patch another organization by id.
+        updates.forEach(update -> {
+            if (!orgSecurity.isMemberOrAdmin(update.getId())) {
+                throw new org.tornotron.echno_backend.common.exception.TenantAccessDeniedException(
+                        "Not permitted to update organization " + update.getId());
+            }
+        });
+
         List<Long> organizationIds = updates.stream().map(OrganizationPatchDto::getId).collect(Collectors.toList());
         List<Organization> organizations = repository.findAllById(organizationIds);
 

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
@@ -1,0 +1,82 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.organization.dto.OrganizationPatchDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Batch organization update must authorize each id, because Organization is the
+ * tenant root (not a TenantScopedEntity) and so is guarded by neither the org
+ * filter nor the fail-closed load listener. Without the check a member of one
+ * organization could patch another organization by passing its id.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationServiceBatchAuthzTest {
+
+    @Mock private OrganizationRepository repository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private KeycloakGroupService keycloakGroupService;
+    @Mock private SubscriptionService subscriptionService;
+    @Mock private UserContextService userContextService;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationMapper organizationMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private OrganizationService service() {
+        return new OrganizationService(repository, attachmentService, fileStorageService,
+                keycloakGroupService, subscriptionService, userContextService, employeeService,
+                organizationMapper, orgSecurity);
+    }
+
+    private OrganizationPatchDto patch(long id) {
+        OrganizationPatchDto dto = new OrganizationPatchDto();
+        dto.setId(id);
+        dto.setUpdates(Map.of("name", "Renamed"));
+        return dto;
+    }
+
+    @Test
+    void rejectsUpdateToAnOrganizationTheCallerCannotAccess() {
+        when(orgSecurity.isMemberOrAdmin(2L)).thenReturn(false);
+
+        assertThatExceptionOfType(TenantAccessDeniedException.class)
+                .isThrownBy(() -> service().batchUpdateOrganization(List.of(patch(2L))));
+
+        // Rejected before any data is loaded or written.
+        verify(repository, never()).findAllById(anyList());
+        verify(repository, never()).saveAll(any());
+    }
+
+    @Test
+    void proceedsWhenTheCallerIsAMemberOrAdmin() {
+        when(orgSecurity.isMemberOrAdmin(1L)).thenReturn(true);
+        when(repository.findAllById(anyList())).thenReturn(List.of());
+
+        service().batchUpdateOrganization(List.of(patch(1L)));
+
+        // Passed the guard and reached the persistence step.
+        verify(repository).saveAll(any());
+    }
+}


### PR DESCRIPTION
**Security (tenant isolation).** `PATCH /api/v1/organization/batch` was gated only by `hasAuthority('organization:update')`, with no per-organization membership check, while the sibling get-by-id and delete endpoints both require `@orgSecurity.isMember(#id)`.

`Organization` is the tenant root (not a `TenantScopedEntity`), so neither the Hibernate org filter nor the fail-closed load listener guards it. The batch body is a list of `{id, updates}`, and the service applied each by id after a plain `findAllById`. A member of one organization could therefore rewrite another organization's profile by passing its id.

**Fix:** authorize each id in `OrganizationService.batchUpdateOrganization` with `orgSecurity.isMemberOrAdmin(id)` (member of that org, or a platform admin), rejecting the whole request with `TenantAccessDeniedException` before any load or write. Adds `OrganizationServiceBatchAuthzTest` (Mockito, 2 tests: rejects a non-member id without touching the repository; proceeds for a member/admin).

Found by a tenant-isolation audit; the isolation design itself (two-layer filter + fail-closed listener, header validated against membership) is otherwise sound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Batch organization updates now verify access for each organization before processing.
  * Unauthorized requests are rejected, while organization members and platform administrators can continue.
* **Bug Fixes**
  * Prevented unauthorized batch updates from reading or modifying organization records.
* **Tests**
  * Added coverage for authorized and unauthorized batch update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->