### PR TITLE
Allow org role-holders to read projects, not only members

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -66,7 +66,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the list of project DTOs and HTTP status 200 (OK).
      */
     @GetMapping()
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<List<ProjectDto>> readAllProjects(@RequestParam(defaultValue = "0") int pageNo,
                                                             @RequestParam(defaultValue = "10") int pageSize) {
         Page<ProjectDto> projects = service.getAllProjects(pageNo,pageSize);
@@ -81,7 +81,7 @@ public class ProjectControllerWeb {
      * @return A {@link ResponseEntity} containing the project DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<?> readAProject(@PathVariable Long id) {
         ProjectDto project = service.getAProject(id);
         return new ResponseEntity<>(project,HttpStatus.OK);
@@ -145,13 +145,13 @@ public class ProjectControllerWeb {
     }
 
     @GetMapping("{projectId}/employees")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<List<EmployeeDto>> getEmployeesByProjectId(@PathVariable Long projectId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getEmployeesByProjectId(projectId));
     }
 
     @GetMapping("employees/{employeeId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     public ResponseEntity<List<ProjectDto>> getProjectsByEmployeeId(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getProjectsByEmployeeId(employeeId));
     }

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
@@ -1,0 +1,96 @@
+package org.tornotron.echno_backend.project;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization tests for the read endpoints on ProjectControllerWeb.
+ * They lock in the guard that a caller may read projects when they are either a
+ * member of the current tenant OR hold an elevated org role (system-admin /
+ * project-manager) for it. The role branch matters because the write endpoints on
+ * this same controller gate on the role alone: without it a role-holder who is not
+ * recorded as a member (for example the bootstrap admin) could create and edit
+ * projects yet get 403 listing them. @orgSecurity is mocked so each branch is
+ * exercised independently; if a read @PreAuthorize is ever narrowed back to
+ * membership only, the role-without-membership test fails.
+ */
+@WebMvcTest(ProjectControllerWeb.class)
+@Import(ProjectControllerWebAuthzTest.TestSecurityConfig.class)
+class ProjectControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProjectService projectService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @Test
+    void readAllProjects_isOk_forAMemberWithoutAnElevatedRole() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+        when(projectService.getAllProjects(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/project/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void readAllProjects_isOk_forARoleHolderThatIsNotRecordedAsAMember() throws Exception {
+        // The fix: an org system-admin / project-manager can read even without the
+        // ORG_MEMBER_ authority, matching how create/update/delete already gate.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
+        when(projectService.getAllProjects(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/project/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void readAllProjects_isForbidden_forACallerWithNeitherMembershipNorRole() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/project/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The read endpoints on `ProjectControllerWeb` (list, detail, a project's employees, an employee's projects) gate on `@orgSecurity.isMemberOfCurrentTenant()`, while create/update/delete gate on `hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')`. All `ConstructionInvoiceControllerWeb` endpoints (including list) use the role check too.

A caller who holds the org role without a recorded `ORG_MEMBER_{orgId}` authority (for example the bootstrap admin account) can therefore create and edit projects but gets **403** when listing them. Read is stricter than write, which is backwards. Surfaced while smoke-testing `echno.in`: the Projects page returned 403 for an org system-admin.

## Fix

Widen the four read guards to accept **either** tenant membership **or** the elevated role, mirroring the write endpoints on the same controller and how the finance controllers already gate. Normal org members are unaffected (the membership branch still passes); the change only additionally admits role-holders.

## Test

Adds `ProjectControllerWebAuthzTest` (web-slice, `@orgSecurity` mocked) covering the three branches on the list endpoint:
- member without the elevated role -> 200
- role without membership -> 200 (the fix)
- neither -> 403

All three pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project and employee retrieval access so authorized system administrators and project managers can view records even without current-tenant membership.
  * Preserved access restrictions for callers lacking both tenant membership and elevated roles.

* **Tests**
  * Added authorization coverage for members, elevated role holders, and unauthorized callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->