### PR TITLE
Fix financial reports counting out-of-window and unposted amounts

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/report/service/ReportService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/service/ReportService.java
@@ -32,8 +32,8 @@ public class ReportService {
         Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
                 SELECT a.code, a.name, a.type,
-                                   COALESCE(SUM(l.debit), 0)  AS total_debit,
-                                   COALESCE(SUM(l.credit), 0) AS total_credit
+                                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.debit ELSE 0 END), 0)  AS total_debit,
+                                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.credit ELSE 0 END), 0) AS total_credit
                             FROM accounts a
                             LEFT JOIN journal_entry_lines l ON l.account_id = a.id
                             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id
@@ -44,8 +44,8 @@ public class ReportService {
                 + acctOrgWhere(orgId)
                 + """
                             GROUP BY a.code, a.name, a.type
-                            HAVING COALESCE(SUM(l.debit), 0) <> 0
-                                OR COALESCE(SUM(l.credit), 0) <> 0
+                            HAVING COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.debit ELSE 0 END), 0) <> 0
+                                OR COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.credit ELSE 0 END), 0) <> 0
                             ORDER BY a.code
                 """;
 
@@ -105,8 +105,8 @@ public class ReportService {
         Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
                 SELECT a.code, a.name, a.type,
-                                   COALESCE(SUM(l.debit), 0)  AS total_debit,
-                                   COALESCE(SUM(l.credit), 0) AS total_credit
+                                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.debit ELSE 0 END), 0)  AS total_debit,
+                                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.credit ELSE 0 END), 0) AS total_credit
                             FROM accounts a
                             LEFT JOIN journal_entry_lines l ON l.account_id = a.id
                             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id
@@ -179,8 +179,8 @@ public class ReportService {
         Long orgId = TenantContext.getCurrentOrgId();
         String sql = """
             SELECT a.code, a.name, a.type,
-                   COALESCE(SUM(l.debit), 0)  AS total_debit,
-                   COALESCE(SUM(l.credit), 0) AS total_credit
+                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.debit ELSE 0 END), 0)  AS total_debit,
+                   COALESCE(SUM(CASE WHEN je.id IS NOT NULL THEN l.credit ELSE 0 END), 0) AS total_credit
             FROM accounts a
             LEFT JOIN journal_entry_lines l ON l.account_id = a.id
             LEFT JOIN journal_entries je    ON je.id = l.journal_entry_id

--- a/src/test/java/org/tornotron/echno_backend/finance/report/service/ReportServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/report/service/ReportServiceIT.java
@@ -140,6 +140,22 @@ class ReportServiceIT extends AbstractIntegrationTest {
     // --- Profit and loss --------------------------------------------------
 
     @Test
+    void profitAndLoss_excludesEntriesOutsideTheReportingPeriod() {
+        // A posting dated before the reporting window must not leak into the P&L. The
+        // entry_date predicate sits on the journal_entries join while the amounts are
+        // summed from journal_entry_lines, so without guarding the sum on a matched
+        // entry the out-of-window line amounts would still count.
+        post(today.minusDays(30), line(cashId, "800", "0"), line(revenueId, "0", "800"));
+
+        ProfitAndLossReport report = reportService.profitAndLoss(today.minusDays(1), today);
+
+        // Only the in-window seed activity counts; the older 800 of income is excluded.
+        assertThat(report.totalIncome()).isEqualByComparingTo("1000");
+        assertThat(report.totalExpense()).isEqualByComparingTo("300");
+        assertThat(report.netProfit()).isEqualByComparingTo("700");
+    }
+
+    @Test
     void profitAndLoss_nettsIncomeAgainstExpenseForThePeriod() {
         ProfitAndLossReport report = reportService.profitAndLoss(today.minusDays(1), today);
 


### PR DESCRIPTION
## Bug (surfaced while adding ReportService tests)

`ReportService`'s trial-balance, P&L and balance-sheet native SQL puts the `POSTED` / `entry_date` / organization predicates on the `journal_entries` LEFT JOIN, but sums `debit`/`credit` from `journal_entry_lines` (joined on `account_id` only). A line whose parent entry fails those predicates keeps its row (with null `je` columns), so **its amount still counts** -- financial reports were including out-of-window, non-POSTED, and other-organization line amounts.

## Fix

Guard every sum (and the trial-balance `HAVING`) with `SUM(CASE WHEN je.id IS NOT NULL THEN l.debit ELSE 0 END)`. `je.id` is null exactly when the parent entry did not match the join, so only qualifying lines count; accounts with no qualifying activity still appear with a zero total.

Adds `profitAndLoss_excludesEntriesOutsideTheReportingPeriod` (fails before the fix). Verified: full `ReportServiceIT` green on the build box (5 tests, 0 failures).