### PR TITLE
harden tenant-isolation edges

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
@@ -45,9 +45,13 @@ public class TenantFilter extends OncePerRequestFilter {
                 return;
             }
 
-            // Check if user is a global admin — bypass tenant context
+            // Check if user is a global admin — bypass tenant context. This
+            // disables both the org filter and the fail-closed load listener for
+            // the whole request, so audit who did it and against what, at WARN,
+            // for accountability (the bypass is otherwise invisible).
             if (hasAuthority(authentication, ORG_ADMIN_AUTHORITY)) {
-                log.debug("[TenantFilter] Global admin detected, bypassing tenant filter");
+                log.warn("[TenantFilter] Tenant isolation bypassed for global admin '{}' on {} {}",
+                        authentication.getName(), request.getMethod(), request.getRequestURI());
                 TenantContext.setBypass(true);
                 filterChain.doFilter(request, response);
                 return;
@@ -104,10 +108,14 @@ public class TenantFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
+        // The organization and user endpoints are intentionally filtered: they
+        // rely on per-id membership checks, not a blanket bypass. Only the exact
+        // /user/web lookup and the pre-tenant / infra paths below skip the filter.
+        // (Two earlier patterns, /organizations and /users/profile, never matched
+        // the real singular paths and were removed to avoid the false impression
+        // that those endpoints are unfiltered.)
         return path.startsWith("/actuator")
                 || path.equals("/api/" + backendVersion + "/auth/register")
-                || path.startsWith("/api/" + backendVersion + "/organizations")
-                || path.startsWith("/api/" + backendVersion + "/users/profile")
                 || path.equals("/api/" + backendVersion + "/user/web")
                 || path.startsWith("/api/" + backendVersion + "/billing");
     }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
@@ -15,8 +15,10 @@ import org.tornotron.echno_backend.organization.Organization;
  *
  * <p>Legitimate cross-tenant work (seeding, startup, system-admin operations) runs
  * under {@code @BypassTenantFilter}, which sets the bypass flag this listener honors.
- * Rows with no organization (legacy data pending backfill) are left alone: isolation
- * cannot be enforced on them here.
+ * A tenant-scoped row with no organization cannot be proven to belong to the caller,
+ * so under an active tenant context it is denied rather than leaked. Every create
+ * path sets the organization, so a null here is legacy data pending backfill, and
+ * denying is the safe failure.
  */
 public class TenantIsolationLoadListener implements PostLoadEventListener {
 
@@ -32,16 +34,19 @@ public class TenantIsolationLoadListener implements PostLoadEventListener {
         }
 
         Organization organization = scoped.getOrganization();
-        if (organization == null) {
-            return;
-        }
-
         // Reading the id off a lazy proxy does not initialize it.
-        Long entityOrgId = organization.getId();
-        if (entityOrgId != null && !entityOrgId.equals(contextOrgId)) {
+        Long entityOrgId = organization == null ? null : organization.getId();
+
+        // Deny a foreign organization, and also a null one: a tenant-scoped row
+        // with no organization cannot be proven to belong to the caller's tenant,
+        // and letting it through was the earlier hole (any tenant could read a
+        // null-org row by id).
+        if (entityOrgId == null || !entityOrgId.equals(contextOrgId)) {
             throw new TenantAccessDeniedException(
                     "Cross-tenant access denied: " + event.getEntity().getClass().getSimpleName()
-                            + " belongs to organization " + entityOrgId
+                            + (entityOrgId == null
+                                    ? " has no organization"
+                                    : " belongs to organization " + entityOrgId)
                             + " but the request is scoped to organization " + contextOrgId);
         }
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationRepository.java
@@ -23,10 +23,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     long countByRecipientIdAndIsReadFalse(Long recipientId);
 
+    // Bulk DML does not honor the Hibernate orgFilter, so scope by organization
+    // explicitly for defence in depth (the recipient predicate already limits it
+    // to the caller's own notifications).
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true, n.readAt = CURRENT_TIMESTAMP " +
-           "WHERE n.recipient.id = :recipientId AND n.isRead = false")
-    int markAllAsReadByRecipientId(@Param("recipientId") Long recipientId);
+           "WHERE n.recipient.id = :recipientId AND n.organization.id = :organizationId AND n.isRead = false")
+    int markAllAsReadByRecipientId(@Param("recipientId") Long recipientId,
+                                   @Param("organizationId") Long organizationId);
 
     List<Notification> findByEntityTypeAndEntityId(String entityType, Long entityId);
 

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
@@ -183,6 +183,6 @@ public class NotificationService {
 
     @Transactional
     public int markAllAsRead(Long employeeId) {
-        return notificationRepository.markAllAsReadByRecipientId(employeeId);
+        return notificationRepository.markAllAsReadByRecipientId(employeeId, TenantContext.getCurrentOrgId());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
@@ -78,8 +78,13 @@ public class OrganizationController {
      * @param creatorId The ID of the user who created the organizations.
      * @return A {@link ResponseEntity} containing a list of organization DTOs and HTTP status 200 (OK).
      */
+    // Platform-admin only: this returns organizations created by an arbitrary
+    // user id, with no tie between the caller and the returned records, so a
+    // plain member must not be able to enumerate another user's organizations.
+    // A member's own organizations come from the tenant-scoped /web listing,
+    // which is filtered to their memberships.
     @GetMapping("/creator/{creatorId}")
-    @PreAuthorize("hasAuthority('organization:read') or hasAuthority('organization:admin')")
+    @PreAuthorize("hasAuthority('organization:admin')")
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsByCreatorId(@PathVariable Integer creatorId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganizationsByCreatorId(creatorId));
     }

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListenerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListenerTest.java
@@ -1,0 +1,84 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.hibernate.event.spi.PostLoadEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.organization.Organization;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The fail-closed load listener denies a tenant-scoped entity that belongs to a
+ * different organization than the request, and also one with no organization at
+ * all (a null org cannot be proven to belong to the caller, and letting it
+ * through let any tenant read a null-org row by id).
+ */
+class TenantIsolationLoadListenerTest {
+
+    private final TenantIsolationLoadListener listener = new TenantIsolationLoadListener();
+
+    @AfterEach
+    void clear() {
+        TenantContext.clear();
+    }
+
+    private PostLoadEvent eventFor(Object entity) {
+        PostLoadEvent event = mock(PostLoadEvent.class);
+        when(event.getEntity()).thenReturn(entity);
+        return event;
+    }
+
+    private TenantScopedEntity scoped(Long orgId) {
+        Organization org = orgId == null ? null : new Organization();
+        if (org != null) {
+            org.setId(orgId);
+        }
+        return new TenantScopedEntity() {
+            @Override
+            public Organization getOrganization() {
+                return org;
+            }
+
+            @Override
+            public void setOrganization(Organization organization) {
+            }
+        };
+    }
+
+    @Test
+    void deniesAForeignOrganization() {
+        TenantContext.setCurrentOrgId(1L);
+        assertThatExceptionOfType(TenantAccessDeniedException.class)
+                .isThrownBy(() -> listener.onPostLoad(eventFor(scoped(2L))));
+    }
+
+    @Test
+    void deniesANullOrganization() {
+        TenantContext.setCurrentOrgId(1L);
+        assertThatExceptionOfType(TenantAccessDeniedException.class)
+                .isThrownBy(() -> listener.onPostLoad(eventFor(scoped(null))));
+    }
+
+    @Test
+    void allowsTheCallersOwnOrganization() {
+        TenantContext.setCurrentOrgId(1L);
+        assertThatCode(() -> listener.onPostLoad(eventFor(scoped(1L)))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsWhenBypassed() {
+        TenantContext.setCurrentOrgId(1L);
+        TenantContext.setBypass(true);
+        assertThatCode(() -> listener.onPostLoad(eventFor(scoped(2L)))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void ignoresNonTenantScopedEntities() {
+        TenantContext.setCurrentOrgId(1L);
+        assertThatCode(() -> listener.onPostLoad(eventFor("not a tenant entity"))).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Closes the lower-severity tenant-isolation edges from the audit (the design itself is sound; the exploitable org-batch endpoint was fixed in #392).

- **Fail-closed listener now denies null-org rows.** It skipped a tenant-scoped entity with no organization, so any tenant could read a legacy null-org row by id. New rows always set an organization, so a null is legacy data and denial is the safe failure. Unit test added (foreign-org and null-org denials, plus the allow/bypass/non-scoped cases).
- **Org-by-creator endpoint restricted to platform admin.** `GET /organization/creator/{creatorId}` returned an arbitrary user's organizations with no tie to the caller; a member's own orgs come from the tenant-scoped `/web` listing.
- **Notification mark-all-read scoped by organization** (bulk DML bypasses the Hibernate org filter; the recipient predicate already limited it to self, this is defence in depth).
- **Admin bypass is audit-logged at WARN** (who + method + path), since an org-admin request disables both the filter and the listener.
- **Two dead `shouldNotFilter` patterns removed** (they used plural/ paths that never matched the real singular controllers, giving a false impression those endpoints were unfiltered).

Full suite green on the build box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened organization-level data isolation by blocking access to records without an organization or belonging to another organization.
  * Improved auditing of global administrator access by recording the user and request details.
  * Restricted organization listings to authorized organization administrators.

* **Bug Fixes**
  * Ensured bulk notification updates affect only notifications within the current organization.
  * Added safeguards and coverage for tenant-isolation scenarios, including bypass and unauthorized-access cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->