### PR TITLE
Add unit tests for procurement, receipt, ledger and attendance services

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceCalculationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceCalculationServiceTest.java
@@ -1,0 +1,259 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.dto.AttendanceSummaryDto;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for AttendanceCalculationService, the hours-and-status engine that feeds
+ * payroll. The service is pure (no repositories or Spring context), so the attendance
+ * and shift graph is built entirely in memory. Two responsibilities are covered:
+ * recalculate() (per-day durations, overtime, late/early flags, derived status) and
+ * buildMonthlySummary() (the month roll-up and effective-day arithmetic).
+ */
+class AttendanceCalculationServiceTest {
+
+    private final AttendanceCalculationService service = new AttendanceCalculationService();
+
+    private static final LocalDate DAY = LocalDate.of(2026, 8, 3);
+
+    /** Standard 9-to-6 shift: 15 min grace, 8h minimum, 4h half day, 9h overtime threshold. */
+    private ShiftTiming standardShift() {
+        return ShiftTiming.builder()
+                .id(1L)
+                .shiftName("General")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .lunchBreakStart(LocalTime.of(13, 0))
+                .lunchBreakEnd(LocalTime.of(14, 0))
+                .gracePeriodMinutes(15)
+                .minimumWorkHours(BigDecimal.valueOf(8.0))
+                .halfDayWorkHours(BigDecimal.valueOf(4.0))
+                .overtimeThreshold(BigDecimal.valueOf(9.0))
+                .build();
+    }
+
+    private ClockEvent event(ClockEventType type, int hour, int minute) {
+        return ClockEvent.builder()
+                .eventType(type)
+                .eventTimestamp(LocalDateTime.of(DAY, LocalTime.of(hour, minute)))
+                .build();
+    }
+
+    private Attendance attendanceWith(ClockEvent... events) {
+        List<ClockEvent> list = new ArrayList<>(List.of(events));
+        return Attendance.builder()
+                .employeeId(1L)
+                .clockEvents(list)
+                .build();
+    }
+
+    @Test
+    void fullDayWithLunch_computesSessionsBreakAndPresentStatus() {
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.LUNCH_BREAK_START, 13, 0),
+                event(ClockEventType.LUNCH_BREAK_END, 14, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 18, 0));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getMorningSessionMinutes()).isEqualTo(240);
+        assertThat(a.getAfternoonSessionMinutes()).isEqualTo(240);
+        assertThat(a.getBreakDurationMinutes()).isEqualTo(60);
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(480);
+        assertThat(a.getOvertimeMinutes()).isZero();
+        assertThat(a.getIsOvertime()).isFalse();
+        assertThat(a.getIsLateArrival()).isFalse();
+        assertThat(a.getIsEarlyCheckout()).isFalse();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.PRESENT);
+    }
+
+    @Test
+    void beyondThreshold_recordsOvertimeAndOvertimeStatus() {
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.LUNCH_BREAK_START, 13, 0),
+                event(ClockEventType.LUNCH_BREAK_END, 14, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 19, 30));
+
+        service.recalculate(a, standardShift());
+
+        // 4h morning + 5.5h afternoon = 9.5h; 0.5h past the 9h threshold = 30 min OT.
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(570);
+        assertThat(a.getOvertimeMinutes()).isEqualTo(30);
+        assertThat(a.getIsOvertime()).isTrue();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.OVERTIME);
+    }
+
+    @Test
+    void singleCycleWithoutLunch_treatsWholeSpanAsMorning() {
+        // 09:00 to 17:30 with no lunch punches: whole 8.5h span counts as the morning session.
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 17, 30));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getMorningSessionMinutes()).isEqualTo(510);
+        assertThat(a.getAfternoonSessionMinutes()).isZero();
+        assertThat(a.getBreakDurationMinutes()).isZero();
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(510);
+        assertThat(a.getIsEarlyCheckout()).isFalse();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.PRESENT);
+    }
+
+    @Test
+    void halfDayHours_deriveHalfDayStatus() {
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.LUNCH_BREAK_START, 13, 0));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(240);
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.HALF_DAY);
+    }
+
+    @Test
+    void arrivalAfterGrace_flagsLateAndDerivesLateStatus() {
+        // 09:30 arrival is past the 09:15 grace end; full 8h still worked.
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 30),
+                event(ClockEventType.LUNCH_BREAK_START, 13, 0),
+                event(ClockEventType.LUNCH_BREAK_END, 14, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 18, 30));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(480);
+        assertThat(a.getIsLateArrival()).isTrue();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.LATE);
+    }
+
+    @Test
+    void departureBeforeThreshold_flagsEarlyCheckoutStatus() {
+        // 08:00 in (not late), 17:00 out is before the 17:30 early threshold; 8h worked.
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 8, 0),
+                event(ClockEventType.LUNCH_BREAK_START, 13, 0),
+                event(ClockEventType.LUNCH_BREAK_END, 14, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 17, 0));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(480);
+        assertThat(a.getIsLateArrival()).isFalse();
+        assertThat(a.getIsEarlyCheckout()).isTrue();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.EARLY_CHECKOUT);
+    }
+
+    @Test
+    void noClockIn_isAbsent() {
+        Attendance a = attendanceWith();
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isZero();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.ABSENT);
+    }
+
+    @Test
+    void leaveIdSet_shortCircuitsToLeaveStatus() {
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 18, 0));
+        a.setLeaveId(42L);
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.LEAVE);
+    }
+
+    @Test
+    void clockInOnlyWithoutClockOut_isPendingRegularization() {
+        Attendance a = attendanceWith(event(ClockEventType.MORNING_CLOCK_IN, 9, 0));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isZero();
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.PENDING_REGULARIZATION);
+    }
+
+    @Test
+    void clockedOutButBelowHalfDay_isAbsent() {
+        // 09:00 in, 09:30 out: 30 min single cycle, under the half-day floor, and clocked out.
+        Attendance a = attendanceWith(
+                event(ClockEventType.MORNING_CLOCK_IN, 9, 0),
+                event(ClockEventType.EVENING_CLOCK_OUT, 9, 30));
+
+        service.recalculate(a, standardShift());
+
+        assertThat(a.getTotalWorkMinutes()).isEqualTo(30);
+        assertThat(a.getStatus()).isEqualTo(AttendanceStatus.ABSENT);
+    }
+
+    // ==================== buildMonthlySummary ====================
+
+    private Attendance record(AttendanceStatus status, int workMinutes, int overtimeMinutes) {
+        return Attendance.builder()
+                .status(status)
+                .totalWorkMinutes(workMinutes)
+                .overtimeMinutes(overtimeMinutes)
+                .build();
+    }
+
+    @Test
+    void monthlySummary_aggregatesCountsHoursAndEffectiveDays() {
+        List<Attendance> records = List.of(
+                record(AttendanceStatus.PRESENT, 480, 0),
+                record(AttendanceStatus.PRESENT, 480, 0),
+                record(AttendanceStatus.HALF_DAY, 240, 0),
+                record(AttendanceStatus.ABSENT, 0, 0),
+                record(AttendanceStatus.LEAVE, 0, 0),
+                record(AttendanceStatus.LATE, 480, 0),
+                record(AttendanceStatus.OVERTIME, 540, 60));
+
+        AttendanceSummaryDto summary = service.buildMonthlySummary(7L, "Ravi", records, 8, 2026);
+
+        assertThat(summary.getEmployeeId()).isEqualTo(7L);
+        assertThat(summary.getPresentDays()).isEqualTo(2);
+        assertThat(summary.getHalfDays()).isEqualTo(1);
+        assertThat(summary.getAbsentDays()).isEqualTo(1);
+        assertThat(summary.getLeaveDays()).isEqualTo(1);
+        assertThat(summary.getLateDays()).isEqualTo(1);
+        assertThat(summary.getOvertimeDays()).isEqualTo(1);
+        // workingDays = present + half + absent + leave + late + overtime = 7 (weekly-off/holiday excluded)
+        assertThat(summary.getTotalWorkingDays()).isEqualTo(7);
+        // 480+480+240+0+0+480+540 = 2220 min = 37.0h
+        assertThat(summary.getTotalHoursWorked()).isEqualTo(37.0);
+        assertThat(summary.getTotalOvertimeHours()).isEqualTo(1.0);
+        // present 2 + half 0.5 + leave 1 + late 0.9 + overtime 1 = 5.4
+        assertThat(summary.getEffectiveWorkDays()).isEqualTo(5.4);
+        assertThat(summary.getAverageWorkHours()).isEqualTo(37.0 / 7);
+        assertThat(summary.getAttendancePercentage()).isEqualTo(5.4 / 7 * 100);
+    }
+
+    @Test
+    void monthlySummary_emptyRecords_yieldsZeroesNoDivideByZero() {
+        AttendanceSummaryDto summary = service.buildMonthlySummary(7L, "Ravi", List.of(), 8, 2026);
+
+        assertThat(summary.getTotalWorkingDays()).isZero();
+        assertThat(summary.getTotalHoursWorked()).isEqualTo(0.0);
+        assertThat(summary.getAverageWorkHours()).isEqualTo(0.0);
+        assertThat(summary.getAttendancePercentage()).isEqualTo(0.0);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/service/AccountServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/service/AccountServiceTest.java
@@ -1,0 +1,173 @@
+package org.tornotron.echno_backend.finance.ledger.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidJournalException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.dtos.AccountTreeDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.CreateAccountRequest;
+import org.tornotron.echno_backend.finance.ledger.mapper.AccountMapper;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for AccountService. Repositories, mapper, and the code generator are mocked;
+ * the account graph is built in memory. Focus is on the branch logic the service owns:
+ * deriving a child's type from its parent (and rejecting a conflicting supplied type),
+ * choosing between a supplied and an auto-generated code, duplicate-code rejection, and
+ * the in-memory assembly of the account tree with the leaf-only postable flag. The mapper
+ * is a mock, so create() assertions read the Account captured on save().
+ */
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    @Mock private AccountRepository repo;
+    @Mock private AccountMapper mapper;
+    @Mock private AccountCodeGenerator codeGenerator;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+
+    private AccountService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AccountService(repo, mapper, codeGenerator, tenantEntityHelper);
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        lenient().when(repo.save(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private Account account(UUID id, String code, AccountType type, Account parent) {
+        Account a = new Account();
+        a.setId(id);
+        a.setCode(code);
+        a.setType(type);
+        a.setParent(parent);
+        a.setActive(true);
+        return a;
+    }
+
+    private ArgumentCaptor<Account> captureSaved() {
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+        verify(repo).save(captor.capture());
+        return captor;
+    }
+
+    @Test
+    void create_root_usesSuppliedTypeAndCode() {
+        CreateAccountRequest req = new CreateAccountRequest("1000", "Assets", "ASSET", null, "root");
+        when(repo.existsByCode("1000")).thenReturn(false);
+
+        service.create(req);
+
+        Account saved = captureSaved().getValue();
+        assertThat(saved.getType()).isEqualTo(AccountType.ASSET);
+        assertThat(saved.getCode()).isEqualTo("1000");
+        assertThat(saved.getParent()).isNull();
+        assertThat(saved.isActive()).isTrue();
+    }
+
+    @Test
+    void create_child_inheritsTypeFromParent() {
+        Account parent = account(UUID.randomUUID(), "1000", AccountType.ASSET, null);
+        when(repo.findScopedById(parent.getId())).thenReturn(Optional.of(parent));
+        // No type on the request: it must come from the parent.
+        CreateAccountRequest req = new CreateAccountRequest("1100", "Current Assets", null, parent.getId(), null);
+        when(repo.existsByCode("1100")).thenReturn(false);
+
+        service.create(req);
+
+        assertThat(captureSaved().getValue().getType()).isEqualTo(AccountType.ASSET);
+    }
+
+    @Test
+    void create_child_typeConflictingWithParent_throws() {
+        Account parent = account(UUID.randomUUID(), "1000", AccountType.ASSET, null);
+        when(repo.findScopedById(parent.getId())).thenReturn(Optional.of(parent));
+        CreateAccountRequest req = new CreateAccountRequest("1100", "Wrong", "EXPENSE", parent.getId(), null);
+
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(InvalidJournalException.class);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void create_blankCode_autoGeneratesFromSiblings() {
+        Account parent = account(UUID.randomUUID(), "1000", AccountType.ASSET, null);
+        when(repo.findScopedById(parent.getId())).thenReturn(Optional.of(parent));
+        when(repo.findByParent(parent)).thenReturn(List.of());
+        when(codeGenerator.nextCode(parent, AccountType.ASSET, List.of())).thenReturn("1100");
+        when(repo.existsByCode("1100")).thenReturn(false);
+        CreateAccountRequest req = new CreateAccountRequest("  ", "Current Assets", null, parent.getId(), null);
+
+        service.create(req);
+
+        assertThat(captureSaved().getValue().getCode()).isEqualTo("1100");
+        verify(codeGenerator).nextCode(parent, AccountType.ASSET, List.of());
+    }
+
+    @Test
+    void create_duplicateCode_throws() {
+        CreateAccountRequest req = new CreateAccountRequest("1000", "Assets", "ASSET", null, null);
+        when(repo.existsByCode("1000")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(InvalidJournalException.class);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void findAccountTree_nestsChildrenAndFlagsLeavesPostable() {
+        Account root = account(UUID.randomUUID(), "1000", AccountType.ASSET, null);
+        Account child = account(UUID.randomUUID(), "1100", AccountType.ASSET, root);
+        Account grandchild = account(UUID.randomUUID(), "1110", AccountType.ASSET, child);
+        when(repo.findAll(any(org.springframework.data.domain.Sort.class)))
+                .thenReturn(List.of(root, child, grandchild));
+
+        List<AccountTreeDto> tree = service.findAccountTree();
+
+        assertThat(tree).hasSize(1);
+        AccountTreeDto rootNode = tree.get(0);
+        assertThat(rootNode.code()).isEqualTo("1000");
+        assertThat(rootNode.postable()).isFalse();      // has a child
+        assertThat(rootNode.children()).hasSize(1);
+
+        AccountTreeDto childNode = rootNode.children().get(0);
+        assertThat(childNode.code()).isEqualTo("1100");
+        assertThat(childNode.postable()).isFalse();      // has a grandchild
+        assertThat(childNode.children()).hasSize(1);
+
+        AccountTreeDto leaf = childNode.children().get(0);
+        assertThat(leaf.code()).isEqualTo("1110");
+        assertThat(leaf.postable()).isTrue();            // leaf: accepts journal lines
+        assertThat(leaf.children()).isEmpty();
+    }
+
+    @Test
+    void deactivate_setsInactive() {
+        Account a = account(UUID.randomUUID(), "1000", AccountType.ASSET, null);
+        when(repo.findScopedById(a.getId())).thenReturn(Optional.of(a));
+
+        service.deactivate(a.getId());
+
+        assertThat(a.isActive()).isFalse();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
@@ -1,0 +1,211 @@
+package org.tornotron.echno_backend.goodsReceivedNote;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GrnItemDto;
+import org.tornotron.echno_backend.goodsReceivedNote.mapper.GoodsReceivedNoteMapper;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+import org.tornotron.echno_backend.grnItem.GrnItemRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+import org.tornotron.echno_backend.vendor.Vendor;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for GoodsReceivedNoteService.createGoodsReceivedNote, the receipt path that
+ * seeds stock valuation. Repositories, mapper, tenant helper, and the event publisher are
+ * mocked; the entity graph is built in memory. Focus is on the logic the service owns:
+ * duplicate-number rejection, validation of the referenced vendor/employee/project/PO,
+ * building the GRN line items from their materials, and publishing GrnCreatedEvent (the
+ * trigger for the downstream inventory update). Assertions read the entities captured on
+ * save/publish since the mapper is a mock.
+ */
+@ExtendWith(MockitoExtension.class)
+class GoodsReceivedNoteServiceTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private GoodsReceivedNoteRepository goodsReceivedNoteRepository;
+    @Mock private GrnItemRepository grnItemRepository;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private GoodsReceivedNoteMapper goodsReceivedNoteMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+
+    private GoodsReceivedNoteService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new GoodsReceivedNoteService(goodsReceivedNoteRepository, grnItemRepository,
+                vendorRepository, userRepository, materialRepository, eventPublisher,
+                goodsReceivedNoteMapper, tenantEntityHelper, employeeRepository, projectRepository,
+                storageLocationRepository, purchaseOrderRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void stubMasterLookups() {
+        Vendor vendor = new Vendor();
+        vendor.setId(5L);
+        Employee employee = new Employee();
+        employee.setId(7L);
+        Project project = new Project();
+        project.setId(9L);
+        PurchaseOrder po = new PurchaseOrder();
+        po.setId(3L);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(vendor));
+        lenient().when(employeeRepository.findByIdAndOrganizationId(7L, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(9L, ORG)).thenReturn(Optional.of(project));
+        lenient().when(purchaseOrderRepository.findByIdAndOrganization_Id(3L, ORG)).thenReturn(Optional.of(po));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(goodsReceivedNoteRepository.save(any(GoodsReceivedNote.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private GrnItemDto itemDto(Long materialId, int ordered, int received, String unitCost) {
+        GrnItemDto dto = new GrnItemDto();
+        dto.setMaterialId(materialId);
+        dto.setOrderedQuantity(ordered);
+        dto.setReceivedQuantity(received);
+        dto.setUnitCost(new BigDecimal(unitCost));
+        return dto;
+    }
+
+    private GoodsReceivedNoteCreationDto baseDto() {
+        GoodsReceivedNoteCreationDto dto = new GoodsReceivedNoteCreationDto();
+        dto.setGrnNumber("GRN-001");
+        dto.setReceivedOn(LocalDateTime.of(2026, 8, 3, 10, 0));
+        dto.setReceivedByEmployeeId(7L);
+        dto.setVendorId(5L);
+        dto.setProjectId(9L);
+        dto.setPurchaseOrderId(3L);
+        dto.setItems(List.of(itemDto(11L, 10, 9, "25.50")));
+        return dto;
+    }
+
+    private Material material(Long id) {
+        Material m = new Material();
+        m.setId(id);
+        return m;
+    }
+
+    @Test
+    void create_duplicateGrnNumber_throws() {
+        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createGoodsReceivedNote(baseDto()))
+                .isInstanceOf(DuplicateResourceException.class);
+
+        verify(goodsReceivedNoteRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void create_unknownPurchaseOrder_throwsNotFound() {
+        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
+        Vendor vendor = new Vendor();
+        vendor.setId(5L);
+        Employee employee = new Employee();
+        employee.setId(7L);
+        Project project = new Project();
+        project.setId(9L);
+        when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(vendor));
+        when(employeeRepository.findByIdAndOrganizationId(7L, ORG)).thenReturn(Optional.of(employee));
+        when(projectRepository.findByIdAndOrganization_Id(9L, ORG)).thenReturn(Optional.of(project));
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(3L, ORG)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createGoodsReceivedNote(baseDto()))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void create_buildsItemsSavesThemAndPublishesEvent() {
+        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
+        stubMasterLookups();
+        when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
+
+        service.createGoodsReceivedNote(baseDto());
+
+        // The line items are persisted with the received quantity and cost from the DTO,
+        // each back-linked to the parent GRN.
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<GrnItem>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(grnItemRepository).saveAll(itemsCaptor.capture());
+        List<GrnItem> items = itemsCaptor.getValue();
+        assertThat(items).hasSize(1);
+        GrnItem item = items.get(0);
+        assertThat(item.getMaterial().getId()).isEqualTo(11L);
+        assertThat(item.getReceivedQuantity()).isEqualTo(9);
+        assertThat(item.getUnitCost()).isEqualByComparingTo("25.50");
+        assertThat(item.getGoodsReceivedNote()).isNotNull();
+
+        // The inventory-update trigger fires, carrying the saved GRN with its items attached.
+        ArgumentCaptor<GrnCreatedEvent> eventCaptor = ArgumentCaptor.forClass(GrnCreatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        GoodsReceivedNote published = eventCaptor.getValue().getGoodsReceivedNote();
+        assertThat(published.getGrnNumber()).isEqualTo("GRN-001");
+        assertThat(published.getItems()).hasSize(1);
+        assertThat(published.getVendor().getId()).isEqualTo(5L);
+    }
+
+    @Test
+    void create_unknownStorageLocation_throwsNotFound() {
+        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
+        stubMasterLookups();
+        when(storageLocationRepository.findByIdAndOrganization_Id(88L, ORG)).thenReturn(Optional.empty());
+
+        GoodsReceivedNoteCreationDto dto = baseDto();
+        dto.setStorageLocationId(88L);
+
+        assertThatThrownBy(() -> service.createGoodsReceivedNote(dto))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
@@ -1,0 +1,243 @@
+package org.tornotron.echno_backend.purchaseOrder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.indent.IndentRepository;
+import org.tornotron.echno_backend.indentItem.IndentItem;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
+import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
+import org.tornotron.echno_backend.vendor.Vendor;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PurchaseOrderService. The repositories, mapper, and tenant helper are
+ * mocked; the entity graph is built in memory. Focus is on the logic the service owns:
+ * duplicate rejection, validation of referenced entities, the line-item price and
+ * order-total arithmetic, and marking indent items as converted. The mapper is a mock,
+ * so assertions are made on the PurchaseOrder captured on save() rather than the DTO.
+ */
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderServiceTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private IndentRepository indentRepository;
+    @Mock private PurchaseOrderMapper purchaseOrderMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private PurchaseOrderItemRepository purchaseOrderItemRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private IndentItemRepository indentItemRepository;
+
+    private PurchaseOrderService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new PurchaseOrderService(purchaseOrderRepository, vendorRepository, indentRepository,
+                purchaseOrderMapper, tenantEntityHelper, employeeRepository, projectRepository,
+                purchaseOrderItemRepository, materialRepository, indentItemRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void stubMasterLookups() {
+        Vendor vendor = new Vendor();
+        vendor.setId(5L);
+        Employee employee = new Employee();
+        employee.setId(7L);
+        Project project = new Project();
+        project.setId(9L);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(vendor));
+        lenient().when(employeeRepository.findByIdAndOrganizationId(7L, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(9L, ORG)).thenReturn(Optional.of(project));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(purchaseOrderRepository.save(any(PurchaseOrder.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private PurchaseOrderCreationDto baseDto() {
+        PurchaseOrderCreationDto dto = new PurchaseOrderCreationDto();
+        dto.setPoNumber("PO-001");
+        dto.setVendorId(5L);
+        dto.setCreatedBy(7L);
+        dto.setProjectId(9L);
+        dto.setStatus("DRAFT");
+        return dto;
+    }
+
+    private PurchaseOrderItemCreationDto item(Long materialId, int qty, String unitPrice) {
+        PurchaseOrderItemCreationDto i = new PurchaseOrderItemCreationDto();
+        i.setMaterialId(materialId);
+        i.setOrderedQuantity(qty);
+        i.setUnitPrice(new BigDecimal(unitPrice));
+        return i;
+    }
+
+    private Material material(Long id) {
+        Material m = new Material();
+        m.setId(id);
+        return m;
+    }
+
+    @Test
+    void createPurchaseOrder_duplicatePoNumber_throws() {
+        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createPurchaseOrder(baseDto()))
+                .isInstanceOf(DuplicateResourceException.class);
+
+        verify(purchaseOrderRepository, never()).save(any());
+    }
+
+    @Test
+    void createPurchaseOrder_unknownVendor_throwsNotFound() {
+        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
+        when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createPurchaseOrder(baseDto()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void createPurchaseOrder_withoutItems_totalIsZero() {
+        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
+        stubMasterLookups();
+
+        service.createPurchaseOrder(baseDto());
+
+        ArgumentCaptor<PurchaseOrder> captor = ArgumentCaptor.forClass(PurchaseOrder.class);
+        verify(purchaseOrderRepository).save(captor.capture());
+        PurchaseOrder saved = captor.getValue();
+        assertThat(saved.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(saved.getStatus()).isEqualTo(PurchaseOrderStatus.DRAFT);
+        assertThat(saved.getItems()).isEmpty();
+    }
+
+    @Test
+    void createPurchaseOrder_withItems_computesLineAndOrderTotals() {
+        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
+        stubMasterLookups();
+        when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
+        when(materialRepository.findByIdAndOrganization_Id(12L, ORG)).thenReturn(Optional.of(material(12L)));
+
+        PurchaseOrderCreationDto dto = baseDto();
+        // 10 x 25.50 = 255.00 ; 3 x 100.00 = 300.00 ; order total = 555.00
+        dto.setItems(List.of(item(11L, 10, "25.50"), item(12L, 3, "100.00")));
+
+        service.createPurchaseOrder(dto);
+
+        ArgumentCaptor<PurchaseOrder> captor = ArgumentCaptor.forClass(PurchaseOrder.class);
+        verify(purchaseOrderRepository).save(captor.capture());
+        PurchaseOrder saved = captor.getValue();
+
+        assertThat(saved.getItems()).hasSize(2);
+        assertThat(saved.getItems().get(0).getTotalPrice()).isEqualByComparingTo("255.00");
+        assertThat(saved.getItems().get(1).getTotalPrice()).isEqualByComparingTo("300.00");
+        assertThat(saved.getItems().get(0).getReceivedQuantity()).isZero();
+        // every item is back-linked to its parent PO
+        assertThat(saved.getItems()).allSatisfy(i -> assertThat(i.getPurchaseOrder()).isSameAs(saved));
+        assertThat(saved.getTotalAmount()).isEqualByComparingTo("555.00");
+    }
+
+    @Test
+    void createPurchaseOrder_itemFromIndentItem_marksItConverted() {
+        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
+        stubMasterLookups();
+        when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
+        IndentItem indentItem = new IndentItem();
+        indentItem.setId(21L);
+        indentItem.setConvertedToPurchaseOrder(false);
+        when(indentItemRepository.findByIdAndOrganization_Id(21L, ORG)).thenReturn(Optional.of(indentItem));
+
+        PurchaseOrderCreationDto dto = baseDto();
+        PurchaseOrderItemCreationDto line = item(11L, 2, "50.00");
+        line.setIndentItemId(21L);
+        dto.setItems(List.of(line));
+
+        service.createPurchaseOrder(dto);
+
+        assertThat(indentItem.getConvertedToPurchaseOrder()).isTrue();
+        verify(indentItemRepository).save(indentItem);
+    }
+
+    @Test
+    void recalculateTotalAmount_nullSum_resetsToZero() {
+        PurchaseOrder po = new PurchaseOrder();
+        po.setId(1L);
+        po.setTotalAmount(new BigDecimal("999.00"));
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(1L, ORG)).thenReturn(Optional.of(po));
+        when(purchaseOrderItemRepository.sumTotalPriceByPurchaseOrderId(1L)).thenReturn(null);
+
+        service.recalculateTotalAmount(1L);
+
+        assertThat(po.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        verify(purchaseOrderRepository).save(po);
+    }
+
+    @Test
+    void recalculateTotalAmount_usesRepositorySum() {
+        PurchaseOrder po = new PurchaseOrder();
+        po.setId(1L);
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(1L, ORG)).thenReturn(Optional.of(po));
+        when(purchaseOrderItemRepository.sumTotalPriceByPurchaseOrderId(1L)).thenReturn(new BigDecimal("742.00"));
+
+        service.recalculateTotalAmount(1L);
+
+        assertThat(po.getTotalAmount()).isEqualByComparingTo("742.00");
+    }
+
+    @Test
+    void updatePurchaseOrderStatus_setsAndSaves() {
+        PurchaseOrder po = new PurchaseOrder();
+        po.setId(1L);
+        po.setStatus(PurchaseOrderStatus.DRAFT);
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(1L, ORG)).thenReturn(Optional.of(po));
+
+        service.updatePurchaseOrderStatus(1L, PurchaseOrderStatus.APPROVED);
+
+        assertThat(po.getStatus()).isEqualTo(PurchaseOrderStatus.APPROVED);
+        verify(purchaseOrderRepository).save(po);
+    }
+}


### PR DESCRIPTION
Adds fast unit-test coverage (plain JUnit 5 + Mockito, no Spring context or database) for four services that carried real business logic but had no tests. Each builds the entity graph in memory and mocks the repositories, mapper, and tenant helper.

## Services covered

- **AttendanceCalculationService** (feeds pay): per-day session, break and overtime minutes, the late-arrival and early-checkout flags, every branch of the derived status (present, overtime, half day, late, early checkout, absent, leave, pending regularization), and the monthly summary roll-up with its effective-work-day and percentage arithmetic.
- **PurchaseOrderService** (procurement): duplicate PO-number rejection, validation of the referenced vendor/employee/project, line-item price and order-total computation, marking an indent item as converted, and the total-amount recalculation reset when the sum is null.
- **AccountService** (chart of accounts): child type inherited from parent, rejection of a supplied type that conflicts with the parent, supplied vs auto-generated code paths, duplicate-code rejection, and the in-memory account-tree assembly with the leaf-only postable flag.
- **GoodsReceivedNoteService** (receipts feeding stock valuation): duplicate GRN-number rejection, missing purchase-order and storage-location handling, building the GRN line items from their materials, and publishing GrnCreatedEvent (the inventory-update trigger).

## Notes

- All assertions read the entity captured on save or on the published event, since the MapStruct mappers are mocked.
- CustomerService was reviewed and left out: it is a thin CRUD passthrough to the repository with no arithmetic or branching worth asserting in a unit test.

31 tests, all passing locally.