### PR TITLE
Add JaCoCo coverage reporting + no-regression gate (14% floor, ratchets up)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Compile
         run: ./gradlew --no-daemon bootJar -x test
 
-      # There is currently one test, a context-load check. This job exists so
-      # that adding real tests immediately gates merges, rather than requiring
-      # a pipeline change first.
+      # Run the full test suite and enforce the JaCoCo line-coverage floor
+      # (jacocoLineFloor in build.gradle) so a merge cannot regress coverage.
       - name: Test
-        run: ./gradlew --no-daemon test
+        run: ./gradlew --no-daemon test jacocoTestCoverageVerification
 
   secrets:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.4.13'
     id 'io.spring.dependency-management' version '1.1.6'
 }
 ext {
     springCloudVersion = "2024.0.2"
+    // Minimum line-coverage ratio enforced by jacocoTestCoverageVerification.
+    // Set just under the current measured level (14.5% at introduction) so it locks
+    // in no-regression with a small margin for run-to-run variance; raise it as
+    // tests are added. Denominator excludes generated/DTO/config classes.
+    jacocoLineFloor = 0.14
 }
 
 repositories {
@@ -96,4 +102,52 @@ tasks.named('test') {
         events 'started', 'passed', 'skipped', 'failed'
         exceptionFormat 'short'
     }
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = '0.8.12'
+}
+
+// Coverage report over real business logic. Generated and non-logic classes are
+// excluded from the denominator so the number tracks tested behaviour, not Lombok
+// getters, MapStruct output, Spring config or the application entrypoint.
+def jacocoLogicExclusions = [
+        '**/EchnoBackendApplication.class',
+        '**/config/**', '**/configuration/**',
+        '**/dto/**', '**/dtos/**',
+        '**/*MapperImpl.class',
+]
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    classDirectories.setFrom(files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, exclude: jacocoLogicExclusions)
+    }))
+}
+
+// No-regression coverage gate. The floor ratchets upward as tests are added; it is
+// deliberately set at (not above) the current level so the build stays green while
+// coverage climbs, the same ratchet idea as the ArchUnit endpoint rule.
+tasks.named('jacocoTestCoverageVerification') {
+    dependsOn jacocoTestReport
+    classDirectories.setFrom(files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, exclude: jacocoLogicExclusions)
+    }))
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = jacocoLineFloor
+            }
+        }
+    }
+}
+tasks.named('check') {
+    dependsOn jacocoTestCoverageVerification
 }


### PR DESCRIPTION
Test-coverage audit found no coverage measurement configured. This wires **JaCoCo**:

- **Report** (xml + html) over real business logic — generated mappers, DTOs, Spring config and the app entrypoint are excluded from the denominator, so the number reflects tested behaviour not Lombok/boilerplate.
- **Gate** — `jacocoTestCoverageVerification` enforces a line-coverage floor, run in CI after the suite. Starts at **14%** (just under the current 14.5%) to lock in no-regression, and **ratchets up** as tests land (same idea as the ArchUnit endpoint ratchet).

Verified on the build box: `jacocoTestCoverageVerification` BUILD SUCCESSFUL at 14.5% line coverage. This is the foundation for the test-coverage push; subsequent PRs add tests for the highest-risk untested code (OrganizationSecurityService, billing/finance services, controller-web authz twins) and raise the floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated code-coverage reporting for test runs.
  * Enforced a minimum 14% line-coverage threshold during builds.
  * Enabled XML and HTML coverage reports for easier review.
  * Excluded generated and infrastructure-only code from coverage verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->