### PR TITLE
test: stop a lock-wait from hanging the CI suite for hours

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # A hard ceiling so a hung test can never burn a multi-hour runner again. The
+    # suite completes in a few minutes; anything approaching this is a hang to fix.
+    timeout-minutes: 20
     steps:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/build.gradle
+++ b/build.gradle
@@ -83,4 +83,10 @@ tasks.named('test') {
     // pinned version from the 'api.version' system property (not DOCKER_API_VERSION,
     // which is a docker-CLI variable). 1.44 is accepted by both CI and the lab host.
     systemProperty 'api.version', '1.44'
+    // Print each test as it starts and finishes so a CI log always shows which test
+    // is running; without this, a hung test leaves no trace of which one stalled.
+    testLogging {
+        events 'started', 'passed', 'skipped', 'failed'
+        exceptionFormat 'short'
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
@@ -26,5 +26,11 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.url", COCKROACH::getJdbcUrl);
         registry.add("spring.datasource.username", COCKROACH::getUsername);
         registry.add("spring.datasource.password", COCKROACH::getPassword);
+        // Bound every statement so a lock-wait cannot hang the suite. The tests share one
+        // container and run sequentially, so a single test that blocks on a row lock (for
+        // example a pessimistic SELECT ... FOR UPDATE held open by a rolled-back test
+        // transaction while a REQUIRES_NEW call waits on it) would otherwise stall the whole
+        // run for hours. With this it aborts after 30s and that one test fails fast instead.
+        registry.add("spring.datasource.hikari.connection-init-sql", () -> "SET statement_timeout = '30s'");
     }
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+# Belt-and-suspenders timeout: the datasource statement_timeout (30s) catches SQL
+# lock-waits; this catches any non-SQL hang so no single test can stall the suite.
+# The suite's real tests run in seconds, so 5 minutes is far above any legitimate case.
+junit.jupiter.execution.timeout.test.method.default = 5m
+junit.jupiter.execution.timeout.lifecycle.method.default = 5m


### PR DESCRIPTION
The backend CI Test step took **4h4m** on a recent run; ~98% of that was a single test blocked on a row lock with no timeout, stalling the whole sequential suite (tests share one CockroachDB container and run in one JVM). Root cause is the known self-deadlock: a pessimistic `SELECT ... FOR UPDATE` held open by a rolled-back `@DataJpaTest` transaction while a `REQUIRES_NEW` sequence call waits on it; CockroachDB cannot detect it and there was no statement timeout.

Fixes:
- **statement_timeout=30s** on the test datasource (AbstractIntegrationTest) so any lock-wait aborts and that test fails fast instead of hanging the suite.
- **timeout-minutes: 20** on the build-and-test job as a hard ceiling.
- **5m JUnit per-method/lifecycle timeout** as a non-SQL backstop.
- **per-test logging** (started/passed/failed) so the CI log always names the running test.

This removes the 4-hour risk for the whole team. If a specific test now fails on the 30s timeout, that is the self-deadlocking test and gets the committed-transaction fix in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clearer test execution reporting, including started, passed, skipped, and failed tests.
  * Added five-minute safeguards for tests and lifecycle operations.
  * Added a 30-second database statement timeout for integration tests.

* **Chores**
  * Added a 20-minute timeout to the pull request build and test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->