### PR TITLE
Raise the JaCoCo coverage floor to 18% (locks in the new tests)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,12 @@ plugins {
 ext {
     springCloudVersion = "2024.0.2"
     // Minimum line-coverage ratio enforced by jacocoTestCoverageVerification.
-    // Set just under the current measured level (14.5% at introduction) so it locks
-    // in no-regression with a small margin for run-to-run variance; raise it as
-    // tests are added. Denominator excludes generated/DTO/config classes.
-    jacocoLineFloor = 0.14
+    // Set just under the current measured level so it locks in no-regression with a
+    // small margin for run-to-run variance; raise it as tests are added. Denominator
+    // excludes generated/DTO/config classes. History: 14% at introduction (14.5%
+    // measured), raised to 18% after the RBAC, billing, procurement, receipt, ledger
+    // and attendance service tests landed (18.77% measured).
+    jacocoLineFloor = 0.18
 }
 
 repositories {


### PR DESCRIPTION
The wave of service tests (RBAC, billing, procurement, receipt, ledger, attendance) raised measured backend line coverage from 14.5% to 18.77%. This ratchets the no-regression floor from 14% to 18% so the gain is enforced. Verified: `jacocoTestCoverageVerification` BUILD SUCCESSFUL at 18.77%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the minimum required code coverage threshold from 14% to 18%.
  * Updated coverage documentation to reflect recent measurements and excluded code categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->