### PR TITLE
Bump Spring Boot to 3.4.13 (security CVE fixes) + modernize deprecated test APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.0'
+    id 'org.springframework.boot' version '3.4.13'
     id 'io.spring.dependency-management' version '1.1.6'
 }
 ext {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,10 @@
 [versions]
 org-postgresql-postgresql = "42.7.4"
 org-projectlombok-lombok = "1.18.36"
-org-springframework-boot-spring-boot-starter-data-jpa = "3.4.0"
-org-springframework-boot-spring-boot-starter-test = "3.4.0"
-org-springframework-boot-spring-boot-starter-validation = "3.4.0"
-org-springframework-boot-spring-boot-starter-web = "3.4.0"
+org-springframework-boot-spring-boot-starter-data-jpa = "3.4.13"
+org-springframework-boot-spring-boot-starter-test = "3.4.13"
+org-springframework-boot-spring-boot-starter-validation = "3.4.13"
+org-springframework-boot-spring-boot-starter-web = "3.4.13"
 
 [libraries]
 org-postgresql-postgresql = { module = "org.postgresql:postgresql", version.ref = "org-postgresql-postgresql" }

--- a/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
+++ b/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
@@ -1,7 +1,6 @@
 package org.tornotron.echno_backend.keycloak;
 
 import org.springframework.security.access.prepost.PreAuthorize;
-import io.prometheus.metrics.shaded.com_google_protobuf_4_28_3.Api;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -57,7 +57,7 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     @Autowired
     private ComplianceGenerationService service;
 
-    @MockBean
+    @MockitoBean
     private ClaudeComplianceService claudeComplianceService;
 
     @PersistenceContext

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -50,7 +50,7 @@ class PayableServiceIT extends AbstractIntegrationTest {
 
     // The attachment mapper in the payable mapper chain autowires this; nothing
     // in these payment tests touches file storage, so a mock satisfies the graph.
-    @MockBean
+    @MockitoBean
     private FileStorageService fileStorageService;
 
     private Long orgId;

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -40,16 +40,16 @@ class ProjectControllerWebAuthzTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ProjectService projectService;
 
     // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
-    @MockBean(name = "orgSecurity")
+    @MockitoBean(name = "orgSecurity")
     private OrganizationSecurityService orgSecurity;
 
     // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
     // because .with(jwt(...)) sets the authentication directly.
-    @MockBean
+    @MockitoBean
     private KeycloakAuthorizationService keycloakAuthorizationService;
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/user/UserControllerAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserControllerAuthzTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -37,16 +37,16 @@ class UserControllerAuthzTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
-    @MockBean(name = "orgSecurity")
+    @MockitoBean(name = "orgSecurity")
     private OrganizationSecurityService orgSecurity;
 
     // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
     // because .with(jwt(...)) sets the authentication directly.
-    @MockBean
+    @MockitoBean
     private KeycloakAuthorizationService keycloakAuthorizationService;
 
     @Test


### PR DESCRIPTION
## Why

Dependency/CVE audit found the backend carried active CVE exposure, nearly all of it fixed by a single Spring Boot patch bump.

Spring Boot **3.4.0 → 3.4.13** (patch-level within 3.4.x) pulls the patched transitives:

| CVE | Component | Impact |
|---|---|---|
| CVE-2025-22228 | spring-security 6.4.1→6.4.x | BCrypt stopped enforcing the 72-byte limit → passwords ≥72 bytes match = auth bypass |
| CVE-2025-22223 | spring-framework 6.2.0→6.2.x | `@EnableMethodSecurity` authorization bypass — directly undercut the `@PreAuthorize` sweep |
| CVE-2025-24813 | tomcat 10.1.33→10.1.x | partial-PUT path-equivalence → info-disclosure/RCE |
| CVE-2025-24970 | netty 4.1.115→4.1.x | `SslHandler` TLS DoS |
| CVE-2024-12798/12801 | logback 1.5.12→1.5.x | Janino/SaxEvent injection |

## What else

- **Latent bug fixed:** `KeycloakManagementController` imported `io.prometheus.metrics.shaded...protobuf...Api` (unused) — it only compiled by accident with the old prometheus shading; the bump exposed it. Removed.
- **`@MockBean` → `@MockitoBean`** (4 test files) — `@MockBean` is deprecated-for-removal in Boot 3.4.

## Verification

Full test suite green on the build box (BUILD SUCCESSFUL, 4m51s, zero failures) with 3.4.13; the four migrated tests re-run green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Spring Boot platform and starter components to version 3.4.13.
  * Removed an unused internal import.

* **Tests**
  * Updated test mocking configuration to use the current supported Spring testing annotations.
  * Preserved existing mock behavior and authorization coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->