### PR TITLE
Move openhtmltopdf to its maintained fork (+ PDFBox 3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.openhtmltopdf:openhtmltopdf-slf4j:1.0.10'
-    implementation('com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10') {
+    implementation 'io.github.openhtmltopdf:openhtmltopdf-slf4j:1.1.75'
+    implementation('io.github.openhtmltopdf:openhtmltopdf-pdfbox:1.1.75') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'org.mapstruct:mapstruct:1.6.3'


### PR DESCRIPTION
The dependency audit flagged `com.openhtmltopdf` 1.0.10 as dormant (2021, PDFBox 2.x). The project **continues under a maintained fork**, `io.github.openhtmltopdf`, now at **1.1.75**. This is a drop-in: the Java package stays `com.openhtmltopdf.*` so `ReportController` needs no change, and it pulls **PDFBox 3.0.7** (the actual modernization). Compiles clean on the build box.

Low risk (same rendering engine, newer version), but since the engine version changes, worth an eyeball on a generated report PDF after the next deploy to confirm layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PDF generation components to a newer release, improving compatibility and access to the latest fixes.
  * Preserved the existing logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->