### PR TITLE
Enrich OpenAPI docs for high-traffic modules and correct the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,96 @@
 # Echno Backend
 
-This repository contains the source code for the Echno Backend
+REST API and business core for Echno, the Echno construction management platform. This service is the
+source of truth: it exposes the HTTP API, owns the domain logic, and persists application data.
 
 ## Description
 
-The Echno Backend provides a comprehensive set of features for managing employees, projects, tasks, attendance, inventory, and more. It is built with a modern technology stack and includes robust security and monitoring capabilities.
+The Echno Backend provides a comprehensive set of features for managing employees, projects, tasks,
+attendance, inventory, and construction finance. It is built with Java 21 and Spring Boot 3, secured with
+Keycloak-issued JWTs, and ships with OpenAPI documentation plus Prometheus, Grafana and Loki
+observability.
 
 ## Features
 
-*   **User Management:** Secure user authentication and authorization using JWT.
-*   **Project and Task Management:** Create and manage projects, assign tasks, and track progress.
-*   **Employee Management:** Maintain employee records and track attendance.
-*   **Inventory Management:** Manage materials, track inventory transactions, and handle goods received notes.
-*   **Issue Tracking:** Report and manage issues related to projects or tasks.
-*   **PDF Generation:** Generate PDF reports for various modules.
-*   **Monitoring:** Integrated with Prometheus and Grafana for monitoring application metrics.
-*   **Logging:** Centralized logging with Loki.
+* **User management:** authentication and authorization using Keycloak-issued JWT access tokens, with
+  tenant-scoped roles.
+* **Project and task management:** create and manage projects, break work down (WBS), assign tasks, and
+  track progress.
+* **Employee management:** maintain employee records, roles, attendance and leave.
+* **Inventory management:** manage materials, record inventory transactions, and handle goods received
+  notes (GRN) against purchase orders.
+* **Construction finance:** vendor and progress invoices, payments, and a double-entry ledger (chart of
+  accounts, journal entries, customers, financial reports).
+* **Issue tracking:** report and manage issues related to projects or tasks.
+* **PDF generation:** generate PDF reports for various modules.
+* **Multi-tenancy:** every request is scoped to a tenant, enforced fail-closed at the data layer.
+* **Monitoring and logging:** Prometheus metrics, Grafana dashboards, and centralized logging with Loki.
 
 ## Technologies Used
 
-*   **Backend:** Java 21, Spring Boot 3
-*   **Database:** PostgreSQL
-*   **Authentication:** Spring Security with JWT (connected to Keycloak)
-*   **Build Tool:** Gradle
-*   **API Documentation:** OpenAPI (Swagger)
-*   **Monitoring:** Prometheus, Grafana
-*   **Logging:** Loki
-*   **Containerization:** Docker
+* **Backend:** Java 21, Spring Boot 3
+* **Application database:** CockroachDB (PostgreSQL wire protocol). Keycloak uses a separate PostgreSQL
+  instance; the application itself talks to CockroachDB.
+* **Authentication:** Spring Security resource server with JWT, backed by Keycloak (OpenID Connect)
+* **Build tool:** Gradle
+* **API documentation:** OpenAPI (springdoc), served through Swagger UI
+* **Object storage:** DigitalOcean Spaces (S3 compatible) for attachments
+* **Monitoring:** Prometheus, Grafana
+* **Logging:** Loki
+* **Containerization:** Docker
+
+## Architecture and module map
+
+The code is organized by domain module under `src/main/java/org/tornotron/echno_backend`. Each module
+holds its own domain entities, DTOs, mappers, repositories, services and web controllers. The deeper
+design notes for the major modules live in [`docs/`](docs):
+
+| Area | Package | Reference |
+|------|---------|-----------|
+| Construction finance (invoices, payments, ledger, reports) | `finance` | [finance-module-mvp-guide.md](docs/finance-module-mvp-guide.md) |
+| Attendance | `attendance` | [ATTENDANCE_MODULE.md](docs/ATTENDANCE_MODULE.md), [usage guide](docs/ATTENDANCE_MODULE_USAGE_GUIDE.md) |
+| Leave | `leave` | [LEAVE_MODULE.md](docs/LEAVE_MODULE.md) |
+| Work breakdown structure | `wbs` | [WBS_MODULE.md](docs/WBS_MODULE.md) |
+| Inventory and goods receipts | `inventoryTransaction`, `goodsReceivedNote`, `material` | [PROJECT_LEVEL_INVENTORY.md](docs/PROJECT_LEVEL_INVENTORY.md), [Goods Managment Summary](docs/Goods%20Managment%20Summary) |
+| Multi-tenancy | `common`, `aspect` | [MULTI_TENANCY_FILTER_GUIDE.md](docs/MULTI_TENANCY_FILTER_GUIDE.md) |
+| Organization-scoped roles | `organization`, `auth` | [org-scoped-roles.md](docs/org-scoped-roles.md) |
+| Caching | (cross-cutting) | [REDIS_CACHING_GUIDE.md](docs/REDIS_CACHING_GUIDE.md) |
+| Database operations | (CockroachDB) | [cockroachdb-ops-handbook.md](docs/cockroachdb-ops-handbook.md) |
+| Scaling | (cross-cutting) | [BACKEND_SCALING_PLAN.md](docs/BACKEND_SCALING_PLAN.md) |
+
+Once the service is running, the live, generated API reference is available at `/swagger-ui.html`
+(OpenAPI JSON at `/v3/api-docs`). Controllers and DTOs carry OpenAPI annotations, so the Swagger UI
+groups endpoints by module and documents request and response fields.
 
 ## Getting Started
 
 ### Prerequisites
 
-*   Java 21
-*   Gradle 8+
-*   PostgreSQL
-*   Docker (optional, for running in a container)
-*   Keycloak (or any other OpenID Connect provider)
+* Java 21
+* Gradle 8+
+* CockroachDB (the application database)
+* Keycloak (or another OpenID Connect provider) for authentication
+* Docker (optional, for running in a container)
 
 ### Installation
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/your-username/echno_backend.git
-    cd echno_backend
+    git clone https://github.com/tornotron/echno-backend.git
+    cd echno-backend
     ```
 
 2.  **Configure the application:**
 
-    Create an `application-local.yml` file in `src/main/resources` and override the necessary properties from `application.yml`. At a minimum, you will need to configure the database connection and the JWT issuer URI but currently keycloak is disabled for testing so issuer-uri wound be needed.
+    Create an `application-local.yml` file in `src/main/resources` and override the properties you need
+    from `application.yml`. At a minimum, configure the database connection and the JWT issuer URI.
+    CockroachDB speaks the PostgreSQL wire protocol, so the standard PostgreSQL JDBC driver and URL are
+    used:
 
     ```yaml
     spring:
       datasource:
-        url: jdbc:postgresql://localhost:5432/your-database
+        url: jdbc:postgresql://localhost:26257/echno?sslmode=disable
         username: your-username
         password: your-password
       security:
@@ -72,8 +109,6 @@ The Echno Backend provides a comprehensive set of features for managing employee
 
 ### Running the application
 
-You can run the application using the following command:
-
 ```bash
 ./gradlew bootRun
 ```
@@ -82,13 +117,13 @@ The application will be available at `http://localhost:8080`.
 
 ### Running with Docker
 
-You can also run the application using Docker. First, build the Docker image:
+Build the image:
 
 ```bash
 docker build -t echno-backend .
 ```
 
-Then, run the Docker container:
+Run the container:
 
 ```bash
 docker run -p 8080:8080 echno-backend
@@ -96,16 +131,18 @@ docker run -p 8080:8080 echno-backend
 
 ## Configuration
 
-The main configuration file is `src/main/resources/application.yml`. You can override the default configuration by creating an `application-local.yml` file in the same directory or by setting environment variables.
+The main configuration file is `src/main/resources/application.yml`. Override the defaults by creating an
+`application-local.yml` in the same directory or by setting environment variables.
 
 ## Monitoring
 
-The application exposes metrics in Prometheus format at `/actuator/prometheus`. You can use the provided `prometheus.yml` and `grafana-provisioning` to set up a monitoring stack.
+The application exposes metrics in Prometheus format at `/actuator/prometheus`. Use the provided
+`prometheus.yml` and `grafana-provisioning` to set up a monitoring stack.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a pull request.
+Contributions are welcome. Please open a pull request.
 
 ## License
 
-This project is licensed under the MIT License.
+This project is planned for release under the GNU Affero General Public License v3.0 (AGPL-3.0).

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/OpenApiConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/OpenApiConfig.java
@@ -1,0 +1,46 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Central OpenAPI document metadata and the bearer-token security scheme.
+ * <p>
+ * The API is protected by JWT access tokens issued by Keycloak. Declaring the
+ * scheme here lets the Swagger UI "Authorize" dialog attach a bearer token to
+ * requests, and applies it as the default requirement for every operation.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_SCHEME = "bearerAuth";
+
+    @Bean
+    public OpenAPI echnoOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Echno Backend API")
+                        .description("REST API for the Echno construction management platform. "
+                                + "It covers employees, projects, tasks, attendance, inventory and goods "
+                                + "receipts, issue tracking, PDF reporting, and a double-entry construction "
+                                + "finance ledger. All endpoints are tenant scoped and require a Keycloak "
+                                + "bearer token unless documented otherwise.")
+                        .version("v1")
+                        .contact(new Contact().name("Echno").url("https://echno.xyz").email("info@echno.xyz"))
+                        .license(new License().name("AGPL-3.0").url("https://www.gnu.org/licenses/agpl-3.0.html")))
+                .components(new Components().addSecuritySchemes(BEARER_SCHEME, new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .description("Keycloak-issued JWT access token. Paste the raw token (without the "
+                                + "\"Bearer\" prefix) into the Authorize dialog.")))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.employee;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/employee")
 @Validated
+@Tag(
+        name = "Employees",
+        description = "Employee records within an organization, covering personal and employment details, "
+                + "reporting line, roles and status. Endpoints let a user join an organization and cover "
+                + "creating, browsing, reading, updating and deleting employees. Access is gated by the "
+                + "employee authorities, with an admin authority that grants all operations."
+)
 public class EmployeeController {
 
     private final EmployeeService employeeService;
@@ -46,6 +56,17 @@ public class EmployeeController {
      */
     @PostMapping("/joinOrganization/{userId}/{orgId}")
     @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Add a user to an organization as an employee",
+            description = "Creates an employee record that links the given user to the given organization, "
+                    + "using the supplied employment details. Returns the created employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee record created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The employment details failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user or organization with the given id")
+    })
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.joinOrganization(userId, orgId, employeeJoinOrgDto));
     }
@@ -58,6 +79,16 @@ public class EmployeeController {
      */
     @PostMapping
     @PreAuthorize("hasAuthority('employee:create') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Create an employee",
+            description = "Creates an employee from the supplied personal and employment details, and "
+                    + "returns the created employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request body failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee create or admin authority")
+    })
     public ResponseEntity<EmployeeDto> createEmployee(@Valid @RequestBody EmployeeCreationDto employeeCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.addEmployee(employeeCreationDto));
     }
@@ -69,6 +100,14 @@ public class EmployeeController {
      */
     @GetMapping
     @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "List all employees",
+            description = "Returns every employee the caller is permitted to see."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee read or admin authority")
+    })
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return new ResponseEntity<>(employeeService.displayAllEmployees(),HttpStatus.OK);
     }
@@ -81,6 +120,15 @@ public class EmployeeController {
      */
     @GetMapping("{id}")
     @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Get an employee by id",
+            description = "Returns a single employee including their personal details, roles and status."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
         EmployeeDto employee = employeeService.displayAnEmployee(id);
        return ResponseEntity.status(HttpStatus.OK).body(employee);
@@ -95,6 +143,16 @@ public class EmployeeController {
      */
     @GetMapping("/organization/{id}")
     @PreAuthorize("(hasAuthority('employee:read') and @orgSecurity.isMember(#id)) or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "List employees in an organization",
+            description = "Returns the employees belonging to the given organization. A non-admin caller "
+                    + "must be a member of that organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the organization and lacks the employee admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> readEmployeesByOrganizationId(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.displayEmployeesByOrganization(id));
     }
@@ -108,6 +166,17 @@ public class EmployeeController {
      */
     @PatchMapping("{id}")
     @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Partially update an employee",
+            description = "Applies the supplied map of fields to the employee with the given id, "
+                    + "changing only the fields present in the request."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the supplied fields is not valid"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(@RequestBody Map<String,Object> updates,@PathVariable Long id) {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
@@ -121,6 +190,16 @@ public class EmployeeController {
      */
     @PatchMapping("/batch")
     @PreAuthorize("hasAuthority('employee:update') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Batch update employees",
+            description = "Applies partial updates to several employees in one call. Each entry names an "
+                    + "employee id and the map of fields to change on that employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee update or admin authority")
+    })
     public ResponseEntity<ApiResponse> batchUpdateEmployees(@Valid @RequestBody List<EmployeePatchDto> updates) {
         employeeService.batchUpdateEmployees(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -134,6 +213,15 @@ public class EmployeeController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('employee:delete') or hasAuthority('employee:admin')")
+    @Operation(
+            summary = "Delete an employee",
+            description = "Deletes the employee with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteEmployee(@PathVariable Long id) {
         employeeService.deleteAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" has been deleted"));

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
@@ -7,47 +8,61 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to create an employee record with their personal and employment details.")
 @Data
 public class EmployeeCreationDto {
 
+    @Schema(description = "Job title of the employee.", example = "Site Engineer")
     @NotBlank(message = "designation is required")
     @Size(min = 3, max = 50, message = "designation must be between 3 and 50 characters")
     private String designation;
 
+    @Schema(description = "Department the employee works in.", example = "Civil")
     @NotBlank(message = "department is required")
     @Size(min = 3, max = 50, message = "department must be between 3 and 50 characters")
     private String department;
 
+    @Schema(description = "Date the employee joined.", example = "2026-01-15T00:00:00")
     private LocalDateTime joiningDate;
 
+    @Schema(description = "Organization-assigned employee code.", example = "EMP-0042")
     private String employeeId;
 
+    @Schema(description = "Monthly or annual salary, per organization convention.", example = "65000.0")
     private Double salary;
 
+    @Schema(description = "Id of this employee's reporting manager.", example = "5")
     private Long managerId;
 
+    @Schema(description = "Working shift.", example = "09:00-18:00")
     private String shiftTiming;
 
+    @Schema(description = "Employment status.", example = "active")
     @NotBlank(message = "status is required")
     @Size(min = 3, max = 50, message = "status must be between 3 and 50 characters")
     @Enumerated(EnumType.STRING)
     private String status;
 
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     @NotBlank(message = "employeeName is required")
     @Size(min = 3,max = 50,message = "employeeName must be between 3 and 50 characters")
     private String employeeName;
 
+    @Schema(description = "Gender of the employee.", example = "male")
     @NotBlank(message = "message is required")
     @Size(min = 3,max = 10,message = "gender must be between 3 and 10 characters")
     private String gender;
 
+    @Schema(description = "Postal address of the employee.", example = "45 Anna Nagar, Chennai")
     @Size(max = 255, message = "address must be at most 255 characters")
     private String address;
 
+    @Schema(description = "Ten-digit contact phone number.", example = "9847012345")
     @NotBlank(message = "phoneNumber is required")
     @Size(min = 10,max = 10,message = "phoneNumber must be of 10 characters")
     private String phoneNumber;
 
+    @Schema(description = "Contact email address.", example = "ravi.kumar@example.com")
     @NotBlank(message = "emailAddress is required")
     @Size(max = 255)
     @Pattern(
@@ -56,11 +71,14 @@ public class EmployeeCreationDto {
     )
     private String emailAddress;
 
+    @Schema(description = "Date of birth of the employee.", example = "1994-03-22T00:00:00")
     @NotNull(message = "dateOfBirth is required")
     private LocalDateTime dateOfBirth;
 
+    @Schema(description = "Name of the organization the employee belongs to.", example = "Asset Homes")
     @Size(max = 255, message = "organizationName must be at most 255 characters")
     private String organizationName;
 
+    @Schema(description = "Whether the employee is a manager.", example = "false")
     private boolean isManager;
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.enums.OrgRole;
@@ -10,38 +11,104 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+@Schema(description = "Full view of an employee, covering personal details, employment, reporting line, "
+        + "roles and status.")
 @Data
 public class EmployeeDto {
+    @Schema(description = "Unique employee id.", example = "7")
     private Long id;
+
+    @Schema(description = "Organization-assigned employee code.", example = "EMP-0042")
     private String employeeId;
+
+    @Schema(description = "Id of the organization the employee belongs to.", example = "3")
     private Long organizationId;
+
+    @Schema(description = "Name of the organization the employee belongs to.", example = "Asset Homes")
     private String organizationName;
+
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Job title of the employee.", example = "Site Engineer")
     private String designation;
+
+    @Schema(description = "Department the employee works in.", example = "Civil")
     private String department;
+
+    @Schema(description = "Date the employee joined.", example = "2026-01-15T00:00:00")
     private LocalDateTime joiningDate;
+
+    @Schema(description = "Gender of the employee.", example = "male")
     private String gender;
+
+    @Schema(description = "Ten-digit contact phone number.", example = "9847012345")
     private String phoneNumber;
+
+    @Schema(description = "Postal address of the employee.", example = "45 Anna Nagar, Chennai")
     private String address;
+
+    @Schema(description = "Contact email address.", example = "ravi.kumar@example.com")
     private String emailAddress;
+
+    @Schema(description = "Date of birth of the employee.", example = "1994-03-22T00:00:00")
     private LocalDateTime dateOfBirth;
+
+    @Schema(description = "Blood group of the employee.", example = "O+")
     private String bloodGroup;
+
+    @Schema(description = "Salary of the employee.", example = "65000.0")
     private Double salary;
+
+    @Schema(description = "Id of this employee's reporting manager.", example = "5")
     private Long managerId;
+
+    @Schema(description = "Name of this employee's reporting manager.", example = "Priya Nair")
     private String managerName;
+
+    @Schema(description = "Working shift.", example = "09:00-18:00")
     private String shiftTiming;
+
+    @Schema(description = "Employment status.", example = "ACTIVE")
     private EmployeeStatus status;
+
+    @Schema(description = "Highest qualification held.", example = "B.E. Civil Engineering")
     private String qualification;
+
+    @Schema(description = "Skills of the employee.", example = "[\"AutoCAD\", \"Estimation\"]")
     private List<String> skills;
+
+    @Schema(description = "Certifications held by the employee.", example = "[\"OSHA\"]")
     private List<String> certifications;
+
+    @Schema(description = "Years of experience.", example = "6")
     private Integer experience;
+
+    @Schema(description = "URL of the employee's stored CV.", example = "https://cdn.echno.xyz/cv/emp-0042.pdf")
     private String cvUrl;
+
+    @Schema(description = "Emergency contact details.", example = "Anita Kumar, 9847098765")
     private String emergencyContact;
+
+    @Schema(description = "Platform-level user role.", example = "USER")
     private UserRole role;
+
+    @Schema(description = "URL of the employee's profile picture.",
+            example = "https://cdn.echno.xyz/avatars/emp-0042.png")
     private String profilePictureUrl;
+
+    @Schema(description = "Whether the employee is a manager.", example = "false")
     private Boolean isManager;
+
+    @Schema(description = "Organization roles granted to the employee.", example = "[\"project-manager\"]")
     private Set<OrgRole> orgRoles;
+
+    @Schema(description = "Creation timestamp.", example = "2026-01-15T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp of the last update.", example = "2026-08-01T12:00:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "Files attached to the employee record.")
     private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
@@ -8,35 +9,47 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Employment details supplied when a user joins an organization as an employee.")
 @Data
 public class EmployeeJoinOrgDto {
 //    @NotBlank(message = "designation is required")
+    @Schema(description = "Job title within the organization.", example = "Site Engineer")
     @Size(min = 3, max = 50, message = "designation must be between 3 and 50 characters")
     private String designation;
 
 //    @NotBlank(message = "department is required")
+    @Schema(description = "Department within the organization.", example = "Civil")
     @Size(min = 3, max = 50, message = "department must be between 3 and 50 characters")
     private String department;
 
+    @Schema(description = "Date the employee joined.", example = "2026-01-15T00:00:00")
     private LocalDateTime joiningDate;
 
+    @Schema(description = "Organization-assigned employee code.", example = "EMP-0042")
     private String employeeId;
 
+    @Schema(description = "Salary of the employee.", example = "65000.0")
     private Double salary;
 
+    @Schema(description = "Id of this employee's reporting manager.", example = "5")
     private Long managerId;
 
+    @Schema(description = "Working shift.", example = "09:00-18:00")
     private String shiftTiming;
 
+    @Schema(description = "Employment status. Defaults to active.", example = "active")
     @NotBlank(message = "status is required")
     @Size(min = 3, max = 50, message = "status must be between 3 and 50 characters")
     @Enumerated(EnumType.STRING)
     private String status = "active";
 
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     private String employeeName;
 
+    @Schema(description = "Contact email address.", example = "ravi.kumar@example.com")
     private String email;
 
+    @Schema(description = "Contact phone number.", example = "9847012345")
     private String phone;
 
 

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeePatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeePatchDto.java
@@ -1,11 +1,18 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
+@Schema(description = "A single employee's partial update within a batch: the employee id and the map "
+        + "of fields to change on them.")
 @Data
 public class EmployeePatchDto {
+    @Schema(description = "Id of the employee to update.", example = "7")
     private Long id;
+
+    @Schema(description = "Fields to change, keyed by employee field name.",
+            example = "{\"designation\": \"Senior Site Engineer\", \"salary\": 72000.0}")
     private Map<String,Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
@@ -10,37 +11,102 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A construction invoice with its computed totals, lifecycle status and line items.")
 public record ConstructionInvoiceDto(
+        @Schema(description = "Unique invoice id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Human-readable invoice number assigned by the system.", example = "CINV-2026-0042")
         String invoiceNumber,
+
+        @Schema(description = "Kind of invoice.", example = "VENDOR_BILL")
         ConstructionInvoiceType type,
+
+        @Schema(description = "Lifecycle status of the invoice.", example = "APPROVED")
         ConstructionInvoiceStatus status,
+
+        @Schema(description = "Settlement status derived from paid and outstanding amounts.", example = "PARTIALLY_PAID")
         ConstructionPaymentStatus paymentStatus,
+
+        @Schema(description = "Project the invoice is billed against.", example = "42")
         Long projectId,
+
+        @Schema(description = "Vendor being invoiced, if any.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Matched purchase order, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Matched goods receipt, if any.", example = "231")
         Long goodsReceiptId,
+
+        @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
         LocalDate issueDate,
+
+        @Schema(description = "Date payment is due.", example = "2026-08-31")
         LocalDate dueDate,
+
+        @Schema(description = "Date the invoice was fully paid, once settled.", example = "2026-08-28")
         LocalDate paymentDate,
+
+        @Schema(description = "Sum of line amounts before tax and discount.", example = "67500.00")
         BigDecimal subtotal,
+
+        @Schema(description = "Total tax across all lines.", example = "12150.00")
         BigDecimal taxAmount,
+
+        @Schema(description = "Total discount across all lines.", example = "3375.00")
         BigDecimal discountAmount,
+
+        @Schema(description = "Invoice grand total after tax and discount.", example = "76275.00")
         BigDecimal totalAmount,
+
+        @Schema(description = "Amount paid so far.", example = "40000.00")
         BigDecimal paidAmount,
+
+        @Schema(description = "Outstanding balance still due.", example = "36275.00")
         BigDecimal balanceAmount,
+
+        @Schema(description = "Free-text payment terms.", example = "Net 30")
         String paymentTerms,
+
+        @Schema(description = "Settlement method.", example = "BANK_TRANSFER")
         String paymentMethod,
+
+        @Schema(description = "Vendor GST registration number.", example = "29ABCDE1234F1Z5")
         String gstNumber,
+
+        @Schema(description = "Tax treatment applied to the invoice.", example = "CGST_SGST")
         String taxType,
+
+        @Schema(description = "Internal notes.", example = "Second progress claim for tower B")
         String notes,
+
+        @Schema(description = "Terms and conditions printed on the invoice.")
         String termsAndConditions,
+
+        @Schema(description = "User id that submitted the invoice for approval.", example = "5")
         Long submittedBy,
+
+        @Schema(description = "Timestamp the invoice was submitted.", example = "2026-08-02T09:15:00Z")
         Instant submittedAt,
+
+        @Schema(description = "User id that approved the invoice.", example = "2")
         Long approvedBy,
+
+        @Schema(description = "Timestamp the invoice was approved.", example = "2026-08-03T11:40:00Z")
         Instant approvedAt,
+
+        @Schema(description = "User id that recorded the most recent payment.", example = "5")
         Long paymentRecordedBy,
+
+        @Schema(description = "Ledger journal entry posted when the invoice was approved.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
         UUID journalEntryId,
+
+        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after posting.")
         UUID reversalJournalEntryId,
+
+        @Schema(description = "Invoice line items.")
         List<ConstructionInvoiceLineDto> lines
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
@@ -1,21 +1,51 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Schema(description = "A single line on a construction invoice with its computed tax, discount and totals.")
 public record ConstructionInvoiceLineDto(
+        @Schema(description = "Unique line id.", example = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
         UUID id,
+
+        @Schema(description = "What the line is billing for.", example = "OPC 53 grade cement")
         String description,
+
+        @Schema(description = "Quantity billed.", example = "200")
         BigDecimal quantity,
+
+        @Schema(description = "Unit of measure for the quantity.", example = "bag")
         String unit,
+
+        @Schema(description = "Price per unit.", example = "350.00")
         BigDecimal unitPrice,
+
+        @Schema(description = "Tax rate applied to the line, as a percentage.", example = "18.0")
         BigDecimal taxRate,
+
+        @Schema(description = "Tax charged on the line.", example = "12600.00")
         BigDecimal taxAmount,
+
+        @Schema(description = "Discount rate applied to the line, as a percentage.", example = "5.0")
         BigDecimal discountRate,
+
+        @Schema(description = "Discount amount deducted from the line.", example = "3500.00")
         BigDecimal discountAmount,
+
+        @Schema(description = "Line amount before tax and discount.", example = "70000.00")
         BigDecimal subtotal,
+
+        @Schema(description = "Line total after tax and discount.", example = "79100.00")
         BigDecimal total,
+
+        @Schema(description = "Inventory item the line draws from, if any.", example = "512")
         Long inventoryItemId,
+
+        @Schema(description = "Asset the line relates to, if any.", example = "88")
         Long assetId,
+
+        @Schema(description = "Task the line is charged against, if any.", example = "1204")
         Long taskId
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
@@ -9,14 +10,33 @@ import java.math.BigDecimal;
  * discount, total) are computed server-side from quantity, unit price and the
  * percentage rates; the client only supplies the inputs.
  */
+@Schema(description = "A single invoice line. The client supplies quantity, unit price and the "
+        + "percentage rates; the server computes the line and invoice totals.")
 public record ConstructionInvoiceLineRequest(
+        @Schema(description = "Description of the billed item or work.", example = "Ready-mix concrete M25")
         @NotBlank @Size(max = 500) String description,
+
+        @Schema(description = "Quantity billed.", example = "12.5")
         @NotNull @DecimalMin(value = "0.0001") BigDecimal quantity,
+
+        @Schema(description = "Unit of measure for the quantity.", example = "cubic metre")
         @NotBlank @Size(max = 50) String unit,
+
+        @Schema(description = "Price per unit before tax and discount.", example = "5400.00")
         @NotNull @DecimalMin(value = "0.0") BigDecimal unitPrice,
+
+        @Schema(description = "Tax rate applied to the line, as a percentage from 0 to 100.", example = "18.0")
         @DecimalMin(value = "0.0") @DecimalMax(value = "100.0") BigDecimal taxRate,
+
+        @Schema(description = "Discount rate applied to the line, as a percentage from 0 to 100.", example = "5.0")
         @DecimalMin(value = "0.0") @DecimalMax(value = "100.0") BigDecimal discountRate,
+
+        @Schema(description = "Inventory item this line draws from, if applicable.", example = "88")
         Long inventoryItemId,
+
+        @Schema(description = "Asset this line relates to, if applicable.", example = "14")
         Long assetId,
+
+        @Schema(description = "Task this line is attributed to, if applicable.", example = "512")
         Long taskId
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
@@ -10,32 +11,88 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
+@Schema(description = "A construction payment voucher recording money paid out to a vendor, subcontractor, "
+        + "labour or employee on a project, with its method, payee and verification details.")
 public record ConstructionPaymentDto(
+        @Schema(description = "Unique payment voucher id.", example = "7c9e6679-7425-40de-944b-e07fc1f90ae7")
         UUID id,
+
+        @Schema(description = "Human-readable voucher number assigned by the system.", example = "CPMT-2026-0031")
         String paymentNumber,
+
+        @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         ConstructionPaymentType type,
+
+        @Schema(description = "Lifecycle status of the voucher.", example = "VERIFIED")
         ConstructionPaymentVoucherStatus status,
+
+        @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
         ConstructionPaymentMethod method,
+
+        @Schema(description = "Category of party being paid.", example = "VENDOR")
         ConstructionPayeeType payeeType,
+
+        @Schema(description = "Project the payment is charged to.", example = "42")
         Long projectId,
+
+        @Schema(description = "Construction invoice this payment settles, if any.",
+                example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID invoiceId,
+
+        @Schema(description = "Purchase order the payment relates to, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Vendor being paid, when the payee is a vendor.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Employee being paid, when the payee is an employee.", example = "5")
         Long employeeId,
+
+        @Schema(description = "Subcontract the payment relates to, when the payee is a subcontractor.", example = "23")
         Long subContractId,
+
+        @Schema(description = "Labour record being paid, when the payee is labour.", example = "61")
         Long labourId,
+
+        @Schema(description = "Name of the party being paid.", example = "Sundar Building Materials")
         String payeeName,
+
+        @Schema(description = "Free-text payee details.", example = "Contact: Ravi, GST 29ABCDE1234F1Z5")
         String payeeDetails,
+
+        @Schema(description = "Amount paid.", example = "40000.00")
         BigDecimal amount,
+
+        @Schema(description = "Currency code.", example = "INR")
         String currency,
+
+        @Schema(description = "Date the payment was made.", example = "2026-08-05")
         LocalDate paymentDate,
+
+        @Schema(description = "Bank or gateway transaction id.", example = "TXN20260805123456")
         String transactionId,
+
+        @Schema(description = "Cheque or reference number for the payment.", example = "CHQ-000123")
         String referenceNumber,
+
+        @Schema(description = "Bank the payment was drawn on.", example = "HDFC Bank")
         String bankName,
+
+        @Schema(description = "Bank account number used for the payment.", example = "50100123456789")
         String accountNumber,
+
+        @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         String ifscCode,
+
+        @Schema(description = "User id that verified the voucher.", example = "2")
         Long verifiedBy,
+
+        @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
         Instant verifiedAt,
+
+        @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         String description,
+
+        @Schema(description = "Internal notes.", example = "Approved by site engineer")
         String notes
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionInvoiceRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
@@ -7,19 +8,49 @@ import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Payload to create a construction invoice. Line and header monetary totals are "
+        + "computed server side from the line inputs.")
 public record CreateConstructionInvoiceRequest(
+        @Schema(description = "Kind of invoice being raised, for example a vendor bill or a progress claim.",
+                example = "VENDOR_BILL")
         @NotNull ConstructionInvoiceType type,
+
+        @Schema(description = "Project the invoice is billed against.", example = "42")
         @NotNull Long projectId,
+
+        @Schema(description = "Vendor being invoiced, when the invoice originates from a vendor.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Purchase order the invoice is matched to, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Goods receipt the invoice is matched to, if any.", example = "231")
         Long goodsReceiptId,
+
+        @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
         @NotNull LocalDate issueDate,
+
+        @Schema(description = "Date payment is due.", example = "2026-08-31")
         @NotNull LocalDate dueDate,
+
+        @Schema(description = "Free-text payment terms.", example = "Net 30")
         @Size(max = 100) String paymentTerms,
+
+        @Schema(description = "Preferred settlement method.", example = "BANK_TRANSFER")
         @Size(max = 50) String paymentMethod,
+
+        @Schema(description = "Vendor GST registration number.", example = "29ABCDE1234F1Z5")
         @Size(max = 30) String gstNumber,
+
+        @Schema(description = "Tax treatment applied to the invoice.", example = "CGST_SGST")
         @Size(max = 20) String taxType,
+
+        @Schema(description = "Internal notes about the invoice.", example = "Second progress claim for tower B")
         @Size(max = 1000) String notes,
+
+        @Schema(description = "Terms and conditions printed on the invoice.")
         @Size(max = 2000) String termsAndConditions,
+
+        @Schema(description = "Invoice line items. At least one line is required.")
         @NotNull @Size(min = 1) @Valid List<ConstructionInvoiceLineRequest> lines
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
@@ -15,29 +16,79 @@ import java.util.UUID;
  * voucher always starts PENDING (no ledger posting in this increment). The payment
  * number is generated server-side with the CPMT sequence.
  */
+@Schema(description = "Payload to create a construction payment voucher. The status is not accepted here: "
+        + "a new voucher always starts pending, and the payment number is generated server side.")
 public record CreateConstructionPaymentRequest(
+        @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         @NotNull ConstructionPaymentType type,
+
+        @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
         @NotNull ConstructionPaymentMethod method,
+
+        @Schema(description = "Category of party being paid.", example = "VENDOR")
         ConstructionPayeeType payeeType,
+
+        @Schema(description = "Project the payment is charged to.", example = "42")
         @NotNull Long projectId,
+
+        @Schema(description = "Construction invoice this payment settles, if any.",
+                example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID invoiceId,
+
+        @Schema(description = "Purchase order the payment relates to, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Vendor being paid, when the payee is a vendor.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Employee being paid, when the payee is an employee.", example = "5")
         Long employeeId,
+
+        @Schema(description = "Subcontract the payment relates to, when the payee is a subcontractor.", example = "23")
         Long subContractId,
+
+        @Schema(description = "Labour record being paid, when the payee is labour.", example = "61")
         Long labourId,
+
+        @Schema(description = "Name of the party being paid.", example = "Sundar Building Materials")
         @Size(max = 200) String payeeName,
+
+        @Schema(description = "Free-text payee details.", example = "Contact: Ravi, GST 29ABCDE1234F1Z5")
         @Size(max = 500) String payeeDetails,
+
+        @Schema(description = "Amount to pay. Must be positive.", example = "40000.00")
         @NotNull @Positive BigDecimal amount,
+
+        @Schema(description = "Currency code.", example = "INR")
         @Size(max = 10) String currency,
+
+        @Schema(description = "Date the payment was made.", example = "2026-08-05")
         @NotNull LocalDate paymentDate,
+
+        @Schema(description = "Bank or gateway transaction id.", example = "TXN20260805123456")
         @Size(max = 100) String transactionId,
+
+        @Schema(description = "Cheque or reference number for the payment.", example = "CHQ-000123")
         @Size(max = 100) String referenceNumber,
+
+        @Schema(description = "Bank the payment was drawn on.", example = "HDFC Bank")
         @Size(max = 100) String bankName,
+
+        @Schema(description = "Bank account number used for the payment.", example = "50100123456789")
         @Size(max = 50) String accountNumber,
+
+        @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         @Size(max = 20) String ifscCode,
+
+        @Schema(description = "User id that verified the voucher, if already verified.", example = "2")
         Long verifiedBy,
+
+        @Schema(description = "Timestamp the voucher was verified, if already verified.", example = "2026-08-06T10:20:00Z")
         Instant verifiedAt,
+
+        @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         @Size(max = 1000) String description,
+
+        @Schema(description = "Internal notes.", example = "Approved by site engineer")
         @Size(max = 1000) String notes
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionInvoiceRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
@@ -14,22 +15,57 @@ import java.util.List;
  * are set directly (no ledger posting in this increment); money totals are always
  * recomputed from the supplied lines.
  */
+@Schema(description = "Payload to fully replace an editable construction invoice. Status and payment "
+        + "status are set directly, and money totals are always recomputed from the supplied lines.")
 public record UpdateConstructionInvoiceRequest(
+        @Schema(description = "Kind of invoice.", example = "VENDOR_BILL")
         @NotNull ConstructionInvoiceType type,
+
+        @Schema(description = "Lifecycle status to set on the invoice.", example = "APPROVED")
         @NotNull ConstructionInvoiceStatus status,
+
+        @Schema(description = "Settlement status to set on the invoice.", example = "PARTIALLY_PAID")
         @NotNull ConstructionPaymentStatus paymentStatus,
+
+        @Schema(description = "Project the invoice is billed against.", example = "42")
         @NotNull Long projectId,
+
+        @Schema(description = "Vendor being invoiced, if any.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Matched purchase order, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Matched goods receipt, if any.", example = "231")
         Long goodsReceiptId,
+
+        @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
         @NotNull LocalDate issueDate,
+
+        @Schema(description = "Date payment is due.", example = "2026-08-31")
         @NotNull LocalDate dueDate,
+
+        @Schema(description = "Date the invoice was paid, once settled.", example = "2026-08-28")
         LocalDate paymentDate,
+
+        @Schema(description = "Free-text payment terms.", example = "Net 30")
         @Size(max = 100) String paymentTerms,
+
+        @Schema(description = "Settlement method.", example = "BANK_TRANSFER")
         @Size(max = 50) String paymentMethod,
+
+        @Schema(description = "Vendor GST registration number.", example = "29ABCDE1234F1Z5")
         @Size(max = 30) String gstNumber,
+
+        @Schema(description = "Tax treatment applied to the invoice.", example = "CGST_SGST")
         @Size(max = 20) String taxType,
+
+        @Schema(description = "Internal notes about the invoice.", example = "Second progress claim for tower B")
         @Size(max = 1000) String notes,
+
+        @Schema(description = "Terms and conditions printed on the invoice.")
         @Size(max = 2000) String termsAndConditions,
+
+        @Schema(description = "Invoice line items. At least one line is required.")
         @NotNull @Size(min = 1) @Valid List<ConstructionInvoiceLineRequest> lines
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.construction.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
@@ -16,30 +17,82 @@ import java.util.UUID;
  * directly (no ledger posting in this increment); no JournalEntry is created on any
  * status transition.
  */
+@Schema(description = "Payload to fully replace an editable construction payment voucher. The status is "
+        + "set directly, and no ledger journal entry is created on any status transition.")
 public record UpdateConstructionPaymentRequest(
+        @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         @NotNull ConstructionPaymentType type,
+
+        @Schema(description = "Lifecycle status to set on the voucher.", example = "VERIFIED")
         @NotNull ConstructionPaymentVoucherStatus status,
+
+        @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
         @NotNull ConstructionPaymentMethod method,
+
+        @Schema(description = "Category of party being paid.", example = "VENDOR")
         ConstructionPayeeType payeeType,
+
+        @Schema(description = "Project the payment is charged to.", example = "42")
         @NotNull Long projectId,
+
+        @Schema(description = "Construction invoice this payment settles, if any.",
+                example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID invoiceId,
+
+        @Schema(description = "Purchase order the payment relates to, if any.", example = "108")
         Long purchaseOrderId,
+
+        @Schema(description = "Vendor being paid, when the payee is a vendor.", example = "17")
         Long vendorId,
+
+        @Schema(description = "Employee being paid, when the payee is an employee.", example = "5")
         Long employeeId,
+
+        @Schema(description = "Subcontract the payment relates to, when the payee is a subcontractor.", example = "23")
         Long subContractId,
+
+        @Schema(description = "Labour record being paid, when the payee is labour.", example = "61")
         Long labourId,
+
+        @Schema(description = "Name of the party being paid.", example = "Sundar Building Materials")
         @Size(max = 200) String payeeName,
+
+        @Schema(description = "Free-text payee details.", example = "Contact: Ravi, GST 29ABCDE1234F1Z5")
         @Size(max = 500) String payeeDetails,
+
+        @Schema(description = "Amount to pay. Must be positive.", example = "40000.00")
         @NotNull @Positive BigDecimal amount,
+
+        @Schema(description = "Currency code.", example = "INR")
         @Size(max = 10) String currency,
+
+        @Schema(description = "Date the payment was made.", example = "2026-08-05")
         @NotNull LocalDate paymentDate,
+
+        @Schema(description = "Bank or gateway transaction id.", example = "TXN20260805123456")
         @Size(max = 100) String transactionId,
+
+        @Schema(description = "Cheque or reference number for the payment.", example = "CHQ-000123")
         @Size(max = 100) String referenceNumber,
+
+        @Schema(description = "Bank the payment was drawn on.", example = "HDFC Bank")
         @Size(max = 100) String bankName,
+
+        @Schema(description = "Bank account number used for the payment.", example = "50100123456789")
         @Size(max = 50) String accountNumber,
+
+        @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         @Size(max = 20) String ifscCode,
+
+        @Schema(description = "User id that verified the voucher.", example = "2")
         Long verifiedBy,
+
+        @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
         Instant verifiedAt,
+
+        @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         @Size(max = 1000) String description,
+
+        @Schema(description = "Internal notes.", example = "Approved by site engineer")
         @Size(max = 1000) String notes
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.construction.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,24 +25,61 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/construction-invoices/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Construction Invoices",
+        description = "Vendor and progress invoices raised against construction projects. "
+                + "Invoices move through a draft, submitted, approved and paid lifecycle, and posting "
+                + "an approved invoice creates the matching ledger journal entry. All endpoints are "
+                + "tenant scoped and limited to system administrators and project managers."
+)
 public class ConstructionInvoiceControllerWeb {
 
     private final ConstructionInvoiceService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a construction invoice",
+            description = "Creates a draft invoice from the supplied header and line items. "
+                    + "Line-level subtotal, tax, discount and total amounts are computed server side "
+                    + "from the quantity, unit price and percentage rates on each line."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Invoice created and returned in draft status"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ConstructionInvoiceDto> create(@Valid @RequestBody CreateConstructionInvoiceRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a construction invoice by id",
+            description = "Returns a single invoice, including its computed totals and line items."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List construction invoices",
+            description = "Returns a paged list of invoices in the current tenant. The optional project, "
+                    + "vendor, status and type parameters narrow the result; omitting a parameter leaves "
+                    + "that dimension unfiltered."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching invoices"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public Page<ConstructionInvoiceDto> list(@RequestParam(required = false) Long projectId,
                                              @RequestParam(required = false) Long vendorId,
                                              @RequestParam(required = false) ConstructionInvoiceStatus status,
@@ -49,6 +90,17 @@ public class ConstructionInvoiceControllerWeb {
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update a construction invoice",
+            description = "Replaces the editable header and line items of a draft invoice. "
+                    + "Invoices that have already been submitted or approved cannot be edited."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, or the invoice is not in an editable state"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto update(@PathVariable UUID id,
                                          @Valid @RequestBody UpdateConstructionInvoiceRequest req) {
         return service.update(id, req);
@@ -56,24 +108,67 @@ public class ConstructionInvoiceControllerWeb {
 
     @PostMapping("/{id}/submit")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Submit a draft invoice for approval",
+            description = "Transitions a draft invoice to submitted status so it can be reviewed and approved."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice submitted"),
+            @ApiResponse(responseCode = "400", description = "Invoice is not in a state that can be submitted"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto submit(@PathVariable UUID id) {
         return service.submit(id);
     }
 
     @PostMapping("/{id}/approve")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Approve a submitted invoice",
+            description = "Approves a submitted invoice and posts the matching journal entry to the ledger. "
+                    + "Once approved the invoice is eligible for payment."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice approved and posted"),
+            @ApiResponse(responseCode = "400", description = "Invoice is not in a state that can be approved"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto approve(@PathVariable UUID id) {
         return service.approve(id);
     }
 
     @PostMapping("/{id}/cancel")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Cancel an invoice",
+            description = "Cancels an invoice and records the supplied reason. If the invoice was already "
+                    + "posted, the ledger entry is reversed."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice cancelled"),
+            @ApiResponse(responseCode = "400", description = "Invoice is already paid or otherwise cannot be cancelled"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
         return service.cancel(id, reason);
     }
 
     @PostMapping("/{id}/record-payment")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Record a payment against an invoice",
+            description = "Applies a payment of the given amount to an approved invoice, reducing its "
+                    + "outstanding balance and advancing the payment status once fully settled."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment recorded and balance updated"),
+            @ApiResponse(responseCode = "400", description = "Amount is invalid or exceeds the outstanding balance"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public ConstructionInvoiceDto recordPayment(@PathVariable UUID id, @RequestParam BigDecimal amount) {
         return service.recordPayment(id, amount);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.construction.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,24 +25,61 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/construction-payments/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Construction Payments",
+        description = "Payment vouchers recording money paid out on construction projects to vendors, "
+                + "subcontractors, labour and employees. A voucher captures the amount, method and payee "
+                + "details and moves through a pending and verified lifecycle. This increment does not post "
+                + "ledger journal entries. All endpoints are tenant scoped and limited to system "
+                + "administrators and project managers."
+)
 public class ConstructionPaymentControllerWeb {
 
     private final ConstructionPaymentService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a construction payment voucher",
+            description = "Creates a payment voucher in pending status. The payment number is generated "
+                    + "server side from the CPMT sequence. The status cannot be set on creation."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Voucher created and returned in pending status"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ConstructionPaymentDto> create(@Valid @RequestBody CreateConstructionPaymentRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a construction payment voucher by id",
+            description = "Returns a single payment voucher with its amount, method and payee details."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Voucher found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No voucher with the given id in the current tenant")
+    })
     public ConstructionPaymentDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List construction payment vouchers",
+            description = "Returns a paged list of payment vouchers in the current tenant. The optional "
+                    + "project, vendor, status, type and payee type parameters narrow the result; omitting "
+                    + "a parameter leaves that dimension unfiltered."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching vouchers"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public Page<ConstructionPaymentDto> list(@RequestParam(required = false) Long projectId,
                                              @RequestParam(required = false) Long vendorId,
                                              @RequestParam(required = false) ConstructionPaymentVoucherStatus status,
@@ -50,6 +91,17 @@ public class ConstructionPaymentControllerWeb {
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update a construction payment voucher",
+            description = "Replaces the editable fields of a payment voucher, including its status, which "
+                    + "is set directly. No ledger journal entry is created on any status transition."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Voucher updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, or the voucher is not in an editable state"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No voucher with the given id in the current tenant")
+    })
     public ConstructionPaymentDto update(@PathVariable UUID id,
                                          @Valid @RequestBody UpdateConstructionPaymentRequest req) {
         return service.update(id, req);

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/CreateInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/CreateInvoiceRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.invoice.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 
@@ -8,18 +9,40 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "Payload to create a draft customer invoice. Line and header totals are computed "
+        + "server side from the line inputs.")
 public record CreateInvoiceRequest(
+        @Schema(description = "Customer the invoice is billed to.", example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
         @NotNull UUID customerId,
+
+        @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
         @NotNull LocalDate invoiceDate,
+
+        @Schema(description = "Date payment is due.", example = "2026-08-31")
         @NotNull LocalDate dueDate,
+
+        @Schema(description = "Internal notes about the invoice.", example = "First milestone billing")
         @Size(max = 500) String notes,
+
+        @Schema(description = "Invoice line items. At least one line is required.")
         @NotNull @Size(min = 1) @Valid List<LineRequest> lines
 ) {
+    @Schema(description = "A single line on a customer invoice.")
     public record LineRequest(
+            @Schema(description = "What the line is charging for.", example = "Structural design consultancy")
             @NotBlank @Size(max = 500) String description,
+
+            @Schema(description = "Quantity billed. Must be greater than zero.", example = "10")
             @NotNull @DecimalMin(value = "0.0001") BigDecimal quantity,
+
+            @Schema(description = "Price per unit.", example = "5000.00")
             @NotNull @DecimalMin(value = "0.0") BigDecimal unitPrice,
+
+            @Schema(description = "Tax rate applied to the line, as a percentage between 0 and 100.", example = "18.0")
             @NotNull @DecimalMin(value = "0.0") @DecimalMax(value = "100.0") BigDecimal taxRate,
+
+            @Schema(description = "Revenue account the line is credited to.",
+                    example = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
             @NotNull UUID revenueAccountId
     ) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.invoice.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 
 import java.math.BigDecimal;
@@ -7,15 +8,55 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A customer invoice with its computed totals, receivable status and line items.")
 public record InvoiceDto(
-        UUID id, String invoiceNumber,
-        UUID customerId, String customerName,
-        LocalDate invoiceDate, LocalDate dueDate,
+        @Schema(description = "Unique invoice id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        UUID id,
+
+        @Schema(description = "Human-readable invoice number assigned by the system.", example = "INV-2026-0042")
+        String invoiceNumber,
+
+        @Schema(description = "Customer the invoice is billed to.", example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+        UUID customerId,
+
+        @Schema(description = "Customer name captured on the invoice.", example = "Asset Homes Pvt Ltd")
+        String customerName,
+
+        @Schema(description = "Date the invoice was issued.", example = "2026-08-01")
+        LocalDate invoiceDate,
+
+        @Schema(description = "Date payment is due.", example = "2026-08-31")
+        LocalDate dueDate,
+
+        @Schema(description = "Lifecycle status of the invoice.", example = "ISSUED")
         InvoiceStatus status,
-        BigDecimal subtotal, BigDecimal taxTotal, BigDecimal total,
-        BigDecimal amountPaid, BigDecimal balanceDue,
-        UUID journalEntryId, UUID reversalJournalEntryId,
+
+        @Schema(description = "Sum of line amounts before tax.", example = "50000.00")
+        BigDecimal subtotal,
+
+        @Schema(description = "Total tax across all lines.", example = "9000.00")
+        BigDecimal taxTotal,
+
+        @Schema(description = "Invoice grand total after tax.", example = "59000.00")
+        BigDecimal total,
+
+        @Schema(description = "Amount received against the invoice so far.", example = "20000.00")
+        BigDecimal amountPaid,
+
+        @Schema(description = "Outstanding balance still due.", example = "39000.00")
+        BigDecimal balanceDue,
+
+        @Schema(description = "Ledger journal entry posted when the invoice was issued.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID journalEntryId,
+
+        @Schema(description = "Reversal journal entry, present when the invoice was cancelled after issue.")
+        UUID reversalJournalEntryId,
+
+        @Schema(description = "Internal notes.", example = "First milestone billing")
         String notes,
+
+        @Schema(description = "Invoice line items.")
         List<InvoiceLineDto> lines
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/InvoiceLineDto.java
@@ -1,10 +1,40 @@
 package org.tornotron.echno_backend.finance.invoice.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Schema(description = "A single line on a customer invoice with its computed subtotal, tax and total.")
 public record InvoiceLineDto(
-        UUID id, String description, BigDecimal quantity, BigDecimal unitPrice,
-        BigDecimal lineSubtotal, BigDecimal taxRate, BigDecimal taxAmount, BigDecimal lineTotal,
-        UUID revenueAccountId, String revenueAccountCode
+        @Schema(description = "Unique line id.", example = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
+        UUID id,
+
+        @Schema(description = "What the line is charging for.", example = "Structural design consultancy")
+        String description,
+
+        @Schema(description = "Quantity billed.", example = "10")
+        BigDecimal quantity,
+
+        @Schema(description = "Price per unit.", example = "5000.00")
+        BigDecimal unitPrice,
+
+        @Schema(description = "Line amount before tax.", example = "50000.00")
+        BigDecimal lineSubtotal,
+
+        @Schema(description = "Tax rate applied to the line, as a percentage.", example = "18.0")
+        BigDecimal taxRate,
+
+        @Schema(description = "Tax charged on the line.", example = "9000.00")
+        BigDecimal taxAmount,
+
+        @Schema(description = "Line total including tax.", example = "59000.00")
+        BigDecimal lineTotal,
+
+        @Schema(description = "Revenue account the line is credited to.",
+                example = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e")
+        UUID revenueAccountId,
+
+        @Schema(description = "Code of the revenue account.", example = "4000")
+        String revenueAccountCode
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
@@ -1,6 +1,10 @@
 package org.tornotron.echno_backend.finance.invoice.web;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,30 +20,78 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/invoices/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Customer Invoices",
+        description = "Accounts-receivable invoices raised to customers. An invoice is created as a draft, "
+                + "issued to post its receivable journal entry, and can be cancelled with a reversing entry. "
+                + "All endpoints are tenant scoped and limited to system administrators and project managers."
+)
 public class InvoiceControllerWeb {
 
     private final InvoiceService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a draft invoice",
+            description = "Creates a draft customer invoice from the supplied header and line items. "
+                    + "Line subtotals, tax and totals are computed server side. A draft posts no ledger entry "
+                    + "until it is issued."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Invoice created and returned in draft status"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<InvoiceDto> createDraft(@Valid @RequestBody CreateInvoiceRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.createDraft(req));
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get an invoice by id",
+            description = "Returns a single customer invoice, including its computed totals and line items."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public InvoiceDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @PostMapping("/{id}/issue")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Issue a draft invoice",
+            description = "Issues a draft invoice, transitioning it to issued status and posting the "
+                    + "receivable journal entry to the ledger. Once issued the invoice can be paid."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice issued and posted"),
+            @ApiResponse(responseCode = "400", description = "Invoice is not in a state that can be issued"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public InvoiceDto issue(@PathVariable UUID id) {
         return service.issue(id);
     }
 
     @PostMapping("/{id}/cancel")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Cancel an invoice",
+            description = "Cancels an invoice and records the supplied reason. If the invoice was already "
+                    + "issued, a reversing journal entry is posted to back out the receivable."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invoice cancelled"),
+            @ApiResponse(responseCode = "400", description = "Invoice is already paid or otherwise cannot be cancelled"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
+    })
     public InvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
         return service.cancel(id, reason);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
@@ -1,16 +1,32 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 
 import java.util.UUID;
 
+@Schema(description = "An account in the chart of accounts, with its code, type and place in the hierarchy.")
 public record AccountDto(
+        @Schema(description = "Unique account id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Account code, unique within the tenant.", example = "1100")
         String code,
+
+        @Schema(description = "Account name.", example = "Cash and Cash Equivalents")
         String name,
+
+        @Schema(description = "Root account type this account belongs to.", example = "ASSET")
         AccountType type,
+
+        @Schema(description = "Parent account id, or null for a root account.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
         UUID parentId,
+
+        @Schema(description = "Whether the account is active and available for posting.", example = "true")
         boolean active,
+
+        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
         String description
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountTreeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountTreeDto.java
@@ -1,18 +1,36 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "An account and its child accounts, forming one node of the chart of accounts tree.")
 public record AccountTreeDto(
+        @Schema(description = "Unique account id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Account code, unique within the tenant.", example = "1100")
         String code,
+
+        @Schema(description = "Account name.", example = "Cash and Cash Equivalents")
         String name,
+
+        @Schema(description = "Root account type this account belongs to.", example = "ASSET")
         AccountType type,
+
+        @Schema(description = "Whether the account is active and available for posting.", example = "true")
         boolean active,
+
+        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
         String description,
+
+        @Schema(description = "Whether entries can be posted directly to this account. Only leaf accounts "
+                + "are postable.", example = "true")
         boolean postable,
+
+        @Schema(description = "Child accounts nested under this account.")
         List<AccountTreeDto> children
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AddressDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AddressDto.java
@@ -1,33 +1,42 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "A postal address, used for customer billing.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AddressDto {
 
+    @Schema(description = "First address line.", example = "12 Marina Boulevard")
     @Size(max = 200,message = "Address line 1 cannot exceed 200 characters")
     private String line1;
 
+    @Schema(description = "Second address line.", example = "Suite 400")
     @Size(max = 200,message = "Address line 2 cannot exceed 200 characters")
     private String line2;
 
+    @Schema(description = "City.", example = "Chennai")
     @Size(max = 100,message = "City cannot exceed 100 characters")
     private String city;
 
+    @Schema(description = "State or province.", example = "Tamil Nadu")
     @Size(max = 100,message = "State cannot exceed 100 characters")
     private String state;
 
+    @Schema(description = "GST state code.", example = "33")
     @Size(max = 2,message = "State code cannot exceed 2 characters")
     private String stateCode;
 
+    @Schema(description = "Postal or PIN code.", example = "600001")
     @Size(max = 20,message = "Postal code cannot exceed 20 characters")
     private String postalCode;
 
+    @Schema(description = "ISO 3166-1 alpha-2 country code.", example = "IN")
     @Size(max = 2,message = "Country code cannot exceed 2 characters")
     private String country;
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CreateAccountRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CreateAccountRequest.java
@@ -1,26 +1,37 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
+@Schema(description = "Payload to create an account in the chart of accounts.")
 public record CreateAccountRequest(
 
         // Optional: when blank the code is auto-generated from the parent and
         // existing siblings. Supply a value only to override the generated code.
+        @Schema(description = "Account code. When left blank it is generated from the parent and existing "
+                + "sibling accounts. Supply a value only to override the generated code.", example = "1100")
         @Size(max = 20) String code,
 
+        @Schema(description = "Account name.", example = "Cash and Cash Equivalents")
         @NotBlank @Size(max = 200) String name,
 
         // Optional for children (type is inherited from the parent); required for
         // roots, which declare their own type. See typeProvidedForRoot().
+        @Schema(description = "Root account type. Optional for a child account, where the type is inherited "
+                + "from the parent, and required for a root account, which declares its own type.",
+                example = "ASSET")
         @Size(max = 20) String type,
 
+        @Schema(description = "Parent account id. Omit to create a root account.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
         UUID parentId,
 
+        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
         @Size(max = 500) String description
 ) {
 

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CreateCustomerRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CreateCustomerRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -8,35 +9,45 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Payload to create a customer. The customer code must be unique within the tenant.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCustomerRequest {
 
+        @Schema(description = "Customer code, unique within the tenant.", example = "CUST-0042")
         @NotBlank @Size(max = 30)
         private String code;
 
+        @Schema(description = "Customer name.", example = "Asset Homes Pvt Ltd")
         @NotBlank @Size(max = 200)
         private String name;
 
+        @Schema(description = "GST identification number.", example = "29ABCDE1234F1Z5")
         @Size(max = 15)
         private String gstin;
 
+        @Schema(description = "Permanent account number.", example = "ABCDE1234F")
         @Size(max = 10)
         private String pan;
 
+        @Schema(description = "Contact email address.", example = "accounts@assethomes.example")
         @Email @Size(max = 200)
         private String email;
 
+        @Schema(description = "Contact phone number.", example = "+91 98765 43210")
         @Size(max = 20)
         private String phone;
 
+        @Schema(description = "Billing address.")
         @Valid
         private AddressDto billingAddress;
 
+        @Schema(description = "Credit limit extended to the customer.", example = "500000.00")
         @DecimalMin("0.0")
         private BigDecimal creditLimit;
 
+        @Schema(description = "Default payment terms in days, between 0 and 365.", example = "30")
         @Min(0)
         @Max(365)
         private Integer paymentTermsDays;

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CustomerDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CustomerDto.java
@@ -1,19 +1,44 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Schema(description = "A customer with tax registration, contact and billing details, credit limit and "
+        + "payment terms.")
 public record CustomerDto(
+        @Schema(description = "Unique customer id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Customer code, unique within the tenant.", example = "CUST-0042")
         String code,
+
+        @Schema(description = "Customer name.", example = "Asset Homes Pvt Ltd")
         String name,
+
+        @Schema(description = "GST identification number.", example = "29ABCDE1234F1Z5")
         String gstin,
+
+        @Schema(description = "Permanent account number.", example = "ABCDE1234F")
         String pan,
+
+        @Schema(description = "Contact email address.", example = "accounts@assethomes.example")
         String email,
+
+        @Schema(description = "Contact phone number.", example = "+91 98765 43210")
         String phone,
+
+        @Schema(description = "Billing address.")
         AddressDto billingAddress,
+
+        @Schema(description = "Credit limit extended to the customer.", example = "500000.00")
         BigDecimal creditLimit,
+
+        @Schema(description = "Default payment terms in days.", example = "30")
         Integer paymentTermsDays,
+
+        @Schema(description = "Whether the customer is active.", example = "true")
         boolean active
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
 
 import java.time.Instant;
@@ -7,19 +8,49 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A posted journal entry with its balanced debit and credit lines.")
 public record JournalEntryDto(
+        @Schema(description = "Unique journal entry id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Human-readable entry number assigned by the system.", example = "JE-2026-0042")
         String entryNumber,
+
+        @Schema(description = "Accounting date of the entry.", example = "2026-08-01")
         LocalDate entryDate,
+
+        @Schema(description = "Description of the entry.", example = "Vendor bill CINV-2026-0042 posted")
         String description,
+
+        @Schema(description = "Free-text reference, such as a document number.", example = "CINV-2026-0042")
         String reference,
+
+        @Schema(description = "Status of the entry.", example = "POSTED")
         JournalStatus status,
+
+        @Schema(description = "Id of the entry that reversed this entry, present once it has been reversed.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
         UUID reversedByEntryId,
+
+        @Schema(description = "Id of the entry this entry reverses, present when it is itself a reversal.",
+                example = "1c2f3d44-5a6e-4b7b-8f9a-0c1d2e3f4a5b")
         UUID reversesEntryId,
+
+        @Schema(description = "Type of the source document that generated the entry, if any.",
+                example = "CONSTRUCTION_INVOICE")
         String sourceType,
+
+        @Schema(description = "Id of the source document that generated the entry, if any.",
+                example = "7a1e9b2f-1c44-4e2b-9f0a-2c8d5e6f7a10")
         UUID sourceId,
+
+        @Schema(description = "Debit and credit lines that make up the entry.")
         List<JournalEntryLineDto> lines,
+
+        @Schema(description = "Timestamp the entry was created.", example = "2026-08-01T09:15:00Z")
         Instant createdAt,
+
+        @Schema(description = "User that created the entry.", example = "abin")
         String createdBy
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/JournalEntryLineDto.java
@@ -1,16 +1,34 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Schema(description = "One line of a journal entry, debiting or crediting a single account.")
 public record JournalEntryLineDto(
+        @Schema(description = "Unique line id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
         UUID id,
+
+        @Schema(description = "Id of the account posted to.", example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
         UUID accountId,
+
+        @Schema(description = "Code of the account posted to.", example = "1100")
         String accountCode,
+
+        @Schema(description = "Name of the account posted to.", example = "Cash and Cash Equivalents")
         String accountName,
+
+        @Schema(description = "Debit amount on this line. Zero when the line is a credit.", example = "76275.00")
         BigDecimal debit,
+
+        @Schema(description = "Credit amount on this line. Zero when the line is a debit.", example = "0.00")
         BigDecimal credit,
+
+        @Schema(description = "Optional narration for the line.", example = "Payment received from customer")
         String narration,
+
+        @Schema(description = "Order of the line within the entry, starting at zero.", example = "0")
         int lineOrder
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/PostJournalRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/PostJournalRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -11,16 +12,37 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "Payload to post a journal entry. The lines must balance, with total debits equal to "
+        + "total credits.")
 public record PostJournalRequest(
+        @Schema(description = "Accounting date of the entry.", example = "2026-08-01")
         @NotNull LocalDate entryDate,
+
+        @Schema(description = "Description of the entry.", example = "Vendor bill CINV-2026-0042 posted")
         @NotBlank @Size(max = 500) String description,
+
+        @Schema(description = "Free-text reference, such as a document number.", example = "CINV-2026-0042")
         @Size(max = 100) String reference,
+
+        @Schema(description = "Debit and credit lines. At least two lines are required and they must balance.")
         @NotNull @Size(min = 2, message = "At least 2 lines required") @Valid List<LineRequest> lines
 ) {
+    @Schema(description = "One line of a journal entry to post. A line carries either a debit or a credit, "
+            + "with the other amount set to zero.")
     public record LineRequest(
+            @Schema(description = "Id of the account to post to. Must be an active postable account.",
+                    example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
             @NotNull UUID accountId,
+
+            @Schema(description = "Debit amount for this line. Use zero when the line is a credit.",
+                    example = "76275.00")
             @NotNull @DecimalMin(value = "0.0", inclusive = true) BigDecimal debit,
+
+            @Schema(description = "Credit amount for this line. Use zero when the line is a debit.",
+                    example = "0.00")
             @NotNull @DecimalMin(value = "0.0", inclusive = true) BigDecimal credit,
+
+            @Schema(description = "Optional narration for the line.", example = "Payment received from customer")
             @Size(max = 500) String narration
     ) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
@@ -1,9 +1,13 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Payload to reverse a posted journal entry.")
 public record ReverseJournalRequest(
+        @Schema(description = "Reason the entry is being reversed, recorded on the reversing entry.",
+                example = "Vendor bill cancelled after posting")
         @NotBlank @Size(max = 500) String reason
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/UpdateCustomerRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/UpdateCustomerRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.ledger.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -8,33 +9,43 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Payload to update a customer. The customer code is fixed at creation and is not "
+        + "changed here.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateCustomerRequest {
+        @Schema(description = "Customer name.", example = "Asset Homes Pvt Ltd")
         @NotBlank
         @Size(max = 200)
         private String name;
 
+        @Schema(description = "GST identification number.", example = "29ABCDE1234F1Z5")
         @Size(max = 15)
         private String gstin;
 
+        @Schema(description = "Permanent account number.", example = "ABCDE1234F")
         @Size(max = 10)
         private String pan;
 
+        @Schema(description = "Contact email address.", example = "accounts@assethomes.example")
         @Email
         @Size(max = 200)
         private String email;
 
+        @Schema(description = "Contact phone number.", example = "+91 98765 43210")
         @Size(max = 20)
         private String phone;
 
+        @Schema(description = "Billing address.")
         @Valid
         private AddressDto billingAddress;
 
+        @Schema(description = "Credit limit extended to the customer.", example = "500000.00")
         @DecimalMin("0.0")
         private BigDecimal creditLimit;
 
+        @Schema(description = "Default payment terms in days, between 0 and 365.", example = "30")
         @Min(0)
         @Max(365)
         private Integer paymentTermsDays;

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.ledger.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +23,13 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/accounts/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Ledger Accounts",
+        description = "Chart of accounts for double-entry bookkeeping. Accounts are arranged in a "
+                + "hierarchy under the five root types (asset, liability, equity, income, expense), and "
+                + "only leaf accounts are postable. All endpoints are tenant scoped and limited to system "
+                + "administrators and project managers, apart from the default seed, which is admin only."
+)
 public class AccountControllerWeb {
 
     private final AccountService service;
@@ -26,36 +37,95 @@ public class AccountControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List accounts",
+            description = "Returns the flat list of accounts in the current tenant. By default only active "
+                    + "accounts are returned; set activeOnly to false to include deactivated accounts."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of accounts"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public List<AccountDto> list(@RequestParam(defaultValue = "true") boolean activeOnly) {
         return activeOnly ? service.findAllActiveAccounts() : service.findAllAccounts();
     }
 
     @GetMapping("/tree")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get the chart of accounts as a tree",
+            description = "Returns the accounts of the current tenant as a nested tree rooted at the five "
+                    + "account types, with each account carrying its child accounts."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Account tree"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public List<AccountTreeDto> tree() {
         return service.findAccountTree();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get an account by id",
+            description = "Returns a single account by its unique id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Account found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No account with the given id in the current tenant")
+    })
     public AccountDto get(@PathVariable UUID id) {
         return service.findAccountById(id);
     }
 
     @GetMapping("/by-code/{code}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get an account by code",
+            description = "Returns a single account by its account code, which is unique within the tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Account found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No account with the given code in the current tenant")
+    })
     public AccountDto getByCode(@PathVariable String code) {
         return service.findByAccountByCode(code);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create an account",
+            description = "Creates a new account in the chart. When a parent is given, the account type is "
+                    + "inherited from the parent; a root account must declare its own type. When the code is "
+                    + "left blank it is generated from the parent and existing sibling accounts."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Account created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "The referenced parent account does not exist")
+    })
     public ResponseEntity<AccountDto> create(@Valid @RequestBody CreateAccountRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PostMapping("/{id}/deactivate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Deactivate an account",
+            description = "Marks an account inactive so it can no longer be used on new journal entries. "
+                    + "Existing entries that reference the account are left unchanged."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Account deactivated"),
+            @ApiResponse(responseCode = "400", description = "Account cannot be deactivated in its current state"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No account with the given id in the current tenant")
+    })
     public AccountDto deactivate(@PathVariable UUID id) {
         return service.deactivate(id);
     }
@@ -67,6 +137,17 @@ public class AccountControllerWeb {
      */
     @PostMapping("/seed-defaults")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Seed the default chart of accounts",
+            description = "Creates the default chart of accounts for the current tenant. The operation is "
+                    + "idempotent: a tenant that already has a chart is left untouched, so it can safely "
+                    + "back-fill an organization created before seeding was wired in. Returns the number of "
+                    + "accounts created. Restricted to system administrators."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Seed complete, returns the count of accounts created"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant")
+    })
     public Map<String, Integer> seedDefaults() {
         return Map.of("created", chartOfAccountsSeeder.seedDefaults());
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/CustomerControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/CustomerControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.ledger.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,36 +23,91 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/customers/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Customers",
+        description = "Customers billed by the ledger, holding their tax registration, contact and billing "
+                + "details along with a credit limit and payment terms. All endpoints are tenant scoped and "
+                + "limited to system administrators and project managers."
+)
 public class CustomerControllerWeb {
 
     private final CustomerService service;
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Search customers",
+            description = "Returns a page of customers in the current tenant. The optional name parameter "
+                    + "filters by customer name; omitting it returns all customers, subject to paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of matching customers"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public List<CustomerDto> list(@RequestParam(required = false) String name, Pageable pageable) {
         return service.search(name, pageable).getContent();
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a customer by id",
+            description = "Returns a single customer, including the billing address, by its unique id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Customer found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No customer with the given id in the current tenant")
+    })
     public CustomerDto get(@RequestParam UUID id) {
         return service.findById(id);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a customer",
+            description = "Creates a new customer from the supplied details. The customer code must be "
+                    + "unique within the tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Customer created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<CustomerDto> create(@Valid @RequestBody CreateCustomerRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update a customer",
+            description = "Updates the editable details of an existing customer. The customer code is fixed "
+                    + "at creation and is not changed here."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Customer updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No customer with the given id in the current tenant")
+    })
     public CustomerDto update(@PathVariable UUID id, @Valid @RequestBody UpdateCustomerRequest req) {
         return service.update(id, req);
     }
 
     @PostMapping("/{id}/deactivate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Deactivate a customer",
+            description = "Marks a customer inactive so it can no longer be selected on new documents. "
+                    + "Existing records that reference the customer are left unchanged."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Customer deactivated"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No customer with the given id in the current tenant")
+    })
     public ResponseEntity<Void> deactivate(@PathVariable UUID id) {
         service.deactivate(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.ledger.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,24 +22,61 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/journal-entries/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Journal Entries",
+        description = "Double-entry journal entries posted to the ledger. Each entry carries two or more "
+                + "lines whose total debits must equal total credits. A posted entry is immutable and can "
+                + "only be undone by posting a reversing entry. All endpoints are tenant scoped and limited "
+                + "to system administrators and project managers."
+)
 public class JournalEntryControllerWeb {
 
     private final JournalPostingService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Post a journal entry",
+            description = "Posts a balanced journal entry to the ledger. The supplied lines must balance, "
+                    + "with total debits equal to total credits, and every referenced account must be an "
+                    + "active postable account. The entry number is assigned by the system."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Journal entry posted"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, or the entry does not balance"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "A referenced account does not exist in the current tenant")
+    })
     public ResponseEntity<JournalEntryDto> post(@Valid @RequestBody PostJournalRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.post(req));
     }
 
     @GetMapping()
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a journal entry by id",
+            description = "Returns a single journal entry, including its lines, by its unique id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Journal entry found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No journal entry with the given id in the current tenant")
+    })
     public JournalEntryDto get(@RequestParam UUID id) {
         return service.findById(id);
     }
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List journal entries",
+            description = "Returns a page of journal entries in the current tenant. Use pageNo and pageSize "
+                    + "to page through the results."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of journal entries"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<JournalEntryDto>> getAll(@RequestParam(defaultValue = "0") int pageNo,
                                         @RequestParam(defaultValue = "10") int pageSize) {
         Page<JournalEntryDto> journalEntries = service.findAll(pageNo,pageSize);
@@ -44,6 +85,18 @@ public class JournalEntryControllerWeb {
 
     @PostMapping("/reverse")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Reverse a journal entry",
+            description = "Posts a reversing entry that negates the original entry, swapping its debits and "
+                    + "credits, and records the supplied reason. The original entry is left in place and "
+                    + "linked to its reversal. An entry that has already been reversed cannot be reversed again."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Reversing entry posted"),
+            @ApiResponse(responseCode = "400", description = "Entry cannot be reversed, for example it is already reversed"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No journal entry with the given id in the current tenant")
+    })
     public ResponseEntity<JournalEntryDto> reverse(
             @RequestParam UUID id,
             @Valid @RequestBody ReverseJournalRequest req) {

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/PaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/PaymentDto.java
@@ -1,19 +1,70 @@
 package org.tornotron.echno_backend.finance.payment.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A payment received from a customer, with the amount allocated across their invoices.")
 public record PaymentDto(
-        UUID id, String paymentNumber,
-        UUID customerId, String customerName,
-        LocalDate paymentDate, BigDecimal amount,
-        UUID companyBankAccountId, String bankName, String bankAccountNumber,
-        String externalReference, UUID journalEntryId, String notes,
+        @Schema(description = "Unique payment id.", example = "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+        UUID id,
+
+        @Schema(description = "Human-readable payment number assigned by the system.", example = "PMT-2026-0031")
+        String paymentNumber,
+
+        @Schema(description = "Customer the payment was received from.",
+                example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+        UUID customerId,
+
+        @Schema(description = "Customer name captured on the payment.", example = "Asset Homes Pvt Ltd")
+        String customerName,
+
+        @Schema(description = "Date the payment was received.", example = "2026-08-10")
+        LocalDate paymentDate,
+
+        @Schema(description = "Total amount received.", example = "20000.00")
+        BigDecimal amount,
+
+        @Schema(description = "Company bank account the payment was deposited into.",
+                example = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")
+        UUID companyBankAccountId,
+
+        @Schema(description = "Name of the receiving bank.", example = "HDFC Bank")
+        String bankName,
+
+        @Schema(description = "Receiving bank account number.", example = "50100123456789")
+        String bankAccountNumber,
+
+        @Schema(description = "External reference for the payment, such as a UTR or cheque number.",
+                example = "UTR2026081012345")
+        String externalReference,
+
+        @Schema(description = "Ledger journal entry posted for the receipt.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID journalEntryId,
+
+        @Schema(description = "Internal notes.", example = "Part payment against August invoices")
+        String notes,
+
+        @Schema(description = "How the payment amount was allocated across invoices.")
         List<AllocationDto> allocations
 ) {
+    @Schema(description = "Allocation of part of a payment to a single invoice.")
     public record AllocationDto(
-            UUID id, UUID invoiceId, String invoiceNumber, BigDecimal allocatedAmount
+            @Schema(description = "Unique allocation id.", example = "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80")
+            UUID id,
+
+            @Schema(description = "Invoice the amount was applied to.",
+                    example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+            UUID invoiceId,
+
+            @Schema(description = "Number of the invoice the amount was applied to.", example = "INV-2026-0042")
+            String invoiceNumber,
+
+            @Schema(description = "Amount of the payment applied to this invoice.", example = "12000.00")
+            BigDecimal allocatedAmount
     ) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/RecordPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/dtos/RecordPaymentRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.finance.payment.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
@@ -10,17 +11,40 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "Payload to record a customer payment and allocate it across outstanding invoices. "
+        + "The allocations must sum to the payment amount.")
 public record RecordPaymentRequest(
+        @Schema(description = "Customer the payment was received from.",
+                example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
         @NotNull UUID customerId,
+
+        @Schema(description = "Date the payment was received.", example = "2026-08-10")
         @NotNull LocalDate paymentDate,
+
+        @Schema(description = "Total amount received. Must be greater than zero.", example = "20000.00")
         @NotNull @DecimalMin(value = "0.0001") BigDecimal amount,
+
+        @Schema(description = "Company bank account the payment was deposited into.",
+                example = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")
         @NotNull UUID companyBankAccountId,
+
+        @Schema(description = "External reference for the payment, such as a UTR or cheque number.",
+                example = "UTR2026081012345")
         @Size(max = 100) String externalReference,
+
+        @Schema(description = "Internal notes.", example = "Part payment against August invoices")
         @Size(max = 500) String notes,
+
+        @Schema(description = "How to allocate the amount across invoices. At least one allocation is required.")
         @NotNull @Size(min = 1) @Valid List<AllocationRequest> allocations
 ) {
+    @Schema(description = "Allocation of part of the payment to a single invoice.")
     public record AllocationRequest(
+            @Schema(description = "Invoice to apply the amount to.",
+                    example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
             @NotNull UUID invoiceId,
+
+            @Schema(description = "Amount to apply to this invoice. Must be greater than zero.", example = "12000.00")
             @NotNull @DecimalMin(value = "0.0001") BigDecimal allocatedAmount
     ) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/web/PaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/web/PaymentControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.payment.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,12 +19,32 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/payments/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Customer Payments",
+        description = "Payments received from customers and allocated across their outstanding invoices. "
+                + "Recording a payment posts the receipt to the ledger and reduces the balance due on each "
+                + "allocated invoice. All endpoints are tenant scoped and limited to system administrators "
+                + "and project managers."
+)
 public class PaymentControllerWeb {
 
     private final PaymentService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Record a customer payment",
+            description = "Records a payment received from a customer and allocates it across the invoices "
+                    + "named in the request. The allocations must sum to the payment amount. An optional "
+                    + "Idempotency-Key header lets a retried request return the original result instead of "
+                    + "creating a duplicate payment."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Payment recorded and allocated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, or the allocations do not reconcile with the amount or the invoice balances"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "A referenced customer, bank account or invoice was not found in the current tenant")
+    })
     public ResponseEntity<PaymentDto> record(
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody RecordPaymentRequest req
@@ -30,6 +54,15 @@ public class PaymentControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a payment by id",
+            description = "Returns a single customer payment with its invoice allocations."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No payment with the given id in the current tenant")
+    })
     public PaymentDto get(@PathVariable UUID id) {
         return service.findById(id);
     }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.goodsReceivedNote;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +22,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/grns")
 @Validated
+@Tag(
+        name = "Goods Received Notes",
+        description = "Goods received notes (GRNs) record the receipt of materials from a vendor against "
+                + "a purchase order. Each GRN carries the vendor, project, storage location, delivery and "
+                + "invoice references and a list of received line items with ordered and received "
+                + "quantities. Creating a GRN posts the received quantities into stock. Endpoints require "
+                + "the matching grn create, read, update or admin authority."
+)
 public class GoodsReceivedNoteController {
 
     private final GoodsReceivedNoteService goodsReceivedNoteService;
@@ -28,6 +40,17 @@ public class GoodsReceivedNoteController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('grn:create') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "Create a goods received note",
+            description = "Records a goods receipt from a vendor with its line items. The received "
+                    + "quantities are posted into stock at the given storage location as GRN transactions."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "GRN created and returned"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn create or admin authority"),
+            @ApiResponse(responseCode = "404", description = "A referenced vendor, project, storage location or material was not found")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> createGrn(@Valid @RequestBody GoodsReceivedNoteCreationDto creationDto) {
         GoodsReceivedNoteDto created = goodsReceivedNoteService.createGoodsReceivedNote(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -35,6 +58,15 @@ public class GoodsReceivedNoteController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "Get a goods received note by id",
+            description = "Returns a single GRN with its header details and received line items."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GRN found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No GRN with the given id")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> getGrnById(@PathVariable Long id) {
         GoodsReceivedNoteDto grn = goodsReceivedNoteService.getGrnById(id);
         return ResponseEntity.ok(grn);
@@ -42,6 +74,15 @@ public class GoodsReceivedNoteController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "List all goods received notes",
+            description = "Returns every GRN as an unpaged list. Use the paginated variant for large "
+                    + "result sets."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of GRNs"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getAllGrns() {
         List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns();
         return ResponseEntity.ok(grns);
@@ -49,6 +90,15 @@ public class GoodsReceivedNoteController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "List goods received notes (paginated)",
+            description = "Returns a page of GRNs. The pageNo and pageSize parameters control the slice "
+                    + "returned."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of GRNs"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
+    })
     public ResponseEntity<Page<GoodsReceivedNoteDto>> getAllGrnsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -59,6 +109,14 @@ public class GoodsReceivedNoteController {
 
     @GetMapping("/vendor/{vendorId}")
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "List goods received notes for a vendor",
+            description = "Returns every GRN recorded against the given vendor."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of GRNs for the vendor"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getGrnsByVendor(@PathVariable Long vendorId) {
         List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getGrnsByVendor(vendorId);
         return ResponseEntity.ok(grns);
@@ -66,6 +124,18 @@ public class GoodsReceivedNoteController {
 
     @PatchMapping
     @PreAuthorize("hasAuthority('grn:update') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "Update a goods received note",
+            description = "Updates the editable header fields of an existing GRN (receipt date, receiver, "
+                    + "delivery challan, invoice details and storage location). The GRN to update is "
+                    + "identified by the id in the request body. Line items are not changed here."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GRN updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn update or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No GRN with the given id")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> updateGrn(@Valid @RequestBody GoodsReceivedNoteUpdateDto updateDto) {
         GoodsReceivedNoteDto updated = goodsReceivedNoteService.updateGoodsReceivedNote(updateDto);
         return ResponseEntity.ok(updated);
@@ -73,6 +143,16 @@ public class GoodsReceivedNoteController {
 
     @GetMapping("/date-range")
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
+    @Operation(
+            summary = "List goods received notes in a date range",
+            description = "Returns GRNs whose received date falls between the startDate and endDate "
+                    + "parameters (both ISO date-time values)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of GRNs in the range"),
+            @ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid ISO date-time"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getGrnsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.goodsReceivedNote.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -11,36 +12,49 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
+@Schema(description = "Payload to record a goods received note. The received quantities on the items are "
+        + "posted into stock at the given storage location.")
 public class GoodsReceivedNoteCreationDto {
 
+    @Schema(description = "Goods received note number, unique within the tenant.", example = "GRN-2026-0042")
     @NotBlank(message = "GRN number is required")
     @Size(min = 1, max = 50, message = "GRN number must be between 1 and 50 characters")
     private String grnNumber;
 
+    @Schema(description = "When the goods were received.", example = "2026-08-01T10:30:00")
     @NotNull(message = "received on date is required")
     private LocalDateTime receivedOn;
 
+    @Schema(description = "Employee who received the goods.", example = "15")
     @NotNull(message = "received by username is required")
     private Long receivedByEmployeeId;
 
+    @Schema(description = "Vendor the goods were received from.", example = "17")
     @NotNull(message = "vendor ID is required")
     private Long vendorId;
 
+    @Schema(description = "Purchase order the receipt is matched against, if any.", example = "108")
     private Long purchaseOrderId;
 
+    @Schema(description = "Vendor delivery challan number.", example = "DC-88213")
     @Size(max = 50, message = "delivery challan number must not exceed 50 characters")
     private String deliveryChallanNumber;
 
+    @Schema(description = "Vendor invoice number for the receipt, if supplied.", example = "INV-5567")
     @Size(max = 50, message = "invoice number must not exceed 50 characters")
     private String invoiceNumber;
 
+    @Schema(description = "Vendor invoice amount for the receipt, if supplied.", example = "41475.00")
     private Double invoiceAmount;
 
+    @Schema(description = "Project the goods are received for.", example = "42")
     @NotNull(message = "project ID is required")
     private Long projectId;
 
+    @Schema(description = "Storage location the received quantities are booked into.", example = "7")
     private Long storageLocationId;
 
+    @Schema(description = "Received line items. At least one item is required.")
     @NotEmpty(message = "items list cannot be empty")
     @Valid
     private List<GrnItemDto> items;

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.goodsReceivedNote.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.user.dto.UserDto;
@@ -8,22 +9,54 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
+@Schema(description = "A goods received note with its vendor, project, storage location and received line items.")
 public class GoodsReceivedNoteDto {
 
+    @Schema(description = "Unique GRN id.", example = "231")
     private Long id;
+
+    @Schema(description = "Goods received note number.", example = "GRN-2026-0042")
     private String grnNumber;
+
+    @Schema(description = "When the goods were received.", example = "2026-08-01T10:30:00")
     private LocalDateTime receivedOn;
+
+    @Schema(description = "Employee who received the goods.")
     private EmployeeDto receivedBy;
+
+    @Schema(description = "Vendor the goods were received from.", example = "17")
     private Long vendorId;
+
+    @Schema(description = "Vendor name.", example = "Ambuja Cements Ltd")
     private String vendorName;
+
+    @Schema(description = "Purchase order the receipt is matched against, if any.", example = "108")
     private Long purchaseOrderId;
+
+    @Schema(description = "Purchase order number, if matched.", example = "PO-2026-0311")
     private String purchaseOrderNumber;
+
+    @Schema(description = "Vendor delivery challan number.", example = "DC-88213")
     private String deliveryChallanNumber;
+
+    @Schema(description = "Vendor invoice number for the receipt, if supplied.", example = "INV-5567")
     private String invoiceNumber;
+
+    @Schema(description = "Vendor invoice amount for the receipt, if supplied.", example = "41475.00")
     private Double invoiceAmount;
+
+    @Schema(description = "Project the goods were received for.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Project name.", example = "Tower B fit-out")
     private String projectName;
+
+    @Schema(description = "Storage location the received quantities were booked into.", example = "7")
     private Long storageLocationId;
+
+    @Schema(description = "Storage location name.", example = "Site A main store")
     private String storageLocationName;
+
+    @Schema(description = "Received line items.")
     private List<GrnItemDto> items;
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteUpdateDto.java
@@ -1,25 +1,35 @@
 package org.tornotron.echno_backend.goodsReceivedNote.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
+@Schema(description = "Payload to update the editable header fields of an existing goods received note. "
+        + "Line items are not changed through this payload.")
 public class GoodsReceivedNoteUpdateDto {
 
+    @Schema(description = "Id of the GRN to update.", example = "231")
     @NotNull(message = "GRN ID is required")
     private Long id;
 
+    @Schema(description = "Revised receipt date.", example = "2026-08-01T10:30:00")
     private LocalDateTime receivedOn;
 
+    @Schema(description = "Revised receiving employee.", example = "15")
     private Long receivedByEmployeeId;
 
+    @Schema(description = "Revised delivery challan number.", example = "DC-88213")
     private String deliveryChallanNumber;
 
+    @Schema(description = "Revised vendor invoice number.", example = "INV-5567")
     private String invoiceNumber;
 
+    @Schema(description = "Revised vendor invoice amount.", example = "41475.00")
     private Double invoiceAmount;
 
+    @Schema(description = "Revised storage location.", example = "7")
     private Long storageLocationId;
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GrnItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GrnItemDto.java
@@ -1,27 +1,36 @@
 package org.tornotron.echno_backend.goodsReceivedNote.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import java.math.BigDecimal;
 
 @Data
+@Schema(description = "A single line on a goods received note: the material received with its ordered and "
+        + "received quantities and unit cost.")
 public class GrnItemDto {
 
+    @Schema(description = "Line id. Present on returned lines, omit when creating a GRN.", example = "902")
     private Long id;
 
+    @Schema(description = "Material received on this line.", example = "310")
     @NotNull(message = "material ID is required")
     private Long materialId;
 
+    @Schema(description = "Material name.", example = "Portland Cement 53 grade")
     private String materialName;
 
+    @Schema(description = "Quantity ordered for this material.", example = "100")
     @NotNull(message = "ordered quantity is required")
     @Min(value = 0, message = "ordered quantity must be at least 0")
     private Integer orderedQuantity;
 
+    @Schema(description = "Quantity actually received. This amount is posted into stock.", example = "95")
     @NotNull(message = "received quantity is required")
     @Min(value = 0, message = "received quantity must be at least 0")
     private Integer receivedQuantity;
 
+    @Schema(description = "Unit cost of the received material.", example = "395.00")
     private BigDecimal unitCost;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.inventoryTransaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +22,16 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/inventory-transactions")
 @Validated
+@Tag(
+        name = "Inventory Transactions",
+        description = "Read access to the inventory transaction ledger and derived stock positions. "
+                + "Every stock movement (goods receipt, consumption, transfer between storage locations, "
+                + "adjustment or opening balance) is recorded as a transaction that carries the opening, "
+                + "changed and closing quantity for a material. These endpoints query the ledger by "
+                + "material, project, task, storage location, transaction type or date range, and roll it "
+                + "up into current stock by location and material. All endpoints require the "
+                + "inventory-transaction read or admin authority."
+)
 public class InventoryTransactionController {
 
     private final InventoryTransactionService inventoryTransactionService;
@@ -31,6 +45,16 @@ public class InventoryTransactionController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "Get an inventory transaction by id",
+            description = "Returns a single inventory transaction, including its opening, changed and "
+                    + "closing quantities and the material, project, task and storage location it applies to."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Transaction found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No transaction with the given id")
+    })
     public ResponseEntity<InventoryTransactionDto> getTransactionById(@PathVariable Long id) {
         InventoryTransactionDto transaction = inventoryTransactionService.getTransactionById(id);
         return ResponseEntity.ok(transaction);
@@ -38,6 +62,15 @@ public class InventoryTransactionController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List all inventory transactions",
+            description = "Returns every inventory transaction as an unpaged list. Use the paginated "
+                    + "variant for large ledgers."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getAllTransactions() {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions();
         return ResponseEntity.ok(transactions);
@@ -45,6 +78,15 @@ public class InventoryTransactionController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List inventory transactions (paginated)",
+            description = "Returns a page of inventory transactions ordered by the service default. "
+                    + "The pageNo and pageSize parameters control the slice returned."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of transactions"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<Page<InventoryTransactionDto>> getAllTransactionsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -55,6 +97,15 @@ public class InventoryTransactionController {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions for a material",
+            description = "Returns every stock movement recorded for the given material across all "
+                    + "projects and storage locations."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions for the material"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByMaterial(@PathVariable Long materialId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByMaterial(materialId);
         return ResponseEntity.ok(transactions);
@@ -62,6 +113,14 @@ public class InventoryTransactionController {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions for a project",
+            description = "Returns every inventory transaction booked against the given project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions for the project"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByProject(@PathVariable Long projectId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByProject(projectId);
         return ResponseEntity.ok(transactions);
@@ -69,6 +128,16 @@ public class InventoryTransactionController {
 
     @GetMapping("/type/{transactionType}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions by type",
+            description = "Returns transactions of a single movement type, for example GRN (goods received), "
+                    + "USE (consumption), TRANSFER_OUT, TRANSFER_IN, ADJUST or OPENING_BALANCE."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions of the given type"),
+            @ApiResponse(responseCode = "400", description = "The path value is not a recognised transaction type"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByType(@PathVariable InventoryTransactionType transactionType) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByType(transactionType);
         return ResponseEntity.ok(transactions);
@@ -76,6 +145,16 @@ public class InventoryTransactionController {
 
     @GetMapping("/date-range")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions in a date range",
+            description = "Returns transactions whose transaction date falls between the startDate and "
+                    + "endDate parameters (both ISO date-time values)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions in the range"),
+            @ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid ISO date-time"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
@@ -86,6 +165,14 @@ public class InventoryTransactionController {
 
     @GetMapping("/storage-location/{storageLocationId}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions for a storage location",
+            description = "Returns every stock movement recorded at the given storage location."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions for the storage location"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByStorageLocation(
             @PathVariable Long storageLocationId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByStorageLocation(storageLocationId);
@@ -94,6 +181,16 @@ public class InventoryTransactionController {
 
     @GetMapping("/storage-location/{storageLocationId}/stock")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "Get current stock at a storage location",
+            description = "Rolls up the transaction ledger into the current stock held at the given "
+                    + "storage location, broken down by material with per-material quantity and value "
+                    + "and the location totals."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current stock for the storage location"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<InventoryMaterialStockDto> getStockByStorageLocation(
             @PathVariable Long storageLocationId) {
         InventoryMaterialStockDto stock = inventoryService.getStockByStorageLocation(storageLocationId);
@@ -102,6 +199,16 @@ public class InventoryTransactionController {
 
     @GetMapping("/material/{materialId}/stock")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "Get current stock for a material",
+            description = "Rolls up the transaction ledger into the current stock of the given material, "
+                    + "broken down by storage location with per-location quantity and value and the "
+                    + "material totals."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current stock for the material"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<MaterialLocationStockDto> getStockByMaterial(
             @PathVariable Long materialId) {
         MaterialLocationStockDto stock = inventoryService.getStockByMaterial(materialId);
@@ -110,6 +217,15 @@ public class InventoryTransactionController {
 
     @GetMapping("/task/{taskId}")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "List transactions for a task",
+            description = "Returns the stock movements booked against the given task, typically the "
+                    + "material consumed while working on it."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of transactions for the task"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByTask(@PathVariable Long taskId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByTask(taskId);
         return ResponseEntity.ok(transactions);
@@ -117,6 +233,15 @@ public class InventoryTransactionController {
 
     @GetMapping("/project/{projectId}/task-summary")
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "Get material usage per task for a project",
+            description = "Summarises consumption across the given project grouped by task: for each task "
+                    + "the materials used with their quantity and cost, plus the task totals."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Per-task material usage summary for the project"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
     public ResponseEntity<List<TaskMaterialUsageDto>> getTaskMaterialUsageSummary(@PathVariable Long projectId) {
         List<TaskMaterialUsageDto> summary = inventoryTransactionService.getTaskMaterialUsageSummary(projectId);
         return ResponseEntity.ok(summary);

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/InventoryMaterialStockDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/InventoryMaterialStockDto.java
@@ -1,16 +1,30 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Data
+@Schema(description = "Current stock held at a single storage location, broken down by material with the "
+        + "location totals.")
 public class InventoryMaterialStockDto {
+    @Schema(description = "Storage location id.", example = "7")
     private Long storageLocationId;
+
+    @Schema(description = "Storage location name.", example = "Site A main store")
     private String storageLocationName;
+
+    @Schema(description = "Project the storage location belongs to.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Per-material stock lines held at this location.")
     private List<StockDto> materialStock;
+
+    @Schema(description = "Total quantity on hand across all materials at this location.", example = "265.0")
     private Double totalStock;
+
+    @Schema(description = "Total value of stock on hand at this location.", example = "108900.00")
     private BigDecimal totalStockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/InventoryTransactionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/InventoryTransactionDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
@@ -8,24 +9,66 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Data
+@Schema(description = "A single inventory transaction: one stock movement of a material, carrying the "
+        + "opening, changed and closing quantity along with the project, task and storage location it "
+        + "applies to.")
 public class InventoryTransactionDto {
 
+    @Schema(description = "Unique transaction id.", example = "5012")
     private Long id;
+
+    @Schema(description = "When the movement was recorded.", example = "2026-08-01T10:30:00")
     private LocalDateTime transactionDate;
+
+    @Schema(description = "Material that moved.", example = "310")
     private Long materialId;
+
+    @Schema(description = "Material name at the time of the movement.", example = "Portland Cement 53 grade")
     private String materialName;
+
+    @Schema(description = "Stock on hand before this movement.", example = "120.0")
     private Double openingStock;
+
+    @Schema(description = "Signed change applied by this movement. Positive for stock in, negative for stock out.",
+            example = "-15.0")
     private Double quantityChanged;
+
+    @Schema(description = "Stock on hand after this movement.", example = "105.0")
     private Double closingStock;
+
+    @Schema(description = "Movement type, for example GRN, USE, TRANSFER_OUT, TRANSFER_IN, ADJUST or OPENING_BALANCE.",
+            example = "USE")
     private InventoryTransactionType transactionType;
+
+    @Schema(description = "Source document reference for the movement, for example a GRN or challan number.",
+            example = "GRN-2026-0042")
     private String referenceNumber;
+
+    @Schema(description = "Free-text remarks about the movement.", example = "Issued to slab casting crew")
     private String remarks;
+
+    @Schema(description = "Project the movement is booked against.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Project name.", example = "Tower B fit-out")
     private String projectName;
+
+    @Schema(description = "Storage location the movement applies to.", example = "7")
     private Long storageLocationId;
+
+    @Schema(description = "Storage location name.", example = "Site A main store")
     private String storageLocationName;
+
+    @Schema(description = "Task the movement is booked against, when the movement is task consumption.",
+            example = "884")
     private Long taskId;
+
+    @Schema(description = "Task title.", example = "Second floor slab casting")
     private String taskTitle;
+
+    @Schema(description = "Employee who recorded the movement.")
     private EmployeeDto createdBy;
+
+    @Schema(description = "Unit cost applied to the moved quantity.", example = "395.00")
     private BigDecimal unitCost;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/LocationStockDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/LocationStockDto.java
@@ -1,14 +1,28 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import java.math.BigDecimal;
 
 @Data
+@Schema(description = "Current stock of one material held at a single storage location, with its on-hand "
+        + "quantity and value.")
 public class LocationStockDto {
+    @Schema(description = "Storage location id.", example = "7")
     private Long storageLocationId;
+
+    @Schema(description = "Storage location name.", example = "Site A main store")
     private String storageLocationName;
+
+    @Schema(description = "Project the stock at this location belongs to.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Project name.", example = "Tower B fit-out")
     private String projectName;
+
+    @Schema(description = "Quantity on hand at this location.", example = "60.0")
     private Double stock;
+
+    @Schema(description = "Value of the on-hand quantity at this location.", example = "23700.00")
     private BigDecimal stockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialLocationStockDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialLocationStockDto.java
@@ -1,15 +1,27 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Data
+@Schema(description = "Current stock of a single material, broken down by the storage locations that hold "
+        + "it with the material totals.")
 public class MaterialLocationStockDto {
+    @Schema(description = "Material id.", example = "310")
     private Long materialId;
+
+    @Schema(description = "Material name.", example = "Portland Cement 53 grade")
     private String materialName;
+
+    @Schema(description = "Per-location stock lines for this material.")
     private List<LocationStockDto> locationStock;
+
+    @Schema(description = "Total quantity on hand across all locations.", example = "105.0")
     private Double totalStock;
+
+    @Schema(description = "Total value of stock on hand across all locations.", example = "41475.00")
     private BigDecimal totalStockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/StockDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/StockDto.java
@@ -1,13 +1,24 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import java.math.BigDecimal;
 
 @Data
+@Schema(description = "Current stock of one material at a storage location, with its on-hand quantity and value.")
 public class StockDto {
+    @Schema(description = "Material name.", example = "Portland Cement 53 grade")
     private String materialName;
+
+    @Schema(description = "Material id.", example = "310")
     private Long materialId;
+
+    @Schema(description = "Unit of measure the quantity is expressed in.", example = "bag")
     private String unit;
+
+    @Schema(description = "Quantity on hand.", example = "105.0")
     private Double stock;
+
+    @Schema(description = "Value of the on-hand quantity.", example = "41475.00")
     private BigDecimal stockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/TaskMaterialUsageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/TaskMaterialUsageDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inventoryTransaction.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,22 +11,43 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Material consumption rolled up for a single task: the materials used with their "
+        + "quantity and cost, plus the task totals.")
 public class TaskMaterialUsageDto {
 
+    @Schema(description = "Task id.", example = "884")
     private Long taskId;
+
+    @Schema(description = "Task title.", example = "Second floor slab casting")
     private String taskTitle;
+
+    @Schema(description = "Per-material usage lines for this task.")
     private List<MaterialUsageItem> materials;
+
+    @Schema(description = "Total quantity consumed across all materials on this task.", example = "180.0")
     private Double totalQuantityUsed;
+
+    @Schema(description = "Total cost of material consumed on this task.", example = "71100.00")
     private BigDecimal totalCost;
 
+    @Schema(description = "Consumption of one material on the task, with quantity and cost.")
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MaterialUsageItem {
+        @Schema(description = "Material id.", example = "310")
         private Long materialId;
+
+        @Schema(description = "Material name.", example = "Portland Cement 53 grade")
         private String materialName;
+
+        @Schema(description = "Unit of measure the quantity is expressed in.", example = "bag")
         private String unit;
+
+        @Schema(description = "Quantity of this material consumed on the task.", example = "45.0")
         private Double totalQuantityUsed;
+
+        @Schema(description = "Cost of this material consumed on the task.", example = "17775.00")
         private BigDecimal totalCost;
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +33,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/project")
 @Validated
+@Tag(
+        name = "Projects",
+        description = "Construction projects and their team assignments. Endpoints cover creating a "
+                + "project with attachments, browsing and reading projects, batch updates, deletion, "
+                + "and adding or removing the employees assigned to a project. Access is gated by the "
+                + "project authorities, with an admin authority that grants all operations."
+)
 public class ProjectController {
 
     private final ProjectService service;
@@ -53,6 +63,17 @@ public class ProjectController {
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('project:create') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Create a project",
+            description = "Creates a project from a multipart request. The data part carries the project "
+                    + "details as JSON and the optional attachments part carries supporting files. "
+                    + "Returns the created project as a simple view without its tasks or team."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Project created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project create or admin authority")
+    })
     public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") @Valid String data,
                                                           @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         ProjectCreationDto dto = new ObjectMapper().readValue(data, ProjectCreationDto.class);
@@ -69,6 +90,15 @@ public class ProjectController {
      */
     @GetMapping
     @PreAuthorize("hasAuthority('project:read') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "List projects",
+            description = "Returns a single page of projects. The pageNo and pageSize parameters control "
+                    + "paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of projects returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project read or admin authority")
+    })
     public ResponseEntity<List<ProjectDto>> readAllProjects(@RequestParam(defaultValue = "0") int pageNo,
                                                                  @RequestParam(defaultValue = "10") int pageSize) {
           Page<ProjectDto> projects = service.getAllProjects(pageNo,pageSize);
@@ -84,6 +114,15 @@ public class ProjectController {
      */
     @GetMapping("{id}")
     @PreAuthorize("hasAuthority('project:read') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Get a project by id",
+            description = "Returns a single project including its team, tasks, attachments and progress."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<?> readAProject(@PathVariable Long id) {
         ProjectDto project = service.getAProject(id);
         return new ResponseEntity<>(project,HttpStatus.OK);
@@ -111,6 +150,16 @@ public class ProjectController {
      */
     @PatchMapping("/batch")
     @PreAuthorize("hasAuthority('project:update') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Batch update projects",
+            description = "Applies partial updates to several projects in one call. Each entry names a "
+                    + "project id and the map of fields to change on that project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project update or admin authority")
+    })
     public ResponseEntity<ApiResponse> batchUpdateProjects(@Valid @RequestBody List<ProjectPatchDto> updates) {
         service.batchUpdateProjects(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -124,6 +173,15 @@ public class ProjectController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('project:delete') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Delete a project",
+            description = "Deletes the project with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteProject(@PathVariable Long id) {
         service.deleteAProject(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Project with id: "+id+" has been deleted"));
@@ -137,6 +195,15 @@ public class ProjectController {
      */
     @GetMapping("{id}/organization")
     @PreAuthorize("hasAuthority('project:read') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Get the organization id for a project",
+            description = "Returns the id of the organization that owns the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization id returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<Long> getOrganizationIdByProjectId(@PathVariable Long id) {
         Long organizationId = service.getOrganizationIdByProjectId(id);
         return new ResponseEntity<>(organizationId, HttpStatus.OK);
@@ -144,12 +211,31 @@ public class ProjectController {
 
     @PostMapping("{projectId}/employees/{employeeId}")
     @PreAuthorize("hasAuthority('project:update') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Assign an employee to a project",
+            description = "Adds the given employee to the project team and returns the project's updated "
+                    + "list of assigned employees."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee assigned, updated team returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or employee with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> addEmployeeToProject(@PathVariable Long projectId, @PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.addEmployeeToProject(projectId, employeeId));
     }
 
     @DeleteMapping("{projectId}/employees/{employeeId}")
     @PreAuthorize("hasAuthority('project:update') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "Remove an employee from a project",
+            description = "Removes the given employee from the project team."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee removed from the project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or employee with the given id")
+    })
     public ResponseEntity<ApiResponse> removeEmployeeFromProject(@PathVariable Long projectId, @PathVariable Long employeeId) {
         service.removeEmployeeFromProject(projectId, employeeId);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee removed from project"));
@@ -157,6 +243,15 @@ public class ProjectController {
 
     @GetMapping("{projectId}/employees")
     @PreAuthorize("hasAuthority('project:read') or hasAuthority('project:admin')")
+    @Operation(
+            summary = "List the employees on a project",
+            description = "Returns the employees currently assigned to the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Assigned employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> getEmployeesByProjectId(@PathVariable Long projectId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getEmployeesByProjectId(projectId));
     }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
@@ -10,35 +11,46 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to create a construction project. Sent as the JSON data part of the "
+        + "multipart create request.")
 @Data
 public class ProjectCreationDto {
 
+    @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     @NotBlank(message = "projectName is required")
     @Size(min = 3,max = 50,message = "projectName must be between 3 and 50 characters")
     private String projectName;
 
+    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
     @NotBlank(message = "projectAddress is required")
     @Size(min = 3,max = 50,message = "projectAddress must be between 3 and 50 characters")
     private String projectAddress;
 
+    @Schema(description = "Creation timestamp, set server side when omitted.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "Initial project status.", example = "IN_PROGRESS")
     @NotBlank(message = "status is required")
     @Size(min = 3,max = 50,message = "status must be between 3 and 50 characters")
     @Enumerated(EnumType.STRING)
     private String status;
 
     /** Optional construction category (e.g. RESIDENTIAL, COMMERCIAL). Drives compliance matching. */
+    @Schema(description = "Optional construction category. Drives compliance matching.", example = "RESIDENTIAL")
     @Size(max = 50, message = "projectType must be at most 50 characters")
     private String projectType;
 
+    @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
     @NotNull
     private Float projectLatitude;
 
+    @Schema(description = "Site longitude in decimal degrees.", example = "80.2707")
     @NotNull
     private Float projectLongitude;
 
+    @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")
     private LocalDateTime startDate;
 
+    @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -10,20 +11,49 @@ import org.tornotron.echno_backend.task.dto.TaskDto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Full view of a construction project, including its team, tasks, attachments "
+        + "and overall progress.")
 @Data
 public class ProjectDto {
+    @Schema(description = "Unique project id.", example = "42")
     private Long id;
+
+    @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     private String projectName;
+
+    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
     private String projectAddress;
+
+    @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Current project status.", example = "IN_PROGRESS")
     private ProjectCreationStatus status;
+
+    @Schema(description = "Construction category of the project.", example = "RESIDENTIAL")
     private ProjectType projectType;
+
+    @Schema(description = "Employees assigned to the project team.")
     private List<EmployeeDto> employees;
+
+    @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
     private Float projectLatitude;
+
+    @Schema(description = "Site longitude in decimal degrees.", example = "80.2707")
     private Float projectLongitude;
+
+    @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")
     private LocalDateTime startDate;
+
+    @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
+
+    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1.", example = "0.35")
     private Double progress;
+
+    @Schema(description = "Tasks that belong to the project.")
     private List<TaskDto> tasks;
+
+    @Schema(description = "Files attached to the project.")
     private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectPatchDto.java
@@ -1,11 +1,18 @@
 package org.tornotron.echno_backend.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
+@Schema(description = "A single project's partial update within a batch: the project id and the map of "
+        + "fields to change on it.")
 @Data
 public class ProjectPatchDto {
+    @Schema(description = "Id of the project to update.", example = "42")
     private Long id;
+
+    @Schema(description = "Fields to change, keyed by project field name.",
+            example = "{\"status\": \"COMPLETED\", \"progress\": 1.0}")
     private Map<String,Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.enums.ProjectType;
@@ -7,17 +8,40 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Condensed view of a construction project without its team, tasks or attachments. "
+        + "Returned when a project is created.")
 @Data
 public class ProjectSimpleDto {
+    @Schema(description = "Unique project id.", example = "42")
     private Long id;
+
+    @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     private String projectName;
+
+    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
     private String projectAddress;
+
+    @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Current project status.", example = "IN_PROGRESS")
     private ProjectCreationStatus status;
+
+    @Schema(description = "Construction category of the project.", example = "RESIDENTIAL")
     private ProjectType projectType;
+
+    @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
     private Float projectLatitude;
+
+    @Schema(description = "Site longitude in decimal degrees.", example = "80.2707")
     private Float projectLongitude;
+
+    @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")
     private LocalDateTime startDate;
+
+    @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
+
+    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1.", example = "0.35")
     private Double progress;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +32,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/tasks")
 @Validated
+@Tag(
+        name = "Tasks",
+        description = "Work items tracked against a project. A task carries a title, schedule, assignees, "
+                + "category, tags, progress and status. Endpoints cover creating a task with attachments, "
+                + "browsing and reading tasks, batch updates and deletion. Access is gated by the task "
+                + "authorities, with an admin authority that grants all operations."
+)
 public class TaskController {
 
     private final TaskService service;
@@ -49,12 +59,23 @@ public class TaskController {
     /**
      * Creates a new task.
      *
-     *  taskCreationDto DTO containing the details for the new task.
+     * @param data JSON payload containing the details for the new task.
      * @return A {@link ResponseEntity} with a success message and HTTP status 201 (Created).
      */
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('task:create') or hasAuthority('task:admin')")
+    @Operation(
+            summary = "Create a task",
+            description = "Creates a task from a multipart request. The data part carries the task details "
+                    + "as JSON and the optional attachments part carries supporting files. Returns the "
+                    + "created task as a simple view without its resolved assignees or category."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Task created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task create or admin authority")
+    })
     public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data,
                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
@@ -71,6 +92,15 @@ public class TaskController {
      */
     @GetMapping
     @PreAuthorize("hasAuthority('task:read') or hasAuthority('task:admin')")
+    @Operation(
+            summary = "List tasks",
+            description = "Returns a single page of tasks. The pageNo and pageSize parameters control "
+                    + "paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of tasks returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task read or admin authority")
+    })
     public ResponseEntity<List<TaskDto>> readAllTasks(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<TaskDto> tasks = service.getAllTasks(pageNo, pageSize);
@@ -86,6 +116,16 @@ public class TaskController {
      */
     @GetMapping("{id}")
     @PreAuthorize("hasAuthority('task:read') or hasAuthority('task:admin')")
+    @Operation(
+            summary = "Get a task by id",
+            description = "Returns a single task including its creator, assignees, category, issues and "
+                    + "attachments."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<?> readATask(@PathVariable Long id) {
         TaskDto taskDto = service.getATask(id);
         return new ResponseEntity<>(taskDto, HttpStatus.OK);
@@ -112,6 +152,16 @@ public class TaskController {
      */
     @PatchMapping("/batch")
     @PreAuthorize("hasAuthority('task:update') or hasAuthority('task:admin')")
+    @Operation(
+            summary = "Batch update tasks",
+            description = "Applies partial updates to several tasks in one call. Each entry names a task "
+                    + "id and the map of fields to change on that task."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task update or admin authority")
+    })
     public ResponseEntity<ApiResponse> batchUpdateTasks(@Valid @RequestBody List<TaskPatchDto> updates) {
         service.batchUpdateTasks(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -125,6 +175,15 @@ public class TaskController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('task:delete') or hasAuthority('task:admin')")
+    @Operation(
+            summary = "Delete a task",
+            description = "Deletes the task with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteATask(@PathVariable Long id) {
         service.deleteATask(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Task with id: " + id + " deleted"));

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.task.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,36 +9,50 @@ import lombok.Data;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Payload to create a task under a project. Sent as the JSON data part of the "
+        + "multipart create request.")
 @Data
 public class TaskCreationDto {
+    @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
     @NotBlank(message = "title is required")
     @Size(min = 3, max = 50, message = "title must be between 3 and 50 characters")
     private String title;
 
+    @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
     private LocalDateTime startDate;
 
+    @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
     private LocalDateTime endDate;
 
+    @Schema(description = "Longer description of the work to be done.",
+            example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
     private String description;
 
+    @Schema(description = "Id of the employee creating the task.", example = "5")
     @NotNull(message = "creatorId is required(type: Long)")
     private Long creatorId;
 
+    @Schema(description = "Id of the project the task belongs to.", example = "42")
     @NotNull(message = "projectId is required(type: Long)")
     private Long projectId;
 
+    @Schema(description = "Ids of the employees assigned to the task.", example = "[7, 9]")
     @NotNull(message = "assigneeIds is required(type: List<Long>)")
     private List<Long> assigneeIds;
 
+    @Schema(description = "Id of the category the task is filed under.", example = "3")
     @NotNull(message = "categoryId is required(type: Long)")
     private Long categoryId;
 
+    @Schema(description = "Initial completion of the task, as a fraction from 0 to 1.", example = "0.0")
     @NotNull(message = "progress is required(type: Double)")
     private Double progress;
 
+    @Schema(description = "Free-text tags applied to the task.", example = "[\"concrete\", \"structural\"]")
     @NotNull(message = "tags is required(type: List<String>)")
     private List<String> tags;
 
+    @Schema(description = "Initial task status.", example = "TODO")
     @NotBlank(message = "status is required")
     private String status;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.task.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
@@ -12,22 +13,56 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+@Schema(description = "Full view of a task, with its resolved creator, assignees, category, issues "
+        + "and attachments.")
 @Data
 public class TaskDto {
+    @Schema(description = "Unique task id.", example = "108")
     private Long id;
+
+    @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
     private String title;
+
+    @Schema(description = "Longer description of the work to be done.",
+            example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
     private String description;
+
+    @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
     private LocalDateTime startDate;
+
+    @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
     private LocalDateTime endDate;
+
+    @Schema(description = "Employee who created the task.")
     private EmployeeDto creator;
+
+    @Schema(description = "Id of the project the task belongs to.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Employees assigned to the task.")
     private Set<EmployeeDto> assignees;
+
+    @Schema(description = "Category the task is filed under.")
     private CategoryDto category;
+
+    @Schema(description = "Completion of the task, as a fraction from 0 to 1.", example = "0.5")
     private Double progress;
+
+    @Schema(description = "Free-text tags applied to the task.", example = "[\"concrete\", \"structural\"]")
     private List<String> tags;
+
+    @Schema(description = "Creation timestamp.", example = "2026-09-01T10:15:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp of the last update.", example = "2026-09-06T14:30:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "Current task status.", example = "IN_PROGRESS")
     private TaskStatus status;
+
+    @Schema(description = "Issues raised against the task.")
     private List<IssueDto> issues;
+
+    @Schema(description = "Files attached to the task.")
     private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskPatchDto.java
@@ -1,12 +1,19 @@
 package org.tornotron.echno_backend.task.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
 
+@Schema(description = "A single task's partial update within a batch: the task id and the map of fields "
+        + "to change on it.")
 @Data
 public class TaskPatchDto {
+    @Schema(description = "Id of the task to update.", example = "108")
     private Long id;
+
+    @Schema(description = "Fields to change, keyed by task field name.",
+            example = "{\"status\": \"DONE\", \"progress\": 1.0}")
     private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskSimpleDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.task.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -10,19 +11,47 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+@Schema(description = "Condensed view of a task carrying id references instead of resolved objects. "
+        + "Returned when a task is created.")
 @Data
 public class TaskSimpleDto {
+    @Schema(description = "Unique task id.", example = "108")
     private Long id;
+
+    @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
     private String title;
+
+    @Schema(description = "Longer description of the work to be done.",
+            example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
     private String description;
+
+    @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
     private LocalDateTime startDate;
+
+    @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
     private LocalDateTime endDate;
+
+    @Schema(description = "Id of the employee who created the task.", example = "5")
     private Long creatorId;
+
+    @Schema(description = "Id of the project the task belongs to.", example = "42")
     private Long projectId;
+
+    @Schema(description = "Id of the category the task is filed under.", example = "3")
     private Long categoryId;
+
+    @Schema(description = "Completion of the task, as a fraction from 0 to 1.", example = "0.0")
     private Double progress;
+
+    @Schema(description = "Free-text tags applied to the task.", example = "[\"concrete\", \"structural\"]")
     private List<String> tags;
+
+    @Schema(description = "Creation timestamp.", example = "2026-09-01T10:15:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp of the last update.", example = "2026-09-06T14:30:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "Current task status.", example = "TODO")
     private TaskStatus status;
 }


### PR DESCRIPTION
## What this does

The generated OpenAPI spec was bare: auto-generated with no tags, operation summaries, response codes, or schema descriptions. This establishes the annotation pattern and applies it to the most-used modules, so the Swagger UI groups endpoints by area and documents the request and response fields consumers actually use.

### API annotations
Each controller in scope gets a class `@Tag` and per-endpoint `@Operation` with `@ApiResponse` entries for the meaningful statuses (created, validation, forbidden, not found). The matching request and response DTOs get `@Schema` descriptions and examples on their fields.

Modules covered:
- Construction finance: construction invoices, construction payments, the invoice and payment surfaces, and the ledger (accounts, journal entries, customers)
- Inventory transactions and goods received notes (GRN)
- Project, task, employee

This deliberately does not cover all controllers; it sets the pattern and documents the highest-traffic API.

### Global config
Adds `OpenApiConfig` with the document info and a Keycloak bearer-token security scheme, so the Swagger UI Authorize dialog attaches a JWT.

### Fixes
- Corrects a malformed `@param` in `TaskController.createTask` (it named a non-existent parameter; now points at the real `data` part).
- README: the application database is CockroachDB, not PostgreSQL (Keycloak uses a separate PostgreSQL); the license plan is AGPL, not MIT; the clone URL points at the real repository; the stale "Keycloak disabled for testing" note is removed; a module map linking the existing `docs/` guides is added.

## Verification
`./gradlew compileJava` passes. Changes are annotation and documentation only, with no logic or validation changes.