### PR TITLE
test: cover inventory write and finance services

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountServiceTest.java
@@ -1,0 +1,121 @@
+package org.tornotron.echno_backend.finance.bank.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.bank.domain.CompanyBankAccount;
+import org.tornotron.echno_backend.finance.bank.dtos.CreateCompanyBankAccountRequest;
+import org.tornotron.echno_backend.finance.bank.mapper.CompanyBankAccountMapper;
+import org.tornotron.echno_backend.finance.bank.repositories.CompanyBankAccountRepository;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for CompanyBankAccountService. Repositories, the mapper, and the tenant
+ * helper are mocked. The focus is the small amount of logic this service owns: create
+ * must resolve and attach the tenant-scoped ledger account (and reject an unknown one
+ * before saving), stamp the current organization; deactivate flips the active flag by
+ * dirty-checking the loaded entity; and the scoped reads reject a missing id.
+ */
+@ExtendWith(MockitoExtension.class)
+class CompanyBankAccountServiceTest {
+
+    @Mock private CompanyBankAccountRepository repository;
+    @Mock private AccountRepository accountRepository;
+    @Mock private CompanyBankAccountMapper mapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+
+    private CompanyBankAccountService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CompanyBankAccountService(repository, accountRepository, mapper, tenantEntityHelper);
+        lenient().when(repository.save(any(CompanyBankAccount.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private CreateCompanyBankAccountRequest request(UUID ledgerAccountId) {
+        return new CreateCompanyBankAccountRequest("HDFC", "000111222", "Echno Pvt Ltd",
+                "HDFC0000123", "HDFCINBB", true, ledgerAccountId);
+    }
+
+    @Test
+    void create_unknownLedgerAccount_throws() {
+        UUID ledgerId = UUID.randomUUID();
+        when(accountRepository.findScopedById(ledgerId)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(AccountNotFoundException.class)
+                .isThrownBy(() -> service.create(request(ledgerId)));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void create_resolvesLedgerAndStampsOrganization() {
+        UUID ledgerId = UUID.randomUUID();
+        Account ledger = new Account();
+        ledger.setId(ledgerId);
+        when(accountRepository.findScopedById(ledgerId)).thenReturn(Optional.of(ledger));
+        Organization org = new Organization();
+        org.setId(100L);
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+
+        service.create(request(ledgerId));
+
+        ArgumentCaptor<CompanyBankAccount> captor = ArgumentCaptor.forClass(CompanyBankAccount.class);
+        verify(repository).save(captor.capture());
+        CompanyBankAccount saved = captor.getValue();
+        assertThat(saved.getBankName()).isEqualTo("HDFC");
+        assertThat(saved.getLedgerAccount()).isSameAs(ledger);
+        assertThat(saved.getOrganization()).isSameAs(org);
+        assertThat(saved.isDefault()).isTrue();
+    }
+
+    @Test
+    void deactivate_unknownId_throws() {
+        UUID id = UUID.randomUUID();
+        when(repository.findScopedById(id)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.deactivate(id));
+    }
+
+    @Test
+    void deactivate_flipsActiveFlag() {
+        UUID id = UUID.randomUUID();
+        CompanyBankAccount account = new CompanyBankAccount();
+        account.setActive(true);
+        when(repository.findScopedById(id)).thenReturn(Optional.of(account));
+
+        service.deactivate(id);
+
+        assertThat(account.isActive()).isFalse();
+        verify(mapper).toDto(account);
+    }
+
+    @Test
+    void findById_unknownId_throws() {
+        UUID id = UUID.randomUUID();
+        when(repository.findScopedById(id)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.findById(id));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/report/service/ReportServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/report/service/ReportServiceIT.java
@@ -1,0 +1,222 @@
+package org.tornotron.echno_backend.finance.report.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.mapper.JournalEntryMapperImpl;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.report.dtos.BalanceSheetReport;
+import org.tornotron.echno_backend.finance.report.dtos.ProfitAndLossReport;
+import org.tornotron.echno_backend.finance.report.dtos.TrialBalanceReport;
+import org.tornotron.echno_backend.finance.report.dtos.TrialBalanceRow;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Integration tests for the financial-report aggregation against a real CockroachDB.
+ * The reports read POSTED journal activity with native SQL, so they only exercise
+ * meaningfully over real rows. A two-entry fixture (a sale funded to cash, then an
+ * expense paid from cash) drives all three reports so the normal-balance arithmetic,
+ * the retained-earnings roll-up, and the balance checks are pinned end to end.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ReportService.class, JournalPostingService.class, JournalEntryMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class})
+class ReportServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private JournalPostingService journalPostingService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+    private UUID cashId;      // ASSET  (debit-normal)
+    private UUID revenueId;   // INCOME (credit-normal)
+    private UUID expenseId;   // EXPENSE (debit-normal)
+
+    private final LocalDate today = LocalDate.now();
+
+    // The tenant seed (org + accounts) is committed, not held in the test's rolled-back
+    // transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW and only sees committed
+    // rows. The journal entries themselves are posted inside the test transaction, which the
+    // report queries read in the same transaction.
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Report Org");
+            Account cash = persistAccount(org, "1000", "Cash", AccountType.ASSET);
+            Account revenue = persistAccount(org, "4000", "Revenue", AccountType.INCOME);
+            Account expense = persistAccount(org, "5000", "Office Rent", AccountType.EXPENSE);
+            entityManager.flush();
+            orgId = org.getId();
+            cashId = cash.getId();
+            revenueId = revenue.getId();
+            expenseId = expense.getId();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+
+        // Sale: cash +1000 against revenue. Expense: office rent 300 paid from cash.
+        post(today, line(cashId, "1000", "0"), line(revenueId, "0", "1000"));
+        post(today, line(expenseId, "300", "0"), line(cashId, "0", "300"));
+        entityManager.flush();
+    }
+
+    @AfterEach
+    void cleanup() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM journal_entry_lines WHERE journal_entry_id IN "
+                    + "(SELECT id FROM journal_entries WHERE organization_id = :org)");
+            exec("DELETE FROM journal_entries WHERE organization_id = :org");
+            exec("DELETE FROM document_sequence WHERE organization_id = :org");
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    // --- Trial balance ----------------------------------------------------
+
+    @Test
+    void trialBalance_placesEachAccountOnItsNormalSideAndBalances() {
+        TrialBalanceReport report = reportService.trailBalanceReport(today);
+
+        assertThat(report.balanced()).isTrue();
+        assertThat(report.totalDebit()).isEqualByComparingTo("1000");
+        assertThat(report.totalCredit()).isEqualByComparingTo("1000");
+
+        // Cash is debit-normal and net debit 700 (1000 in, 300 out) → debit column.
+        TrialBalanceRow cash = row(report, "1000");
+        assertThat(cash.debitBalance()).isEqualByComparingTo("700");
+        assertThat(cash.creditBalance()).isEqualByComparingTo("0");
+
+        // Revenue is credit-normal → credit column carries 1000.
+        TrialBalanceRow revenue = row(report, "4000");
+        assertThat(revenue.creditBalance()).isEqualByComparingTo("1000");
+        assertThat(revenue.debitBalance()).isEqualByComparingTo("0");
+
+        // Expense is debit-normal → debit column carries 300.
+        TrialBalanceRow expense = row(report, "5000");
+        assertThat(expense.debitBalance()).isEqualByComparingTo("300");
+    }
+
+    // --- Profit and loss --------------------------------------------------
+
+    @Test
+    void profitAndLoss_nettsIncomeAgainstExpenseForThePeriod() {
+        ProfitAndLossReport report = reportService.profitAndLoss(today.minusDays(1), today);
+
+        assertThat(report.totalIncome()).isEqualByComparingTo("1000");
+        assertThat(report.totalExpense()).isEqualByComparingTo("300");
+        assertThat(report.netProfit()).isEqualByComparingTo("700");
+        assertThat(report.income()).hasSize(1);
+        assertThat(report.expense()).hasSize(1);
+    }
+
+    @Test
+    void profitAndLoss_endDateBeforeStartDate_isRejected() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reportService.profitAndLoss(today, today.minusDays(5)));
+    }
+
+    // --- Balance sheet ----------------------------------------------------
+
+    @Test
+    void balanceSheet_flowsPeriodProfitIntoRetainedEarningsAndBalances() {
+        BalanceSheetReport report = reportService.balanceSheet(today);
+
+        // Only asset is cash at 700; the period profit of 700 becomes retained earnings,
+        // so assets equal liabilities plus equity.
+        assertThat(report.totalAssets()).isEqualByComparingTo("700");
+        assertThat(report.retainedEarningsForPeriod()).isEqualByComparingTo("700");
+        assertThat(report.totalEquity()).isEqualByComparingTo("700");
+        assertThat(report.totalLiabilitiesAndEquity()).isEqualByComparingTo("700");
+        assertThat(report.balanced()).isTrue();
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private TrialBalanceRow row(TrialBalanceReport report, String code) {
+        return report.rows().stream()
+                .filter(r -> r.accountCode().equals(code))
+                .findFirst().orElseThrow(() -> new AssertionError("no trial-balance row for account " + code));
+    }
+
+    private void post(LocalDate date, PostJournalRequest.LineRequest... lines) {
+        journalPostingService.postInternal(
+                new PostJournalRequest(date, "Report fixture", null, List.of(lines)), "MANUAL", null);
+    }
+
+    private PostJournalRequest.LineRequest line(UUID accountId, String debit, String credit) {
+        return new PostJournalRequest.LineRequest(accountId, new BigDecimal(debit), new BigDecimal(credit), null);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private Account persistAccount(Organization org, String code, String name, AccountType type) {
+        Account account = new Account();
+        account.setCode(code);
+        account.setName(name);
+        account.setType(type);
+        account.setParent(null);
+        account.setActive(true);
+        account.setOrganization(org);
+        entityManager.persist(account);
+        return account;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionServiceTest.java
@@ -1,0 +1,187 @@
+package org.tornotron.echno_backend.materialConsumption;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.events.MaterialConsumedEvent;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionCreationDto;
+import org.tornotron.echno_backend.materialConsumption.mapper.MaterialConsumptionMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for MaterialConsumptionService. Repositories, the inventory service, the
+ * event publisher, and the mapper are mocked; the entity graph is built in memory. The
+ * focus is the logic this service owns before the row is persisted: rejecting unknown
+ * referenced entities, rejecting a task that belongs to a different project, choosing the
+ * location-scoped vs project-scoped stock check, and publishing the consumed event that
+ * drives the inventory depletion.
+ */
+@ExtendWith(MockitoExtension.class)
+class MaterialConsumptionServiceTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 11L;
+    private static final Long EMPLOYEE = 7L;
+    private static final Long PROJECT = 9L;
+    private static final Long LOCATION = 3L;
+
+    @Mock private MaterialConsumptionRepository materialConsumptionRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private MaterialConsumptionMapper materialConsumptionMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private TaskRepository taskRepository;
+
+    private MaterialConsumptionService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new MaterialConsumptionService(materialConsumptionRepository, materialRepository,
+                inventoryService, eventPublisher, materialConsumptionMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository, taskRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void stubMasterLookups() {
+        Material material = new Material();
+        material.setId(MATERIAL);
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE);
+        Project project = new Project();
+        project.setId(PROJECT);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG)).thenReturn(Optional.of(material));
+        lenient().when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(PROJECT, ORG)).thenReturn(Optional.of(project));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(materialConsumptionRepository.save(any(MaterialConsumption.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private MaterialConsumptionCreationDto baseDto() {
+        MaterialConsumptionCreationDto dto = new MaterialConsumptionCreationDto();
+        dto.setConsumptionDate(LocalDateTime.now());
+        dto.setMaterialId(MATERIAL);
+        dto.setQuantity(5);
+        dto.setConsumptionType("USED_FROM_STOCK");
+        dto.setProjectId(PROJECT);
+        dto.setCreatedBy(EMPLOYEE);
+        return dto;
+    }
+
+    @Test
+    void create_unknownMaterial_throwsNotFound() {
+        when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.createMaterialConsumption(baseDto()));
+
+        verify(materialConsumptionRepository, never()).save(any());
+    }
+
+    @Test
+    void create_withStorageLocation_usesLocationScopedStockCheck() {
+        stubMasterLookups();
+        StorageLocation location = new StorageLocation();
+        location.setId(LOCATION);
+        when(storageLocationRepository.findByIdAndOrganization_Id(LOCATION, ORG)).thenReturn(Optional.of(location));
+
+        MaterialConsumptionCreationDto dto = baseDto();
+        dto.setStorageLocationId(LOCATION);
+
+        service.createMaterialConsumption(dto);
+
+        verify(inventoryService).validateSufficientStockAtLocation(MATERIAL, PROJECT, LOCATION, 5.0);
+        verify(inventoryService, never()).validateSufficientStock(anyLong(), anyLong(), anyDouble());
+    }
+
+    @Test
+    void create_withoutStorageLocation_usesProjectScopedStockCheck() {
+        stubMasterLookups();
+
+        service.createMaterialConsumption(baseDto());
+
+        verify(inventoryService).validateSufficientStock(MATERIAL, PROJECT, 5.0);
+        verify(inventoryService, never()).validateSufficientStockAtLocation(anyLong(), anyLong(), anyLong(), anyDouble());
+    }
+
+    @Test
+    void create_taskFromAnotherProject_throwsIllegalArgument() {
+        stubMasterLookups();
+        Project otherProject = new Project();
+        otherProject.setId(999L);
+        Task task = new Task();
+        task.setId(21L);
+        task.setProject(otherProject);
+        when(taskRepository.findByIdAndOrganization_Id(21L, ORG)).thenReturn(Optional.of(task));
+
+        MaterialConsumptionCreationDto dto = baseDto();
+        dto.setTaskId(21L);
+
+        assertThatThrownBy(() -> service.createMaterialConsumption(dto))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(materialConsumptionRepository, never()).save(any());
+    }
+
+    @Test
+    void create_happyPath_savesParsesTypeAndPublishesEvent() {
+        stubMasterLookups();
+
+        service.createMaterialConsumption(baseDto());
+
+        ArgumentCaptor<MaterialConsumption> captor = ArgumentCaptor.forClass(MaterialConsumption.class);
+        verify(materialConsumptionRepository).save(captor.capture());
+        MaterialConsumption saved = captor.getValue();
+        org.assertj.core.api.Assertions.assertThat(saved.getConsumptionType())
+                .isEqualTo(org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType.USED_FROM_STOCK);
+        org.assertj.core.api.Assertions.assertThat(saved.getMaterial().getId()).isEqualTo(MATERIAL);
+        org.assertj.core.api.Assertions.assertThat(saved.getOrganization().getId()).isEqualTo(ORG);
+
+        verify(eventPublisher).publishEvent(any(MaterialConsumedEvent.class));
+        verify(materialConsumptionMapper).toDto(eq(saved));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -1,0 +1,230 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for SiteTransferService. Repositories, the inventory service, the event
+ * publisher, and the mapper are mocked; the entity graph is built in memory. The focus
+ * is the logic this service owns: rejecting a duplicate transfer number, rejecting
+ * unknown referenced entities, aggregating the per-material required quantities that feed
+ * the sending-side stock check, choosing the location-scoped vs project-scoped variant of
+ * that check, and building one transfer item per request line.
+ */
+@ExtendWith(MockitoExtension.class)
+class SiteTransferServiceTest {
+
+    private static final Long ORG = 100L;
+    private static final Long SENDER = 7L;
+    private static final Long SENDING_PROJECT = 9L;
+    private static final Long RECEIVING_PROJECT = 10L;
+    private static final Long SENDING_LOCATION = 3L;
+    private static final Long MATERIAL = 11L;
+
+    @Mock private SiteTransferRepository siteTransferRepository;
+    @Mock private SiteTransferItemRepository siteTransferItemRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private SiteTransferMapper siteTransferMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+
+    private SiteTransferService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
+                materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void stubMasterLookups() {
+        Employee sender = new Employee();
+        sender.setId(SENDER);
+        Project sending = new Project();
+        sending.setId(SENDING_PROJECT);
+        Project receiving = new Project();
+        receiving.setId(RECEIVING_PROJECT);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(false);
+        lenient().when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG)).thenReturn(Optional.of(sender));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.of(sending));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(RECEIVING_PROJECT, ORG)).thenReturn(Optional.of(receiving));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(siteTransferRepository.save(any(SiteTransfer.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(materialRepository.findByIdAndOrganization_Id(eq(MATERIAL), eq(ORG)))
+                .thenAnswer(inv -> {
+                    Material m = new Material();
+                    m.setId(MATERIAL);
+                    return Optional.of(m);
+                });
+    }
+
+    private SiteTransferItemDto item(Long materialId, int qty) {
+        SiteTransferItemDto i = new SiteTransferItemDto();
+        i.setMaterialId(materialId);
+        i.setSentQuantity(qty);
+        return i;
+    }
+
+    private SiteTransferCreationDto baseDto() {
+        SiteTransferCreationDto dto = new SiteTransferCreationDto();
+        dto.setTransferNumber("ST-001");
+        dto.setIssueDate(LocalDateTime.now());
+        dto.setSendingPerson(SENDER);
+        dto.setSendingProjectId(SENDING_PROJECT);
+        dto.setReceivingProjectId(RECEIVING_PROJECT);
+        dto.setStatus("PENDING");
+        dto.setItems(List.of(item(MATERIAL, 4)));
+        return dto;
+    }
+
+    @Test
+    void create_duplicateTransferNumber_throws() {
+        when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(true);
+
+        assertThatExceptionOfType(DuplicateResourceException.class)
+                .isThrownBy(() -> service.createSiteTransfer(baseDto()));
+
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void create_unknownSendingProject_throwsNotFound() {
+        when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(false);
+        when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG))
+                .thenReturn(Optional.of(new Employee()));
+        when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.createSiteTransfer(baseDto()));
+
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void create_aggregatesQuantitiesOfRepeatedMaterial_forStockCheck() {
+        stubMasterLookups();
+        SiteTransferCreationDto dto = baseDto();
+        // Same material on two lines: 4 + 6 must be summed to 10 for the single stock check.
+        dto.setItems(List.of(item(MATERIAL, 4), item(MATERIAL, 6)));
+
+        service.createSiteTransfer(dto);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Long, Double>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(inventoryService).validateSufficientStockForMultipleItems(captor.capture(), eq(SENDING_PROJECT));
+        assertThat(captor.getValue()).containsEntry(MATERIAL, 10.0);
+    }
+
+    @Test
+    void create_withSendingLocation_usesLocationScopedStockCheck() {
+        stubMasterLookups();
+        StorageLocation location = new StorageLocation();
+        location.setId(SENDING_LOCATION);
+        when(storageLocationRepository.findByIdAndOrganization_Id(SENDING_LOCATION, ORG)).thenReturn(Optional.of(location));
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+
+        service.createSiteTransfer(dto);
+
+        verify(inventoryService).validateSufficientStockForMultipleItemsAtLocation(any(), eq(SENDING_PROJECT), eq(SENDING_LOCATION));
+        verify(inventoryService, never()).validateSufficientStockForMultipleItems(any(), anyLong());
+    }
+
+    @Test
+    void create_happyPath_savesItemsParsesStatusAndPublishesEvent() {
+        stubMasterLookups();
+
+        service.createSiteTransfer(baseDto());
+
+        ArgumentCaptor<SiteTransfer> transferCaptor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(transferCaptor.capture());
+        assertThat(transferCaptor.getValue().getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<SiteTransferItem>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(siteTransferItemRepository).saveAll(itemsCaptor.capture());
+        List<SiteTransferItem> items = itemsCaptor.getValue();
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0).getMaterial().getId()).isEqualTo(MATERIAL);
+        assertThat(items.get(0).getSiteTransfer()).isNotNull();
+
+        verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void updateStatus_unknownTransfer_throwsNotFound() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.updateSiteTransferStatus(5L, SiteTransferStatus.COMPLETED));
+    }
+
+    @Test
+    void updateStatus_setsAndSaves() {
+        SiteTransfer transfer = new SiteTransfer();
+        transfer.setStatus(SiteTransferStatus.PENDING);
+        when(siteTransferRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(transfer));
+
+        service.updateSiteTransferStatus(5L, SiteTransferStatus.COMPLETED);
+
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.COMPLETED);
+        verify(siteTransferRepository).save(transfer);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -1,0 +1,210 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for StockAdjustmentService. The MVP service persists the document only (it
+ * does not yet move stock), so the logic worth pinning is the reference resolution it
+ * owns: an id that names nothing in the current tenant is rejected, a null id resolves to
+ * no association rather than an error, line items are wired to their parent and stamped
+ * with the organization, and an update replaces the whole line-item collection. The
+ * repositories, mapper, and tenant helper are mocked; assertions read the entity captured
+ * on saveAndFlush.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentServiceTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 11L;
+    private static final Long LOCATION = 3L;
+    private static final Long PROJECT = 9L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+
+    private StockAdjustmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository);
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
+            Organization org = new Organization();
+            org.setId(ORG);
+            return org;
+        });
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private StockAdjustmentLineItemCreationDto line(Long materialId, Long locationId) {
+        StockAdjustmentLineItemCreationDto l = new StockAdjustmentLineItemCreationDto();
+        l.setMaterialId(materialId);
+        l.setLocationId(locationId);
+        l.setDescription("line");
+        return l;
+    }
+
+    private StockAdjustmentCreationDto baseDto() {
+        StockAdjustmentCreationDto dto = new StockAdjustmentCreationDto();
+        dto.setAdjustmentNumber("ADJ-001");
+        dto.setType("write_off");
+        dto.setStatus("draft");
+        return dto;
+    }
+
+    private void stubReferenceLookups() {
+        Material material = new Material();
+        material.setId(MATERIAL);
+        StorageLocation location = new StorageLocation();
+        location.setId(LOCATION);
+        Project project = new Project();
+        project.setId(PROJECT);
+        lenient().when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG)).thenReturn(Optional.of(material));
+        lenient().when(storageLocationRepository.findByIdAndOrganization_Id(LOCATION, ORG)).thenReturn(Optional.of(location));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(PROJECT, ORG)).thenReturn(Optional.of(project));
+    }
+
+    @Test
+    void create_resolvesReferencesAndWiresLineItems() {
+        stubReferenceLookups();
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setLocationId(LOCATION);
+        dto.setProjectId(PROJECT);
+        dto.setLineItems(List.of(line(MATERIAL, LOCATION)));
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        StockAdjustment saved = captor.getValue();
+        assertThat(saved.getOrganization().getId()).isEqualTo(ORG);
+        assertThat(saved.getLocation().getId()).isEqualTo(LOCATION);
+        assertThat(saved.getProject().getId()).isEqualTo(PROJECT);
+        assertThat(saved.getLineItems()).hasSize(1);
+        StockAdjustmentLineItem item = saved.getLineItems().get(0);
+        assertThat(item.getMaterial().getId()).isEqualTo(MATERIAL);
+        assertThat(item.getOrganization().getId()).isEqualTo(ORG);
+        assertThat(item.getStockAdjustment()).isSameAs(saved);
+    }
+
+    @Test
+    void create_nullHeaderReferences_leaveAssociationsNull() {
+        StockAdjustmentCreationDto dto = baseDto();     // no locationId / projectId / lineItems
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        StockAdjustment saved = captor.getValue();
+        assertThat(saved.getLocation()).isNull();
+        assertThat(saved.getProject()).isNull();
+        assertThat(saved.getLineItems()).isEmpty();
+    }
+
+    @Test
+    void create_unknownLineMaterial_throwsNotFound() {
+        when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG)).thenReturn(Optional.empty());
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setLineItems(List.of(line(MATERIAL, null)));
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.create(dto));
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void update_unknownDocument_throwsNotFound() {
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.update(5L, baseDto()));
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void update_replacesLineItemCollection() {
+        stubReferenceLookups();
+        StockAdjustment existing = new StockAdjustment();
+        Organization org = new Organization();
+        org.setId(ORG);
+        existing.setOrganization(org);
+        StockAdjustmentLineItem stale = new StockAdjustmentLineItem();
+        existing.addLineItem(stale);
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(existing));
+
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setLineItems(List.of(line(MATERIAL, null)));
+
+        service.update(5L, dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        StockAdjustment saved = captor.getValue();
+        assertThat(saved.getLineItems()).hasSize(1);
+        assertThat(saved.getLineItems()).doesNotContain(stale);
+        assertThat(saved.getLineItems().get(0).getMaterial().getId()).isEqualTo(MATERIAL);
+    }
+
+    @Test
+    void delete_unknownDocument_throwsNotFound() {
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.delete(5L));
+
+        verify(stockAdjustmentRepository, never()).delete(any());
+    }
+
+    @Test
+    void delete_existingDocument_deletes() {
+        StockAdjustment existing = new StockAdjustment();
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(existing));
+
+        service.delete(5L);
+
+        verify(stockAdjustmentRepository).delete(existing);
+    }
+}


### PR DESCRIPTION
Adds unit and integration tests for backend services whose behaviour was previously exercised only through repository integration tests, or not at all. No production code is changed; these tests only raise coverage, so the 18% JaCoCo floor stays satisfied.

## What is covered

- **MaterialConsumptionService** (Mockito): rejects an unknown material, chooses the location-scoped stock check when a storage location is given and the project-scoped one otherwise, rejects a task belonging to a different project, and publishes the consumed event that drives inventory depletion.
- **SiteTransferService** (Mockito): rejects a duplicate transfer number and an unknown sending project, sums the quantities of a material repeated across lines into the single sending-side stock check, uses the location-scoped variant when a sending location is given, builds one item per line, and updates status.
- **StockAdjustmentService** (Mockito): resolves tenant-scoped references (and rejects unknown ones), leaves associations null for null ids, wires line items to their parent and organization, and replaces the whole line-item collection on update. This service is MVP (persists the document only, no stock movement yet), so only that resolution and wiring logic is pinned.
- **CompanyBankAccountService** (Mockito): resolves and attaches the ledger account and stamps the organization on create (rejecting an unknown ledger account before saving), and flips the active flag on deactivate.
- **ReportService** (Testcontainers CockroachDB): a two-entry fixture drives all three reports, asserting trial-balance normal-side placement and balance, profit-and-loss netting and the end-before-start rejection, and the balance-sheet retained-earnings roll-up.

## Notes

- The Mockito service tests are plain JUnit 5 + Mockito (no container). `ReportServiceIT` uses `@DataJpaTest` + `AbstractIntegrationTest` because the reports run native SQL that only exercises over real rows.
- While writing the report tests I found that the trial-balance, P&L and balance-sheet SQL place the `entry_date` / `status` predicates on the `journal_entries` join while summing `debit`/`credit` from `journal_entry_lines`, which is joined on `account_id` only, so out-of-window and non-POSTED line amounts still contribute to the totals. This PR does not touch that; it is flagged for a separate fix, and no test here asserts the incorrect behaviour as correct.