### PR TITLE
test: prove the authz guards on finance and inventory web twins

### DIFF
--- a/src/test/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWebAuthzTest.java
@@ -1,0 +1,80 @@
+package org.tornotron.echno_backend.finance.report.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.report.dtos.TrialBalanceReport;
+import org.tornotron.echno_backend.finance.report.service.ReportService;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for ReportControllerWeb. The financial reports are
+ * restricted to the elevated finance roles, so this pins that the guard admits a caller
+ * holding system-admin or project-manager for the current tenant and forbids one with
+ * neither. The stubs use exact role arguments, so the test also proves the controller
+ * passes precisely those two role names to @orgSecurity; @orgSecurity itself is mocked.
+ */
+@WebMvcTest(ReportControllerWeb.class)
+@Import(ReportControllerWebAuthzTest.TestSecurityConfig.class)
+class ReportControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @Test
+    void trialBalance_isOk_forAnElevatedFinanceRoleHolder() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(reportService.trailBalanceReport(any()))
+                .thenReturn(new TrialBalanceReport(null, List.of(), null, null, true));
+
+        mockMvc.perform(get("/api/v1/finance/reports/web/trial-balance")
+                        .param("asOfDate", "2026-01-01").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void trialBalance_isForbidden_forACallerWithoutAnElevatedFinanceRole() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/finance/reports/web/trial-balance")
+                        .param("asOfDate", "2026-01-01").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
@@ -1,0 +1,85 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for SiteTransferControllerWeb. Every endpoint on this
+ * controller gates on the single system-admin role, so the reads are more tightly
+ * restricted than on the inventory-document controllers (which let any member read).
+ * The stubs use exact role arguments: the system-admin test proves admittance, and the
+ * project-manager test proves that role alone is refused, which locks in the exact role
+ * name the guard requires. @orgSecurity is mocked.
+ */
+@WebMvcTest(SiteTransferControllerWeb.class)
+@Import(SiteTransferControllerWebAuthzTest.TestSecurityConfig.class)
+class SiteTransferControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SiteTransferService siteTransferService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @Test
+    void readAll_isOk_forASystemAdmin() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
+        when(siteTransferService.getAllSiteTransfers()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void readAll_isForbidden_forAProjectManagerWhoIsNotASystemAdmin() throws Exception {
+        // Only 'project-manager' holds here; the guard demands 'system-admin', so the
+        // controller's exact-role check must reject this caller.
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("project-manager")).thenReturn(true);
+
+        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void readAll_isForbidden_forACallerWithNoElevatedRole() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
@@ -1,0 +1,95 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for StockAdjustmentControllerWeb, whose endpoints split
+ * the guard: any member of the current tenant may read, but only a system-admin or
+ * project-manager may write. This pins both halves and, crucially, that a plain member
+ * who holds neither role is refused a write. If the write guard were ever loosened to
+ * membership, the member-without-role delete test fails. @orgSecurity is mocked so each
+ * branch is exercised independently.
+ */
+@WebMvcTest(StockAdjustmentControllerWeb.class)
+@Import(StockAdjustmentControllerWebAuthzTest.TestSecurityConfig.class)
+class StockAdjustmentControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StockAdjustmentService stockAdjustmentService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @Test
+    void read_isOk_forAnyMember() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(stockAdjustmentService.getAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/stock-adjustments/web").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void read_isForbidden_forANonMember() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/stock-adjustments/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void delete_isOk_forAnElevatedRoleHolder() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+
+        mockMvc.perform(delete("/api/v1/stock-adjustments/web/1").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void delete_isForbidden_forAPlainMemberWithoutAnElevatedRole() throws Exception {
+        // A member may read but must not write: the write guard is the role, not membership.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/stock-adjustments/web/1").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
The ArchUnit ratchet proves every web-slice endpoint carries a `@PreAuthorize`, but not that the guard admits the right callers and refuses everyone else. This extends the `@WebMvcTest` + mocked `@orgSecurity` slice pattern (the one already used for `ProjectControllerWeb`) to three high-value finance and inventory twins, so each guard is verified for correctness. No production code changes; coverage only rises.

## What is proven

- **ReportControllerWeb**: the trial-balance endpoint admits a caller holding `system-admin` or `project-manager` for the current tenant and forbids one with neither. The stubs use exact role arguments, so the controller is also shown to pass precisely those two role names.
- **SiteTransferControllerWeb**: every endpoint gates on the single `system-admin` role, more tightly than the inventory-document controllers that let any member read. A `system-admin` is admitted, a `project-manager` alone is refused, and a caller with no elevated role is refused, which locks in the exact required role.
- **StockAdjustmentControllerWeb**: reads gate on tenant membership, writes on `system-admin` / `project-manager`. Both halves are pinned, including that a plain member who holds neither role is refused a delete, so the read/write split cannot loosen unnoticed.

Each guard branch is exercised independently because `@orgSecurity` is mocked, matching the existing `ProjectControllerWebAuthzTest`.