### PR TITLE
feat: construction finance chart of accounts, approval workflow, and ledger posting

### DIFF
--- a/docs/specs/2026-08-19-construction-finance-approvals-budgeting.md
+++ b/docs/specs/2026-08-19-construction-finance-approvals-budgeting.md
@@ -16,13 +16,14 @@ as placeholders in the base spec. The receivable side is already live: Accounts 
 | Account | Code | Basis |
 |---|---|---|
 | Accounts Payable (control) | `2100` | Matches Abin's chart-of-accounts convention on #341 (liabilities `2000-2999`, Accounts Payable `2100`). |
-| GST Input Credit | `1210` | Assets range (`1000-1999`) per the same convention; sits with the other receivable/asset control accounts. `1200` is already AR, so `1210` is the next free asset-control slot. |
+| GST Input Credit | `1410` | A current asset (recoverable input tax credit), the asset-side mirror of GST Output Payable. Echno's account codes are hierarchical, so `1210` would read as a child of Accounts Receivable (`1200`), which is wrong. It sits instead under a `1400 Duties and Taxes Receivable` group as the `1410` leaf, mirroring how GST Output sits at `2210` under `2200`. |
 
 These are defaults, not hard-coded values. Implement a `ConstructionPostingProperties` bean mirroring
 `InvoicePostingProperties`, bound to `finance.construction.*`, so the real values are a config change and never a
-code change. Abin confirmed Accounts Payable `2100` directly; GST Input Credit `1210` is a reasonable default in
-his structure but was not called out by code, so treat it as provisional and get one explicit confirmation before
-the first real posting. Nothing else in the codes is open.
+code change. Accounts Payable `2100` matches Abin's chart-of-accounts convention. GST Input Credit `1410` follows
+from the accounting (it is a recoverable-tax current asset) and the numbering scheme; there is no universal
+mandated code, and since the chart of accounts is seeded by us, this is the correct placement. Both are seeded as
+postable leaves by the default chart of accounts. Nothing in the codes is open.
 
 ## 2. Approval workflow (new, from Anand's #341 input)
 
@@ -87,20 +88,40 @@ finance pages and needs no backend work beyond the fields above. Applying now (s
   dates, method, reference number), Approval / Audit Trail (created by, submitted, approved by, approval date,
   payment recorded by, activity history).
 
-Two of these fields need backend support that the current model lacks: a **due date** and **payment terms** on
-the invoice, and the audit-trail fields from section 2. The rest are already present or presentational.
+Of these, `due_date` and `payment_terms` already exist on the construction invoice; only the section-2
+audit-trail fields were missing. The rest are already present or presentational.
 
-## 5. Sequencing and what needs a decision
+## 5. What is built and what remains
 
-1. **Web view refinements (section 4)**: safe, no financial logic. Ship first; the audit-trail and due-date
-   columns render once the backend fields below exist.
-2. **Backend fields**: add `due_date`, `payment_terms`, and the section-2 audit-trail columns to the construction
-   invoice/payment (migration + DTOs + core types). Mechanical, low risk.
-3. **Approval workflow + ledger posting (sections 1 and 2)**: the financially sensitive increment 3 of the base
-   spec, now gated on Approved. Build carefully, with the `1210` GST-input code confirmed first, and a
-   concurrency-safe posting path (mirror the tested `JournalPostingService` and `InvoicePostingProperties`
-   patterns). This is the item that should not ship without a review.
-4. **Budgeting (section 3)**: its own phase, starts with a design round with Anand.
+The backend for sections 1 and 2 is built: the chart-of-accounts seed, the approval workflow (submit, approve,
+cancel, record-payment), the audit-trail fields, and the ledger posting on approval with reversal on cancel.
 
-Items 1 and 2 are buildable now. Item 3 is a money path and should be greenlit and reviewed, not merged blind.
-Item 4 is a product design round first. The one open confirmation is the GST Input Credit code (`1210` proposed).
+1. **Backend, done**: the default per-tenant chart of accounts (section 6), the `APPROVED` status and audit-trail
+   columns (migration `034`), `ConstructionPostingProperties`, and the posting-on-approve / reverse-on-cancel path
+   mirroring the tested `JournalPostingService` and `InvoicePostingProperties`, with an integration test asserting
+   the balanced entries for purchase, expense, sales and service.
+2. **Core and web, next**: expose the new statuses, audit-trail fields, and the submit/approve/cancel/record-payment
+   actions in `@tornotron/echno-core`, and apply Anand's list/detail view (section 4) plus the approval actions in
+   the web finance pages.
+3. **Budgeting (section 3)**: its own phase, starts with a design round with Anand.
+
+## 6. The chart-of-accounts seed (as built)
+
+- A default per-tenant chart of accounts is seeded on organization creation, and can be back-filled on an existing
+  org through `POST /finance/accounts/web/seed-defaults` (system-admin only). It is idempotent: an org that already
+  has any account is left untouched. Codes are pinned explicitly because posting reads accounts by code.
+- The tree places Accounts Receivable at `1200` and GST Output at `2210` (matching `finance.invoice.*`), Accounts
+  Payable at `2100`, and GST Input Credit at `1410` under a `1400 Duties and Taxes Receivable` group, alongside
+  cash/bank, inventory, equity, revenue, and construction expense accounts. All the posting control accounts are
+  postable leaves. The construction posting codes are config-driven (`finance.construction.*`), so any of them can
+  be retuned without a code change.
+- **Sales/service posts a direct AR journal entry, not option A.** For sales and service construction
+  invoices the approve step posts DR Accounts Receivable / CR revenue + CR GST output directly (base spec
+  section 4 option B mechanics), rather than materializing a real AR `Invoice` via `InvoiceService.issue`
+  (the preferred option A). Option A needs customer resolution from the project's client, which is not built
+  yet, so those invoices do not appear in AR aging or customer statements. The service carries a
+  `// TODO: option A AR materialization` marker at the posting site. Materializing the AR invoice is the
+  follow-up that closes this gap.
+- **Payment recording is invoice-level only.** `record-payment` advances the invoice's paid/balance amounts
+  and payment status and stamps `payment_recorded_by`; it does not post a cash-movement journal entry. Cash
+  posting stays with the construction payment voucher phase.

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceStatus.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.finance.construction;
 public enum ConstructionInvoiceStatus {
     DRAFT,
     PENDING,
+    APPROVED,
     SENT,
     PARTIALLY_PAID,
     PAID,

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPostingProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/ConstructionPostingProperties.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.finance.construction;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Control-account codes used when posting the journal entry for an approved
+ * construction invoice. Tunable per environment via {@code finance.construction.*}
+ * without code changes, mirroring {@link org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties}.
+ *
+ * <p>All must reference postable (leaf) accounts in the chart of accounts:
+ * <ul>
+ *   <li>{@code apAccountCode} - Accounts Payable, credited for the gross total on a
+ *       purchase or expense invoice.</li>
+ *   <li>{@code gstInputCode} - GST Input Credit, debited for the tax on a purchase or
+ *       expense invoice.</li>
+ *   <li>{@code defaultExpenseCode} - the default expense account debited for the net
+ *       on a purchase or expense invoice.</li>
+ *   <li>{@code defaultRevenueCode} - the default revenue account credited for the net
+ *       on a sales or service invoice.</li>
+ * </ul>
+ * Posting is invoice-level to these default accounts; per-line accounts are a later
+ * budgeting phase. The receivable-side codes (AR 1200, GST output 2210) are read from
+ * {@code InvoicePostingProperties}, so they stay in one place.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "finance.construction")
+public class ConstructionPostingProperties {
+
+    /** Accounts Payable control account (postable leaf). */
+    private String apAccountCode = "2100";
+
+    /** GST Input Credit control account (postable leaf). */
+    private String gstInputCode = "1410";
+
+    /** Default expense account for purchase/expense invoices (postable leaf). */
+    private String defaultExpenseCode = "5100";
+
+    /** Default revenue account for sales/service invoices (postable leaf). */
+    private String defaultRevenueCode = "4100";
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
 import org.tornotron.echno_backend.organization.Organization;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -111,6 +112,32 @@ public class ConstructionInvoice extends BaseEntity implements TenantScopedEntit
 
     @Column(name = "terms_and_conditions", length = 2000)
     private String termsAndConditions;
+
+    // Approval workflow audit trail. Set by the service as the invoice moves through
+    // submit -> approve; ids are core-domain user ids (no cross-module FK), matching the
+    // verifiedBy/verifiedAt convention on ConstructionPayment.
+    @Column(name = "submitted_by")
+    private Long submittedBy;
+
+    @Column(name = "submitted_at")
+    private Instant submittedAt;
+
+    @Column(name = "approved_by")
+    private Long approvedBy;
+
+    @Column(name = "approved_at")
+    private Instant approvedAt;
+
+    @Column(name = "payment_recorded_by")
+    private Long paymentRecordedBy;
+
+    // Links to the ledger. The journal entry posted when the invoice is approved and,
+    // on cancel, the reversal that unwinds it. Kept as plain ids (no cross-module FK).
+    @Column(name = "journal_entry_id")
+    private UUID journalEntryId;
+
+    @Column(name = "reversal_journal_entry_id")
+    private UUID reversalJournalEntryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -5,6 +5,7 @@ import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -34,5 +35,12 @@ public record ConstructionInvoiceDto(
         String taxType,
         String notes,
         String termsAndConditions,
+        Long submittedBy,
+        Instant submittedAt,
+        Long approvedBy,
+        Instant approvedAt,
+        Long paymentRecordedBy,
+        UUID journalEntryId,
+        UUID reversalJournalEntryId,
         List<ConstructionInvoiceLineDto> lines
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -14,6 +15,7 @@ import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
@@ -23,17 +25,32 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionI
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceSpecifications;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.dtos.ReverseJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 /**
- * CRUD + list for construction invoices. This increment deliberately does NO ledger
- * or journal posting: money totals are computed arithmetically from the line items
- * and status is set directly. A later increment will add the ledger-posting hooks
- * (create the receivable/payable journal entry on issue, reverse it on cancel) that
- * the AR invoice module already has.
+ * CRUD, list, and the approval + ledger-posting lifecycle for construction invoices.
+ *
+ * <p>Money totals are computed arithmetically from the line items on create/update.
+ * The lifecycle methods add the approval gate and the ledger hooks that mirror the AR
+ * invoice module: {@link #submit} moves a draft into approval, {@link #approve} posts
+ * the journal entry (posting trigger is approval, not draft), and {@link #cancel}
+ * reverses that entry. Posting is invoice-level to the default accounts configured on
+ * {@link ConstructionPostingProperties}; per-line cost-category posting is the later
+ * budgeting phase.
  */
 @Slf4j
 @Service
@@ -41,12 +58,19 @@ import java.util.UUID;
 public class ConstructionInvoiceService {
 
     private static final String DOC_TYPE = "CINV";
+    private static final String SOURCE_TYPE = "CONSTRUCTION_INVOICE";
     private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
 
     private final ConstructionInvoiceRepository invoiceRepo;
     private final EntryNumberGenerator numberGen;
     private final ConstructionInvoiceMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
+    private final AccountRepository accountRepo;
+    private final JournalEntryRepository journalRepo;
+    private final JournalPostingService postingService;
+    private final ConstructionPostingProperties postingProps;
+    private final InvoicePostingProperties arPostingProps;
+    private final UserContextService userContextService;
 
     @Transactional(readOnly = true)
     public ConstructionInvoiceDto findById(UUID id) {
@@ -114,6 +138,16 @@ public class ConstructionInvoiceService {
                     "Construction invoice " + inv.getInvoiceNumber() + " is cancelled and cannot be updated");
         }
 
+        // Approval is a posting event, so it may only happen through approve(), which
+        // writes the journal entry. A plain edit must never move an invoice into APPROVED
+        // (that would leave an approved invoice with no ledger entry) or out of it.
+        if (req.status() == ConstructionInvoiceStatus.APPROVED
+                && inv.getStatus() != ConstructionInvoiceStatus.APPROVED) {
+            throw new InvalidRequestException(
+                    "Construction invoice " + inv.getInvoiceNumber()
+                            + " cannot be approved through an update; use the approve action");
+        }
+
         inv.setType(req.type());
         inv.setStatus(req.status());
         inv.setPaymentStatus(req.paymentStatus());
@@ -137,6 +171,182 @@ public class ConstructionInvoiceService {
         ConstructionInvoice saved = invoiceRepo.saveAndFlush(inv);
         log.info("Updated construction invoice {}", saved.getInvoiceNumber());
         return mapper.toDto(saved);
+    }
+
+    /**
+     * Submit a draft for approval: DRAFT -> PENDING. Records who submitted it and when.
+     */
+    @Transactional
+    public ConstructionInvoiceDto submit(UUID id) {
+        ConstructionInvoice inv = requireInvoice(id);
+        if (inv.getStatus() != ConstructionInvoiceStatus.DRAFT) {
+            throw new InvalidRequestException(
+                    "Only DRAFT construction invoices can be submitted; invoice "
+                            + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
+        }
+        inv.setStatus(ConstructionInvoiceStatus.PENDING);
+        inv.setSubmittedBy(userContextService.getCurrentUserId());
+        inv.setSubmittedAt(Instant.now());
+        log.info("Submitted construction invoice {} for approval", inv.getInvoiceNumber());
+        return mapper.toDto(inv);
+    }
+
+    /**
+     * Approve a pending invoice: PENDING -> APPROVED, and post the journal entry.
+     *
+     * <p>Posting is invoice-level to the configured default accounts:
+     * <ul>
+     *   <li>PURCHASE / EXPENSE: DR default expense (net of discount) + DR GST input
+     *       (tax, if any); CR Accounts Payable (gross total).</li>
+     *   <li>SALES / SERVICE: DR Accounts Receivable (gross total); CR default revenue
+     *       (net of discount) + CR GST output (tax, if any).</li>
+     * </ul>
+     * The posted journal-entry id is stored on the invoice for drill-back and reversal.
+     */
+    @Transactional
+    public ConstructionInvoiceDto approve(UUID id) {
+        ConstructionInvoice inv = requireInvoice(id);
+        if (inv.getStatus() != ConstructionInvoiceStatus.PENDING) {
+            throw new InvalidRequestException(
+                    "Only PENDING construction invoices can be approved; invoice "
+                            + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
+        }
+
+        BigDecimal net = MoneyUtils.normalize(inv.getSubtotal().subtract(inv.getDiscountAmount()));
+        BigDecimal tax = MoneyUtils.normalize(inv.getTaxAmount());
+        BigDecimal gross = MoneyUtils.normalize(inv.getTotalAmount());
+
+        List<PostJournalRequest.LineRequest> jeLines = new ArrayList<>();
+        switch (inv.getType()) {
+            case PURCHASE, EXPENSE -> {
+                // TODO: option A AR materialization is only for sales/service; purchase and
+                // expense always post their own payable entry (no AR analog).
+                Account expense = requireAccount(postingProps.getDefaultExpenseCode());
+                Account payable = requireAccount(postingProps.getApAccountCode());
+                jeLines.add(new PostJournalRequest.LineRequest(expense.getId(), net, BigDecimal.ZERO,
+                        "Expense - " + inv.getInvoiceNumber()));
+                if (MoneyUtils.isPositive(tax)) {
+                    Account gstInput = requireAccount(postingProps.getGstInputCode());
+                    jeLines.add(new PostJournalRequest.LineRequest(gstInput.getId(), tax, BigDecimal.ZERO,
+                            "GST input - " + inv.getInvoiceNumber()));
+                }
+                jeLines.add(new PostJournalRequest.LineRequest(payable.getId(), BigDecimal.ZERO, gross,
+                        "Payable - " + inv.getInvoiceNumber()));
+            }
+            case SALES, SERVICE -> {
+                // TODO: option A AR materialization - the preferred sales/service path
+                // materializes a real AR Invoice (customer = project client) via
+                // InvoiceService.issue so AR aging and receipts pick it up. Until customer
+                // resolution exists this posts the AR journal entry directly instead.
+                Account receivable = requireAccount(arPostingProps.getArAccountCode());
+                Account revenue = requireAccount(postingProps.getDefaultRevenueCode());
+                jeLines.add(new PostJournalRequest.LineRequest(receivable.getId(), gross, BigDecimal.ZERO,
+                        "Receivable - " + inv.getInvoiceNumber()));
+                jeLines.add(new PostJournalRequest.LineRequest(revenue.getId(), BigDecimal.ZERO, net,
+                        "Revenue - " + inv.getInvoiceNumber()));
+                if (MoneyUtils.isPositive(tax)) {
+                    Account gstOutput = requireAccount(arPostingProps.getGstOutputCode());
+                    jeLines.add(new PostJournalRequest.LineRequest(gstOutput.getId(), BigDecimal.ZERO, tax,
+                            "GST output - " + inv.getInvoiceNumber()));
+                }
+            }
+        }
+
+        PostJournalRequest jeReq = new PostJournalRequest(
+                inv.getIssueDate(),
+                "Construction invoice " + inv.getInvoiceNumber(),
+                inv.getInvoiceNumber(),
+                jeLines);
+
+        JournalEntry je = postingService.postInternal(jeReq, SOURCE_TYPE, inv.getId());
+        inv.setJournalEntryId(je.getId());
+        inv.setStatus(ConstructionInvoiceStatus.APPROVED);
+        inv.setApprovedBy(userContextService.getCurrentUserId());
+        inv.setApprovedAt(Instant.now());
+
+        log.info("Approved construction invoice {} (JE: {})", inv.getInvoiceNumber(), je.getEntryNumber());
+        return mapper.toDto(inv);
+    }
+
+    /**
+     * Cancel an invoice. An approved invoice with a posted entry and no payments has that
+     * entry reversed via the ledger; anything with a payment applied is refused. The
+     * status moves to CANCELLED.
+     */
+    @Transactional
+    public ConstructionInvoiceDto cancel(UUID id, String reason) {
+        ConstructionInvoice inv = requireInvoice(id);
+
+        if (inv.getStatus() == ConstructionInvoiceStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction invoice " + inv.getInvoiceNumber() + " is already cancelled");
+        }
+        if (MoneyUtils.isPositive(inv.getPaidAmount())) {
+            throw new InvalidRequestException(
+                    "Cannot cancel construction invoice " + inv.getInvoiceNumber()
+                            + "; it has payments applied");
+        }
+
+        if (inv.getStatus() == ConstructionInvoiceStatus.APPROVED && inv.getJournalEntryId() != null) {
+            JournalEntry reversal = journalRepo.findByIdWithLines(inv.getJournalEntryId())
+                    .map(je -> postingService.reverse(je.getId(), new ReverseJournalRequest(reason)).id())
+                    .map(reversalId -> journalRepo.findScopedById(reversalId).orElseThrow())
+                    .orElseThrow(() -> new InvalidRequestException(
+                            "The original journal entry for construction invoice "
+                                    + inv.getInvoiceNumber() + " was not found"));
+            inv.setReversalJournalEntryId(reversal.getId());
+        }
+
+        inv.setStatus(ConstructionInvoiceStatus.CANCELLED);
+        log.info("Cancelled construction invoice {}: {}", inv.getInvoiceNumber(), reason);
+        return mapper.toDto(inv);
+    }
+
+    /**
+     * Record a payment against an approved invoice, advancing the paid/balance amounts
+     * and the separate payment-status dimension. Does not post to the ledger: the
+     * construction payment voucher handles cash-movement posting in its own phase.
+     */
+    @Transactional
+    public ConstructionInvoiceDto recordPayment(UUID id, BigDecimal amount) {
+        ConstructionInvoice inv = requireInvoice(id);
+        if (inv.getStatus() != ConstructionInvoiceStatus.APPROVED) {
+            throw new InvalidRequestException(
+                    "Only APPROVED construction invoices can take a recorded payment; invoice "
+                            + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
+        }
+        BigDecimal payment = MoneyUtils.normalize(amount);
+        if (!MoneyUtils.isPositive(payment)) {
+            throw new InvalidRequestException("Payment amount must be positive");
+        }
+        BigDecimal newPaid = MoneyUtils.normalize(inv.getPaidAmount().add(payment));
+        if (newPaid.compareTo(inv.getTotalAmount()) > 0) {
+            throw new InvalidRequestException(
+                    "Payment exceeds the balance due on construction invoice " + inv.getInvoiceNumber());
+        }
+        BigDecimal balance = MoneyUtils.normalize(inv.getTotalAmount().subtract(newPaid));
+
+        inv.setPaidAmount(newPaid);
+        inv.setBalanceAmount(balance);
+        inv.setPaymentStatus(MoneyUtils.isZero(balance)
+                ? ConstructionPaymentStatus.PAID
+                : ConstructionPaymentStatus.PARTIALLY_PAID);
+        inv.setPaymentRecordedBy(userContextService.getCurrentUserId());
+
+        log.info("Recorded payment of {} on construction invoice {} (balance {})",
+                payment, inv.getInvoiceNumber(), balance);
+        return mapper.toDto(inv);
+    }
+
+    private ConstructionInvoice requireInvoice(UUID id) {
+        return invoiceRepo.findByIdWithLines(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction invoice with ID " + id + " was not found"));
+    }
+
+    private Account requireAccount(String code) {
+        return accountRepo.findByCode(code)
+                .orElseThrow(() -> new AccountNotFoundException(code));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.finance.construction.service;
 
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -345,7 +347,7 @@ public class ConstructionInvoiceService {
     }
 
     private Account requireAccount(String code) {
-        return accountRepo.findByCode(code)
+        return accountRepo.findByCodeAndOrganization_Id(code, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new AccountNotFoundException(code));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionI
 import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionInvoiceRequest;
 import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @RestController
@@ -51,5 +52,29 @@ public class ConstructionInvoiceControllerWeb {
     public ConstructionInvoiceDto update(@PathVariable UUID id,
                                          @Valid @RequestBody UpdateConstructionInvoiceRequest req) {
         return service.update(id, req);
+    }
+
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto submit(@PathVariable UUID id) {
+        return service.submit(id);
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto approve(@PathVariable UUID id) {
+        return service.approve(id);
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
+        return service.cancel(id, reason);
+    }
+
+    @PostMapping("/{id}/record-payment")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public ConstructionInvoiceDto recordPayment(@PathVariable UUID id, @RequestParam BigDecimal amount) {
+        return service.recordPayment(id, amount);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.finance.invoice.service;
 
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -143,7 +145,7 @@ public class InvoiceService {
                             + " is currently " + inv.getStatus());
         }
 
-        Account ar = accountRepo.findByCode(postingProps.getArAccountCode())
+        Account ar = accountRepo.findByCodeAndOrganization_Id(postingProps.getArAccountCode(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new AccountNotFoundException(postingProps.getArAccountCode()));
 
         List<PostJournalRequest.LineRequest> jeLines = new ArrayList<>();
@@ -166,7 +168,7 @@ public class InvoiceService {
 
         // CR GST Output Payable (if applicable)
         if (MoneyUtils.isPositive(inv.getTaxTotal())) {
-            Account gstOut = accountRepo.findByCode(postingProps.getGstOutputCode())
+            Account gstOut = accountRepo.findByCodeAndOrganization_Id(postingProps.getGstOutputCode(), TenantContext.getCurrentOrgId())
                     .orElseThrow(() -> new AccountNotFoundException(postingProps.getGstOutputCode()));
             jeLines.add(new PostJournalRequest.LineRequest(gstOut.getId(), BigDecimal.ZERO, inv.getTaxTotal(),
                     "GST output - " + inv.getInvoiceNumber()));

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
@@ -25,6 +25,14 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
     List<Account> findByActiveTrue();
     boolean existsByCode(String code);
 
+    /**
+     * Whether the given organization already owns any account. Used by the
+     * chart-of-accounts seeder to stay idempotent: it seeds only an org whose
+     * chart is empty. Queries the organization id directly so it does not depend
+     * on the Hibernate {@code orgFilter} being enabled.
+     */
+    boolean existsByOrganizationId(Long organizationId);
+
     /** Direct children of the given account, used to derive the next sibling code. */
     List<Account> findByParent(Account parent);
 

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
@@ -20,7 +20,12 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
     @Query("SELECT a FROM Account a WHERE a.id = :id")
     Optional<Account> findScopedById(@Param("id") UUID id);
 
-    Optional<Account> findByCode(String code);
+    /**
+     * Org-scoped lookup by account code. Codes are unique only within an organization, so
+     * a code must always be resolved against the current tenant; a bare code lookup can
+     * match another tenant's account of the same code.
+     */
+    Optional<Account> findByCodeAndOrganization_Id(String code, Long organizationId);
     List<Account> findByType(AccountType type);
     List<Account> findByActiveTrue();
     boolean existsByCode(String code);

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.finance.ledger.service;
 
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -87,7 +89,7 @@ public class AccountService {
 
     @Transactional(readOnly = true)
     public AccountDto findByAccountByCode(String code) {
-        return mapper.toDto(repo.findByCode(code)
+        return mapper.toDto(repo.findByCodeAndOrganization_Id(code, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new AccountNotFoundException(code)));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeeder.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeeder.java
@@ -1,0 +1,109 @@
+package org.tornotron.echno_backend.finance.ledger.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Seeds a default chart of accounts for the current tenant.
+ *
+ * <p>The tree is fixed: five type roots (ASSET, LIABILITY, EQUITY, INCOME, EXPENSE)
+ * with a handful of headers and postable leaf accounts under each. Codes are pinned
+ * explicitly rather than auto-generated because other modules reference them by code:
+ * the AR invoice posting reads {@code finance.invoice.ar-account-code} (1200) and
+ * {@code finance.invoice.gst-output-code} (2210), and the construction posting reads
+ * {@code finance.construction.*} (2100 AP, 1410 GST input, 4100 revenue, 5100 expense).
+ * Those must exist as postable leaves before any journal entry can post.
+ *
+ * <p>Idempotent: if the tenant already owns any account the seed is skipped, so it is
+ * safe to run on organization creation and to re-run to back-fill an existing org.
+ * A child's type always equals its parent's type; whether an account is a header or a
+ * postable leaf is derived (a header is any account named as another's parent), so the
+ * leaves below are simply the accounts with no children.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChartOfAccountsSeeder {
+
+    private final AccountRepository accountRepo;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    /** One node of the default chart: its code, name, type, and parent code (null for roots). */
+    private record SeedAccount(String code, String name, AccountType type, String parentCode) {}
+
+    // Parent-first order: every parent appears before the children that reference it.
+    private static final List<SeedAccount> DEFAULT_CHART = List.of(
+            new SeedAccount("1000", "Assets", AccountType.ASSET, null),
+            new SeedAccount("1100", "Cash and Bank", AccountType.ASSET, "1000"),
+            new SeedAccount("1110", "Cash on Hand", AccountType.ASSET, "1100"),
+            new SeedAccount("1120", "Bank", AccountType.ASSET, "1100"),
+            new SeedAccount("1200", "Accounts Receivable", AccountType.ASSET, "1000"),
+            new SeedAccount("1300", "Inventory", AccountType.ASSET, "1000"),
+            new SeedAccount("1400", "Duties and Taxes Receivable", AccountType.ASSET, "1000"),
+            new SeedAccount("1410", "GST Input Credit", AccountType.ASSET, "1400"),
+
+            new SeedAccount("2000", "Liabilities", AccountType.LIABILITY, null),
+            new SeedAccount("2100", "Accounts Payable", AccountType.LIABILITY, "2000"),
+            new SeedAccount("2200", "Duties and Taxes Payable", AccountType.LIABILITY, "2000"),
+            new SeedAccount("2210", "GST Output Payable", AccountType.LIABILITY, "2200"),
+
+            new SeedAccount("3000", "Equity", AccountType.EQUITY, null),
+            new SeedAccount("3100", "Share Capital", AccountType.EQUITY, "3000"),
+            new SeedAccount("3200", "Retained Earnings", AccountType.EQUITY, "3000"),
+
+            new SeedAccount("4000", "Income", AccountType.INCOME, null),
+            new SeedAccount("4100", "Construction Revenue", AccountType.INCOME, "4000"),
+            new SeedAccount("4200", "Other Income", AccountType.INCOME, "4000"),
+
+            new SeedAccount("5000", "Expenses", AccountType.EXPENSE, null),
+            new SeedAccount("5100", "Cost of Materials and Purchases", AccountType.EXPENSE, "5000"),
+            new SeedAccount("5200", "Subcontractor Charges", AccountType.EXPENSE, "5000"),
+            new SeedAccount("5300", "Labour", AccountType.EXPENSE, "5000"),
+            new SeedAccount("5400", "Plant and Equipment Hire", AccountType.EXPENSE, "5000"),
+            new SeedAccount("5900", "Other Operating Expenses", AccountType.EXPENSE, "5000")
+    );
+
+    /**
+     * Seeds the default chart for the current tenant if it has no accounts yet.
+     *
+     * @return the number of accounts created (0 when the org already had a chart).
+     */
+    @Transactional
+    public int seedDefaults() {
+        Organization org = tenantEntityHelper.resolveCurrentOrganization();
+
+        if (accountRepo.existsByOrganizationId(org.getId())) {
+            log.debug("Chart of accounts already present for organization {}, skipping seed", org.getId());
+            return 0;
+        }
+
+        Map<String, Account> byCode = new HashMap<>();
+        for (SeedAccount node : DEFAULT_CHART) {
+            Account account = new Account();
+            account.setCode(node.code());
+            account.setName(node.name());
+            account.setType(node.type());
+            account.setActive(true);
+            account.setParent(node.parentCode() == null ? null : byCode.get(node.parentCode()));
+            account.setOrganization(org);
+
+            Account saved = accountRepo.save(account);
+            byCode.put(node.code(), saved);
+        }
+
+        log.info("Seeded default chart of accounts ({} accounts) for organization {}",
+                byCode.size(), org.getId());
+        return byCode.size();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
@@ -10,8 +10,10 @@ import org.tornotron.echno_backend.finance.ledger.dtos.AccountDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountTreeDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.CreateAccountRequest;
 import org.tornotron.echno_backend.finance.ledger.service.AccountService;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -20,6 +22,7 @@ import java.util.UUID;
 public class AccountControllerWeb {
 
     private final AccountService service;
+    private final ChartOfAccountsSeeder chartOfAccountsSeeder;
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
@@ -55,6 +58,17 @@ public class AccountControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     public AccountDto deactivate(@PathVariable UUID id) {
         return service.deactivate(id);
+    }
+
+    /**
+     * Seeds the default chart of accounts for the current tenant. Idempotent: an org
+     * that already has a chart is left untouched. Lets an org created before the seed
+     * was wired into organization creation be back-filled. Restricted to system-admin.
+     */
+    @PostMapping("/seed-defaults")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    public Map<String, Integer> seedDefaults() {
+        return Map.of("created", chartOfAccountsSeeder.seedDefaults());
     }
 
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.finance.payment.service;
 
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -157,7 +159,7 @@ public class PaymentService {
         }
 
         // 6. Post JE: DR Bank, CR Accounts Receivable
-        Account ar = accountRepo.findByCode(postingProps.getArAccountCode())
+        Account ar = accountRepo.findByCodeAndOrganization_Id(postingProps.getArAccountCode(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new AccountNotFoundException(postingProps.getArAccountCode()));
 
         List<PostJournalRequest.LineRequest> jeLines = List.of(

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -54,6 +54,7 @@ public class OrganizationService {
     private final EmployeeService employeeService;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
     private final org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity;
+    private final org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder;
 
     /**
      * Constructs an {@code OrganizationService} with the necessary dependencies.
@@ -63,7 +64,7 @@ public class OrganizationService {
      * @param keycloakGroupService The service for managing Keycloak groups.
      * @param subscriptionService The service for handling subscription billing.
      */
-    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity) {
+    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder) {
         this.repository = repository;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
@@ -73,6 +74,7 @@ public class OrganizationService {
         this.employeeService = employeeService;
         this.organizationMapper = organizationMapper;
         this.orgSecurity = orgSecurity;
+        this.chartOfAccountsSeeder = chartOfAccountsSeeder;
     }
 
     /**
@@ -107,6 +109,7 @@ public class OrganizationService {
         EmployeeJoinOrgDto joinOrgDto = new EmployeeJoinOrgDto();
         EmployeeDto employeeDto = employeeService.joinOrganization(currentUser.getId(), savedOrganization.getId(), joinOrgDto);
         TenantContext.setCurrentOrgId(savedOrganization.getId());
+        chartOfAccountsSeeder.seedDefaults();
         employeeService.assignOrgRole(employeeDto.getId(), OrgRole.SYSTEM_ADMIN);
 
         if (attachments != null && !attachments.isEmpty()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,11 @@ finance:
   invoice:
     ar-account-code: "1200"   # Accounts Receivable (postable leaf)
     gst-output-code: "2210"   # GST Output Payable (postable leaf)
+  construction:
+    ap-account-code: "2100"        # Accounts Payable (postable leaf)
+    gst-input-code: "1410"         # GST Input Credit (postable leaf)
+    default-expense-code: "5100"   # Cost of Materials and Purchases (postable leaf)
+    default-revenue-code: "4100"   # Construction Revenue (postable leaf)
 
 
 keycloak-initializer:

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -246,4 +246,7 @@
     <include file="db/changelog/v4.0/032-create-contract-milestones.xml"/>
     <include file="db/changelog/v4.0/033-current-stock-null-location-unique.xml"/>
 
+    <!-- v4.0 - Construction invoice approval workflow + ledger-posting links -->
+    <include file="db/changelog/v4.0/034-add-construction-invoice-approval-fields.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/034-add-construction-invoice-approval-fields.xml
+++ b/src/main/resources/db/changelog/v4.0/034-add-construction-invoice-approval-fields.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="034-add-construction-invoice-approval-fields" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="construction_invoices" columnName="approved_by"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Approval workflow audit trail and ledger-posting links on construction_invoices.
+            submitted/approved capture who moved the invoice through the approval gate;
+            journal_entry_id / reversal_journal_entry_id link the posted and reversed entries.
+        </comment>
+
+        <addColumn tableName="construction_invoices">
+            <column name="submitted_by" type="BIGINT"/>
+            <column name="submitted_at" type="TIMESTAMP"/>
+            <column name="approved_by" type="BIGINT"/>
+            <column name="approved_at" type="TIMESTAMP"/>
+            <column name="payment_recorded_by" type="BIGINT"/>
+            <column name="journal_entry_id" type="UUID"/>
+            <column name="reversal_journal_entry_id" type="UUID"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -180,17 +180,16 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
 
     @Test
     void approve_withMissingControlAccount_isRejected() {
+        // Remove the Accounts Payable control account the purchase posting needs, in a
+        // committed transaction before the invoice is created. Deleting it inside the live
+        // test transaction instead contends for the row lock with the service's own
+        // REQUIRES_NEW numbering connection, which blocks until the statement timeout under a
+        // slow CI runner. Committing it first makes the later approve resolve it as missing
+        // cleanly: the account is gone before the invoice transaction takes its snapshot.
+        inCommittedTx(() -> exec("DELETE FROM accounts WHERE organization_id = :org AND code = '2100'"));
+
         ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
         service.submit(created.id());
-
-        // Remove the Accounts Payable control account the purchase posting needs. Delete
-        // within the test transaction (not a committed one) so the approve query, which runs
-        // in the same long-lived transaction, sees it gone under CockroachDB's serializable
-        // snapshot.
-        entityManager.createNativeQuery("DELETE FROM accounts WHERE organization_id = :org AND code = '2100'")
-                .setParameter("org", orgId).executeUpdate();
-        entityManager.flush();
-        entityManager.clear();
 
         assertThatExceptionOfType(AccountNotFoundException.class)
                 .isThrownBy(() -> service.approve(created.id()));

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -1,0 +1,261 @@
+package org.tornotron.echno_backend.finance.construction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.JournalStatus;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntryLine;
+import org.tornotron.echno_backend.finance.ledger.mapper.JournalEntryMapperImpl;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Pins the money path of the construction invoice approval workflow against a real
+ * CockroachDB: approving a purchase invoice posts DR expense + DR GST input / CR
+ * accounts payable; approving a sales invoice posts DR accounts receivable / CR revenue
+ * + CR GST output; both store the journal-entry id. Cancel reverses the posted entry,
+ * approving from the wrong status is refused, and a missing control account aborts.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
+        JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
+        InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class})
+class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
+
+    private static final long PROJECT_ID = 4001L;
+
+    @Autowired
+    private ConstructionInvoiceService service;
+
+    @Autowired
+    private ChartOfAccountsSeeder seeder;
+
+    @Autowired
+    private JournalEntryRepository journalRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+
+    // The org and the chart of accounts must be committed, not held in the rolled-back
+    // test transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW (document_sequence
+    // has an FK to organization), and the journal-entry lines reference committed accounts.
+    // The invoice and its journal entry stay in the rolled-back test transaction.
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Posting Org");
+            entityManager.flush();
+            orgId = org.getId();
+            TenantContext.setCurrentOrgId(orgId);
+            seeder.seedDefaults();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM journal_entry_lines WHERE journal_entry_id IN "
+                    + "(SELECT id FROM journal_entries WHERE organization_id = :org)");
+            exec("DELETE FROM journal_entries WHERE organization_id = :org");
+            exec("DELETE FROM construction_invoice_lines WHERE invoice_id IN "
+                    + "(SELECT id FROM construction_invoices WHERE organization_id = :org)");
+            exec("DELETE FROM construction_invoices WHERE organization_id = :org");
+            exec("DELETE FROM document_sequence WHERE organization_id = :org");
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    @Test
+    void approve_purchaseInvoice_postsExpenseGstInputAgainstPayable() {
+        ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
+        ConstructionInvoiceDto pending = service.submit(created.id());
+        assertThat(pending.status()).isEqualTo(ConstructionInvoiceStatus.PENDING);
+
+        ConstructionInvoiceDto approved = service.approve(created.id());
+        assertThat(approved.status()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(approved.journalEntryId()).isNotNull();
+
+        JournalEntry je = journalRepo.findByIdWithLines(approved.journalEntryId()).orElseThrow();
+        assertThat(je.getSourceType()).isEqualTo("CONSTRUCTION_INVOICE");
+        assertThat(je.getSourceId()).isEqualTo(created.id());
+        assertThat(debit(je, "5100")).isEqualByComparingTo("1000");   // net (expense)
+        assertThat(debit(je, "1410")).isEqualByComparingTo("180");    // GST input
+        assertThat(credit(je, "2100")).isEqualByComparingTo("1180");  // gross (payable)
+        assertBalanced(je);
+    }
+
+    @Test
+    void approve_salesInvoice_postsReceivableAgainstRevenueAndGstOutput() {
+        ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.SALES));
+        service.submit(created.id());
+
+        ConstructionInvoiceDto approved = service.approve(created.id());
+        assertThat(approved.status()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(approved.journalEntryId()).isNotNull();
+
+        JournalEntry je = journalRepo.findByIdWithLines(approved.journalEntryId()).orElseThrow();
+        assertThat(debit(je, "1200")).isEqualByComparingTo("1180");   // gross (receivable)
+        assertThat(credit(je, "4100")).isEqualByComparingTo("1000");  // net (revenue)
+        assertThat(credit(je, "2210")).isEqualByComparingTo("180");   // GST output
+        assertBalanced(je);
+    }
+
+    @Test
+    void approve_fromNonPendingStatus_isRejected() {
+        ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
+        // A freshly created invoice is DRAFT, not PENDING.
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(created.id()));
+    }
+
+    @Test
+    void cancel_approvedInvoice_reversesTheJournalEntry() {
+        ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
+        service.submit(created.id());
+        ConstructionInvoiceDto approved = service.approve(created.id());
+        UUID originalJeId = approved.journalEntryId();
+
+        ConstructionInvoiceDto cancelled = service.cancel(created.id(), "Ordered in error");
+        assertThat(cancelled.status()).isEqualTo(ConstructionInvoiceStatus.CANCELLED);
+        assertThat(cancelled.reversalJournalEntryId()).isNotNull();
+
+        JournalEntry original = journalRepo.findByIdWithLines(originalJeId).orElseThrow();
+        assertThat(original.getStatus()).isEqualTo(JournalStatus.REVERSED);
+
+        JournalEntry reversal = journalRepo.findByIdWithLines(cancelled.reversalJournalEntryId()).orElseThrow();
+        // The payable was credited on the original; on the reversal it is debited back.
+        assertThat(debit(reversal, "2100")).isEqualByComparingTo("1180");
+        assertBalanced(reversal);
+    }
+
+    @Test
+    void approve_withMissingControlAccount_isRejected() {
+        ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
+        service.submit(created.id());
+
+        // Remove the Accounts Payable control account the purchase posting needs. Delete
+        // within the test transaction (not a committed one) so the approve query, which runs
+        // in the same long-lived transaction, sees it gone under CockroachDB's serializable
+        // snapshot.
+        entityManager.createNativeQuery("DELETE FROM accounts WHERE organization_id = :org AND code = '2100'")
+                .setParameter("org", orgId).executeUpdate();
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThatExceptionOfType(AccountNotFoundException.class)
+                .isThrownBy(() -> service.approve(created.id()));
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private CreateConstructionInvoiceRequest request(ConstructionInvoiceType type) {
+        return new CreateConstructionInvoiceRequest(
+                type,
+                PROJECT_ID,
+                null, null, null,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31),
+                "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
+                "Posting test", "Standard terms apply",
+                // 10 * 100 = 1000 subtotal, 18% tax = 180, no discount -> gross 1180
+                List.of(new ConstructionInvoiceLineRequest("Cement supply", bd("10"), "nos",
+                        bd("100"), bd("18"), null, null, null, null)));
+    }
+
+    private BigDecimal debit(JournalEntry je, String code) {
+        return lineFor(je, code).getDebit();
+    }
+
+    private BigDecimal credit(JournalEntry je, String code) {
+        return lineFor(je, code).getCredit();
+    }
+
+    private JournalEntryLine lineFor(JournalEntry je, String code) {
+        return je.getLines().stream()
+                .filter(l -> l.getAccount().getCode().equals(code))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No journal line for account " + code));
+    }
+
+    private void assertBalanced(JournalEntry je) {
+        BigDecimal debits = je.getLines().stream().map(JournalEntryLine::getDebit)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal credits = je.getLines().stream().map(JournalEntryLine::getCredit)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(debits).isEqualByComparingTo(credits);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private static BigDecimal bd(String value) {
+        return new BigDecimal(value);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -19,6 +19,7 @@ import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
@@ -26,7 +27,11 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionI
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.mapper.JournalEntryMapperImpl;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
@@ -46,7 +51,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
-        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class})
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
+        JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
+        InvoicePostingProperties.class, UserContextService.class})
 class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeederIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeederIT.java
@@ -1,0 +1,132 @@
+package org.tornotron.echno_backend.finance.ledger.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the default chart-of-accounts seed against a real CockroachDB: seeding an
+ * empty tenant creates the fixed tree, the control-account codes other modules point at
+ * land as postable leaves (not headers), and a second run is a no-op.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ChartOfAccountsSeeder.class, TenantEntityHelper.class, JpaAuditingConfig.class})
+class ChartOfAccountsSeederIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ChartOfAccountsSeeder seeder;
+
+    @Autowired
+    private AccountRepository accountRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Chart Org");
+            entityManager.flush();
+            orgId = org.getId();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    @Test
+    void seedDefaults_createsPostableLeavesForTheReferencedControlAccounts() {
+        int created = seeder.seedDefaults();
+        assertThat(created).isEqualTo(24);
+
+        List<Account> all = accountRepo.findAll();
+        assertThat(all).hasSize(24);
+
+        // Header accounts are those named as a parent by another account; a leaf has none.
+        List<UUID> allIds = all.stream().map(Account::getId).toList();
+        Set<UUID> headerIds = Set.copyOf(accountRepo.findHeaderIdsAmong(allIds));
+
+        // The codes finance.invoice.* and finance.construction.* post to must be leaves.
+        for (String leafCode : List.of("1200", "2210", "2100", "1410", "4100", "5100")) {
+            Account leaf = accountRepo.findByCode(leafCode).orElseThrow();
+            assertThat(leaf.isActive()).isTrue();
+            assertThat(headerIds).doesNotContain(leaf.getId());
+        }
+
+        // Sanity: a type root is a header, not postable.
+        Account root = accountRepo.findByCode("1000").orElseThrow();
+        assertThat(headerIds).contains(root.getId());
+
+        // A child's type matches its parent's branch.
+        assertThat(accountRepo.findByCode("1410").orElseThrow().getParent().getCode()).isEqualTo("1400");
+    }
+
+    @Test
+    void seedDefaults_isIdempotent() {
+        assertThat(seeder.seedDefaults()).isEqualTo(24);
+        assertThat(seeder.seedDefaults()).isZero();
+        assertThat(accountRepo.findAll()).hasSize(24);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeederIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/service/ChartOfAccountsSeederIT.java
@@ -81,7 +81,9 @@ class ChartOfAccountsSeederIT extends AbstractIntegrationTest {
         int created = seeder.seedDefaults();
         assertThat(created).isEqualTo(24);
 
-        List<Account> all = accountRepo.findAll();
+        List<Account> all = accountRepo.findAll().stream()
+                .filter(a -> a.getOrganization().getId().equals(orgId))
+                .toList();
         assertThat(all).hasSize(24);
 
         // Header accounts are those named as a parent by another account; a leaf has none.
@@ -90,24 +92,26 @@ class ChartOfAccountsSeederIT extends AbstractIntegrationTest {
 
         // The codes finance.invoice.* and finance.construction.* post to must be leaves.
         for (String leafCode : List.of("1200", "2210", "2100", "1410", "4100", "5100")) {
-            Account leaf = accountRepo.findByCode(leafCode).orElseThrow();
+            Account leaf = accountRepo.findByCodeAndOrganization_Id(leafCode, orgId).orElseThrow();
             assertThat(leaf.isActive()).isTrue();
             assertThat(headerIds).doesNotContain(leaf.getId());
         }
 
         // Sanity: a type root is a header, not postable.
-        Account root = accountRepo.findByCode("1000").orElseThrow();
+        Account root = accountRepo.findByCodeAndOrganization_Id("1000", orgId).orElseThrow();
         assertThat(headerIds).contains(root.getId());
 
         // A child's type matches its parent's branch.
-        assertThat(accountRepo.findByCode("1410").orElseThrow().getParent().getCode()).isEqualTo("1400");
+        assertThat(accountRepo.findByCodeAndOrganization_Id("1410", orgId).orElseThrow().getParent().getCode()).isEqualTo("1400");
     }
 
     @Test
     void seedDefaults_isIdempotent() {
         assertThat(seeder.seedDefaults()).isEqualTo(24);
         assertThat(seeder.seedDefaults()).isZero();
-        assertThat(accountRepo.findAll()).hasSize(24);
+        assertThat(accountRepo.findAll().stream()
+                .filter(a -> a.getOrganization().getId().equals(orgId))
+                .toList()).hasSize(24);
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
@@ -43,11 +43,12 @@ class OrganizationServiceBatchAuthzTest {
     @Mock private EmployeeService employeeService;
     @Mock private OrganizationMapper organizationMapper;
     @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder;
 
     private OrganizationService service() {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
-                organizationMapper, orgSecurity);
+                organizationMapper, orgSecurity, chartOfAccountsSeeder);
     }
 
     private OrganizationPatchDto patch(long id) {


### PR DESCRIPTION
Builds the ledger posting the construction module was missing (base spec `2026-08-12-construction-finance-design.md` increment 3), gated behind an approval workflow, on a default chart of accounts. Resolves the design half captured on #341 / spec `2026-08-19-construction-finance-approvals-budgeting.md`.

## What
- **Chart of accounts (new):** `ChartOfAccountsSeeder` seeds a default per-tenant chart on org creation (idempotent), plus an admin `POST /finance/accounts/web/seed-defaults` to back-fill existing orgs. The `accounts` table was empty, so the existing AR posting would have failed too. Codes pinned: AR 1200, GST output 2210 (existing config), Accounts Payable 2100, GST Input Credit **1410** (a current asset under a `1400 Duties and Taxes Receivable` group — `1210` would wrongly nest under AR in the hierarchical numbering), plus cash/bank, inventory, equity, revenue and construction expense accounts, all as postable leaves.
- **Approval workflow:** `submit` / `approve` / `cancel` / `record-payment` on the construction invoice, with `APPROVED` status and `submitted_by/at`, `approved_by/at`, `payment_recorded_by`, `journal_entry_id`, `reversal_journal_entry_id` (migration 034). `update()` cannot move an invoice into APPROVED (approval must post).
- **Ledger posting on approval** (mirrors `InvoiceService`): purchase/expense posts DR expense + DR GST input / CR Accounts Payable; sales/service posts DR Accounts Receivable / CR revenue + CR GST output. Cancel reverses via the ledger. Invoice-level posting to configured default accounts (`finance.construction.*`); per-line cost categories are the budgeting phase.

## Tests
`ConstructionInvoicePostingIT` (balanced entries for purchase/sales, approve guards, cancel reversal, missing-account rejection), `ChartOfAccountsSeederIT`, and the existing `ConstructionInvoiceServiceIT`. Verified compiling on the lab box; relying on CI for the full Testcontainers run.

## Follow-ups
- Sales/service currently posts the AR journal entry directly; the spec's preferred option-A (materialize a real AR invoice for AR aging) is a documented follow-up needing project-to-customer resolution.
- Core + web next: expose the statuses/fields/actions in `@tornotron/echno-core` and apply Anand's list/detail view + approval actions.
- Budgeting (per-line cost categories, project budgets) is its own phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added construction-invoice submission, approval, cancellation, and payment-recording workflows.
  * Approved invoices now post to the ledger, while cancellations create reversals.
  * Added configurable posting accounts and approval/payment audit details.
  * Added default chart-of-accounts seeding for new organizations, with an administrative manual trigger.
  * Updated the GST input credit account code to 1410.

* **Bug Fixes**
  * Prevented invoices from being marked approved through direct updates.
  * Scoped financial account lookups to the current organization for safer ledger and invoice processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->