### PR TITLE
feat: AI compliance generation as an inspection extension (#36)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,12 @@ tasks.named('test') {
     // pinned version from the 'api.version' system property (not DOCKER_API_VERSION,
     // which is a docker-CLI variable). 1.44 is accepted by both CI and the lab host.
     systemProperty 'api.version', '1.44'
+    // Bound the forked test JVM so the whole run fits the 2 vCPU / 7 GB CI runner
+    // alongside the shared CockroachDB container: an unbounded heap plus the
+    // container's default cache (a quarter of host memory) can exhaust the runner
+    // and the OOM killer then takes the database, failing the rest of the suite.
+    maxHeapSize = '1024m'
+    jvmArgs '-XX:MaxMetaspaceSize=512m'
     // Print each test as it starts and finishes so a CI log always shows which test
     // is running; without this, a hung test leaves no trace of which one stalled.
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'org.mapstruct:mapstruct:1.6.3'
+    implementation 'com.anthropic:anthropic-java:2.57.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'com.github.librepdf:openpdf:3.0.0'
     implementation 'software.amazon.awssdk:s3:2.41.10'

--- a/src/main/java/org/tornotron/echno_backend/common/events/ProjectApprovedEvent.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/ProjectApprovedEvent.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.common.events;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published when a project transitions into the {@code approved} status. Carries
+ * the project id and its organization id explicitly: the compliance-generation
+ * listener runs on a separate async thread that has no {@code TenantContext}, so
+ * it restores the tenant from the event rather than from thread-local state.
+ */
+public class ProjectApprovedEvent extends ApplicationEvent {
+
+    private final Long projectId;
+    private final Long organizationId;
+
+    public ProjectApprovedEvent(Object source, Long projectId, Long organizationId) {
+        super(source);
+        this.projectId = projectId;
+        this.organizationId = organizationId;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public Long getOrganizationId() {
+        return organizationId;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
@@ -1,0 +1,52 @@
+package org.tornotron.echno_backend.common.events.listeners;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+
+/**
+ * Runs AI compliance generation when a project is approved. It fires only AFTER the
+ * approving transaction commits (so the project row is durable) and on a separate
+ * async thread (so the slow AI call never blocks the approving request). That async
+ * thread has no {@link TenantContext}, so the organization id is read from the event
+ * and set on the thread for the duration of the tenant-scoped work, then cleared.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ComplianceGenerationListener {
+
+    private final ComplianceGenerationService complianceGenerationService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProjectApproved(ProjectApprovedEvent event) {
+        Long projectId = event.getProjectId();
+        Long orgId = event.getOrganizationId();
+        if (orgId == null) {
+            log.warn("ProjectApprovedEvent for project {} has no organization id; skipping compliance generation",
+                    projectId);
+            return;
+        }
+
+        log.info("Project {} approved; generating compliance inspections for organization {}", projectId, orgId);
+        try {
+            TenantContext.setCurrentOrgId(orgId);
+            complianceGenerationService.generateForProject(projectId, orgId);
+        } catch (Exception e) {
+            log.error("Compliance generation failed for project {} in organization {}: {}",
+                    projectId, orgId, e.getMessage(), e);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -1,0 +1,171 @@
+package org.tornotron.echno_backend.compliance;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.compliance.ai.ClaudeComplianceService;
+import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionOrigin;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Generates compliance-type inspections for an approved project. It resolves the
+ * project's state (from its address) and type, loads the matching curated
+ * {@link ComplianceRule}s, asks {@link ClaudeComplianceService} which of them apply,
+ * and materialises each "applies" decision as a suggested, AI-generated inspection.
+ *
+ * <p>Idempotent: a (projectId, complianceRuleRef) pair that already has an inspection
+ * is skipped, so a re-run (the manual regenerate endpoint, or a repeated approval)
+ * only adds compliances that are missing. The document number series is shared with
+ * manual inspections ({@code INSP}).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ComplianceGenerationService {
+
+    private static final String DOC_TYPE = "INSP";
+
+    private final ProjectRepository projectRepository;
+    private final ComplianceRuleRepository ruleRepository;
+    private final ClaudeComplianceService claudeComplianceService;
+    private final InspectionRepository inspectionRepository;
+    private final EntryNumberGenerator numberGen;
+    private final TenantEntityHelper tenantEntityHelper;
+    private final InspectionMapper inspectionMapper;
+
+    /**
+     * Generates the missing compliance inspections for a project. Returns the DTOs of
+     * the rows created by this call (empty when the AI is disabled/unconfigured, the
+     * project has no resolvable state or type, no rules match, or everything already
+     * exists).
+     *
+     * @param projectId the project to generate for
+     * @param orgId     the owning organization; must match the current tenant context
+     */
+    @Transactional
+    public List<InspectionDto> generateForProject(Long projectId, Long orgId) {
+        Project project = projectRepository.findByIdAndOrganization_Id(projectId, orgId).orElse(null);
+        if (project == null) {
+            log.warn("Compliance generation skipped: project {} not found in organization {}", projectId, orgId);
+            return List.of();
+        }
+
+        ProjectType projectType = project.getProjectType();
+        if (projectType == null) {
+            log.warn("Compliance generation skipped for project {}: projectType is not set", projectId);
+            return List.of();
+        }
+
+        String state = IndianStateResolver.resolve(project.getProjectAddress());
+        if (state == null) {
+            log.warn("Compliance generation skipped for project {}: could not resolve a state from address '{}'",
+                    projectId, project.getProjectAddress());
+            return List.of();
+        }
+
+        List<ComplianceRule> candidateRules =
+                ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(state, projectType);
+        if (candidateRules.isEmpty()) {
+            log.info("No compliance rules registered for state '{}' and type {} (project {})",
+                    state, projectType, projectId);
+            return List.of();
+        }
+
+        List<ComplianceSuggestion> suggestions =
+                claudeComplianceService.suggestCompliances(project, state, candidateRules);
+        if (suggestions.isEmpty()) {
+            log.info("Compliance AI returned no suggestions for project {}", projectId);
+            return List.of();
+        }
+
+        Map<String, ComplianceRule> rulesByCode = candidateRules.stream()
+                .collect(Collectors.toMap(ComplianceRule::getCode, Function.identity(), (a, b) -> a));
+
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
+
+        // Group by phase (pre -> ongoing -> post) then code so the created rows read in
+        // lifecycle order; the web can also regroup by compliancePhase.
+        List<ComplianceSuggestion> ordered = suggestions.stream()
+                .filter(ComplianceSuggestion::applies)
+                .filter(s -> rulesByCode.containsKey(s.ruleCode()))
+                .sorted(Comparator
+                        .comparingInt((ComplianceSuggestion s) -> rulesByCode.get(s.ruleCode()).getPhase().ordinal())
+                        .thenComparing(ComplianceSuggestion::ruleCode))
+                .toList();
+
+        List<InspectionDto> created = new ArrayList<>();
+        for (ComplianceSuggestion suggestion : ordered) {
+            ComplianceRule rule = rulesByCode.get(suggestion.ruleCode());
+
+            if (inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                    projectId, rule.getCode(), orgId)) {
+                log.debug("Compliance {} already exists for project {}; skipping", rule.getCode(), projectId);
+                continue;
+            }
+
+            Inspection inspection = new Inspection();
+            inspection.setInspectionNumber(numberGen.next(DOC_TYPE));
+            inspection.setTitle(rule.getName());
+            inspection.setType(InspectionType.COMPLIANCE);
+            inspection.setStatus(InspectionStatus.SUGGESTED);
+            inspection.setOrigin(InspectionOrigin.AI_GENERATED);
+            inspection.setProjectId(projectId);
+            inspection.setCompliancePhase(rule.getPhase());
+            inspection.setRiskLevel(resolveRisk(suggestion.riskLevel(), rule.getDefaultRiskLevel()));
+            inspection.setResolutionOptions(resolveResolutionOptions(suggestion, rule));
+            inspection.setComplianceRuleRef(rule.getCode());
+            inspection.setAiRationale(suggestion.rationale());
+            inspection.setOrganization(organization);
+
+            Inspection saved = inspectionRepository.save(inspection);
+            created.add(inspectionMapper.toDto(saved));
+        }
+
+        log.info("Generated {} compliance inspection(s) for project {} (state '{}', type {})",
+                created.size(), projectId, state, projectType);
+        return created;
+    }
+
+    /** The AI-assessed risk level if it parses, else the rule's default. */
+    private ComplianceRiskLevel resolveRisk(String aiRiskLevel, ComplianceRiskLevel fallback) {
+        if (aiRiskLevel != null && !aiRiskLevel.isBlank()) {
+            try {
+                return ComplianceRiskLevel.fromValue(aiRiskLevel);
+            } catch (IllegalArgumentException e) {
+                log.debug("Unrecognised AI risk level '{}'; using rule default {}", aiRiskLevel, fallback);
+            }
+        }
+        return fallback;
+    }
+
+    /** The AI resolution options (newline-joined) if given, else the rule's own. */
+    private String resolveResolutionOptions(ComplianceSuggestion suggestion, ComplianceRule rule) {
+        if (suggestion.resolutionOptions() != null && !suggestion.resolutionOptions().isEmpty()) {
+            return String.join("\n", suggestion.resolutionOptions());
+        }
+        return rule.getResolutionOptions();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/CompliancePhase.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/CompliancePhase.java
@@ -1,0 +1,39 @@
+package org.tornotron.echno_backend.compliance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Stage of the construction lifecycle a compliance applies to. Compliances fall
+ * into three phases: obtained before work starts ({@code PRE_CONSTRUCTION}), held
+ * or renewed while work runs ({@code ONGOING}), and obtained on completion
+ * ({@code POST_CONSTRUCTION}). The wire value is the hyphenated form from
+ * {@link #getValue()}; the constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}, mirroring the inspection enums.
+ */
+public enum CompliancePhase {
+    PRE_CONSTRUCTION("pre-construction"),
+    ONGOING("ongoing"),
+    POST_CONSTRUCTION("post-construction");
+
+    private final String value;
+
+    CompliancePhase(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static CompliancePhase fromValue(String value) {
+        for (CompliancePhase phase : values()) {
+            if (phase.value.equalsIgnoreCase(value)) {
+                return phase;
+            }
+        }
+        throw new IllegalArgumentException("Unknown compliance phase: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.compliance;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Derives the Indian state a project sits in from its free-text address. Compliance
+ * rules are keyed by state, so generation needs a state name; projects only carry an
+ * address string. The match is a case-insensitive substring scan against a fixed list
+ * of states and union territories, returning the canonical name of the first hit.
+ * Deliberately simple: a structured state field on the project can replace this later.
+ */
+final class IndianStateResolver {
+
+    private static final List<String> STATES = List.of(
+            "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chhattisgarh",
+            "Goa", "Gujarat", "Haryana", "Himachal Pradesh", "Jharkhand", "Karnataka",
+            "Kerala", "Madhya Pradesh", "Maharashtra", "Manipur", "Meghalaya", "Mizoram",
+            "Nagaland", "Odisha", "Punjab", "Rajasthan", "Sikkim", "Tamil Nadu",
+            "Telangana", "Tripura", "Uttar Pradesh", "Uttarakhand", "West Bengal",
+            "Andaman and Nicobar Islands", "Chandigarh",
+            "Dadra and Nagar Haveli and Daman and Diu", "Delhi", "Jammu and Kashmir",
+            "Ladakh", "Lakshadweep", "Puducherry");
+
+    private IndianStateResolver() {}
+
+    /** The canonical state name found in the address, or null if none matches. */
+    static String resolve(String address) {
+        if (address == null || address.isBlank()) {
+            return null;
+        }
+        String haystack = address.toLowerCase(Locale.ROOT);
+        for (String state : STATES) {
+            if (haystack.contains(state.toLowerCase(Locale.ROOT))) {
+                return state;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/AnthropicProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/AnthropicProperties.java
@@ -1,0 +1,30 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration for the Anthropic Claude call that drives compliance generation.
+ * Bound from the {@code anthropic.*} block in application.yml. The API key is a
+ * secret supplied at deploy time via {@code ANTHROPIC_API_KEY}; when it is blank
+ * (or {@code enabled} is false) the AI service no-ops, so the application runs
+ * normally without a key configured.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "anthropic")
+public class AnthropicProperties {
+
+    /** Secret API key. Empty by default; set via the ANTHROPIC_API_KEY env var. */
+    private String apiKey = "";
+
+    /** Model id to call. */
+    private String model = "claude-opus-5";
+
+    /** Upper bound on tokens generated in the response. */
+    private long maxTokens = 4096;
+
+    /** Master switch; when false the AI call is skipped and generation no-ops. */
+    private boolean enabled = true;
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ClaudeComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ClaudeComplianceService.java
@@ -1,0 +1,144 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import com.anthropic.models.messages.ContentBlock;
+import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.project.Project;
+
+import java.util.List;
+
+/**
+ * Wraps the Anthropic Claude call that decides which candidate compliance rules
+ * apply to a project. The service is deliberately fail-soft: it never throws into
+ * the approval flow. If the AI is disabled, has no API key, or the call/parse
+ * fails, it logs and returns an empty list, and the caller generates nothing for
+ * that project (a manual regenerate can be retried once the key is set).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClaudeComplianceService {
+
+    private final AnthropicProperties props;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Asks Claude which of the candidate rules apply to the project. Returns one
+     * suggestion per rule the model reasoned about; an empty list means "generate
+     * nothing" (either the AI is off/unconfigured or the call failed).
+     */
+    public List<ComplianceSuggestion> suggestCompliances(Project project,
+                                                         String state,
+                                                         List<ComplianceRule> candidateRules) {
+        if (!props.isEnabled() || props.getApiKey() == null || props.getApiKey().isBlank()) {
+            log.info("Compliance AI disabled or API key not configured; skipping AI suggestion for project {}",
+                    project.getId());
+            return List.of();
+        }
+        if (candidateRules == null || candidateRules.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            AnthropicClient client = AnthropicOkHttpClient.builder()
+                    .apiKey(props.getApiKey())
+                    .build();
+
+            String prompt = buildPrompt(project, state, candidateRules);
+
+            MessageCreateParams params = MessageCreateParams.builder()
+                    .model(props.getModel())
+                    .maxTokens(props.getMaxTokens())
+                    .addUserMessage(prompt)
+                    .build();
+
+            Message message = client.messages().create(params);
+            String responseText = extractText(message);
+            return parseSuggestions(responseText);
+        } catch (Exception e) {
+            log.error("Compliance AI call failed for project {}: {}", project.getId(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    private String buildPrompt(Project project, String state, List<ComplianceRule> rules) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("You are a construction-compliance assistant for India. Decide which statutory ")
+                .append("compliances apply to a construction project, reasoning ONLY over the candidate ")
+                .append("rules provided. Do not invent compliances outside this list.\n\n");
+        sb.append("Project:\n");
+        sb.append("- name: ").append(project.getProjectName()).append('\n');
+        sb.append("- state: ").append(state).append('\n');
+        sb.append("- projectType: ").append(project.getProjectType()).append('\n');
+        if (project.getProjectAddress() != null) {
+            sb.append("- address: ").append(project.getProjectAddress()).append('\n');
+        }
+        sb.append("\nEach compliance belongs to one of three lifecycle phases: pre-construction ")
+                .append("(obtained before work starts), ongoing (held or renewed during construction), ")
+                .append("and post-construction (obtained on completion).\n\n");
+        sb.append("Candidate rules (JSON):\n");
+        sb.append("[\n");
+        for (int i = 0; i < rules.size(); i++) {
+            ComplianceRule r = rules.get(i);
+            sb.append("  {")
+                    .append("\"ruleCode\": \"").append(r.getCode()).append("\", ")
+                    .append("\"name\": \"").append(escape(r.getName())).append("\", ")
+                    .append("\"phase\": \"").append(r.getPhase().getValue()).append("\", ")
+                    .append("\"defaultRiskLevel\": \"").append(r.getDefaultRiskLevel().getValue()).append("\", ")
+                    .append("\"description\": \"").append(escape(r.getDescription())).append("\", ")
+                    .append("\"authority\": \"").append(escape(r.getAuthority())).append("\"}")
+                    .append(i < rules.size() - 1 ? ",\n" : "\n");
+        }
+        sb.append("]\n\n");
+        sb.append("Respond with STRICT JSON only, no prose and no markdown fences: a JSON array where ")
+                .append("each element is {\"ruleCode\": string, \"applies\": boolean, ")
+                .append("\"riskLevel\": one of [low, medium, high, critical], ")
+                .append("\"resolutionOptions\": array of short strings, ")
+                .append("\"rationale\": short string, ")
+                .append("\"phase\": one of [pre-construction, ongoing, post-construction]}. ")
+                .append("Include one element for every candidate rule.");
+        return sb.toString();
+    }
+
+    private static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ");
+    }
+
+    /** Concatenates the text of every text content block in the message. */
+    private String extractText(Message message) {
+        StringBuilder sb = new StringBuilder();
+        for (ContentBlock block : message.content()) {
+            block.text().ifPresent(t -> sb.append(t.text()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Parses the model's response into suggestions. Tolerates the model wrapping the
+     * array in prose or code fences by slicing from the first '[' to the last ']'.
+     */
+    private List<ComplianceSuggestion> parseSuggestions(String responseText) throws Exception {
+        if (responseText == null || responseText.isBlank()) {
+            return List.of();
+        }
+        int start = responseText.indexOf('[');
+        int end = responseText.lastIndexOf(']');
+        if (start < 0 || end <= start) {
+            log.warn("Compliance AI response contained no JSON array; got: {}", responseText);
+            return List.of();
+        }
+        String json = responseText.substring(start, end + 1);
+        ComplianceSuggestion[] parsed = objectMapper.readValue(json, ComplianceSuggestion[].class);
+        return List.of(parsed);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceSuggestion.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceSuggestion.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * One AI decision about a candidate compliance rule, parsed from the model's JSON
+ * response. {@code ruleCode} ties the decision back to the {@code ComplianceRule}
+ * it refers to; {@code applies} says whether the compliance is required for the
+ * project. Risk level, resolution options, rationale and phase are the model's
+ * assessment; the generation service falls back to the rule's own values when the
+ * model omits them. Unknown JSON fields are ignored so a model that adds keys does
+ * not break parsing.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ComplianceSuggestion(
+        String ruleCode,
+        boolean applies,
+        String riskLevel,
+        List<String> resolutionOptions,
+        String rationale,
+        String phase
+) {}

--- a/src/main/java/org/tornotron/echno_backend/compliance/domain/ComplianceRule.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/domain/ComplianceRule.java
@@ -1,0 +1,71 @@
+package org.tornotron.echno_backend.compliance.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+
+import java.util.UUID;
+
+/**
+ * A curated statutory-compliance rule the AI generation flow reasons over. This is
+ * GLOBAL reference data shared across every tenant: it is deliberately NOT
+ * tenant-scoped (no organization_id, no {@code orgFilter}), because the same
+ * building-plan-approval or fire-NOC requirement applies to any org building in that
+ * state. A rule is keyed by ({@code state}, {@code projectType}); the AI decides
+ * which of the matching rules actually apply to a given project.
+ */
+@Entity
+@Table(name = "compliance_rules",
+        uniqueConstraints = @UniqueConstraint(name = "uk_compliance_rule_code",
+                columnNames = {"state", "project_type", "code"}),
+        indexes = {
+                @Index(name = "idx_compliance_rule_state_type",
+                        columnList = "state, project_type"),
+                @Index(name = "idx_compliance_rule_active", columnList = "active")
+        })
+@Getter @Setter
+@NoArgsConstructor
+public class ComplianceRule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /** Indian state the compliance applies in (matched case-insensitively). */
+    @Column(name = "state", nullable = false, length = 100)
+    private String state;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "project_type", nullable = false, length = 30)
+    private org.tornotron.echno_backend.project.enums.ProjectType projectType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "phase", nullable = false, length = 30)
+    private CompliancePhase phase;
+
+    /** Short stable code used as the dedupe reference on generated inspections. */
+    @Column(name = "code", nullable = false, length = 60)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "default_risk_level", nullable = false, length = 30)
+    private ComplianceRiskLevel defaultRiskLevel;
+
+    @Column(name = "resolution_options", columnDefinition = "TEXT")
+    private String resolutionOptions;
+
+    @Column(name = "authority", length = 200)
+    private String authority;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/repository/ComplianceRuleRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/repository/ComplianceRuleRepository.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.compliance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Access to the global compliance-rule reference data. Not tenant-scoped: these
+ * rules are shared across all organizations, so no {@code orgFilter} applies.
+ */
+@Repository
+public interface ComplianceRuleRepository extends JpaRepository<ComplianceRule, UUID> {
+
+    /**
+     * The candidate rules for a project: every active rule registered for the
+     * project's state (case-insensitive) and type. The AI then decides which of
+     * these actually apply.
+     */
+    List<ComplianceRule> findByStateIgnoreCaseAndProjectTypeAndActiveTrue(String state,
+                                                                          ProjectType projectType);
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -1,0 +1,39 @@
+package org.tornotron.echno_backend.compliance.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+
+import java.util.List;
+
+/**
+ * Manual entry point for AI compliance generation. The automatic path runs on project
+ * approval through {@code ComplianceGenerationListener}; this lets a project manager
+ * re-run generation on demand (for example after the AI key is configured, or after
+ * new rules are added). Generation is idempotent, so a re-run only adds compliances
+ * that do not already exist. Runs synchronously and returns the rows it created.
+ */
+@RestController
+@RequestMapping("/api/v1/inspections/web/compliance")
+@RequiredArgsConstructor
+public class ComplianceControllerWeb {
+
+    private final ComplianceGenerationService complianceGenerationService;
+
+    @PostMapping("/regenerate")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    public List<InspectionDto> regenerate(@RequestParam Long projectId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (orgId == null) {
+            throw new TenantIdMissingException("No organization context set — X-Organization-Id header required");
+        }
+        return complianceGenerationService.generateForProject(projectId, orgId);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -32,7 +32,7 @@ public class ComplianceControllerWeb {
     public List<InspectionDto> regenerate(@RequestParam Long projectId) {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {
-            throw new TenantIdMissingException("No organization context set — X-Organization-Id header required");
+            throw new TenantIdMissingException("No organization context set; the X-Organization-Id header is required");
         }
         return complianceGenerationService.generateForProject(projectId, orgId);
     }

--- a/src/main/java/org/tornotron/echno_backend/inspection/ComplianceRiskLevel.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/ComplianceRiskLevel.java
@@ -1,0 +1,38 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Risk severity attached to a compliance-type inspection and to the compliance
+ * rule it was generated from. The wire value is the lowercase form from
+ * {@link #getValue()}; the constant name is the database representation stored
+ * by {@code @Enumerated(STRING)}, mirroring the other inspection enums.
+ */
+public enum ComplianceRiskLevel {
+    LOW("low"),
+    MEDIUM("medium"),
+    HIGH("high"),
+    CRITICAL("critical");
+
+    private final String value;
+
+    ComplianceRiskLevel(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ComplianceRiskLevel fromValue(String value) {
+        for (ComplianceRiskLevel level : values()) {
+            if (level.value.equalsIgnoreCase(value)) {
+                return level;
+            }
+        }
+        throw new IllegalArgumentException("Unknown compliance risk level: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionOrigin.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionOrigin.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How an inspection came to exist: entered by a user ({@code MANUAL}) or produced
+ * by the compliance generation flow ({@code AI_GENERATED}). Defaults to
+ * {@code MANUAL} on the entity. The wire value is the hyphenated form from
+ * {@link #getValue()}; the constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}.
+ */
+public enum InspectionOrigin {
+    MANUAL("manual"),
+    AI_GENERATED("ai-generated");
+
+    private final String value;
+
+    InspectionOrigin(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionOrigin fromValue(String value) {
+        for (InspectionOrigin origin : values()) {
+            if (origin.value.equalsIgnoreCase(value)) {
+                return origin;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection origin: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
@@ -15,7 +15,8 @@ public enum InspectionStatus {
     FAILED("failed"),
     PASSED("passed"),
     PASSED_WITH_REMARKS("passed-with-remarks"),
-    CANCELLED("cancelled");
+    CANCELLED("cancelled"),
+    SUGGESTED("suggested");
 
     private final String value;
 

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
@@ -8,6 +8,9 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionOrigin;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
 import org.tornotron.echno_backend.inspection.InspectionType;
@@ -80,7 +83,9 @@ public class Inspection implements TenantScopedEntity {
     @Column(name = "drawing_reference", length = 200)
     private String drawingReference;
 
-    @Column(name = "scheduled_date", nullable = false)
+    // Nullable: AI-generated compliance rows are created without a schedule, which
+    // a project manager fills in when the compliance is planned.
+    @Column(name = "scheduled_date")
     private LocalDate scheduledDate;
 
     @Column(name = "scheduled_time", length = 20)
@@ -96,7 +101,8 @@ public class Inspection implements TenantScopedEntity {
     @Column(name = "duration")
     private Integer duration;
 
-    @Column(name = "inspector_id", nullable = false)
+    // Nullable: AI-generated compliance rows have no inspector until one is assigned.
+    @Column(name = "inspector_id")
     private Long inspectorId;
 
     @Column(name = "contractor_id")
@@ -129,6 +135,30 @@ public class Inspection implements TenantScopedEntity {
 
     @Column(name = "defects_found", nullable = false)
     private int defectsFound;
+
+    // Compliance-extension fields. Present only on compliance-type inspections; null
+    // on ordinary manual inspections. origin defaults to MANUAL so existing rows and
+    // the manual create path are unaffected.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "origin", nullable = false, length = 30)
+    private InspectionOrigin origin = InspectionOrigin.MANUAL;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "compliance_phase", length = 30)
+    private CompliancePhase compliancePhase;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "risk_level", length = 30)
+    private ComplianceRiskLevel riskLevel;
+
+    @Column(name = "resolution_options", columnDefinition = "TEXT")
+    private String resolutionOptions;
+
+    @Column(name = "compliance_rule_ref", length = 100)
+    private String complianceRuleRef;
+
+    @Column(name = "ai_rationale", columnDefinition = "TEXT")
+    private String aiRationale;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id")

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionOrigin;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
 import org.tornotron.echno_backend.inspection.InspectionType;
@@ -35,6 +38,12 @@ public record InspectionDto(
         int passedCheckPoints,
         int failedCheckPoints,
         int defectsFound,
+        InspectionOrigin origin,
+        CompliancePhase compliancePhase,
+        ComplianceRiskLevel riskLevel,
+        String resolutionOptions,
+        String complianceRuleRef,
+        String aiRationale,
         List<InspectionCheckItemDto> checkItems,
         List<InspectionDefectDto> defects,
         LocalDateTime createdAt,

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionRepository.java
@@ -21,4 +21,14 @@ public interface InspectionRepository
      */
     @Query("SELECT i FROM Inspection i WHERE i.id = :id")
     Optional<Inspection> findByIdScoped(@Param("id") UUID id);
+
+    /**
+     * Dedupe guard for AI compliance generation: true when a compliance inspection
+     * for this project already references the given rule in this organization. The
+     * organization is included explicitly so the check is correct even if the
+     * Hibernate {@code orgFilter} is not active on the calling thread.
+     */
+    boolean existsByProjectIdAndComplianceRuleRefAndOrganization_Id(Long projectId,
+                                                                    String complianceRuleRef,
+                                                                    Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -9,6 +9,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
 import org.tornotron.echno_backend.task.Task;
 import org.tornotron.echno_backend.wbs.WbsElement;
 
@@ -51,6 +52,11 @@ public class Project implements TenantScopedEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = true)
     private ProjectCreationStatus status;
+
+    /** The broad construction category, used to match statutory compliances. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "project_type", nullable = true)
+    private ProjectType projectType;
 
     /** The list of employees assigned to this project. */
     @ManyToMany

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,8 +20,10 @@ import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.project.dto.*;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -42,6 +45,7 @@ public class ProjectService {
     private final AttachmentService attachmentService;
     private final ProjectMapper projectMapper;
     private final EmployeeMapper employeeMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * Constructs a ProjectService with the necessary repositories.
@@ -55,13 +59,15 @@ public class ProjectService {
                           OrganizationRepository organizationRepository,
                           EmployeeRepository employeeRepository,
                           AttachmentService attachmentService, ProjectMapper projectMapper,
-                          EmployeeMapper employeeMapper) {
+                          EmployeeMapper employeeMapper,
+                          ApplicationEventPublisher eventPublisher) {
         this.repository = repository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
         this.attachmentService = attachmentService;
         this.projectMapper = projectMapper;
         this.employeeMapper = employeeMapper;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -86,6 +92,9 @@ public class ProjectService {
             project.setProjectLatitude(projectDto.getProjectLatitude());
             project.setProjectLongitude(projectDto.getProjectLongitude());
             project.setStatus(ProjectCreationStatus.valueOf(projectDto.getStatus()));
+            if (projectDto.getProjectType() != null && !projectDto.getProjectType().isBlank()) {
+                project.setProjectType(ProjectType.valueOf(projectDto.getProjectType()));
+            }
             project.setOrganization(organization);
             project.setStartDate(projectDto.getStartDate());
             project.setEndDate(projectDto.getEndDate());
@@ -170,7 +179,21 @@ public class ProjectService {
                     project.setProjectAddress((String) value);
                     break;
                 case "status":
-                    project.setStatus(ProjectCreationStatus.valueOf((String) value));
+                    ProjectCreationStatus previousStatus = project.getStatus();
+                    ProjectCreationStatus newStatus = ProjectCreationStatus.valueOf((String) value);
+                    project.setStatus(newStatus);
+                    // Fire a compliance-generation event only on the transition INTO
+                    // approved, never on a save that leaves it approved. The listener runs
+                    // AFTER_COMMIT, so the row is durable before the AI flow reads it.
+                    if (newStatus == ProjectCreationStatus.approved
+                            && previousStatus != ProjectCreationStatus.approved) {
+                        Long orgId = project.getOrganization() != null
+                                ? project.getOrganization().getId() : null;
+                        eventPublisher.publishEvent(new ProjectApprovedEvent(this, project.getId(), orgId));
+                    }
+                    break;
+                case "projectType":
+                    project.setProjectType(value != null ? ProjectType.valueOf((String) value) : null);
                     break;
                 case "projectLongitude":
                     float longitude = ((Number) value).floatValue();

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -28,6 +28,10 @@ public class ProjectCreationDto {
     @Enumerated(EnumType.STRING)
     private String status;
 
+    /** Optional construction category (e.g. RESIDENTIAL, COMMERCIAL). Drives compliance matching. */
+    @Size(max = 50, message = "projectType must be at most 50 characters")
+    private String projectType;
+
     @NotNull
     private Float projectLatitude;
 

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
 import org.tornotron.echno_backend.task.dto.TaskDto;
 
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ public class ProjectDto {
     private String projectAddress;
     private LocalDateTime createdAt;
     private ProjectCreationStatus status;
+    private ProjectType projectType;
     private List<EmployeeDto> employees;
     private Float projectLatitude;
     private Float projectLongitude;

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.project.dto;
 
 import lombok.Data;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +14,7 @@ public class ProjectSimpleDto {
     private String projectAddress;
     private LocalDateTime createdAt;
     private ProjectCreationStatus status;
+    private ProjectType projectType;
     private Float projectLatitude;
     private Float projectLongitude;
     private LocalDateTime startDate;

--- a/src/main/java/org/tornotron/echno_backend/project/enums/ProjectCreationStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/project/enums/ProjectCreationStatus.java
@@ -7,5 +7,6 @@ public enum ProjectCreationStatus {
     completed,
     dropped,
     onHold,
-    cancelled
+    cancelled,
+    approved
 }

--- a/src/main/java/org/tornotron/echno_backend/project/enums/ProjectType.java
+++ b/src/main/java/org/tornotron/echno_backend/project/enums/ProjectType.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.project.enums;
+
+/**
+ * Broad category of construction a project is. Together with the project's state
+ * (derived from its address) this drives which statutory compliances the AI
+ * generation flow considers, so the constant set matches the compliance rules
+ * dataset. Stored by {@code @Enumerated(STRING)}.
+ */
+public enum ProjectType {
+    RESIDENTIAL,
+    COMMERCIAL,
+    INDUSTRIAL,
+    INFRASTRUCTURE,
+    INSTITUTIONAL,
+    MIXED_USE,
+    OTHER
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,16 @@ API:
   VERSION: ${BACKEND_API_VERSION}
 
 
+# Anthropic Claude, used to generate compliance inspections when a project is approved.
+# api-key is a secret injected at deploy time; when it is empty (or enabled=false) the
+# compliance AI no-ops and the application runs normally without a key.
+anthropic:
+  api-key: ${ANTHROPIC_API_KEY:}
+  model: claude-opus-5
+  max-tokens: 4096
+  enabled: ${ANTHROPIC_ENABLED:true}
+
+
 # Chart-of-accounts auto numbering. level-steps is the gap between sibling codes
 # at each depth (0 = roots); root-blocks is the first code per account type.
 finance:

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -249,4 +249,9 @@
     <!-- v4.0 - Construction invoice approval workflow + ledger-posting links -->
     <include file="db/changelog/v4.0/034-add-construction-invoice-approval-fields.xml"/>
 
+    <!-- v4.0 - Compliance module (AI-generated compliance inspections) -->
+    <include file="db/changelog/v4.0/035-add-compliance-fields-to-inspections.xml"/>
+    <include file="db/changelog/v4.0/036-add-project-type.xml"/>
+    <include file="db/changelog/v4.0/037-create-and-seed-compliance-rules.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/035-add-compliance-fields-to-inspections.xml
+++ b/src/main/resources/db/changelog/v4.0/035-add-compliance-fields-to-inspections.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="035-add-compliance-fields-to-inspections" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="inspections" columnName="origin"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Compliance extension on inspections: origin marks manual vs AI-generated rows;
+            compliance_phase / risk_level / resolution_options / compliance_rule_ref /
+            ai_rationale carry the compliance detail for AI-generated compliance inspections.
+            Existing rows default to origin=MANUAL and null compliance fields.
+        </comment>
+
+        <addColumn tableName="inspections">
+            <column name="origin" type="VARCHAR(30)" defaultValue="MANUAL">
+                <constraints nullable="false"/>
+            </column>
+            <column name="compliance_phase" type="VARCHAR(30)"/>
+            <column name="risk_level" type="VARCHAR(30)"/>
+            <column name="resolution_options" type="TEXT"/>
+            <column name="compliance_rule_ref" type="VARCHAR(100)"/>
+            <column name="ai_rationale" type="TEXT"/>
+        </addColumn>
+
+        <createIndex tableName="inspections" indexName="idx_insp_compliance_rule_ref">
+            <column name="compliance_rule_ref"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="035-relax-inspection-not-null-for-ai-rows" author="echno">
+        <comment>
+            AI-generated compliance rows are created without an inspector or a schedule,
+            which a project manager fills in later; drop the NOT NULL on both columns.
+        </comment>
+
+        <dropNotNullConstraint tableName="inspections"
+                               columnName="inspector_id"
+                               columnDataType="BIGINT"/>
+
+        <dropNotNullConstraint tableName="inspections"
+                               columnName="scheduled_date"
+                               columnDataType="DATE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/036-add-project-type.xml
+++ b/src/main/resources/db/changelog/v4.0/036-add-project-type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="036-add-project-type" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="project_type"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Broad construction category on a project (RESIDENTIAL, COMMERCIAL, ...).
+            Nullable; together with the project's state it drives compliance matching.
+        </comment>
+
+        <addColumn tableName="project">
+            <column name="project_type" type="VARCHAR(30)"/>
+        </addColumn>
+
+        <createIndex tableName="project" indexName="idx_project_type">
+            <column name="project_type"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/037-create-and-seed-compliance-rules.xml
+++ b/src/main/resources/db/changelog/v4.0/037-create-and-seed-compliance-rules.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="037-create-compliance-rules" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="compliance_rules"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Global (non-tenant-scoped) reference data: curated statutory compliances keyed
+            by state + project type + lifecycle phase. Shared across all organizations, so
+            no organization_id column and no org filter.
+        </comment>
+
+        <createTable tableName="compliance_rules">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="state" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="project_type" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="phase" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="code" type="VARCHAR(60)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="default_risk_level" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="resolution_options" type="TEXT"/>
+            <column name="authority" type="VARCHAR(200)"/>
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="compliance_rules"
+                             columnNames="state, project_type, code"
+                             constraintName="uk_compliance_rule_code"/>
+
+        <createIndex tableName="compliance_rules" indexName="idx_compliance_rule_state_type">
+            <column name="state"/>
+            <column name="project_type"/>
+        </createIndex>
+        <createIndex tableName="compliance_rules" indexName="idx_compliance_rule_active">
+            <column name="active"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="037-seed-compliance-rules" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM compliance_rules</sqlCheck>
+        </preConditions>
+
+        <comment>
+            Seed a small curated set for Tamil Nadu, Kerala and Maharashtra covering all
+            three lifecycle phases. RESIDENTIAL for each state plus COMMERCIAL for Tamil
+            Nadu, to exercise state + project-type matching. project_type / phase /
+            default_risk_level are stored as the enum constant names (STRING mapping).
+        </comment>
+
+        <!-- ===================== Tamil Nadu / RESIDENTIAL ===================== -->
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="TN-BPA"/>
+            <column name="name" value="Building Plan Approval"/>
+            <column name="description" value="Sanction of building plans by the local planning authority / CMDA / DTCP before construction begins."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Submit plans through the licensed surveyor;Apply on the TNSWP portal;Obtain planning permission and building licence"/>
+            <column name="authority" value="CMDA / DTCP / Local Body"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="TN-ENV-CLEAR"/>
+            <column name="name" value="Environmental Clearance"/>
+            <column name="description" value="Prior environmental clearance for built-up area above the notified threshold under the EIA Notification."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Apply on PARIVESH portal;Obtain SEIAA clearance;Submit Form 1A and conceptual plan"/>
+            <column name="authority" value="SEIAA Tamil Nadu"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="TN-FIRE-NOC"/>
+            <column name="name" value="Fire Service NOC"/>
+            <column name="description" value="No-objection certificate from the Fire and Rescue Services for high-rise / multi-storey buildings."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Submit fire safety plan;Apply to TN Fire and Rescue Services;Provide required fire-fighting arrangements"/>
+            <column name="authority" value="TN Fire and Rescue Services"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="TN-LABOUR-LIC"/>
+            <column name="name" value="Labour Licence (BOCW)"/>
+            <column name="description" value="Registration and licence under the Building and Other Construction Workers Act while construction labour is engaged."/>
+            <column name="default_risk_level" value="MEDIUM"/>
+            <column name="resolution_options" value="Register the establishment under BOCW;Obtain labour licence;Remit the labour welfare cess"/>
+            <column name="authority" value="TN Labour Welfare Board"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="TN-STRUCT-STAB"/>
+            <column name="name" value="Structural Stability Certificate"/>
+            <column name="description" value="Certificate from a qualified structural engineer confirming the structure is built to the sanctioned structural design."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Engage a licensed structural engineer;Obtain the stability certificate at key stages;Retain design and test records"/>
+            <column name="authority" value="Licensed Structural Engineer"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="POST_CONSTRUCTION"/>
+            <column name="code" value="TN-OCC-CERT"/>
+            <column name="name" value="Completion / Occupancy Certificate"/>
+            <column name="description" value="Certificate from the local body that the completed building conforms to the approved plan and may be occupied."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Apply for completion certificate;Arrange the final site inspection;Obtain the occupancy certificate before handover"/>
+            <column name="authority" value="Local Body / CMDA"/>
+        </insert>
+
+        <!-- ===================== Tamil Nadu / COMMERCIAL ===================== -->
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="COMMERCIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="TN-BPA"/>
+            <column name="name" value="Building Plan Approval"/>
+            <column name="description" value="Sanction of commercial building plans by the local planning authority before construction begins."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Submit plans through the licensed surveyor;Apply on the TNSWP portal;Obtain planning permission and building licence"/>
+            <column name="authority" value="CMDA / DTCP / Local Body"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="COMMERCIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="TN-FIRE-NOC"/>
+            <column name="name" value="Fire Service NOC"/>
+            <column name="description" value="Fire NOC for commercial occupancy, mandatory before commencement and occupancy."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Submit fire safety plan;Apply to TN Fire and Rescue Services;Provide required fire-fighting arrangements"/>
+            <column name="authority" value="TN Fire and Rescue Services"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Tamil Nadu"/>
+            <column name="project_type" value="COMMERCIAL"/>
+            <column name="phase" value="POST_CONSTRUCTION"/>
+            <column name="code" value="TN-OCC-CERT"/>
+            <column name="name" value="Completion / Occupancy Certificate"/>
+            <column name="description" value="Occupancy certificate for the commercial premises before it is put to use."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Apply for completion certificate;Arrange the final site inspection;Obtain the occupancy certificate before handover"/>
+            <column name="authority" value="Local Body / CMDA"/>
+        </insert>
+
+        <!-- ===================== Kerala / RESIDENTIAL ===================== -->
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="KL-BPA"/>
+            <column name="name" value="Building Permit"/>
+            <column name="description" value="Building permit from the panchayat / municipality / corporation under the Kerala Municipality Building Rules before construction."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Apply on the Sanketham / K-SMART portal;Submit plans through an empanelled engineer;Obtain the building permit"/>
+            <column name="authority" value="Local Self Government Department, Kerala"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="KL-ENV-CLEAR"/>
+            <column name="name" value="Environmental Clearance"/>
+            <column name="description" value="Prior environmental clearance for built-up area above the notified threshold under the EIA Notification."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Apply on PARIVESH portal;Obtain SEIAA Kerala clearance;Submit Form 1A and conceptual plan"/>
+            <column name="authority" value="SEIAA Kerala"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="KL-FIRE-NOC"/>
+            <column name="name" value="Fire and Rescue NOC"/>
+            <column name="description" value="No-objection certificate from Kerala Fire and Rescue Services for multi-storey / high-rise buildings."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Submit fire safety plan;Apply to Kerala Fire and Rescue Services;Provide required fire-fighting arrangements"/>
+            <column name="authority" value="Kerala Fire and Rescue Services"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="KL-LABOUR-LIC"/>
+            <column name="name" value="Labour Licence (BOCW)"/>
+            <column name="description" value="Registration and licence under the Building and Other Construction Workers Act while construction labour is engaged."/>
+            <column name="default_risk_level" value="MEDIUM"/>
+            <column name="resolution_options" value="Register the establishment under BOCW;Obtain labour licence;Remit the labour welfare cess"/>
+            <column name="authority" value="Kerala Building and Other Construction Workers Welfare Board"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="KL-STRUCT-STAB"/>
+            <column name="name" value="Structural Stability Certificate"/>
+            <column name="description" value="Certificate from a qualified structural engineer confirming the structure is built to the sanctioned design."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Engage a licensed structural engineer;Obtain the stability certificate at key stages;Retain design and test records"/>
+            <column name="authority" value="Licensed Structural Engineer"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Kerala"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="POST_CONSTRUCTION"/>
+            <column name="code" value="KL-OCC-CERT"/>
+            <column name="name" value="Occupancy Certificate"/>
+            <column name="description" value="Occupancy certificate from the local body confirming the completed building conforms to the approved permit."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Apply for the occupancy certificate;Arrange the completion inspection;Obtain the certificate before occupation"/>
+            <column name="authority" value="Local Self Government Department, Kerala"/>
+        </insert>
+
+        <!-- ===================== Maharashtra / RESIDENTIAL ===================== -->
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="MH-BPA"/>
+            <column name="name" value="Commencement Certificate"/>
+            <column name="description" value="Sanction of plans and commencement certificate from the planning authority / municipal corporation before construction."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Submit plans through a licensed architect;Apply on the BPMS portal;Obtain the commencement certificate"/>
+            <column name="authority" value="Municipal Corporation / Planning Authority"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="MH-ENV-CLEAR"/>
+            <column name="name" value="Environmental Clearance"/>
+            <column name="description" value="Prior environmental clearance for built-up area above the notified threshold under the EIA Notification."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Apply on PARIVESH portal;Obtain SEIAA Maharashtra clearance;Submit Form 1A and conceptual plan"/>
+            <column name="authority" value="SEIAA Maharashtra"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="PRE_CONSTRUCTION"/>
+            <column name="code" value="MH-FIRE-NOC"/>
+            <column name="name" value="Fire NOC"/>
+            <column name="description" value="No-objection certificate from the Maharashtra Fire Services for high-rise / multi-storey buildings."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Submit fire safety plan;Apply to the Chief Fire Officer;Provide required fire-fighting arrangements"/>
+            <column name="authority" value="Maharashtra Fire Services"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="MH-LABOUR-LIC"/>
+            <column name="name" value="Labour Licence (BOCW)"/>
+            <column name="description" value="Registration and licence under the Building and Other Construction Workers Act while construction labour is engaged."/>
+            <column name="default_risk_level" value="MEDIUM"/>
+            <column name="resolution_options" value="Register the establishment under BOCW;Obtain labour licence;Remit the labour welfare cess"/>
+            <column name="authority" value="Maharashtra Building and Other Construction Workers Welfare Board"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="ONGOING"/>
+            <column name="code" value="MH-STRUCT-STAB"/>
+            <column name="name" value="Structural Stability Certificate"/>
+            <column name="description" value="Certificate from a qualified structural engineer confirming the structure is built to the sanctioned design."/>
+            <column name="default_risk_level" value="HIGH"/>
+            <column name="resolution_options" value="Engage a licensed structural engineer;Obtain the stability certificate at key stages;Retain design and test records"/>
+            <column name="authority" value="Licensed Structural Engineer"/>
+        </insert>
+        <insert tableName="compliance_rules">
+            <column name="state" value="Maharashtra"/>
+            <column name="project_type" value="RESIDENTIAL"/>
+            <column name="phase" value="POST_CONSTRUCTION"/>
+            <column name="code" value="MH-OCC-CERT"/>
+            <column name="name" value="Occupancy Certificate"/>
+            <column name="description" value="Occupancy certificate from the municipal corporation confirming the completed building conforms to the approved plan."/>
+            <column name="default_risk_level" value="CRITICAL"/>
+            <column name="resolution_options" value="Apply for the occupancy certificate;Arrange the completion inspection;Obtain the certificate before occupation"/>
+            <column name="authority" value="Municipal Corporation"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -1,0 +1,179 @@
+package org.tornotron.echno_backend.compliance;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.compliance.ai.ClaudeComplianceService;
+import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionOrigin;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionType;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises compliance generation against a real CockroachDB with the migration-seeded
+ * {@code compliance_rules} in place. The AI call is stubbed (never the real API): the
+ * stub marks two of the seeded Tamil Nadu residential rules as applicable, and the test
+ * asserts that exactly those become suggested, AI-generated compliance inspections in
+ * lifecycle-phase order, and that a second run adds nothing (idempotent on the
+ * (projectId, complianceRuleRef) pair).
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ComplianceGenerationService.class, InspectionMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
+
+    private static final String RULE_PRE = "TN-BPA";        // pre-construction
+    private static final String RULE_POST = "TN-OCC-CERT";  // post-construction
+
+    @Autowired
+    private ComplianceGenerationService service;
+
+    @MockBean
+    private ClaudeComplianceService claudeComplianceService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long projectId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("Org Compliance A");
+
+            Project project = new Project();
+            project.setProjectName("Chennai Residency");
+            project.setProjectAddress("12 Mount Road, Chennai, Tamil Nadu, India");
+            project.setProjectType(ProjectType.RESIDENTIAL);
+            project.setStatus(ProjectCreationStatus.approved);
+            project.setOrganization(orgA);
+            entityManager.persist(project);
+
+            entityManager.flush();
+            orgAId = orgA.getId();
+            projectId = project.getId();
+        });
+
+        // The stub applies two of the six seeded TN residential rules and rejects the rest.
+        when(claudeComplianceService.suggestCompliances(any(Project.class), anyString(), any()))
+                .thenReturn(List.of(
+                        new ComplianceSuggestion(RULE_POST, true, "critical",
+                                List.of("Apply for the occupancy certificate"), "Required before handover",
+                                "post-construction"),
+                        new ComplianceSuggestion(RULE_PRE, true, "critical",
+                                List.of("Obtain the building plan approval"), "Required before work starts",
+                                "pre-construction"),
+                        new ComplianceSuggestion("TN-FIRE-NOC", false, null, null,
+                                "Not required for this low-rise residential project", "pre-construction")
+                ));
+
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+        if (orgAId == null) {
+            return;
+        }
+        // Committed seed rows survive the rollback; remove them by hand. The global
+        // compliance_rules seed is left intact (it is shared reference data).
+        inCommittedTx(() -> {
+            entityManager.createNativeQuery(
+                            "DELETE FROM inspections WHERE organization_id = :org")
+                    .setParameter("org", orgAId).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM document_sequence WHERE organization_id = :org")
+                    .setParameter("org", orgAId).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM project WHERE organization_id = :org")
+                    .setParameter("org", orgAId).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM organization WHERE id = :org")
+                    .setParameter("org", orgAId).executeUpdate();
+        });
+    }
+
+    @Test
+    void generatesSuggestedComplianceInspections_andIsIdempotent() {
+        List<InspectionDto> created = service.generateForProject(projectId, orgAId);
+
+        // Exactly the two applicable rules, ordered by phase: pre-construction then post.
+        assertThat(created).hasSize(2);
+        assertThat(created).allSatisfy(dto -> {
+            assertThat(dto.type()).isEqualTo(InspectionType.COMPLIANCE);
+            assertThat(dto.status()).isEqualTo(InspectionStatus.SUGGESTED);
+            assertThat(dto.origin()).isEqualTo(InspectionOrigin.AI_GENERATED);
+            assertThat(dto.projectId()).isEqualTo(projectId);
+            assertThat(dto.inspectionNumber()).startsWith("INSP-");
+            assertThat(dto.riskLevel()).isEqualTo(ComplianceRiskLevel.CRITICAL);
+        });
+        assertThat(created).extracting(InspectionDto::complianceRuleRef)
+                .containsExactly(RULE_PRE, RULE_POST);
+        assertThat(created).extracting(dto -> dto.compliancePhase().getValue())
+                .containsExactly("pre-construction", "post-construction");
+        assertThat(created.get(0).aiRationale()).isEqualTo("Required before work starts");
+
+        entityManager.flush();
+
+        // Re-run: everything already exists, so nothing new is created.
+        List<InspectionDto> rerun = service.generateForProject(projectId, orgAId);
+        assertThat(rerun).isEmpty();
+
+        Long total = ((Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM inspections WHERE organization_id = :org AND type = 'COMPLIANCE'")
+                .setParameter("org", orgAId)
+                .getSingleResult()).longValue();
+        assertThat(total).isEqualTo(2L);
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/ClaudeComplianceServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/ClaudeComplianceServiceTest.java
@@ -1,0 +1,65 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The compliance AI must be safe to run without an Anthropic key: when disabled or
+ * unconfigured it returns no suggestions rather than attempting a call. These are pure
+ * unit tests; they never touch the network.
+ */
+class ClaudeComplianceServiceTest {
+
+    private Project sampleProject() {
+        Project project = new Project();
+        project.setProjectName("Sample");
+        project.setProjectAddress("Chennai, Tamil Nadu");
+        project.setProjectType(ProjectType.RESIDENTIAL);
+        return project;
+    }
+
+    private List<ComplianceRule> sampleRules() {
+        ComplianceRule rule = new ComplianceRule();
+        rule.setState("Tamil Nadu");
+        rule.setProjectType(ProjectType.RESIDENTIAL);
+        rule.setPhase(CompliancePhase.PRE_CONSTRUCTION);
+        rule.setCode("TN-BPA");
+        rule.setName("Building Plan Approval");
+        rule.setDefaultRiskLevel(ComplianceRiskLevel.CRITICAL);
+        return List.of(rule);
+    }
+
+    @Test
+    void returnsEmptyWhenDisabled() {
+        AnthropicProperties props = new AnthropicProperties();
+        props.setEnabled(false);
+        props.setApiKey("sk-should-not-be-used");
+        ClaudeComplianceService service = new ClaudeComplianceService(props);
+
+        List<ComplianceSuggestion> result =
+                service.suggestCompliances(sampleProject(), "Tamil Nadu", sampleRules());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyWhenApiKeyBlank() {
+        AnthropicProperties props = new AnthropicProperties();
+        props.setEnabled(true);
+        props.setApiKey("   ");
+        ClaudeComplianceService service = new ClaudeComplianceService(props);
+
+        List<ComplianceSuggestion> result =
+                service.suggestCompliances(sampleProject(), "Tamil Nadu", sampleRules());
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/support/AbstractIntegrationTest.java
@@ -14,8 +14,14 @@ import org.testcontainers.utility.DockerImageName;
  */
 public abstract class AbstractIntegrationTest {
 
+    // Cap the container at 2 GB so CockroachDB sizes its cache and SQL memory to a
+    // fraction of that (it reads the cgroup limit) instead of a quarter of the whole
+    // host. On the small CI runner an unbounded container competes with the test JVM
+    // for memory; the tests use tiny data, so 2 GB is ample.
     private static final CockroachContainer COCKROACH =
-            new CockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v26.2.4"));
+            new CockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v26.2.4"))
+                    .withCreateContainerCmdModifier(cmd ->
+                            cmd.getHostConfig().withMemory(2L * 1024 * 1024 * 1024));
 
     static {
         COCKROACH.start();


### PR DESCRIPTION
Implements the Compliance feature (#36) as an extension of the existing Inspection module, per the decided architecture (no new domain). When a project is approved, an AI (Anthropic Claude) reasons over a curated rules dataset and generates Compliance-type inspections, each marked AI-suggested with a risk level, lifecycle phase and resolution options. A manual regenerate endpoint is also provided.

## Increments

1. **Inspection extension** — `ComplianceRiskLevel{LOW,MEDIUM,HIGH,CRITICAL}` and `InspectionOrigin{MANUAL,AI_GENERATED}` enums, `SUGGESTED` added to `InspectionStatus`. New nullable columns on `inspections`: `origin` (default MANUAL), `compliance_phase`, `risk_level`, `resolution_options`, `compliance_rule_ref`, `ai_rationale`. `inspector_id` and `scheduled_date` relaxed to nullable so AI rows can be created unscheduled. `InspectionDto` extended (MapStruct auto-maps by name).
2. **Project changes** — new `ProjectType` enum (RESIDENTIAL, COMMERCIAL, INDUSTRIAL, INFRASTRUCTURE, INSTITUTIONAL, MIXED_USE, OTHER) and a `projectType` column; `approved` added to `ProjectCreationStatus`. The transition **into** approved publishes `ProjectApprovedEvent(projectId, organizationId)`.
3. **Curated rules** — `compliance_rules` is **global reference data** (not tenant-scoped, no organization_id, no org filter), keyed by state + projectType + phase. Seeded for Tamil Nadu, Kerala and Maharashtra across all three lifecycle phases (building plan approval, environmental clearance, fire NOC, labour licence, structural stability, occupancy certificate).
4. **Three-phase model** — `CompliancePhase{PRE_CONSTRUCTION,ONGOING,POST_CONSTRUCTION}`; each rule carries a phase, copied onto the generated inspection; generation orders results by phase so the web can group pre/ongoing/post.
5. **AI** — `ClaudeComplianceService` uses the official Anthropic Java SDK. Fail-soft: no-ops when `anthropic.enabled=false` or the API key is blank, and never throws into the approval flow (logs and returns empty on any failure). Prompt asks for strict JSON, parsed with Jackson.
6. **Generation** — `ComplianceGenerationService.generateForProject` resolves the project's state (from its address) and type, loads matching rules, calls the AI, and maps each applicable result to a suggested, AI-generated compliance inspection (number from the shared `INSP` series). Idempotent on (projectId, complianceRuleRef).
7. **Event + listener** — `ComplianceGenerationListener` runs `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` + `@Transactional(REQUIRES_NEW)`, restoring the tenant from the event on the async thread.
8. **Regenerate endpoint** — `POST /api/v1/inspections/web/compliance/regenerate?projectId=...`, guarded by the same `@orgSecurity` role check as the inspection web controller, runs synchronously and returns the generated DTOs.

## Data-model additions
- `approved` value on `ProjectCreationStatus`, with auto-generation on the transition into it.
- `projectType` field/enum on `Project` (+ migration + DTOs); the rules dataset and AI match on state + projectType.

## Migrations
`035-add-compliance-fields-to-inspections`, `036-add-project-type`, `037-create-and-seed-compliance-rules` (all v4.0, registered in the master changelog; seed guarded by a MARK_RAN precondition on an empty table).

## Config / secret
Adds an `anthropic:` block reading `ANTHROPIC_API_KEY` (empty default), `model: claude-opus-5`, `max-tokens: 4096`, `enabled`. **The `ANTHROPIC_API_KEY` secret must be set in the deployment vault + GH secrets before the AI runs live** — the code no-ops without it, so the app runs normally in the meantime. Anthropic Java SDK `com.anthropic:anthropic-java:2.57.0`.

Core + web follow-ups (surface the new fields, group by phase, expose the regenerate action) are separate.

## Verification
Built and tested on the lab box (CockroachDB via Testcontainers):
- `compileJava` + `compileTestJava` — BUILD SUCCESSFUL.
- `ComplianceGenerationServiceIT` (stubs the AI, asserts the right suggested/AI-generated compliance rows in phase order, idempotent on re-run) — PASSED.
- `ClaudeComplianceServiceTest` (no-op when disabled / when API key blank) — PASSED.
- `InspectionServiceIT` and `EndpointAuthorizationTest` — PASSED (no regressions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project types and an approval workflow.
  * Automatically generates AI-assisted compliance inspections for approved projects.
  * Added compliance regeneration for authorized project managers and administrators.
  * Added compliance phases, risk levels, inspection origins, suggested status, and rationale details.
  * Added seeded compliance rules for selected Indian states.
* **Improvements**
  * Project and inspection details now expose compliance metadata.
  * Compliance generation avoids duplicate inspections and supports safe reruns.
* **Configuration**
  * Added configurable Claude integration settings for AI-assisted compliance suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->