### PR TITLE
docs(openapi): annotate the remaining controllers and DTOs

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.IssueComment;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,12 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/issues/comments")
 @Validated
+@Tag(
+        name = "Issue Comments",
+        description = "A comment left on an issue, carrying the comment text, its author and a "
+                + "timestamp. Endpoints cover creation, paginated listing and deletion, gated by the "
+                + "issue-comment authorities, with an admin authority that grants all operations."
+)
 public class IssueCommentController {
 
     private final IssueCommentService issueCommentService;
@@ -27,6 +36,16 @@ public class IssueCommentController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('issue-comment:create') or hasAuthority('issue-comment:admin')")
+    @Operation(
+            summary = "Create an issue comment",
+            description = "Adds a comment to the given issue."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueCommentService.addIssueComment(issueCommentCreationDto));
@@ -34,6 +53,15 @@ public class IssueCommentController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('issue-comment:read') or hasAuthority('issue-comment:admin')")
+    @Operation(
+            summary = "List issue comments",
+            description = "Returns a single page of issue comments. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment read or admin authority")
+    })
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
                                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
@@ -42,6 +70,15 @@ public class IssueCommentController {
 
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('issue-comment:delete') or hasAuthority('issue-comment:admin')")
+    @Operation(
+            summary = "Delete an issue comment",
+            description = "Deletes the comment with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comment deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No comment with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnIssueComment(@PathVariable Long id) {
         issueCommentService.deleteAnIssueComment(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("IssueComment with id: "+id+" deleted successfully with"));

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.IssueComment;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/issues/comments/web")
 @Validated
+@Tag(
+        name = "Issue Comments",
+        description = "Web-client twin of the issue comment endpoints. Adds a single-comment read and a "
+                + "lookup of every comment on an issue, alongside the same create, paginated listing "
+                + "and delete operations as the base API. Access is gated by tenant membership, with "
+                + "delete restricted to a system admin or project manager."
+)
 public class IssueCommentControllerWeb {
 
     private final IssueCommentService issueCommentService;
@@ -27,6 +37,16 @@ public class IssueCommentControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Create an issue comment",
+            description = "Adds a comment to the given issue."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueCommentService.addIssueComment(issueCommentCreationDto));
@@ -34,6 +54,15 @@ public class IssueCommentControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List issue comments",
+            description = "Returns a single page of issue comments. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
                                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
@@ -42,18 +71,45 @@ public class IssueCommentControllerWeb {
 
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an issue comment by id",
+            description = "Returns a single issue comment."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comment found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No comment with the given id")
+    })
     public ResponseEntity<IssueCommentDto> getAnIssueComment(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAnIssueComment(id));
     }
 
     @GetMapping("/issueId/{issueId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List comments for an issue",
+            description = "Returns every comment left on the given issue."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<List<IssueCommentDto>> getAllIssueCommentsByIssueId(@PathVariable Long issueId) {
         return ResponseEntity.status(HttpStatus.OK).body(issueCommentService.getAllIssueCommentsByIssueId(issueId));
     }
 
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete an issue comment",
+            description = "Deletes the comment with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Comment deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No comment with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnIssueComment(@PathVariable Long id) {
         issueCommentService.deleteAnIssueComment(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("IssueComment with id: "+id+" deleted successfully with"));

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.asset;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,13 @@ import java.util.List;
 @RestController
 @Validated
 @RequestMapping("/api/v1/assets/web")
+@Tag(
+        name = "Assets",
+        description = "Fixed assets in the organization's asset register: excavators, cranes, vehicles "
+                + "and similar equipment tracked with purchase, condition, maintenance and insurance "
+                + "detail. Endpoints cover listing, paginated listing, lookup by id, creation, update and "
+                + "deletion, scoped to the caller's current tenant organization."
+)
 public class AssetControllerWeb {
 
     private final AssetService assetService;
@@ -26,12 +36,29 @@ public class AssetControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List all assets",
+            description = "Returns every asset in the caller's current tenant organization, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Assets returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<AssetDto>> readAllAssets() {
         return new ResponseEntity<>(assetService.getAllAssets(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List assets, paginated",
+            description = "Returns a page of assets for the caller's current tenant organization. The "
+                    + "pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of assets returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<Page<AssetDto>> readAllAssetsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
@@ -40,24 +67,62 @@ public class AssetControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an asset by id",
+            description = "Returns a single asset, including its resolved vendor and storage location."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Asset found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
     public ResponseEntity<AssetDto> readAnAsset(@PathVariable Long id) {
         return new ResponseEntity<>(assetService.getAssetById(id), HttpStatus.OK);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create an asset",
+            description = "Adds a new asset to the current tenant organization's asset register, for "
+                    + "example a piece of heavy equipment such as a backhoe loader or a tower crane."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Asset created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<AssetDto> createAsset(@Valid @RequestBody AssetCreationDto creationDto) {
         return new ResponseEntity<>(assetService.createAsset(creationDto), HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Update an asset",
+            description = "Replaces the details of an existing asset with the given values."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Asset updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
     public ResponseEntity<AssetDto> updateAsset(@PathVariable Long id, @Valid @RequestBody AssetCreationDto creationDto) {
         return new ResponseEntity<>(assetService.updateAsset(id, creationDto), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete an asset",
+            description = "Removes the asset with the given id from the register."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Asset deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAsset(@PathVariable Long id) {
         assetService.deleteAsset(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Asset with id: " + id + " has been deleted"));

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
@@ -1,49 +1,83 @@
 package org.tornotron.echno_backend.asset.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "Payload to create or fully update a fixed asset in the organization's asset "
+        + "register, such as a piece of heavy equipment or a vehicle.")
 @Data
 public class AssetCreationDto {
 
+    @Schema(description = "Organization-assigned asset code.", example = "AST-0021")
     private String assetId;
 
+    @Schema(description = "Display name of the asset.", example = "JCB 3DX Backhoe Loader")
     @NotBlank
     private String name;
 
+    @Schema(description = "Free-text description of the asset.", example = "Backhoe loader used for excavation and material handling on site.")
     private String description;
+    @Schema(description = "Asset type, a kebab-case value defined by the frontend.", example = "heavy-equipment")
     private String type;
+    @Schema(description = "Asset category, a kebab-case value defined by the frontend.", example = "earthmoving")
     private String category;
+    @Schema(description = "Current lifecycle status, a kebab-case value defined by the frontend.", example = "in-use")
     private String status;
     // The web sends the field as "condition"; the entity column is
     // "asset_condition" (condition is a SQL reserved word). Accept both.
+    @Schema(description = "Physical condition of the asset. Accepted in the request body as either "
+            + "\"assetCondition\" or \"condition\".", example = "good")
     @JsonAlias("condition")
     private String assetCondition;
+    @Schema(description = "Date the asset was purchased.", example = "2023-06-10")
     private LocalDate purchaseDate;
+    @Schema(description = "Purchase price of the asset.", example = "3500000.00")
     private BigDecimal purchasePrice;
+    @Schema(description = "Current book value of the asset.", example = "2800000.00")
     private BigDecimal currentValue;
+    @Schema(description = "Annual depreciation rate as a percentage.", example = "10.0")
     private Double depreciationRate;
+    @Schema(description = "Name of the person the asset is currently assigned to.", example = "Ravi Kumar")
     private String assignedTo;
+    @Schema(description = "Name of the project the asset is currently deployed on.", example = "Marina Heights Towers")
     private String assignedProject;
+    @Schema(description = "Manufacturer of the asset.", example = "JCB India")
     private String manufacturer;
+    @Schema(description = "Model name or number.", example = "3DX")
     private String model;
+    @Schema(description = "Manufacturer serial number.", example = "JCB3DX2023-0456")
     private String serialNumber;
+    @Schema(description = "Government registration number, for registered vehicles and equipment.", example = "KL-07-AB-1234")
     private String registrationNumber;
+    @Schema(description = "Date the manufacturer warranty expires.", example = "2026-06-10")
     private LocalDate warrantyExpiry;
+    @Schema(description = "Date the asset was last serviced.", example = "2026-07-01")
     private LocalDate lastMaintenanceDate;
+    @Schema(description = "Date the next scheduled service is due.", example = "2026-10-01")
     private LocalDate nextMaintenanceDate;
+    @Schema(description = "Date the insurance policy expires.", example = "2027-06-10")
     private LocalDate insuranceExpiry;
+    @Schema(description = "How often the asset is serviced.", example = "Quarterly")
     private String maintenanceSchedule;
+    @Schema(description = "Total hours the asset has been used.", example = "1250.5")
     private Double usageHours;
+    @Schema(description = "Maximum usage hours before the asset is due for major overhaul or replacement.", example = "10000.0")
     private Double maxUsageHours;
+    @Schema(description = "Fuel type the asset runs on.", example = "diesel")
     private String fuelType;
+    @Schema(description = "Name of the insurance provider.", example = "ICICI Lombard")
     private String insuranceProvider;
+    @Schema(description = "Insurance policy number.", example = "POL-887766")
     private String policyNumber;
+    @Schema(description = "Free-text notes about the asset.", example = "Hydraulic hose replaced during last service.")
     private String notes;
+    @Schema(description = "Id of the vendor the asset was purchased from.", example = "3")
     private Long vendorId;
+    @Schema(description = "Id of the storage location the asset is stored at.", example = "7")
     private Long locationId;
 }

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
@@ -1,47 +1,85 @@
 package org.tornotron.echno_backend.asset.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Schema(description = "A fixed asset in the organization's asset register, with its resolved vendor and storage location.")
 @Data
 public class AssetDto {
+    @Schema(description = "Database id of the asset.", example = "12")
     private Long id;
+    @Schema(description = "Organization-assigned asset code.", example = "AST-0021")
     private String assetId;
+    @Schema(description = "Display name of the asset.", example = "JCB 3DX Backhoe Loader")
     private String name;
+    @Schema(description = "Free-text description of the asset.", example = "Backhoe loader used for excavation and material handling on site.")
     private String description;
+    @Schema(description = "Asset type, a kebab-case value defined by the frontend.", example = "heavy-equipment")
     private String type;
+    @Schema(description = "Asset category, a kebab-case value defined by the frontend.", example = "earthmoving")
     private String category;
+    @Schema(description = "Current lifecycle status, a kebab-case value defined by the frontend.", example = "in-use")
     private String status;
+    @Schema(description = "Physical condition of the asset.", example = "good")
     private String assetCondition;
+    @Schema(description = "Date the asset was purchased.", example = "2023-06-10")
     private LocalDate purchaseDate;
+    @Schema(description = "Purchase price of the asset.", example = "3500000.00")
     private BigDecimal purchasePrice;
+    @Schema(description = "Current book value of the asset.", example = "2800000.00")
     private BigDecimal currentValue;
+    @Schema(description = "Annual depreciation rate as a percentage.", example = "10.0")
     private Double depreciationRate;
+    @Schema(description = "Name of the person the asset is currently assigned to.", example = "Ravi Kumar")
     private String assignedTo;
+    @Schema(description = "Name of the project the asset is currently deployed on.", example = "Marina Heights Towers")
     private String assignedProject;
+    @Schema(description = "Manufacturer of the asset.", example = "JCB India")
     private String manufacturer;
+    @Schema(description = "Model name or number.", example = "3DX")
     private String model;
+    @Schema(description = "Manufacturer serial number.", example = "JCB3DX2023-0456")
     private String serialNumber;
+    @Schema(description = "Government registration number, for registered vehicles and equipment.", example = "KL-07-AB-1234")
     private String registrationNumber;
+    @Schema(description = "Date the manufacturer warranty expires.", example = "2026-06-10")
     private LocalDate warrantyExpiry;
+    @Schema(description = "Date the asset was last serviced.", example = "2026-07-01")
     private LocalDate lastMaintenanceDate;
+    @Schema(description = "Date the next scheduled service is due.", example = "2026-10-01")
     private LocalDate nextMaintenanceDate;
+    @Schema(description = "Date the insurance policy expires.", example = "2027-06-10")
     private LocalDate insuranceExpiry;
+    @Schema(description = "How often the asset is serviced.", example = "Quarterly")
     private String maintenanceSchedule;
+    @Schema(description = "Total hours the asset has been used.", example = "1250.5")
     private Double usageHours;
+    @Schema(description = "Maximum usage hours before the asset is due for major overhaul or replacement.", example = "10000.0")
     private Double maxUsageHours;
+    @Schema(description = "Fuel type the asset runs on.", example = "diesel")
     private String fuelType;
+    @Schema(description = "Name of the insurance provider.", example = "ICICI Lombard")
     private String insuranceProvider;
+    @Schema(description = "Insurance policy number.", example = "POL-887766")
     private String policyNumber;
+    @Schema(description = "Free-text notes about the asset.", example = "Hydraulic hose replaced during last service.")
     private String notes;
+    @Schema(description = "Id of the vendor the asset was purchased from.", example = "3")
     private Long vendorId;
+    @Schema(description = "Name of the vendor the asset was purchased from.", example = "BuildTech Equipment Rentals")
     private String vendorName;
+    @Schema(description = "Id of the storage location the asset is stored at.", example = "7")
     private Long locationId;
+    @Schema(description = "Name of the storage location the asset is stored at.", example = "Kochi Yard")
     private String locationName;
+    @Schema(description = "Id of the organization that owns the asset.", example = "1")
     private Long organizationId;
+    @Schema(description = "Timestamp the asset record was created.", example = "2023-06-10T09:30:00")
     private LocalDateTime createdAt;
+    @Schema(description = "Timestamp the asset record was last updated.", example = "2026-07-01T14:15:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
@@ -24,6 +27,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance")
 @Validated
+@Tag(
+        name = "Attendance",
+        description = "Daily attendance records built from clock events across a shift's sessions, for the "
+                + "mobile client. Endpoints cover checking in, recording clock events, reading and browsing "
+                + "records, approving or marking an employee absent, and monthly summaries. Access is scoped "
+                + "to the caller's tenant, with record-level checks gating who can view an employee's history "
+                + "or manage attendance for a project."
+)
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
@@ -36,6 +47,17 @@ public class AttendanceController {
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Check in for the day",
+            description = "Records the first clock event of the day for an employee against a project and "
+                    + "shift, from a multipart request carrying the check-in details as JSON and an optional "
+                    + "photo."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Check-in recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
                                                          @RequestParam(value = "photoUrl", required = false) MultipartFile photoUrl) throws JsonProcessingException {
         AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
@@ -46,6 +68,18 @@ public class AttendanceController {
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Record a clock event",
+            description = "Adds a clock event, such as lunch break start or evening clock-out, to an "
+                    + "existing attendance record, from a multipart request carrying the event details as "
+                    + "JSON and an optional photo."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Clock event recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid clock event JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
                                                                   @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
@@ -54,12 +88,32 @@ public class AttendanceController {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an attendance record by id",
+            description = "Returns a single attendance record including its clock events, movements, "
+                    + "regularizations and approval state."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(attendanceService.getAttendanceById(id));
     }
 
     @GetMapping("/employee/{employeeId}")
     @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
+    @Operation(
+            summary = "List an employee's attendance in a date range",
+            description = "Returns the attendance records for one employee between startDate and endDate, "
+                    + "inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to view this employee's attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<AttendanceResponseDto>> getByEmployee(
             @PathVariable Long employeeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -69,6 +123,17 @@ public class AttendanceController {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "List a project's attendance for a date",
+            description = "Returns a page of attendance records for a project on a given date, optionally "
+                    + "filtered by status or a search term against the employee name, sorted by employee "
+                    + "name."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<AttendanceResponseDto>> getByProject(
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
@@ -83,6 +148,17 @@ public class AttendanceController {
 
     @PostMapping("/{id}/approve")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Approve or reject an attendance record",
+            description = "Sets the approval status of an attendance record, with an optional remark, "
+                    + "typically after a regularization request has been reviewed."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "approvalStatus is missing or invalid"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
@@ -91,6 +167,16 @@ public class AttendanceController {
 
     @PostMapping("/mark-absent")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Mark an employee absent",
+            description = "Creates or updates the attendance record for an employee on a project for the "
+                    + "given date with an absent status, for use when no clock event was recorded."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee marked absent"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or project with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> markAbsent(
             @RequestParam Long employeeId,
             @RequestParam Long projectId,
@@ -100,6 +186,16 @@ public class AttendanceController {
 
     @GetMapping("/summary/{employeeId}")
     @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
+    @Operation(
+            summary = "Get an employee's monthly attendance summary",
+            description = "Returns aggregated counts (present, absent, half days, leave, overtime and so "
+                    + "on) and computed totals for one employee over a calendar month."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Monthly summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to view this employee's attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<AttendanceSummaryDto> getMonthlySummary(
             @PathVariable Long employeeId,
             @RequestParam int month,
@@ -109,6 +205,16 @@ public class AttendanceController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Delete an attendance record",
+            description = "Deletes the attendance record with the given id, along with its clock events "
+                    + "and movements."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<ApiResponse> delete(@PathVariable Long id) {
         attendanceService.deleteAttendance(id);
         return ResponseEntity.ok(new ApiResponse("Attendance record deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
@@ -24,6 +27,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance/web")
 @Validated
+@Tag(
+        name = "Attendance (Web)",
+        description = "Daily attendance records built from clock events across a shift's sessions, for the "
+                + "web client. Endpoints cover checking in, recording clock events, reading and browsing "
+                + "records, approving or marking an employee absent, and monthly summaries. Access is "
+                + "scoped to the caller's tenant, with record-level checks gating who can view an "
+                + "employee's history or manage attendance for a project."
+)
 public class AttendanceControllerWeb {
 
     private final AttendanceService attendanceService;
@@ -36,6 +47,17 @@ public class AttendanceControllerWeb {
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Check in for the day",
+            description = "Records the first clock event of the day for an employee against a project and "
+                    + "shift, from a multipart request carrying the check-in details as JSON and an optional "
+                    + "photo."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Check-in recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
                                                          @RequestParam(value = "photo", required = false)MultipartFile photo) throws JsonProcessingException {
         AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
@@ -44,6 +66,18 @@ public class AttendanceControllerWeb {
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Record a clock event",
+            description = "Adds a clock event, such as lunch break start or evening clock-out, to an "
+                    + "existing attendance record, from a multipart request carrying the event details as "
+                    + "JSON and an optional photo."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Clock event recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid clock event JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
                                                                     @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
@@ -52,12 +86,32 @@ public class AttendanceControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an attendance record by id",
+            description = "Returns a single attendance record including its clock events, movements, "
+                    + "regularizations and approval state."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(attendanceService.getAttendanceById(id));
     }
 
     @GetMapping("/employee/{employeeId}")
     @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
+    @Operation(
+            summary = "List an employee's attendance in a date range",
+            description = "Returns the attendance records for one employee between startDate and endDate, "
+                    + "inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to view this employee's attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<AttendanceResponseDto>> getByEmployee(
             @PathVariable Long employeeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -67,6 +121,17 @@ public class AttendanceControllerWeb {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "List a project's attendance for a date",
+            description = "Returns a page of attendance records for a project on a given date, optionally "
+                    + "filtered by status or a search term against the employee name, sorted by employee "
+                    + "name."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<AttendanceResponseDto>> getByProject(
             @PathVariable Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
@@ -81,6 +146,17 @@ public class AttendanceControllerWeb {
 
     @PostMapping("/{id}/approve")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Approve or reject an attendance record",
+            description = "Sets the approval status of an attendance record, with an optional remark, "
+                    + "typically after a regularization request has been reviewed."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "approvalStatus is missing or invalid"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
@@ -89,6 +165,16 @@ public class AttendanceControllerWeb {
 
     @PostMapping("/mark-absent")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Mark an employee absent",
+            description = "Creates or updates the attendance record for an employee on a project for the "
+                    + "given date with an absent status, for use when no clock event was recorded."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee marked absent"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or project with the given id")
+    })
     public ResponseEntity<AttendanceResponseDto> markAbsent(
             @RequestParam Long employeeId,
             @RequestParam Long projectId,
@@ -98,6 +184,16 @@ public class AttendanceControllerWeb {
 
     @GetMapping("/summary/{employeeId}")
     @PreAuthorize("@attendanceSecurity.canViewEmployeeRecords(#employeeId)")
+    @Operation(
+            summary = "Get an employee's monthly attendance summary",
+            description = "Returns aggregated counts (present, absent, half days, leave, overtime and so "
+                    + "on) and computed totals for one employee over a calendar month."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Monthly summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to view this employee's attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<AttendanceSummaryDto> getMonthlySummary(
             @PathVariable Long employeeId,
             @RequestParam int month,
@@ -107,6 +203,16 @@ public class AttendanceControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Delete an attendance record",
+            description = "Deletes the attendance record with the given id, along with its clock events "
+                    + "and movements."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attendance record deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<ApiResponse> delete(@PathVariable Long id) {
         attendanceService.deleteAttendance(id);
         return ResponseEntity.ok(new ApiResponse("Attendance record deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance-regularizations")
 @Validated
+@Tag(
+        name = "Attendance Regularizations",
+        description = "Requests to correct an attendance record that is missing clock events, for example "
+                + "a forgotten evening clock-out. An employee submits a request naming the missing events "
+                + "and, optionally, the corrected events; a manager approves or rejects it. Submitting and "
+                + "reading a request is tenant scoped, while listing pending requests and processing one is "
+                + "limited to callers who can manage attendance records."
+)
 public class AttendanceRegularizationController {
 
     private final AttendanceRegularizationService regularizationService;
@@ -26,6 +38,17 @@ public class AttendanceRegularizationController {
 
     @PostMapping("/request")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Submit a regularization request",
+            description = "Files a request to correct an attendance record, naming the missing clock "
+                    + "events and, optionally, the events that should be added in their place."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
+            @ApiResponse(responseCode = "400", description = "attendanceId, reason or missingEvents is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
+    })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
             @Valid @RequestBody RegularizationRequestDto dto,
             @RequestParam String requestedBy) {
@@ -35,6 +58,17 @@ public class AttendanceRegularizationController {
 
     @PostMapping("/{id}/process")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Approve or reject a regularization request",
+            description = "Sets the status of a pending regularization request. A rejection should carry "
+                    + "a rejectionReason."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Regularization request processed"),
+            @ApiResponse(responseCode = "400", description = "status is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
+    })
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
             @Valid @RequestBody RegularizationActionDto dto,
@@ -44,12 +78,29 @@ public class AttendanceRegularizationController {
 
     @GetMapping("/pending")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "List pending regularization requests",
+            description = "Returns every regularization request awaiting approval or rejection."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Pending regularization requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records")
+    })
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
         return ResponseEntity.ok(regularizationService.getPendingRegularizations());
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a regularization request by id",
+            description = "Returns a single regularization request including its approval state."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Regularization request found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
+    })
     public ResponseEntity<AttendanceRegularizationDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(regularizationService.getRegularizationById(id));
     }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance-regularizations/web")
 @Validated
+@Tag(
+        name = "Attendance Regularizations (Web)",
+        description = "Requests to correct an attendance record that is missing clock events, for example "
+                + "a forgotten evening clock-out, for the web client. An employee submits a request naming "
+                + "the missing events and, optionally, the corrected events; a manager approves or rejects "
+                + "it. Submitting and reading a request is tenant scoped, while listing pending requests "
+                + "and processing one is limited to callers who can manage attendance records."
+)
 public class AttendanceRegularizationControllerWeb {
 
     private final AttendanceRegularizationService regularizationService;
@@ -26,6 +38,17 @@ public class AttendanceRegularizationControllerWeb {
 
     @PostMapping("/request")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Submit a regularization request",
+            description = "Files a request to correct an attendance record, naming the missing clock "
+                    + "events and, optionally, the events that should be added in their place."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
+            @ApiResponse(responseCode = "400", description = "attendanceId, reason or missingEvents is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
+    })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
             @Valid @RequestBody RegularizationRequestDto dto,
             @RequestParam String requestedBy) {
@@ -35,6 +58,17 @@ public class AttendanceRegularizationControllerWeb {
 
     @PostMapping("/{id}/process")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Approve or reject a regularization request",
+            description = "Sets the status of a pending regularization request. A rejection should carry "
+                    + "a rejectionReason."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Regularization request processed"),
+            @ApiResponse(responseCode = "400", description = "status is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
+    })
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
             @Valid @RequestBody RegularizationActionDto dto,
@@ -44,12 +78,29 @@ public class AttendanceRegularizationControllerWeb {
 
     @GetMapping("/pending")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "List pending regularization requests",
+            description = "Returns every regularization request awaiting approval or rejection."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Pending regularization requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records")
+    })
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
         return ResponseEntity.ok(regularizationService.getPendingRegularizations());
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a regularization request by id",
+            description = "Returns a single regularization request including its approval state."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Regularization request found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
+    })
     public ResponseEntity<AttendanceRegularizationDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(regularizationService.getRegularizationById(id));
     }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance-settings")
 @Validated
+@Tag(
+        name = "Attendance Settings",
+        description = "Organization- and project-level configuration for how attendance is captured: "
+                + "number of check-in/out cycles, whether a photo or geolocation is required, geofence "
+                + "radius, movement tracking, and regularization rules. A project without its own settings "
+                + "falls back to the organization's. Reading settings is tenant scoped; creating, updating "
+                + "and deactivating them is limited to callers who can configure attendance."
+)
 public class AttendanceSettingsController {
 
     private final AttendanceSettingsService settingsService;
@@ -26,30 +38,80 @@ public class AttendanceSettingsController {
 
     @PostMapping
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Create attendance settings",
+            description = "Creates an attendance settings profile for the organization, or for a single "
+                    + "project when projectId is set."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Attendance settings created"),
+            @ApiResponse(responseCode = "400", description = "A required field is missing or out of range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings")
+    })
     public ResponseEntity<AttendanceSettingsDto> create(@Valid @RequestBody AttendanceSettingsCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(settingsService.createSettings(dto));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List attendance settings",
+            description = "Returns every attendance settings profile in the current tenant, organization "
+                    + "level and per project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<AttendanceSettingsDto>> getAll() {
         return ResponseEntity.ok(settingsService.getAllSettings());
     }
 
     @GetMapping("/org")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get organization-level attendance settings",
+            description = "Returns the attendance settings that apply organization-wide, used as the "
+                    + "default for projects without their own settings."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Organization attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No organization-level attendance settings configured")
+    })
     public ResponseEntity<AttendanceSettingsDto> getOrgSettings() {
         return ResponseEntity.ok(settingsService.getOrgSettings());
     }
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a project's attendance settings",
+            description = "Returns the attendance settings for a project, falling back to the "
+                    + "organization-level settings if the project has none of its own."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id, or no settings configured for it")
+    })
     public ResponseEntity<AttendanceSettingsDto> getProjectSettings(@PathVariable Long projectId) {
         return ResponseEntity.ok(settingsService.getProjectSettings(projectId));
     }
 
     @PatchMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Update attendance settings",
+            description = "Applies a partial update to an attendance settings profile. Only the fields "
+                    + "present in the request body are changed."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings updated"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
+    })
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
                                                          @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
@@ -57,6 +119,16 @@ public class AttendanceSettingsController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Deactivate attendance settings",
+            description = "Deactivates the attendance settings profile with the given id. Deactivated "
+                    + "settings no longer apply and are excluded from lookups."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Attendance settings deactivated"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
+    })
     public ResponseEntity<Void> deactivate(@PathVariable Long id) {
         settingsService.deactivateSettings(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attendance-settings/web")
 @Validated
+@Tag(
+        name = "Attendance Settings (Web)",
+        description = "Organization- and project-level configuration for how attendance is captured, for "
+                + "the web client: number of check-in/out cycles, whether a photo or geolocation is "
+                + "required, geofence radius, movement tracking, and regularization rules. A project "
+                + "without its own settings falls back to the organization's. Reading settings is tenant "
+                + "scoped; creating, updating and deactivating them is limited to callers who can configure "
+                + "attendance."
+)
 public class AttendanceSettingsControllerWeb {
 
     private final AttendanceSettingsService settingsService;
@@ -26,30 +39,80 @@ public class AttendanceSettingsControllerWeb {
 
     @PostMapping
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Create attendance settings",
+            description = "Creates an attendance settings profile for the organization, or for a single "
+                    + "project when projectId is set."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Attendance settings created"),
+            @ApiResponse(responseCode = "400", description = "A required field is missing or out of range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings")
+    })
     public ResponseEntity<AttendanceSettingsDto> create(@Valid @RequestBody AttendanceSettingsCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(settingsService.createSettings(dto));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List attendance settings",
+            description = "Returns every attendance settings profile in the current tenant, organization "
+                    + "level and per project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<AttendanceSettingsDto>> getAll() {
         return ResponseEntity.ok(settingsService.getAllSettings());
     }
 
     @GetMapping("/org")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get organization-level attendance settings",
+            description = "Returns the attendance settings that apply organization-wide, used as the "
+                    + "default for projects without their own settings."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Organization attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No organization-level attendance settings configured")
+    })
     public ResponseEntity<AttendanceSettingsDto> getOrgSettings() {
         return ResponseEntity.ok(settingsService.getOrgSettings());
     }
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a project's attendance settings",
+            description = "Returns the attendance settings for a project, falling back to the "
+                    + "organization-level settings if the project has none of its own."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id, or no settings configured for it")
+    })
     public ResponseEntity<AttendanceSettingsDto> getProjectSettings(@PathVariable Long projectId) {
         return ResponseEntity.ok(settingsService.getProjectSettings(projectId));
     }
 
     @PatchMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Update attendance settings",
+            description = "Applies a partial update to an attendance settings profile. Only the fields "
+                    + "present in the request body are changed."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendance settings updated"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
+    })
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
                                                          @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
@@ -57,6 +120,16 @@ public class AttendanceSettingsControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Deactivate attendance settings",
+            description = "Deactivates the attendance settings profile with the given id. Deactivated "
+                    + "settings no longer apply and are excluded from lookups."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Attendance settings deactivated"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
+    })
     public ResponseEntity<Void> deactivate(@PathVariable Long id) {
         settingsService.deactivateSettings(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -15,6 +19,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/movement-records")
 @Validated
+@Tag(
+        name = "Movement Records",
+        description = "Records of an employee travelling away from their checked-in location during a "
+                + "work day, for example a site visit, client meeting or material procurement trip. Each "
+                + "movement is logged against an attendance record with a start and end time, distance and "
+                + "purpose, and can be verified afterwards. Creating and reading movements is tenant "
+                + "scoped; verifying one is limited to callers who can manage attendance records."
+)
 public class MovementRecordController {
 
     private final MovementRecordService movementRecordService;
@@ -25,6 +37,17 @@ public class MovementRecordController {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Log a movement",
+            description = "Records an employee's movement away from their checked-in location against an "
+                    + "existing attendance record."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Movement record created"),
+            @ApiResponse(responseCode = "400", description = "attendanceId, movementType, fromLocation, startTime or purpose is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record or employee with the given id")
+    })
     public ResponseEntity<MovementRecordDto> create(
             @Valid @RequestBody MovementRecordCreationDto dto,
             @RequestParam Long employeeId) {
@@ -34,18 +57,46 @@ public class MovementRecordController {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a movement record by id",
+            description = "Returns a single movement record including its verification state."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement record found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No movement record with the given id")
+    })
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(movementRecordService.getMovementById(id));
     }
 
     @GetMapping("/attendance/{attendanceId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List movements for an attendance record",
+            description = "Returns every movement logged against a given attendance record."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement records returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {
         return ResponseEntity.ok(movementRecordService.getMovementsByAttendance(attendanceId));
     }
 
     @PostMapping("/{id}/verify")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Verify a movement record",
+            description = "Marks a movement record as verified by the given approver, for example after "
+                    + "checking the reported distance and purpose."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement record verified"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @ApiResponse(responseCode = "404", description = "No movement record with the given id")
+    })
     public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
                                                      @RequestParam String verifiedBy) {
         return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -15,6 +19,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/movement-records/web")
 @Validated
+@Tag(
+        name = "Movement Records (Web)",
+        description = "Records of an employee travelling away from their checked-in location during a "
+                + "work day, for example a site visit, client meeting or material procurement trip, for "
+                + "the web client. Each movement is logged against an attendance record with a start and "
+                + "end time, distance and purpose, and can be verified afterwards. Creating and reading "
+                + "movements is tenant scoped; verifying one is limited to callers who can manage "
+                + "attendance records."
+)
 public class MovementRecordControllerWeb {
 
     private final MovementRecordService movementRecordService;
@@ -25,6 +38,17 @@ public class MovementRecordControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Log a movement",
+            description = "Records an employee's movement away from their checked-in location against an "
+                    + "existing attendance record."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Movement record created"),
+            @ApiResponse(responseCode = "400", description = "attendanceId, movementType, fromLocation, startTime or purpose is missing or invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record or employee with the given id")
+    })
     public ResponseEntity<MovementRecordDto> create(
             @Valid @RequestBody MovementRecordCreationDto dto,
             @RequestParam Long employeeId) {
@@ -34,18 +58,46 @@ public class MovementRecordControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a movement record by id",
+            description = "Returns a single movement record including its verification state."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement record found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No movement record with the given id")
+    })
     public ResponseEntity<MovementRecordDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(movementRecordService.getMovementById(id));
     }
 
     @GetMapping("/attendance/{attendanceId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List movements for an attendance record",
+            description = "Returns every movement logged against a given attendance record."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement records returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No attendance record with the given id")
+    })
     public ResponseEntity<List<MovementRecordDto>> getByAttendance(@PathVariable Long attendanceId) {
         return ResponseEntity.ok(movementRecordService.getMovementsByAttendance(attendanceId));
     }
 
     @PostMapping("/{id}/verify")
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "Verify a movement record",
+            description = "Marks a movement record as verified by the given approver, for example after "
+                    + "checking the reported distance and purpose."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movement record verified"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @ApiResponse(responseCode = "404", description = "No movement record with the given id")
+    })
     public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
                                                      @RequestParam String verifiedBy) {
         return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));

--- a/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/shift-timings")
 @Validated
+@Tag(
+        name = "Shift Timings",
+        description = "Named work shifts (start and end time, lunch break window, grace period, and the "
+                + "minimum, half-day and overtime work-hour thresholds) that attendance records are "
+                + "evaluated against. Reading shift timings is tenant scoped; creating, updating and "
+                + "deleting them is limited to callers who can configure attendance."
+)
 public class ShiftTimingController {
 
     private final ShiftTimingService shiftTimingService;
@@ -26,24 +37,62 @@ public class ShiftTimingController {
 
     @PostMapping
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Create a shift timing",
+            description = "Creates a named shift with its start and end time, lunch break window, grace "
+                    + "period and work-hour thresholds."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Shift timing created"),
+            @ApiResponse(responseCode = "400", description = "A required field is missing or out of range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings")
+    })
     public ResponseEntity<ShiftTimingDto> create(@Valid @RequestBody ShiftTimingCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(shiftTimingService.createShiftTiming(dto));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List shift timings",
+            description = "Returns every shift timing defined in the current tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<ShiftTimingDto>> getAll() {
         return ResponseEntity.ok(shiftTimingService.getAllShiftTimings());
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a shift timing by id",
+            description = "Returns a single shift timing."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timing found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<ShiftTimingDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(shiftTimingService.getShiftTimingById(id));
     }
 
     @PatchMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Update a shift timing",
+            description = "Applies a partial update to a shift timing. Only the fields present in the "
+                    + "request body are changed."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timing updated"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<ShiftTimingDto> update(@PathVariable Long id,
                                                   @RequestBody ShiftTimingPatchDto dto) {
         return ResponseEntity.ok(shiftTimingService.updateShiftTiming(id, dto));
@@ -51,6 +100,15 @@ public class ShiftTimingController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Delete a shift timing",
+            description = "Deletes the shift timing with the given id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Shift timing deleted"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         shiftTimingService.deleteShiftTiming(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ShiftTimingControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/shift-timings/web")
 @Validated
+@Tag(
+        name = "Shift Timings (Web)",
+        description = "Named work shifts (start and end time, lunch break window, grace period, and the "
+                + "minimum, half-day and overtime work-hour thresholds) that attendance records are "
+                + "evaluated against, for the web client. Reading shift timings is tenant scoped; creating, "
+                + "updating and deleting them is limited to callers who can configure attendance."
+)
 public class ShiftTimingControllerWeb {
 
     private final ShiftTimingService shiftTimingService;
@@ -26,24 +37,62 @@ public class ShiftTimingControllerWeb {
 
     @PostMapping
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Create a shift timing",
+            description = "Creates a named shift with its start and end time, lunch break window, grace "
+                    + "period and work-hour thresholds."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Shift timing created"),
+            @ApiResponse(responseCode = "400", description = "A required field is missing or out of range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings")
+    })
     public ResponseEntity<ShiftTimingDto> create(@Valid @RequestBody ShiftTimingCreationDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(shiftTimingService.createShiftTiming(dto));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List shift timings",
+            description = "Returns every shift timing defined in the current tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<ShiftTimingDto>> getAll() {
         return ResponseEntity.ok(shiftTimingService.getAllShiftTimings());
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a shift timing by id",
+            description = "Returns a single shift timing."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timing found"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<ShiftTimingDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(shiftTimingService.getShiftTimingById(id));
     }
 
     @PatchMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Update a shift timing",
+            description = "Applies a partial update to a shift timing. Only the fields present in the "
+                    + "request body are changed."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Shift timing updated"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<ShiftTimingDto> update(@PathVariable Long id,
                                                   @RequestBody ShiftTimingPatchDto dto) {
         return ResponseEntity.ok(shiftTimingService.updateShiftTiming(id, dto));
@@ -51,6 +100,15 @@ public class ShiftTimingControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@attendanceSecurity.canConfigureAttendance()")
+    @Operation(
+            summary = "Delete a shift timing",
+            description = "Deletes the shift timing with the given id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Shift timing deleted"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to configure attendance settings"),
+            @ApiResponse(responseCode = "404", description = "No shift timing with the given id")
+    })
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         shiftTimingService.deleteShiftTiming(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceApprovalDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceApprovalDto.java
@@ -1,18 +1,22 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
 
+@Schema(description = "Payload to approve or reject an attendance record.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceApprovalDto {
 
+    @Schema(description = "Decision on the attendance record.", example = "APPROVED")
     @NotNull
     private ApprovalStatus approvalStatus;
 
+    @Schema(description = "Remarks explaining the decision, especially when rejecting.", example = "Confirmed with site supervisor, checked in late due to traffic")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,29 +8,49 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to record an employee's first clock event of the day.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceCheckInDto {
 
+    @Schema(description = "Id of the employee checking in.", example = "42")
     @NotNull
     private Long employeeId;
 
+    @Schema(description = "Id of the project the employee is checking in against.", example = "12")
     @NotNull
     private Long projectId;
 
+    @Schema(description = "Id of the shift the employee is working.", example = "5")
     @NotNull
     private Long shiftTimingId;
 
+    @Schema(description = "Timestamp of the check-in event.", example = "2026-01-15T09:02:00")
     @NotNull
     private LocalDateTime eventTimestamp;
 
+    @Schema(description = "Latitude captured at check-in.", example = "13.0827")
     private Double latitude;
+
+    @Schema(description = "Longitude captured at check-in.", example = "80.2707")
     private Double longitude;
+
+    @Schema(description = "GPS accuracy of the captured coordinates, in metres.", example = "8.5")
     private Double gpsAccuracy;
+
+    @Schema(description = "Altitude captured at check-in, in metres.", example = "12.0")
     private Double altitude;
+
+    @Schema(description = "Platform the check-in was made from.", example = "android")
     private String devicePlatform;
+
+    @Schema(description = "Identifier of the device used to check in.", example = "device-8f3a21")
     private String deviceId;
+
+    @Schema(description = "IP address of the device at check-in.", example = "10.24.6.41")
     private String ipAddress;
+
+    @Schema(description = "Optional remarks about the check-in.", example = "Reported directly to the second floor slab pour")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,27 +9,48 @@ import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to record a clock event against an existing attendance record.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceClockEventDto {
 
+    @Schema(description = "Id of the attendance record the event belongs to.", example = "781")
     @NotNull
     private Long attendanceId;
 
+    @Schema(description = "Type of clock event.", example = "LUNCH_BREAK_START")
     @NotNull
     private ClockEventType eventType;
 
+    @Schema(description = "Timestamp of the event.", example = "2026-01-15T13:00:00")
     @NotNull
     private LocalDateTime eventTimestamp;
 
+    @Schema(description = "Latitude captured for the event.", example = "13.0827")
     private Double latitude;
+
+    @Schema(description = "Longitude captured for the event.", example = "80.2707")
     private Double longitude;
+
+    @Schema(description = "GPS accuracy of the captured coordinates, in metres.", example = "8.5")
     private Double gpsAccuracy;
+
+    @Schema(description = "Altitude captured for the event, in metres.", example = "12.0")
     private Double altitude;
+
+    @Schema(description = "URL of the photo captured with the event, if any.", example = "https://storage.echno.xyz/clock-events/781-lunch.jpg")
     private String photoUrl;
+
+    @Schema(description = "Platform the event was recorded from.", example = "android")
     private String devicePlatform;
+
+    @Schema(description = "Identifier of the device used to record the event.", example = "device-8f3a21")
     private String deviceId;
+
+    @Schema(description = "IP address of the device at the time of the event.", example = "10.24.6.41")
     private String ipAddress;
+
+    @Schema(description = "Optional remarks about the event.", example = "Left site briefly for a material delivery")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceRegularizationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceRegularizationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,19 +10,40 @@ import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A request to correct an attendance record that is missing one or more clock events.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceRegularizationDto {
+
+    @Schema(description = "Id of the regularization request.", example = "56")
     private Long id;
+
+    @Schema(description = "Id of the attendance record being corrected.", example = "781")
     private Long attendanceId;
+
+    @Schema(description = "Reason given for the missing events.", example = "Phone battery died before evening clock-out")
     private String reason;
+
+    @Schema(description = "Name or id of the person who submitted the request.", example = "Ravi Kumar")
     private String requestedBy;
+
+    @Schema(description = "Timestamp the request was submitted.", example = "2026-01-16T08:30:00")
     private LocalDateTime requestedAt;
+
+    @Schema(description = "Name or id of the person who approved or rejected the request.", example = "Anand Rajashekar")
     private String approvedBy;
+
+    @Schema(description = "Timestamp the request was approved or rejected.", example = "2026-01-16T11:00:00")
     private LocalDateTime approvedAt;
+
+    @Schema(description = "Current status of the request.", example = "PENDING")
     private RegularizationStatus status;
+
+    @Schema(description = "Reason given when the request is rejected.", example = "No corroborating movement record for the claimed hours")
     private String rejectionReason;
+
+    @Schema(description = "Clock event types missing from the original attendance record.", example = "[\"EVENING_CLOCK_OUT\"]")
     private List<String> missingEvents;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,42 +12,91 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A single day's attendance record for an employee, with its clock events, movements, regularizations and approval state.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceResponseDto {
+
+    @Schema(description = "Id of the attendance record.", example = "781")
     private Long id;
+
+    @Schema(description = "Id of the employee.", example = "42")
     private Long employeeId;
+
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Calendar date the record covers.", example = "2026-01-15")
     private LocalDate attendanceDate;
+
+    @Schema(description = "Id of the project the employee was assigned to on this date.", example = "12")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Kovilambakkam Phase 2")
     private String projectName;
+
+    @Schema(description = "Computed attendance status for the day.", example = "PRESENT")
     private AttendanceStatus status;
+
+    @Schema(description = "Shift the employee was scheduled to work.")
     private ShiftTimingDto shiftTiming;
 
+    @Schema(description = "Clock events recorded for the day, in chronological order.")
     private List<ClockEventDto> clockEvents;
 
+    @Schema(description = "Total minutes worked across all sessions.", example = "480")
     private Integer totalWorkMinutes;
+
+    @Schema(description = "Minutes worked in the morning session, before the lunch break.", example = "225")
     private Integer morningSessionMinutes;
+
+    @Schema(description = "Minutes worked in the afternoon session, after the lunch break.", example = "255")
     private Integer afternoonSessionMinutes;
+
+    @Schema(description = "Minutes worked beyond the shift's overtime threshold.", example = "30")
     private Integer overtimeMinutes;
+
+    @Schema(description = "Total minutes spent on breaks during the day.", example = "60")
     private Integer breakDurationMinutes;
+
+    @Schema(description = "Whether the employee clocked in after the shift's grace period.", example = "false")
     private Boolean isLateArrival;
+
+    @Schema(description = "Whether the employee clocked out before the shift's end time.", example = "false")
     private Boolean isEarlyCheckout;
+
+    @Schema(description = "Whether the employee worked beyond the overtime threshold.", example = "false")
     private Boolean isOvertime;
 
+    @Schema(description = "Id of the leave request this record was generated from, if the day is on leave.", example = "9")
     private Long leaveId;
+
+    @Schema(description = "Type of leave applied on this date, if any.", example = "CASUAL")
     private String leaveType;
 
+    @Schema(description = "Regularization requests filed against this record.")
     private List<AttendanceRegularizationDto> regularizations;
+
+    @Schema(description = "Movements logged against this record.")
     private List<MovementRecordDto> movements;
 
+    @Schema(description = "Approval status of the record.", example = "APPROVED")
     private ApprovalStatus approvalStatus;
+
+    @Schema(description = "Name or id of the person who approved or rejected the record.", example = "Anand Rajashekar")
     private String approvedBy;
+
+    @Schema(description = "Timestamp the record was approved or rejected.", example = "2026-01-16T10:15:00")
     private LocalDateTime approvedAt;
+
+    @Schema(description = "Remarks attached to the record, for example an approval or rejection note.", example = "Confirmed with site supervisor")
     private String remarks;
 
+    @Schema(description = "Timestamp the record was created.", example = "2026-01-15T09:02:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp the record was last updated.", example = "2026-01-15T18:05:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -8,55 +9,71 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "Payload to create an attendance settings profile for an organization or a project.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceSettingsCreationDto {
 
+    @Schema(description = "Display name for this settings profile.", example = "Standard Site Attendance")
     @NotBlank
     private String settingName;
 
+    @Schema(description = "Id of the project this profile applies to. Omit to create an organization-level default.", example = "12")
     private Long projectId;
 
+    @Schema(description = "Number of check-in/out cycles expected per day.", example = "2")
     @NotNull
     @Min(1) @Max(4)
     private Integer checkInOutCycles;
 
+    @Schema(description = "Whether a photo is required on check-in.", example = "true")
     @NotNull
     private Boolean photoRequiredOnCheckIn;
 
+    @Schema(description = "Whether a photo is required on check-out.", example = "true")
     @NotNull
     private Boolean photoRequiredOnCheckOut;
 
+    @Schema(description = "Whether GPS coordinates are required on clock events.", example = "true")
     @NotNull
     private Boolean geolocationRequired;
 
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "200")
     @NotNull
     @Min(50) @Max(5000)
     private Integer geofenceRadiusMeters;
 
+    @Schema(description = "Whether movements away from the checked-in location must be logged.", example = "true")
     @NotNull
     private Boolean movementTrackingEnabled;
 
+    @Schema(description = "Whether a photo is required when logging a movement.", example = "false")
     @NotNull
     private Boolean movementPhotoRequired;
 
+    @Schema(description = "Whether GPS coordinates are required when logging a movement.", example = "true")
     @NotNull
     private Boolean movementGeolocationRequired;
 
+    @Schema(description = "Hours after shift start with no clock event before the employee is auto-marked absent.", example = "4")
     @NotNull
     @Min(1) @Max(24)
     private Integer autoMarkAbsentAfterHours;
 
+    @Schema(description = "Whether an employee can submit their own regularization requests.", example = "true")
     @NotNull
     private Boolean allowSelfRegularization;
 
+    @Schema(description = "Whether a manager must approve a regularization request before it takes effect.", example = "true")
     @NotNull
     private Boolean regularizationApprovalRequired;
 
+    @Schema(description = "Maximum number of regularization days allowed per employee per month.", example = "3")
     @NotNull
     @Min(0) @Max(31)
     private Integer maxRegularizationDaysPerMonth;
 
+    @Schema(description = "Id of the shift timing to use when a check-in does not specify one.", example = "5")
     private Long defaultShiftTimingId;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,29 +8,70 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Attendance settings profile in force for an organization or a single project.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceSettingsDto {
+
+    @Schema(description = "Id of this settings profile.", example = "3")
     private Long id;
+
+    @Schema(description = "Id of the owning organization.", example = "1")
     private Long organizationId;
+
+    @Schema(description = "Id of the project this profile applies to, or null for the organization-level default.", example = "12")
     private Long projectId;
+
+    @Schema(description = "Display name for this settings profile.", example = "Standard Site Attendance")
     private String settingName;
+
+    @Schema(description = "Number of check-in/out cycles expected per day.", example = "2")
     private Integer checkInOutCycles;
+
+    @Schema(description = "Whether a photo is required on check-in.", example = "true")
     private Boolean photoRequiredOnCheckIn;
+
+    @Schema(description = "Whether a photo is required on check-out.", example = "true")
     private Boolean photoRequiredOnCheckOut;
+
+    @Schema(description = "Whether GPS coordinates are required on clock events.", example = "true")
     private Boolean geolocationRequired;
+
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "200")
     private Integer geofenceRadiusMeters;
+
+    @Schema(description = "Whether movements away from the checked-in location must be logged.", example = "true")
     private Boolean movementTrackingEnabled;
+
+    @Schema(description = "Whether a photo is required when logging a movement.", example = "false")
     private Boolean movementPhotoRequired;
+
+    @Schema(description = "Whether GPS coordinates are required when logging a movement.", example = "true")
     private Boolean movementGeolocationRequired;
+
+    @Schema(description = "Hours after shift start with no clock event before the employee is auto-marked absent.", example = "4")
     private Integer autoMarkAbsentAfterHours;
+
+    @Schema(description = "Whether an employee can submit their own regularization requests.", example = "true")
     private Boolean allowSelfRegularization;
+
+    @Schema(description = "Whether a manager must approve a regularization request before it takes effect.", example = "true")
     private Boolean regularizationApprovalRequired;
+
+    @Schema(description = "Maximum number of regularization days allowed per employee per month.", example = "3")
     private Integer maxRegularizationDaysPerMonth;
+
+    @Schema(description = "Shift timing used when a check-in does not specify one.")
     private ShiftTimingDto defaultShiftTiming;
+
+    @Schema(description = "Whether this settings profile is currently in effect.", example = "true")
     private Boolean isActive;
+
+    @Schema(description = "Timestamp the settings profile was created.", example = "2026-01-15T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp the settings profile was last updated.", example = "2026-02-10T11:30:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsPatchDto.java
@@ -1,25 +1,55 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "Partial update to an attendance settings profile. Only the fields provided are changed.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceSettingsPatchDto {
+
+    @Schema(description = "Display name for this settings profile.", example = "Standard Site Attendance")
     private String settingName;
+
+    @Schema(description = "Number of check-in/out cycles expected per day.", example = "2")
     private Integer checkInOutCycles;
+
+    @Schema(description = "Whether a photo is required on check-in.", example = "true")
     private Boolean photoRequiredOnCheckIn;
+
+    @Schema(description = "Whether a photo is required on check-out.", example = "true")
     private Boolean photoRequiredOnCheckOut;
+
+    @Schema(description = "Whether GPS coordinates are required on clock events.", example = "true")
     private Boolean geolocationRequired;
+
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "250")
     private Integer geofenceRadiusMeters;
+
+    @Schema(description = "Whether movements away from the checked-in location must be logged.", example = "true")
     private Boolean movementTrackingEnabled;
+
+    @Schema(description = "Whether a photo is required when logging a movement.", example = "false")
     private Boolean movementPhotoRequired;
+
+    @Schema(description = "Whether GPS coordinates are required when logging a movement.", example = "true")
     private Boolean movementGeolocationRequired;
+
+    @Schema(description = "Hours after shift start with no clock event before the employee is auto-marked absent.", example = "4")
     private Integer autoMarkAbsentAfterHours;
+
+    @Schema(description = "Whether an employee can submit their own regularization requests.", example = "true")
     private Boolean allowSelfRegularization;
+
+    @Schema(description = "Whether a manager must approve a regularization request before it takes effect.", example = "true")
     private Boolean regularizationApprovalRequired;
+
+    @Schema(description = "Maximum number of regularization days allowed per employee per month.", example = "3")
     private Integer maxRegularizationDaysPerMonth;
+
+    @Schema(description = "Id of the shift timing to use when a check-in does not specify one.", example = "5")
     private Long defaultShiftTimingId;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSummaryDto.java
@@ -1,31 +1,69 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "Aggregated attendance figures for one employee over a calendar month.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceSummaryDto {
+
+    @Schema(description = "Id of the employee.", example = "42")
     private Long employeeId;
+
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Month the summary covers, 1 to 12.", example = "1")
     private Integer month;
+
+    @Schema(description = "Year the summary covers.", example = "2026")
     private Integer year;
+
+    @Schema(description = "Total working days in the month, excluding weekly offs and holidays.", example = "26")
     private Integer totalWorkingDays;
+
+    @Schema(description = "Number of full days present.", example = "22")
     private Integer presentDays;
+
+    @Schema(description = "Number of half days.", example = "1")
     private Integer halfDays;
+
+    @Schema(description = "Number of days absent.", example = "1")
     private Integer absentDays;
+
+    @Schema(description = "Number of days on approved leave.", example = "2")
     private Integer leaveDays;
+
+    @Schema(description = "Number of weekly off days in the month.", example = "4")
     private Integer weeklyOffs;
+
+    @Schema(description = "Number of holidays in the month.", example = "1")
     private Integer holidays;
+
+    @Schema(description = "Number of days the employee arrived late.", example = "3")
     private Integer lateDays;
+
+    @Schema(description = "Number of days the employee worked overtime.", example = "5")
     private Integer overtimeDays;
+
+    @Schema(description = "Total hours worked in the month.", example = "182.5")
     private Double totalHoursWorked;
+
+    @Schema(description = "Total overtime hours worked in the month.", example = "6.0")
     private Double totalOvertimeHours;
+
+    @Schema(description = "Average hours worked per working day.", example = "8.3")
     private Double averageWorkHours;
+
+    @Schema(description = "Attendance percentage for the month.", example = "92.3")
     private Double attendancePercentage;
+
+    @Schema(description = "Effective work days, counting half days as 0.5.", example = "22.5")
     private Double effectiveWorkDays;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,29 +9,48 @@ import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "A single corrected clock event submitted as part of a regularization request.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClockEventCreationDto {
 
+    @Schema(description = "Type of clock event.", example = "EVENING_CLOCK_OUT")
     @NotNull
     private ClockEventType eventType;
 
+    @Schema(description = "Timestamp the event actually occurred.", example = "2026-01-15T18:00:00")
     @NotNull
     private LocalDateTime eventTimestamp;
 
+    @Schema(description = "Latitude captured for the event.", example = "13.0827")
     private Double latitude;
+
+    @Schema(description = "Longitude captured for the event.", example = "80.2707")
     private Double longitude;
+
+    @Schema(description = "GPS accuracy of the captured coordinates, in metres.", example = "8.5")
     private Double gpsAccuracy;
+
+    @Schema(description = "Altitude captured for the event, in metres.", example = "12.0")
     private Double altitude;
 
+    @Schema(description = "URL of the photo captured with the event, if any.", example = "https://storage.echno.xyz/clock-events/781-out.jpg")
     private String photoUrl;
 
+    @Schema(description = "Id of the project the event was recorded against.", example = "12")
     @NotNull
     private Long projectId;
 
+    @Schema(description = "Platform the event was recorded from.", example = "android")
     private String devicePlatform;
+
+    @Schema(description = "Identifier of the device used to record the event.", example = "device-8f3a21")
     private String deviceId;
+
+    @Schema(description = "IP address of the device at the time of the event.", example = "10.24.6.41")
     private String ipAddress;
+
+    @Schema(description = "Optional remarks about the corrected event.", example = "Forgot to clock out before leaving site")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,27 +11,64 @@ import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A single clock event within an attendance record.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClockEventDto {
+
+    @Schema(description = "Id of the clock event.", example = "3301")
     private Long id;
+
+    @Schema(description = "Type of clock event.", example = "MORNING_CLOCK_IN")
     private ClockEventType eventType;
+
+    @Schema(description = "Timestamp of the event.", example = "2026-01-15T09:02:00")
     private LocalDateTime eventTimestamp;
+
+    @Schema(description = "Latitude captured for the event.", example = "13.0827")
     private Double latitude;
+
+    @Schema(description = "Longitude captured for the event.", example = "80.2707")
     private Double longitude;
+
+    @Schema(description = "GPS accuracy of the captured coordinates, in metres.", example = "8.5")
     private Double gpsAccuracy;
+
+    @Schema(description = "URL of the photo captured with the event, if any.", example = "https://storage.echno.xyz/clock-events/3301-in.jpg")
     private String photoUrl;
+
+    @Schema(description = "Id of the project the event was recorded against.", example = "12")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Kovilambakkam Phase 2")
     private String projectName;
+
+    @Schema(description = "Platform the event was recorded from.", example = "android")
     private String devicePlatform;
+
+    @Schema(description = "Whether the event's coordinates fall within the project's geofence.", example = "true")
     private Boolean isWithinGeofence;
+
+    @Schema(description = "Distance from the project site at the time of the event, in metres.", example = "45.0")
     private Double distanceFromProject;
+
+    @Schema(description = "Optional remarks about the event.", example = "Reported directly to the second floor slab pour")
     private String remarks;
+
+    @Schema(description = "Name or id of the person who verified the event, if regularized.", example = "Anand Rajashekar")
     private String verifiedBy;
+
+    @Schema(description = "Timestamp the event was verified.", example = "2026-01-16T11:00:00")
     private LocalDateTime verifiedAt;
+
+    @Schema(description = "Whether this event was added through a regularization request rather than recorded live.", example = "false")
     private Boolean isRegularized;
+
+    @Schema(description = "Reason given if this event was regularized.", example = "Phone battery died before evening clock-out")
     private String regularizationReason;
+
+    @Schema(description = "Attachments supporting the event, for example a check-in photo.")
     private List<AttachmentDto> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -10,37 +11,56 @@ import org.tornotron.echno_backend.attendance.enums.MovementType;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Payload to log a movement away from an employee's checked-in location.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class MovementRecordCreationDto {
 
+    @Schema(description = "Id of the attendance record to log this movement against.", example = "781")
     @NotNull
     private Long attendanceId;
 
+    @Schema(description = "Type of movement.", example = "VENDOR_MEETING")
     @NotNull
     private MovementType movementType;
 
+    @Schema(description = "Location the employee is travelling from.", example = "Kovilambakkam Site Office")
     @NotBlank
     private String fromLocation;
 
+    @Schema(description = "Location the employee is travelling to.", example = "Tile Vendor Showroom, Guindy")
     private String toLocation;
 
+    @Schema(description = "Timestamp the movement started.", example = "2026-01-15T11:00:00")
     @NotNull
     private LocalDateTime startTime;
 
+    @Schema(description = "Timestamp the movement ended, once known.", example = "2026-01-15T12:30:00")
     private LocalDateTime endTime;
 
+    @Schema(description = "Purpose of the movement.", example = "Vendor negotiation for tile supply")
     @NotBlank
     private String purpose;
 
+    @Schema(description = "Optional remarks about the movement.", example = "Approved in advance by site supervisor")
     private String remarks;
 
+    @Schema(description = "Latitude at the start of the movement.", example = "12.9166")
     private Double startLatitude;
+
+    @Schema(description = "Longitude at the start of the movement.", example = "80.1998")
     private Double startLongitude;
+
+    @Schema(description = "Latitude at the end of the movement.", example = "13.0604")
     private Double endLatitude;
+
+    @Schema(description = "Longitude at the end of the movement.", example = "80.2496")
     private Double endLongitude;
+
+    @Schema(description = "Distance travelled, in kilometres.", example = "14.5")
     private Double distanceKm;
 
+    @Schema(description = "URLs of supporting attachments, for example a delivery receipt.", example = "[\"https://storage.echno.xyz/movements/220-receipt.jpg\"]")
     private List<String> attachments;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,32 +10,79 @@ import org.tornotron.echno_backend.attendance.enums.MovementType;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A record of an employee travelling away from their checked-in location during a work day.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class MovementRecordDto {
+
+    @Schema(description = "Id of the movement record.", example = "220")
     private Long id;
+
+    @Schema(description = "Id of the attendance record this movement was logged against.", example = "781")
     private Long attendanceId;
+
+    @Schema(description = "Id of the employee.", example = "42")
     private Long employeeId;
+
+    @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Type of movement.", example = "SITE_TRAVEL")
     private MovementType movementType;
+
+    @Schema(description = "Location the employee travelled from.", example = "Kovilambakkam Site Office")
     private String fromLocation;
+
+    @Schema(description = "Location the employee travelled to.", example = "Asset Homes Corporate Office, Chennai")
     private String toLocation;
+
+    @Schema(description = "Timestamp the movement started.", example = "2026-01-15T11:00:00")
     private LocalDateTime startTime;
+
+    @Schema(description = "Timestamp the movement ended.", example = "2026-01-15T12:30:00")
     private LocalDateTime endTime;
+
+    @Schema(description = "Duration of the movement in minutes.", example = "90")
     private Integer durationMinutes;
+
+    @Schema(description = "Distance travelled, in kilometres.", example = "14.5")
     private Double distanceKm;
+
+    @Schema(description = "Purpose of the movement.", example = "Vendor negotiation for tile supply")
     private String purpose;
+
+    @Schema(description = "Optional remarks about the movement.", example = "Approved in advance by site supervisor")
     private String remarks;
+
+    @Schema(description = "Latitude at the start of the movement.", example = "12.9166")
     private Double startLatitude;
+
+    @Schema(description = "Longitude at the start of the movement.", example = "80.1998")
     private Double startLongitude;
+
+    @Schema(description = "Latitude at the end of the movement.", example = "13.0604")
     private Double endLatitude;
+
+    @Schema(description = "Longitude at the end of the movement.", example = "80.2496")
     private Double endLongitude;
+
+    @Schema(description = "URLs of supporting attachments, for example a delivery receipt.", example = "[\"https://storage.echno.xyz/movements/220-receipt.jpg\"]")
     private List<String> attachments;
+
+    @Schema(description = "Name or id of the person who verified the movement.", example = "Anand Rajashekar")
     private String verifiedBy;
+
+    @Schema(description = "Timestamp the movement was verified.", example = "2026-01-16T09:00:00")
     private LocalDateTime verifiedAt;
+
+    @Schema(description = "Whether the movement has been verified.", example = "false")
     private Boolean isVerified;
+
+    @Schema(description = "Timestamp the movement record was created.", example = "2026-01-15T11:05:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp the movement record was last updated.", example = "2026-01-15T12:35:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/RegularizationActionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/RegularizationActionDto.java
@@ -1,18 +1,22 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 
+@Schema(description = "Payload to approve or reject a regularization request.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegularizationActionDto {
 
+    @Schema(description = "Decision on the regularization request.", example = "APPROVED")
     @NotNull
     private RegularizationStatus status;
 
+    @Schema(description = "Reason given when the request is rejected.", example = "No corroborating movement record for the claimed hours")
     private String rejectionReason;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/RegularizationRequestDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/RegularizationRequestDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -9,19 +10,24 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Schema(description = "Payload to submit a request to correct an attendance record missing one or more clock events.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegularizationRequestDto {
 
+    @Schema(description = "Id of the attendance record to correct.", example = "781")
     @NotNull
     private Long attendanceId;
 
+    @Schema(description = "Reason the events are missing.", example = "Phone battery died before evening clock-out")
     @NotBlank
     private String reason;
 
+    @Schema(description = "Clock event types missing from the original record.", example = "[\"EVENING_CLOCK_OUT\"]")
     @NotEmpty
     private List<String> missingEvents;
 
+    @Schema(description = "Corrected clock events to add in place of the missing ones, if known.")
     private List<ClockEventCreationDto> correctedEvents;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -11,36 +12,46 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
+@Schema(description = "Payload to create a named work shift.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ShiftTimingCreationDto {
 
+    @Schema(description = "Display name of the shift.", example = "General Shift")
     @NotBlank
     private String shiftName;
 
+    @Schema(description = "Scheduled start time.", example = "09:00:00")
     @NotNull
     private LocalTime startTime;
 
+    @Schema(description = "Scheduled end time.", example = "18:00:00")
     @NotNull
     private LocalTime endTime;
 
+    @Schema(description = "Start of the lunch break.", example = "13:00:00")
     @NotNull
     private LocalTime lunchBreakStart;
 
+    @Schema(description = "End of the lunch break.", example = "13:30:00")
     @NotNull
     private LocalTime lunchBreakEnd;
 
+    @Schema(description = "Minutes of grace allowed after startTime before an arrival counts as late.", example = "15")
     @NotNull
     @Min(0) @Max(120)
     private Integer gracePeriodMinutes;
 
+    @Schema(description = "Minimum hours worked to be counted as a full day.", example = "8.0")
     @NotNull
     private BigDecimal minimumWorkHours;
 
+    @Schema(description = "Hours worked below which the day is counted as a half day.", example = "4.0")
     @NotNull
     private BigDecimal halfDayWorkHours;
 
+    @Schema(description = "Hours worked beyond which time is counted as overtime.", example = "9.0")
     @NotNull
     private BigDecimal overtimeThreshold;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,21 +10,46 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+@Schema(description = "A named work shift with its timing windows and work-hour thresholds.")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ShiftTimingDto {
+
+    @Schema(description = "Id of the shift timing.", example = "5")
     private Long id;
+
+    @Schema(description = "Display name of the shift.", example = "General Shift")
     private String shiftName;
+
+    @Schema(description = "Scheduled start time.", example = "09:00:00")
     private LocalTime startTime;
+
+    @Schema(description = "Scheduled end time.", example = "18:00:00")
     private LocalTime endTime;
+
+    @Schema(description = "Start of the lunch break.", example = "13:00:00")
     private LocalTime lunchBreakStart;
+
+    @Schema(description = "End of the lunch break.", example = "13:30:00")
     private LocalTime lunchBreakEnd;
+
+    @Schema(description = "Minutes of grace allowed after startTime before an arrival counts as late.", example = "15")
     private Integer gracePeriodMinutes;
+
+    @Schema(description = "Minimum hours worked to be counted as a full day.", example = "8.0")
     private BigDecimal minimumWorkHours;
+
+    @Schema(description = "Hours worked below which the day is counted as a half day.", example = "4.0")
     private BigDecimal halfDayWorkHours;
+
+    @Schema(description = "Hours worked beyond which time is counted as overtime.", example = "9.0")
     private BigDecimal overtimeThreshold;
+
+    @Schema(description = "Timestamp the shift timing was created.", example = "2026-01-01T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp the shift timing was last updated.", example = "2026-02-05T10:00:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ShiftTimingPatchDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,17 +8,36 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
+@Schema(description = "Partial update to a shift timing. Only the fields provided are changed.")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ShiftTimingPatchDto {
+
+    @Schema(description = "Display name of the shift.", example = "General Shift")
     private String shiftName;
+
+    @Schema(description = "Scheduled start time.", example = "09:00:00")
     private LocalTime startTime;
+
+    @Schema(description = "Scheduled end time.", example = "18:00:00")
     private LocalTime endTime;
+
+    @Schema(description = "Start of the lunch break.", example = "13:00:00")
     private LocalTime lunchBreakStart;
+
+    @Schema(description = "End of the lunch break.", example = "13:30:00")
     private LocalTime lunchBreakEnd;
+
+    @Schema(description = "Minutes of grace allowed after startTime before an arrival counts as late.", example = "15")
     private Integer gracePeriodMinutes;
+
+    @Schema(description = "Minimum hours worked to be counted as a full day.", example = "8.0")
     private BigDecimal minimumWorkHours;
+
+    @Schema(description = "Hours worked below which the day is counted as a half day.", example = "4.0")
     private BigDecimal halfDayWorkHours;
+
+    @Schema(description = "Hours worked beyond which time is counted as overtime.", example = "9.0")
     private BigDecimal overtimeThreshold;
 }

--- a/src/main/java/org/tornotron/echno_backend/auth/AuthController.java
+++ b/src/main/java/org/tornotron/echno_backend/auth/AuthController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
@@ -14,6 +18,11 @@ import org.tornotron.echno_backend.user.dto.UserRegistrationDto;
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@Tag(
+        name = "Auth",
+        description = "Unauthenticated entry point for creating a new account. Registration provisions "
+                + "the Keycloak identity behind a user and the corresponding user record in one call."
+)
 public class AuthController {
 
     private final UserService userService;
@@ -24,6 +33,15 @@ public class AuthController {
 
     @PostMapping("/register")
     @PreAuthorize("permitAll()")
+    @Operation(
+            summary = "Register a new user",
+            description = "Creates a Keycloak identity and a user record from the given registration "
+                    + "details. Open to unauthenticated callers."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "User registered"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation, or the username/email is already taken")
+    })
     public ResponseEntity<UserDto> registerUser(@Valid @RequestBody UserRegistrationDto userRegistrationDto) {
         UserDto createdUser = userService.registerUser(userRegistrationDto);
         return new ResponseEntity<>(createdUser, HttpStatus.CREATED);

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.billing.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +23,13 @@ import java.util.List;
 @RequestMapping("/api/v1/billing/features/web")
 @RequiredArgsConstructor
 @Validated
+@Tag(
+        name = "Billing Features",
+        description = "Individually toggleable capabilities that a plan can grant, such as report exports "
+                + "or a device quota. A feature has a type (boolean, quota or metered) and, once deactivated, "
+                + "is no longer offered on new plans. All endpoints are restricted to the billing admin "
+                + "authority."
+)
 public class FeatureController {
 
     private final FeatureService featureService;
@@ -33,6 +43,15 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
+    @Operation(
+            summary = "List active features",
+            description = "Returns the features that are currently active and available for assignment to "
+                    + "plans."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of active features"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<List<FeatureDto>> getActiveFeatures() {
         List<Feature> features = featureService.getAllActiveFeatures();
         return ResponseEntity.ok(BillingMapper.toFeatureDtoList(features));
@@ -47,6 +66,14 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/all")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "List all features",
+            description = "Returns every feature, including deactivated ones, for administration."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of all features"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<List<FeatureDto>> getAllFeatures() {
         List<Feature> features = featureService.getAllFeatures();
         return ResponseEntity.ok(BillingMapper.toFeatureDtoList(features));
@@ -61,6 +88,15 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a feature by id",
+            description = "Returns a single feature by its numeric id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
+    })
     public ResponseEntity<FeatureDto> getFeatureById(@PathVariable Long id) {
         Feature feature = featureService.getFeatureById(id);
         return ResponseEntity.ok(BillingMapper.toFeatureDto(feature));
@@ -75,6 +111,15 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/code/{code}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a feature by code",
+            description = "Returns a single feature by its unique code, such as report-export."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given code")
+    })
     public ResponseEntity<FeatureDto> getFeatureByCode(@PathVariable String code) {
         Feature feature = featureService.getFeatureByCode(code);
         return ResponseEntity.ok(BillingMapper.toFeatureDto(feature));
@@ -90,6 +135,15 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Create a feature",
+            description = "Creates a new feature that can subsequently be assigned to plans."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Feature created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<FeatureDto> createFeature(@Valid @RequestBody FeatureCreateDto dto) {
         Feature feature = featureService.createFeature(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(BillingMapper.toFeatureDto(feature));
@@ -106,6 +160,16 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Update a feature",
+            description = "Updates the details of an existing feature identified by id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
+    })
     public ResponseEntity<FeatureDto> updateFeature(@PathVariable Long id, @Valid @RequestBody FeatureCreateDto dto) {
         Feature feature = featureService.updateFeature(id, dto);
         return ResponseEntity.ok(BillingMapper.toFeatureDto(feature));
@@ -121,6 +185,16 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Deactivate a feature",
+            description = "Soft-deletes a feature so it can no longer be assigned to new plans. Plans that "
+                    + "already include it are left unchanged."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature deactivated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
+    })
     public ResponseEntity<ApiResponse> deactivateFeature(@PathVariable Long id) {
         featureService.deactivateFeature(id);
         return ResponseEntity.ok(new ApiResponse("Feature deactivated successfully"));
@@ -136,6 +210,15 @@ public class FeatureController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{id}/activate")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Reactivate a feature",
+            description = "Reactivates a previously deactivated feature so it can be assigned to plans again."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature activated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
+    })
     public ResponseEntity<ApiResponse> activateFeature(@PathVariable Long id) {
         featureService.activateFeature(id);
         return ResponseEntity.ok(new ApiResponse("Feature activated successfully"));

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.billing.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +21,13 @@ import java.util.List;
 @RequestMapping("/api/v1/billing/plans/web")
 @RequiredArgsConstructor
 @Validated
+@Tag(
+        name = "Billing Plans",
+        description = "Subscription plans such as Starter, Professional or Enterprise, each carrying a "
+                + "price per billing period and a set of assigned features. Endpoints cover listing public "
+                + "plans, full plan administration, and attaching or detaching features on a plan. All "
+                + "administrative endpoints require the billing admin authority."
+)
 public class PlanController {
 
     private final PlanService planService;
@@ -30,6 +40,14 @@ public class PlanController {
      */
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/public")
+    @Operation(
+            summary = "List public plans",
+            description = "Returns the plans that are both public and active, for display on a pricing page."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of public plans"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<List<PlanDto>> getPublicPlans() {
         List<Plan> plans = planService.getAllPublicPlans();
         return ResponseEntity.ok(BillingMapper.toPlanDtoList(plans));
@@ -44,6 +62,14 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "List all plans",
+            description = "Returns every plan, including private and inactive ones, for administration."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of all plans"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<List<PlanDto>> getAllPlans() {
         List<Plan> plans = planService.getAllPlans();
         return ResponseEntity.ok(BillingMapper.toPlanDtoList(plans));
@@ -58,6 +84,15 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a plan by id",
+            description = "Returns a single plan by its numeric id, including its assigned features."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
+    })
     public ResponseEntity<PlanDto> getPlanById(@PathVariable Long id) {
         Plan plan = planService.getPlanById(id);
         return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
@@ -72,6 +107,15 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/code/{code}")
 //    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a plan by code",
+            description = "Returns a single plan by its unique code, such as professional-monthly."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code")
+    })
     public ResponseEntity<PlanDto> getPlanByCode(@PathVariable String code) {
         Plan plan = planService.getPlanByCode(code);
         return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
@@ -87,6 +131,16 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Create a plan",
+            description = "Creates a new plan with the given price and billing period. Features are attached "
+                    + "afterwards through the plan features endpoints."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Plan created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<PlanDto> createPlan(@Valid @RequestBody PlanCreateDto dto) {
         Plan plan = planService.createPlan(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(BillingMapper.toPlanDto(plan));
@@ -103,6 +157,16 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Update a plan",
+            description = "Updates the price, period or visibility of an existing plan identified by id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
+    })
     public ResponseEntity<PlanDto> updatePlan(@PathVariable Long id, @Valid @RequestBody PlanCreateDto dto) {
         Plan plan = planService.updatePlan(id, dto);
         return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
@@ -118,6 +182,16 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{id}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Deactivate a plan",
+            description = "Soft-deletes a plan so it can no longer be subscribed to. Existing subscriptions "
+                    + "on the plan are left unchanged."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan deactivated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
+    })
     public ResponseEntity<ApiResponse> deactivatePlan(@PathVariable Long id) {
         planService.deactivatePlan(id);
         return ResponseEntity.ok(new ApiResponse("Plan deactivated successfully"));
@@ -133,6 +207,15 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{id}/activate")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Reactivate a plan",
+            description = "Reactivates a previously deactivated plan so it can be subscribed to again."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan activated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
+    })
     public ResponseEntity<ApiResponse> activatePlan(@PathVariable Long id) {
         planService.activatePlan(id);
         return ResponseEntity.ok(new ApiResponse("Plan activated successfully"));
@@ -149,6 +232,17 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/{planId}/features")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Assign a feature to a plan",
+            description = "Attaches a feature to a plan, optionally with a quota or limit value carried in "
+                    + "the request body."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature assigned, plan returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id, or no feature with the given code")
+    })
     public ResponseEntity<PlanDto> assignFeatureToPlan(
             @PathVariable Long planId,
             @Valid @RequestBody PlanFeatureAssignDto dto) {
@@ -167,6 +261,16 @@ public class PlanController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @DeleteMapping("/{planId}/features/{featureCode}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Remove a feature from a plan",
+            description = "Detaches a feature from a plan. Subscribers to the plan lose access to the "
+                    + "feature immediately."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature removed, plan returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id, or the feature is not assigned to it")
+    })
     public ResponseEntity<PlanDto> removeFeatureFromPlan(
             @PathVariable Long planId,
             @PathVariable String featureCode) {

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.billing.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +25,13 @@ import java.util.Optional;
 @RequestMapping("/api/v1/billing/subscriptions/web")
 @RequiredArgsConstructor
 @Validated
+@Tag(
+        name = "Billing Subscriptions",
+        description = "A user's subscription to a plan, tracking its status, billing period and renewal "
+                + "dates. Covers self-service subscription management for the current user, feature access "
+                + "checks, usage recording for metered features, and an admin section for managing any "
+                + "user's subscription."
+)
 public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
@@ -35,6 +45,16 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/current")
+    @Operation(
+            summary = "Get the current user's subscription",
+            description = "Returns the caller's active subscription, if any. An empty body with 204 means "
+                    + "the caller has no active subscription."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Active subscription returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Caller has no active subscription"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<SubscriptionDto> getCurrentSubscription() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
         Optional<Subscription> subscription = subscriptionService.getActiveSubscription(userId);
@@ -50,6 +70,14 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/history")
+    @Operation(
+            summary = "Get the current user's subscription history",
+            description = "Returns every subscription the caller has ever held, most recently created first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SubscriptionDto>> getSubscriptionHistory() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
         List<Subscription> subscriptions = subscriptionRepository.findByUserIdOrderByCreatedAtDesc(userId);
@@ -64,6 +92,18 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
+    @Operation(
+            summary = "Create a subscription",
+            description = "Subscribes the current user to the plan identified by planCode, for the given "
+                    + "billing period."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Subscription created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Caller already has an active subscription")
+    })
     public ResponseEntity<SubscriptionDto> createSubscription(@Valid @RequestBody SubscriptionCreateDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -79,6 +119,17 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PutMapping("/change-plan")
+    @Operation(
+            summary = "Change the current user's plan",
+            description = "Moves the caller's active subscription to a different plan, identified by "
+                    + "newPlanCode, keeping the same subscription record."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription moved to the new plan"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Caller has no active subscription, or no plan with the given code")
+    })
     public ResponseEntity<SubscriptionDto> changeSubscription(@Valid @RequestBody SubscriptionChangeDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -94,6 +145,17 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/cancel")
+    @Operation(
+            summary = "Cancel the current user's subscription",
+            description = "Cancels the caller's active subscription. By default it stays active until the "
+                    + "end of the current billing period; setting immediate true in the request body ends "
+                    + "it right away."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription canceled"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Caller has no active subscription")
+    })
     public ResponseEntity<ApiResponse> cancelSubscription(@RequestBody(required = false) SubscriptionCancelDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -113,6 +175,15 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/features/{featureCode}/access")
+    @Operation(
+            summary = "Check feature access",
+            description = "Reports whether the current user's subscription grants access to the given "
+                    + "feature code, and if it is quota-limited, how much remains."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature access result returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<FeatureAccessResultDto> checkFeatureAccess(@PathVariable String featureCode)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -128,6 +199,17 @@ public class SubscriptionController {
      */
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/usage")
+    @Operation(
+            summary = "Record feature usage",
+            description = "Adds the given amount to the current user's recorded usage of a metered feature, "
+                    + "for quota enforcement and billing."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Usage recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given code")
+    })
     public ResponseEntity<ApiResponse> recordUsage(@Valid @RequestBody UsageRecordDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
@@ -147,6 +229,16 @@ public class SubscriptionController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/user/{userId}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a user's subscription",
+            description = "Returns the active subscription for the given user id. An empty body with 204 "
+                    + "means the user has no active subscription."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Active subscription returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "User has no active subscription"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<SubscriptionDto> getUserSubscription(@PathVariable Long userId) {
         Optional<Subscription> subscription = subscriptionService.getActiveSubscription(userId);
         return subscription
@@ -164,6 +256,15 @@ public class SubscriptionController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @GetMapping("/user/{userId}/history")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Get a user's subscription history",
+            description = "Returns every subscription the given user has ever held, most recently created "
+                    + "first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+    })
     public ResponseEntity<List<SubscriptionDto>> getUserSubscriptionHistory(@PathVariable Long userId) {
         List<Subscription> subscriptions = subscriptionRepository.findByUserIdOrderByCreatedAtDesc(userId);
         return ResponseEntity.ok(BillingMapper.toSubscriptionDtoList(subscriptions));
@@ -180,6 +281,18 @@ public class SubscriptionController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/user/{userId}")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Create a subscription for a user",
+            description = "Subscribes the given user to the plan identified by planCode, for the given "
+                    + "billing period."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Subscription created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "User already has an active subscription")
+    })
     public ResponseEntity<SubscriptionDto> createSubscriptionForUser(
             @PathVariable Long userId,
             @Valid @RequestBody SubscriptionCreateDto dto) {
@@ -198,6 +311,17 @@ public class SubscriptionController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PutMapping("/user/{userId}/change-plan")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Change a user's plan",
+            description = "Moves the given user's active subscription to a different plan, identified by "
+                    + "newPlanCode."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription moved to the new plan"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User has no active subscription, or no plan with the given code")
+    })
     public ResponseEntity<SubscriptionDto> changeSubscriptionForUser(
             @PathVariable Long userId,
             @Valid @RequestBody SubscriptionChangeDto dto) {
@@ -216,6 +340,17 @@ public class SubscriptionController {
     @PreAuthorize("hasAuthority('billing:admin')")
     @PostMapping("/user/{userId}/cancel")
 //    @PreAuthorize("hasAuthority('billing:admin')")
+    @Operation(
+            summary = "Cancel a user's subscription",
+            description = "Cancels the given user's active subscription. By default it stays active until "
+                    + "the end of the current billing period; setting immediate true in the request body "
+                    + "ends it right away."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription canceled"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User has no active subscription")
+    })
     public ResponseEntity<ApiResponse> cancelSubscriptionForUser(
             @PathVariable Long userId,
             @RequestBody(required = false) SubscriptionCancelDto dto) {

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureAccessResultDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureAccessResultDto.java
@@ -1,15 +1,22 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 
+@Schema(description = "Result of checking whether a user's subscription grants access to a feature.")
 @Value
 @Builder
 public class FeatureAccessResultDto {
+    @Schema(description = "Whether the feature may be used.", example = "true")
     boolean allowed;
+    @Schema(description = "User-facing message, such as an upgrade prompt, when access is denied.", example = "Upgrade to higher tier plan")
     String message;
+    @Schema(description = "Machine-readable reason for the result, such as quota-exceeded.", example = "Quota exceeded")
     String reason;
+    @Schema(description = "Amount of the metered feature used in the current period, when quota-limited.", example = "480")
     Long currentUsage;
+    @Schema(description = "Maximum amount allowed in the current period, when quota-limited.", example = "500")
     Long quotaLimit;
 
     public static FeatureAccessResultDto allowed() {

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureCreateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureCreateDto.java
@@ -1,26 +1,33 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 
+@Schema(description = "Payload to create or update a billing feature.")
 @Data
 public class FeatureCreateDto {
 
+    @Schema(description = "Unique code identifying the feature.", example = "report-export")
     @NotBlank(message = "Feature code is required")
     @Size(max = 100, message = "Feature code must not exceed 100 characters")
     private String code;
 
+    @Schema(description = "Display name of the feature.", example = "PDF Report Export")
     @NotBlank(message = "Feature name is required")
     private String name;
 
+    @Schema(description = "Longer description of what the feature grants.", example = "Allows exporting site reports as PDF documents.")
     private String description;
 
+    @Schema(description = "How the feature is measured: a plain toggle, a fixed quota, or a metered count.", example = "BOOLEAN")
     @NotBlank(message = "Feature type is required")
     private String featureType;
 
+    @Schema(description = "Grouping used to organize features in the admin UI.", example = "reporting")
     @Size(max = 50, message = "Category must not exceed 50 characters")
     private String category;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/FeatureDto.java
@@ -1,17 +1,26 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 
+@Schema(description = "A billing feature as returned by the API.")
 @Value
 @Builder
 public class FeatureDto {
+    @Schema(description = "Numeric id of the feature.", example = "12")
     Long id;
+    @Schema(description = "Unique code identifying the feature.", example = "report-export")
     String code;
+    @Schema(description = "Display name of the feature.", example = "PDF Report Export")
     String name;
+    @Schema(description = "Longer description of what the feature grants.", example = "Allows exporting site reports as PDF documents.")
     String description;
+    @Schema(description = "How the feature is measured.", example = "BOOLEAN")
     FeatureType featureType;
+    @Schema(description = "Grouping used to organize features in the admin UI.", example = "reporting")
     String category;
+    @Schema(description = "Whether the feature is currently active and assignable to plans.", example = "true")
     Boolean isActive;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/PlanCreateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/PlanCreateDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,31 +8,42 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Payload to create or update a billing plan.")
 @Data
 public class PlanCreateDto {
 
+    @Schema(description = "Unique code identifying the plan.", example = "professional-monthly")
     @NotBlank(message = "Plan code is required")
     @Size(max = 50, message = "Plan code must not exceed 50 characters")
     private String code;
 
+    @Schema(description = "Display name of the plan.", example = "Professional")
     @NotBlank(message = "Plan name is required")
     private String name;
 
+    @Schema(description = "Longer description shown on the pricing page.", example = "For growing teams managing multiple active sites.")
     private String description;
 
+    @Schema(description = "Price charged per month, in the plan currency.", example = "4999.00")
     @NotNull(message = "Monthly price is required")
     private BigDecimal monthlyPrice;
 
+    @Schema(description = "Price charged per year, in the plan currency, when billed annually.", example = "49990.00")
     private BigDecimal annualPrice;
 
+    @Schema(description = "ISO 4217 currency code for the plan prices.", example = "INR")
     @Size(max = 3, message = "Currency code must be 3 characters")
     private String currency = "INR";
 
+    @Schema(description = "Whether the plan is shown on the public pricing page.", example = "true")
     private Boolean isPublic = true;
 
+    @Schema(description = "Number of trial days granted on first subscription.", example = "14")
     private Integer trialDays = 0;
 
+    @Schema(description = "Maximum number of users allowed under this plan, or null for unlimited.", example = "25")
     private Integer maxUsers;
 
+    @Schema(description = "Display order relative to other plans, ascending.", example = "2")
     private Integer sortOrder = 0;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/PlanDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/PlanDto.java
@@ -1,26 +1,42 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 
 import java.math.BigDecimal;
 import java.util.List;
 
+@Schema(description = "A billing plan, including its price and assigned features, as returned by the API.")
 @Value
 @Builder
 public class PlanDto {
+    @Schema(description = "Numeric id of the plan.", example = "3")
     Long id;
+    @Schema(description = "Unique code identifying the plan.", example = "professional-monthly")
     String code;
+    @Schema(description = "Display name of the plan.", example = "Professional")
     String name;
+    @Schema(description = "Longer description shown on the pricing page.", example = "For growing teams managing multiple active sites.")
     String description;
+    @Schema(description = "Optimistic locking version of the plan record.", example = "4")
     Integer version;
+    @Schema(description = "Price charged per month, in the plan currency.", example = "4999.00")
     BigDecimal monthlyPrice;
+    @Schema(description = "Price charged per year, in the plan currency, when billed annually.", example = "49990.00")
     BigDecimal annualPrice;
+    @Schema(description = "ISO 4217 currency code for the plan prices.", example = "INR")
     String currency;
+    @Schema(description = "Whether the plan currently accepts new subscriptions.", example = "true")
     Boolean isActive;
+    @Schema(description = "Whether the plan is shown on the public pricing page.", example = "true")
     Boolean isPublic;
+    @Schema(description = "Number of trial days granted on first subscription.", example = "14")
     Integer trialDays;
+    @Schema(description = "Maximum number of users allowed under this plan, or null for unlimited.", example = "25")
     Integer maxUsers;
+    @Schema(description = "Display order relative to other plans, ascending.", example = "2")
     Integer sortOrder;
+    @Schema(description = "Features currently assigned to this plan.")
     List<PlanFeatureDto> features;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/PlanFeatureAssignDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/PlanFeatureAssignDto.java
@@ -1,18 +1,24 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
 
+@Schema(description = "Payload to assign a feature to a plan, optionally with a quota.")
 @Data
 public class PlanFeatureAssignDto {
 
+    @Schema(description = "Code of the feature to assign.", example = "report-export")
     @NotBlank(message = "Feature code is required")
     private String featureCode;
 
+    @Schema(description = "Whether the feature is enabled once assigned.", example = "true")
     private Boolean enabled = true;
 
+    @Schema(description = "Maximum usage allowed per quota period, for quota or metered features.", example = "500")
     private Long quotaLimit;
 
+    @Schema(description = "Period over which the quota resets.", example = "MONTHLY")
     private QuotaPeriod quotaPeriod;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/PlanFeatureDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/PlanFeatureDto.java
@@ -1,18 +1,27 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
 
+@Schema(description = "A feature as assigned to a plan, including its quota configuration on that plan.")
 @Value
 @Builder
 public class PlanFeatureDto {
+    @Schema(description = "Numeric id of the plan-feature assignment.", example = "7")
     Long id;
+    @Schema(description = "Code of the assigned feature.", example = "report-export")
     String featureCode;
+    @Schema(description = "Display name of the assigned feature.", example = "PDF Report Export")
     String featureName;
+    @Schema(description = "How the feature is measured.", example = "QUOTA")
     FeatureType featureType;
+    @Schema(description = "Whether the feature is enabled on this plan.", example = "true")
     Boolean enabled;
+    @Schema(description = "Maximum usage allowed per quota period, for quota or metered features.", example = "500")
     Long quotaLimit;
+    @Schema(description = "Period over which the quota resets.", example = "MONTHLY")
     QuotaPeriod quotaPeriod;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionCancelDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionCancelDto.java
@@ -1,11 +1,15 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Payload to cancel a subscription.")
 @Data
 public class SubscriptionCancelDto {
 
+    @Schema(description = "If true, cancel now; if false, cancel at the end of the current billing period.", example = "false")
     private boolean immediate = false;
 
+    @Schema(description = "Optional free-text reason for the cancellation.", example = "Switching to annual billing")
     private String reason;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionChangeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionChangeDto.java
@@ -1,11 +1,14 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+@Schema(description = "Payload to move a subscription to a different plan.")
 @Data
 public class SubscriptionChangeDto {
 
+    @Schema(description = "Code of the plan to move the subscription to.", example = "enterprise-monthly")
     @NotBlank(message = "New plan code is required")
     private String newPlanCode;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionCreateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionCreateDto.java
@@ -1,14 +1,18 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.tornotron.echno_backend.billing.enums.BillingPeriod;
 
+@Schema(description = "Payload to create a subscription to a plan.")
 @Data
 public class SubscriptionCreateDto {
 
+    @Schema(description = "Code of the plan to subscribe to.", example = "professional-monthly")
     @NotBlank(message = "Plan code is required")
     private String planCode;
 
+    @Schema(description = "Billing period for the subscription.", example = "MONTHLY")
     private BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/SubscriptionDto.java
@@ -1,27 +1,44 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
 
 import java.time.Instant;
 
+@Schema(description = "A user's subscription to a plan, as returned by the API.")
 @Value
 @Builder
 public class SubscriptionDto {
+    @Schema(description = "Numeric id of the subscription.", example = "101")
     Long id;
+    @Schema(description = "Id of the subscribing user.", example = "27")
     Long userId;
+    @Schema(description = "Plan the subscription is on.")
     PlanDto plan;
+    @Schema(description = "Current lifecycle status of the subscription.", example = "ACTIVE")
     SubscriptionStatus status;
+    @Schema(description = "Start of the current billing period.", example = "2026-08-01T00:00:00Z")
     Instant currentPeriodStart;
+    @Schema(description = "End of the current billing period.", example = "2026-09-01T00:00:00Z")
     Instant currentPeriodEnd;
+    @Schema(description = "Start of the trial period, if the subscription began with a trial.", example = "2026-07-18T00:00:00Z")
     Instant trialStart;
+    @Schema(description = "End of the trial period, if the subscription began with a trial.", example = "2026-08-01T00:00:00Z")
     Instant trialEnd;
+    @Schema(description = "Whether the subscription is set to cancel at the end of the current period.", example = "false")
     Boolean cancelAtPeriodEnd;
+    @Schema(description = "When the subscription was canceled, if it has been.", example = "null")
     Instant canceledAt;
+    @Schema(description = "When the subscription was first created.", example = "2026-01-15T09:30:00Z")
     Instant createdAt;
+    @Schema(description = "Reason given for cancellation, if any.", example = "Switching to annual billing")
     String cancellationReason;
+    @Schema(description = "Whether the subscription is currently active.", example = "true")
     boolean active;
+    @Schema(description = "Whether the subscription is currently within its trial period.", example = "false")
     boolean inTrial;
+    @Schema(description = "Whether the subscription has expired.", example = "false")
     boolean expired;
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/UsageRecordDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/UsageRecordDto.java
@@ -1,16 +1,20 @@
 package org.tornotron.echno_backend.billing.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+@Schema(description = "Payload to record usage of a metered feature.")
 @Data
 public class UsageRecordDto {
 
+    @Schema(description = "Code of the metered feature being used.", example = "storage-gb")
     @NotBlank(message = "Feature code is required")
     private String featureCode;
 
+    @Schema(description = "Amount of usage to add to the current period's total.", example = "5")
     @NotNull(message = "Amount is required")
     @Min(value = 1, message = "Amount must be at least 1")
     private Long amount;

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryController.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.category;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +26,13 @@ import java.util.List;
 @RestController
 @RequestMapping("api/v1/workCategories")
 @Validated
+@Tag(
+        name = "Categories",
+        description = "Work categories used to classify tasks, such as \"Reinforcement Steel\" or "
+                + "\"Aggregates\". A category carries a name, description and optional icon and image. "
+                + "Endpoints cover creating, listing and deleting categories. Access is gated by the "
+                + "category authorities, with an admin authority that grants all operations."
+)
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -46,6 +56,17 @@ public class CategoryController {
      */
     @PostMapping
     @PreAuthorize("hasAuthority('category:create') or hasAuthority('category:admin')")
+    @Operation(
+            summary = "Create a category",
+            description = "Creates a work category, such as \"Cement & Binders\", available for tagging "
+                    + "tasks. The name is checked against existing categories in the organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Category created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the category create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A category with the same name already exists")
+    })
     public ResponseEntity<CategorySimpleDto> createCategory(@Valid @RequestBody CategoryCreationDto categoryCreationDto) {
         logger.info("Category Added Successfully");
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -61,6 +82,15 @@ public class CategoryController {
      */
     @GetMapping
     @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
+    @Operation(
+            summary = "List categories",
+            description = "Returns a single page of work categories. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of categories returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the category read or admin authority")
+    })
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
@@ -77,6 +107,15 @@ public class CategoryController {
      */
     @GetMapping("{id}")
     @PreAuthorize("hasAuthority('category:read') or hasAuthority('category:admin')")
+    @Operation(
+            summary = "Get a category by id",
+            description = "Returns a single work category."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Category found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the category read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No category with the given id")
+    })
     public ResponseEntity<?> readACategory(@PathVariable Long id) {
         CategoryDto categoryDto = categoryService.getACategory(id);
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
@@ -90,6 +129,15 @@ public class CategoryController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('category:delete') or hasAuthority('category:admin')")
+    @Operation(
+            summary = "Delete a category",
+            description = "Deletes the category with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Category deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the category delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No category with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteACategory(@PathVariable Long id) {
         categoryService.deleteACategory(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.category;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +20,12 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/category/web")
+@Tag(
+        name = "Categories (Web)",
+        description = "Web-console counterpart of the category API, gated by organization role instead "
+                + "of a flat authority. Covers creating, listing and deleting work categories such as "
+                + "\"Reinforcement Steel\" or \"Aggregates\"."
+)
 public class CategoryControllerWeb {
 
     private final CategoryService categoryService;
@@ -40,6 +49,17 @@ public class CategoryControllerWeb {
      */
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create a category",
+            description = "Creates a work category, such as \"Cement & Binders\", available for tagging "
+                    + "tasks. The name is checked against existing categories in the organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Category created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A category with the same name already exists")
+    })
     public ResponseEntity<CategorySimpleDto> createCategory(@Valid @RequestBody CategoryCreationDto categoryCreationDto) {
         logger.info("Category Added Successfully");
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -55,6 +75,15 @@ public class CategoryControllerWeb {
      */
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List categories",
+            description = "Returns a single page of work categories. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of categories returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
@@ -71,6 +100,15 @@ public class CategoryControllerWeb {
      */
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a category by id",
+            description = "Returns a single work category."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Category found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No category with the given id")
+    })
     public ResponseEntity<?> readACategory(@PathVariable Long id) {
         CategoryDto categoryDto = categoryService.getACategory(id);
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
@@ -84,6 +122,15 @@ public class CategoryControllerWeb {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete a category",
+            description = "Deletes the category with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Category deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No category with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteACategory(@PathVariable Long id) {
         categoryService.deleteACategory(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/category/dto/CategoryCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/category/dto/CategoryCreationDto.java
@@ -1,20 +1,26 @@
 package org.tornotron.echno_backend.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to create a work category used to classify tasks.")
 @Data
 public class CategoryCreationDto {
 
+    @Schema(description = "Name of the category.", example = "Reinforcement Steel")
     @NotBlank(message = "name is required")
     private String name;
 
+    @Schema(description = "Short description of what the category covers.", example = "TMT bars, wire mesh and other reinforcement materials")
     @Size(max = 255, message = "description must be at most 255 characters")
     @NotBlank(message = "description is required")
     private String description;
 
+    @Schema(description = "Icon identifier or URL shown alongside the category.", example = "rebar-icon")
     private String icon;
 
+    @Schema(description = "Image URL shown alongside the category.", example = "https://cdn.echno.xyz/categories/reinforcement-steel.png")
     private String image;
 }

--- a/src/main/java/org/tornotron/echno_backend/category/dto/CategoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/category/dto/CategoryDto.java
@@ -1,12 +1,23 @@
 package org.tornotron.echno_backend.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Work category used to classify tasks.")
 @Data
 public class CategoryDto {
+    @Schema(description = "Id of the category.", example = "7")
     private Long id;
+
+    @Schema(description = "Name of the category.", example = "Reinforcement Steel")
     private String name;
+
+    @Schema(description = "Short description of what the category covers.", example = "TMT bars, wire mesh and other reinforcement materials")
     private String description;
+
+    @Schema(description = "Icon identifier or URL shown alongside the category.", example = "rebar-icon")
     private String icon;
+
+    @Schema(description = "Image URL shown alongside the category.", example = "https://cdn.echno.xyz/categories/reinforcement-steel.png")
     private String image;
 }

--- a/src/main/java/org/tornotron/echno_backend/category/dto/CategoryPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/category/dto/CategoryPatchDto.java
@@ -1,11 +1,16 @@
 package org.tornotron.echno_backend.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
+@Schema(description = "Payload naming a category and the fields to change on it, used for batch updates.")
 @Data
 public class CategoryPatchDto {
+    @Schema(description = "Id of the category to update.", example = "7")
     private Long id;
+
+    @Schema(description = "Map of field names to their new values, for example {\"name\": \"Cement & Binders\"}.", example = "{\"description\": \"OPC, PPC and other cementitious binders\"}")
     private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/category/dto/CategorySimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/category/dto/CategorySimpleDto.java
@@ -1,12 +1,23 @@
 package org.tornotron.echno_backend.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Work category used to classify tasks, without resolved relations.")
 @Data
 public class CategorySimpleDto {
+    @Schema(description = "Id of the category.", example = "7")
     private Long id;
+
+    @Schema(description = "Name of the category.", example = "Reinforcement Steel")
     private String name;
+
+    @Schema(description = "Short description of what the category covers.", example = "TMT bars, wire mesh and other reinforcement materials")
     private String description;
+
+    @Schema(description = "Icon identifier or URL shown alongside the category.", example = "rebar-icon")
     private String icon;
+
+    @Schema(description = "Image URL shown alongside the category.", example = "https://cdn.echno.xyz/categories/reinforcement-steel.png")
     private String image;
 }

--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.common.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +30,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/attachment/web")
 @Validated
+@Tag(
+        name = "Attachments",
+        description = "Files attached to a task, project, issue or other entity. Covers the direct "
+                + "multipart upload path and the two-step presign/register path for large files that go "
+                + "straight to object storage, plus reading and deleting attachments by entity. Access "
+                + "is gated by tenant membership."
+)
 public class AttachmentControllerWeb {
 
     private final AttachmentService attachmentService;
@@ -39,6 +49,17 @@ public class AttachmentControllerWeb {
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,value = "/entityId/{entityId}/entityType/{entityType}")
+    @Operation(
+            summary = "Upload attachments directly",
+            description = "Uploads one or more files straight through the API and attaches them to the "
+                    + "given entity. Suitable for small files; large files should use the presign/register "
+                    + "path instead."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Attachments created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "No attachments part was sent"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<AttachmentDto>> creatAttachment(@RequestParam(value = "attachments",required = true)List<MultipartFile> attachments,
                                                          @PathVariable String entityType,
                                                          @PathVariable Long entityId)  {
@@ -66,6 +87,17 @@ public class AttachmentControllerWeb {
     //    after verifying each object is actually present in storage.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/presign/entityId/{entityId}/entityType/{entityType}")
+    @Operation(
+            summary = "Presign attachment uploads",
+            description = "Step 1 of the direct-to-storage upload path: for each declared file, returns "
+                    + "a short-lived URL the client can PUT the file to directly, bypassing the API and "
+                    + "the CDN in front of it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Presigned upload URLs returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PresignedUpload>> presignUploads(
             @RequestBody List<UploadRequest> uploads,
             @PathVariable String entityType,
@@ -76,6 +108,17 @@ public class AttachmentControllerWeb {
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @PostMapping("/register/entityId/{entityId}/entityType/{entityType}")
+    @Operation(
+            summary = "Register presigned uploads",
+            description = "Step 2 of the direct-to-storage upload path: after the client has PUT each "
+                    + "file to its presigned URL, confirms the storage keys and records the attachments "
+                    + "once each object is verified present in storage."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Attachments registered"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A referenced object is missing from storage, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<AttachmentDto>> registerUploads(
             @RequestBody List<RegisterUploadRequest> uploads,
             @PathVariable String entityType,
@@ -99,6 +142,15 @@ public class AttachmentControllerWeb {
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @GetMapping("/entityId/{entityId}/entityType/{entityType}")
+    @Operation(
+            summary = "List attachments for an entity",
+            description = "Returns every attachment recorded against the given entity id and type, "
+                    + "each with a time-limited download URL."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attachments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<AttachmentDto>> readAttachments(@PathVariable String entityType,
                                                                @PathVariable Long entityId) {
         return ResponseEntity.status(HttpStatus.OK).body(attachmentService.getAttachments(entityType,entityId));
@@ -106,6 +158,15 @@ public class AttachmentControllerWeb {
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @DeleteMapping("/attachmentId/{attachmentId}")
+    @Operation(
+            summary = "Delete an attachment",
+            description = "Deletes the attachment with the given id, including its stored file."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Attachment deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attachment with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAttachment(@PathVariable Long attachmentId) {
         attachmentService.deleteAttachment(attachmentId);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Deleted Attachment"));

--- a/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/KeycloakGroupController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.common.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +22,12 @@ import org.tornotron.echno_backend.user.UserRepository;
 @Validated
 @RestController
 @RequestMapping("/api/v1/keycloakGroup/web")
+@Tag(
+        name = "Keycloak Groups",
+        description = "Bridges the platform's users and employees to Keycloak's organization group and "
+                + "role model: adding a user to the current tenant's Keycloak organization, and "
+                + "assigning or removing an employee's org role. Restricted to a system admin."
+)
 public class KeycloakGroupController {
 
     private final KeycloakGroupService keycloakGroupService;
@@ -35,6 +44,16 @@ public class KeycloakGroupController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/assign")
+    @Operation(
+            summary = "Add a user to the tenant's Keycloak organization",
+            description = "Adds the given user's Keycloak identity to the current tenant's Keycloak "
+                    + "organization group."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User added to the Keycloak organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<ApiResponse> assignUserToKeycloakOrg(
             @RequestParam Long userId
     ) {
@@ -52,6 +71,15 @@ public class KeycloakGroupController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/assignRole")
+    @Operation(
+            summary = "Assign an org role to an employee",
+            description = "Grants the named organization role to the given employee's Keycloak user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role assigned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id, or the employee has no Keycloak user")
+    })
     public ResponseEntity<ApiResponse> assignOrgRole(
             @RequestParam Long employeeId,
             @RequestParam String orgRole
@@ -70,6 +98,15 @@ public class KeycloakGroupController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/unassignRole")
+    @Operation(
+            summary = "Remove an org role from an employee",
+            description = "Revokes the named organization role from the given employee's Keycloak user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role unassigned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id, or the employee has no Keycloak user")
+    })
     public ResponseEntity<ApiResponse> unassignOrgRole(
             @RequestParam Long employeeId,
             @RequestParam String orgRole

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.compliance.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,12 +27,31 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/inspections/web/compliance")
 @RequiredArgsConstructor
+@Tag(
+        name = "Compliance Generation",
+        description = "Manual trigger for AI-driven compliance inspection generation. A project's "
+                + "location and type are matched against curated compliance rules and the Anthropic Claude "
+                + "API to create compliance-type inspections; this endpoint re-runs that generation on "
+                + "demand, in addition to the automatic run on project approval."
+)
 public class ComplianceControllerWeb {
 
     private final ComplianceGenerationService complianceGenerationService;
 
     @PostMapping("/regenerate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Regenerate compliance inspections for a project",
+            description = "Runs compliance generation for the given project synchronously and returns the "
+                    + "compliance inspections it created. Idempotent: inspections that already exist for a "
+                    + "matched rule are not duplicated."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Generation ran; the created inspections are returned (possibly empty)"),
+            @ApiResponse(responseCode = "400", description = "No organization context set: the X-Organization-Id header is required"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+    })
     public List<InspectionDto> regenerate(@RequestParam Long projectId) {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.employee;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -21,6 +24,13 @@ import java.util.Set;
 
 @RestController
 @RequestMapping("/api/v1/employee/web")
+@Tag(
+        name = "Employees",
+        description = "Web-client twin of the employee endpoints. Adds joining an organization as an "
+                + "employee, a minimal lookup list for pickers, paginated and filtered listing, manager "
+                + "assignment, subordinate and manager lookups, and org-role assignment, alongside the "
+                + "same read, update and delete operations as the base employee API."
+)
 public class EmployeeControllerWeb {
 
     private final EmployeeService employeeService;
@@ -44,6 +54,17 @@ public class EmployeeControllerWeb {
      */
     @PostMapping("/joinOrganization/userId/{userId}/organizationId/{orgId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Add a user to an organization as an employee",
+            description = "Creates an employee record linking the given user to the given organization, "
+                    + "with the employment details supplied in the request body."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Employee record created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user or organization with the given id")
+    })
     public ResponseEntity<EmployeeDto> joinOrganization(@PathVariable Long userId, @PathVariable Long orgId, @Valid @RequestBody EmployeeJoinOrgDto employeeJoinOrgDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.joinOrganization(userId, orgId, employeeJoinOrgDto));
     }
@@ -71,18 +92,44 @@ public class EmployeeControllerWeb {
      */
     @GetMapping("/lookup")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List employees for pickers",
+            description = "Returns a minimal, non-sensitive list of employees (id and name) for "
+                    + "populating selection widgets. Readable by any tenant member."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<EmployeeLookupDto>> lookupEmployees() {
         return new ResponseEntity<>(employeeService.lookupEmployees(), HttpStatus.OK);
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "List all employees",
+            description = "Returns every employee in the current tenant, with their full details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
         return new ResponseEntity<>(employeeService.displayAllEmployees(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "List employees, paginated and filtered",
+            description = "Returns a single page of employees, optionally filtered by a free-text "
+                    + "search on name, employment status, or department."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<EmployeeDto>> readAllEmployeesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
@@ -100,6 +147,15 @@ public class EmployeeControllerWeb {
      */
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "Get an employee by id",
+            description = "Returns a single employee's full details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<EmployeeDto> readAnEmployee(@PathVariable Long id) {
         EmployeeDto employee = employeeService.displayAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(employee);
@@ -127,6 +183,17 @@ public class EmployeeControllerWeb {
      */
     @PatchMapping("{id}")
     @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Partially update an employee",
+            description = "Applies the given field updates to the employee with the given id. Callable "
+                    + "by the employee themselves or by a system or HR admin."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the updated fields failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system or HR admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<ApiResponse> partialUpdateAnEmployee(@RequestBody Map<String,Object> updates, @PathVariable Long id) {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
@@ -152,6 +219,15 @@ public class EmployeeControllerWeb {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Delete an employee",
+            description = "Deletes the employee record with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteEmployee(@PathVariable Long id) {
         employeeService.deleteAnEmployee(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" has been deleted"));
@@ -166,6 +242,15 @@ public class EmployeeControllerWeb {
      */
     @PutMapping("/employeeId/{employeeId}/managerId/{managerId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Assign a manager",
+            description = "Sets the given manager as the reporting manager of the given employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Manager assigned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or manager with the given id")
+    })
     public ResponseEntity<EmployeeDto> assignManager(@PathVariable Long employeeId, @PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.assignManager(employeeId, managerId));
     }
@@ -178,6 +263,15 @@ public class EmployeeControllerWeb {
      */
     @DeleteMapping("/employeeId/{employeeId}/manager")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Remove a manager assignment",
+            description = "Clears the reporting manager on the given employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Manager removed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<EmployeeDto> removeManager(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.removeManager(employeeId));
     }
@@ -190,36 +284,90 @@ public class EmployeeControllerWeb {
      */
     @GetMapping("/managerId/{managerId}/subordinates")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "List a manager's direct subordinates",
+            description = "Returns every employee who reports directly to the given manager."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subordinates returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> getDirectSubordinates(@PathVariable Long managerId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getDirectSubordinates(managerId));
     }
 
     @GetMapping("/managers")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "List all managers",
+            description = "Returns every employee flagged as a manager in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Managers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<EmployeeDto>> getAllTheManagers() {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagers());
     }
 
     @GetMapping("/managers/organizationId/{organizationId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
+    @Operation(
+            summary = "List managers for an organization",
+            description = "Returns every employee flagged as a manager within the given organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Managers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> getAllManagersForAnOrganization(@PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.readAllTheManagersByOrganizationId(organizationId));
     }
 
     @PostMapping("/{employeeId}/roles")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Assign an org role",
+            description = "Grants the given organization role to the employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role assigned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<EmployeeDto> assignOrgRole(@PathVariable Long employeeId, @Valid @RequestBody OrgRoleAssignmentDto dto) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.assignOrgRole(employeeId, dto.getRole()));
     }
 
     @DeleteMapping("/{employeeId}/roles/{role}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Remove an org role",
+            description = "Revokes the given organization role from the employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role removed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<EmployeeDto> removeOrgRole(@PathVariable Long employeeId, @PathVariable OrgRole role) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.removeOrgRole(employeeId, role));
     }
 
     @GetMapping("/{employeeId}/roles")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an employee's org roles",
+            description = "Returns the set of organization roles held by the given employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Roles returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<Set<OrgRole>> getOrgRoles(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getOrgRoles(employeeId));
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CompanyBankAccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CompanyBankAccountDto.java
@@ -1,17 +1,31 @@
 package org.tornotron.echno_backend.finance.bank.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
+@Schema(description = "A company bank account, including the ledger account it reconciles against, as returned by the API.")
 public record CompanyBankAccountDto(
+        @Schema(description = "Unique id of the bank account record.", example = "9f1c3e2a-6b4d-4e7a-9c1b-2d3e4f5a6b7c")
         UUID id,
+        @Schema(description = "Name of the bank.", example = "HDFC Bank")
         String bankName,
+        @Schema(description = "Account number.", example = "50100234567890")
         String accountNumber,
+        @Schema(description = "Name on the account.", example = "Fereydon Pvt Ltd")
         String accountHolderName,
+        @Schema(description = "IFSC code of the branch.", example = "HDFC0001234")
         String ifscCode,
+        @Schema(description = "SWIFT code, for international transfers.", example = "HDFCINBB")
         String swiftCode,
+        @Schema(description = "Whether this is the default account for new transactions.", example = "true")
         boolean isDefault,
+        @Schema(description = "Whether the account is currently active.", example = "true")
         boolean active,
+        @Schema(description = "Id of the ledger account this bank account reconciles against.", example = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d")
         UUID ledgerAccountId,
+        @Schema(description = "Code of the linked ledger account.", example = "1010")
         String ledgerAccountCode,
+        @Schema(description = "Name of the linked ledger account.", example = "HDFC Current Account")
         String ledgerAccountName
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CreateCompanyBankAccountRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/dtos/CreateCompanyBankAccountRequest.java
@@ -1,17 +1,26 @@
 package org.tornotron.echno_backend.finance.bank.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
+@Schema(description = "Payload to register a new company bank account.")
 public record CreateCompanyBankAccountRequest(
+        @Schema(description = "Name of the bank.", example = "HDFC Bank")
         @NotBlank @Size(max = 200) String bankName,
+        @Schema(description = "Account number.", example = "50100234567890")
         @NotBlank @Size(max = 50) String accountNumber,
+        @Schema(description = "Name on the account.", example = "Fereydon Pvt Ltd")
         @NotBlank @Size(max = 200) String accountHolderName,
+        @Schema(description = "IFSC code of the branch.", example = "HDFC0001234")
         @Size(max = 20) String ifscCode,
+        @Schema(description = "SWIFT code, for international transfers.", example = "HDFCINBB")
         @Size(max = 20) String swiftCode,
+        @Schema(description = "Whether this becomes the default account for new transactions.", example = "true")
         boolean isDefault,
+        @Schema(description = "Id of the ledger account this bank account reconciles against.", example = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d")
         @NotNull UUID ledgerAccountId
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/web/CompanyBankAccountControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.bank.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,30 +20,76 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/finance/company-bank-accounts/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Company Bank Accounts",
+        description = "The organization's own bank accounts used to receive and pay funds, each linked to "
+                + "a ledger account for reconciliation. Endpoints cover listing, reading, creating and "
+                + "deactivating accounts. All endpoints are tenant scoped and limited to system "
+                + "administrators and project managers."
+)
 public class CompanyBankAccountControllerWeb {
 
     private final CompanyBankAccountService service;
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List company bank accounts",
+            description = "Returns the organization's bank accounts. By default only active accounts are "
+                    + "returned; set activeOnly to false to include deactivated accounts as well."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of matching bank accounts"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public List<CompanyBankAccountDto> list(@RequestParam(defaultValue = "true") boolean activeOnly) {
         return activeOnly ? service.findAllActive() : service.findAll();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a company bank account by id",
+            description = "Returns a single company bank account, including the linked ledger account."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Bank account found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No bank account with the given id in the current tenant")
+    })
     public CompanyBankAccountDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a company bank account",
+            description = "Registers a new company bank account, linked to an existing ledger account for "
+                    + "reconciliation."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Bank account created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No ledger account with the given id")
+    })
     public ResponseEntity<CompanyBankAccountDto> create(@Valid @RequestBody CreateCompanyBankAccountRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @PostMapping("/{id}/deactivate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Deactivate a company bank account",
+            description = "Marks a bank account inactive so it can no longer be selected on new "
+                    + "transactions. Existing records that reference it are left unchanged."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Bank account deactivated"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No bank account with the given id in the current tenant")
+    })
     public CompanyBankAccountDto deactivate(@PathVariable UUID id) {
         return service.deactivate(id);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/dtos/BalanceSheetReport.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/dtos/BalanceSheetReport.java
@@ -1,21 +1,40 @@
 package org.tornotron.echno_backend.finance.report.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Balance sheet as of a given date: assets, liabilities and equity, with their totals.")
 public record BalanceSheetReport(
+        @Schema(description = "Date the balance sheet is computed as of.", example = "2026-08-31")
         LocalDate asOfDate,
+        @Schema(description = "Asset accounts with their closing balances.")
         List<AccountLine> assets,
+        @Schema(description = "Sum of all asset account balances.", example = "18500000.00")
         BigDecimal totalAssets,
+        @Schema(description = "Liability accounts with their closing balances.")
         List<AccountLine> liabilities,
+        @Schema(description = "Sum of all liability account balances.", example = "6200000.00")
         BigDecimal totalLiabilities,
+        @Schema(description = "Equity accounts with their closing balances.")
         List<AccountLine> equity,
+        @Schema(description = "Sum of all equity account balances, excluding retained earnings for the period.", example = "9800000.00")
         BigDecimal totalEquity,
+        @Schema(description = "Retained earnings accumulated for the reporting period.", example = "2500000.00")
         BigDecimal retainedEarningsForPeriod,
+        @Schema(description = "Sum of total liabilities and total equity, expected to equal total assets.", example = "18500000.00")
         BigDecimal totalLiabilitiesAndEquity,
+        @Schema(description = "Whether total assets equal total liabilities and equity.", example = "true")
         boolean balanced
 ) {
-    public record AccountLine(String accountCode, String accountName, BigDecimal amount) {}
+    @Schema(description = "A single account line on the balance sheet.")
+    public record AccountLine(
+            @Schema(description = "Account code.", example = "1100")
+            String accountCode,
+            @Schema(description = "Account name.", example = "Accounts Receivable")
+            String accountName,
+            @Schema(description = "Closing balance for the account.", example = "1250000.00")
+            BigDecimal amount) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/dtos/ProfitAndLossReport.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/dtos/ProfitAndLossReport.java
@@ -1,17 +1,34 @@
 package org.tornotron.echno_backend.finance.report.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Profit and loss statement for a date range: income and expense accounts with their totals and the resulting net profit.")
 public record ProfitAndLossReport(
+        @Schema(description = "Start of the reporting period, inclusive.", example = "2026-04-01")
         LocalDate fromDate,
+        @Schema(description = "End of the reporting period, inclusive.", example = "2026-08-31")
         LocalDate toDate,
+        @Schema(description = "Income accounts with their totals for the period.")
         List<AccountLine> income,
+        @Schema(description = "Sum of all income for the period.", example = "9400000.00")
         BigDecimal totalIncome,
+        @Schema(description = "Expense accounts with their totals for the period.")
         List<AccountLine> expense,
+        @Schema(description = "Sum of all expenses for the period.", example = "6900000.00")
         BigDecimal totalExpense,
+        @Schema(description = "Net profit for the period: total income minus total expense.", example = "2500000.00")
         BigDecimal netProfit
 ) {
-    public record AccountLine(String accountCode, String accountName, BigDecimal amount) {}
+    @Schema(description = "A single account line on the profit and loss statement.")
+    public record AccountLine(
+            @Schema(description = "Account code.", example = "4100")
+            String accountCode,
+            @Schema(description = "Account name.", example = "Contract Revenue")
+            String accountName,
+            @Schema(description = "Total for the account over the reporting period.", example = "7200000.00")
+            BigDecimal amount) {}
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/dtos/TrialBalanceReport.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/dtos/TrialBalanceReport.java
@@ -1,14 +1,22 @@
 package org.tornotron.echno_backend.finance.report.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Trial balance as of a given date: every account with its debit and credit totals.")
 public record TrialBalanceReport(
+        @Schema(description = "Date the trial balance is computed as of.", example = "2026-08-31")
         LocalDate asOfDate,
+        @Schema(description = "One row per account with a non-zero balance.")
         List<TrialBalanceRow> rows,
+        @Schema(description = "Sum of debit balances across all accounts.", example = "18500000.00")
         BigDecimal totalDebit,
+        @Schema(description = "Sum of credit balances across all accounts.", example = "18500000.00")
         BigDecimal totalCredit,
+        @Schema(description = "Whether total debits equal total credits.", example = "true")
         boolean balanced
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/dtos/TrialBalanceRow.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/dtos/TrialBalanceRow.java
@@ -1,16 +1,25 @@
 package org.tornotron.echno_backend.finance.report.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 
 import java.math.BigDecimal;
 
+@Schema(description = "A single account's row on the trial balance.")
 public record TrialBalanceRow(
+        @Schema(description = "Account code.", example = "2100")
         String accountCode,
+        @Schema(description = "Account name.", example = "Accounts Payable")
         String accountName,
+        @Schema(description = "Classification of the account.", example = "LIABILITY")
         AccountType type,
+        @Schema(description = "Sum of all debit postings to the account.", example = "1800000.00")
         BigDecimal totalDebit,
+        @Schema(description = "Sum of all credit postings to the account.", example = "2300000.00")
         BigDecimal totalCredit,
+        @Schema(description = "Closing balance shown on the debit side, if the account is in debit.", example = "0.00")
         BigDecimal debitBalance,
+        @Schema(description = "Closing balance shown on the credit side, if the account is in credit.", example = "500000.00")
         BigDecimal creditBalance
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/report/web/ReportControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.finance.report.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,12 +21,29 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/api/v1/finance/reports/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Finance Reports",
+        description = "Standard accounting reports computed from the ledger: trial balance, profit and "
+                + "loss, and balance sheet. Each report is computed on demand from posted journal entries "
+                + "for the requested date or date range. All endpoints are tenant scoped and limited to "
+                + "system administrators and project managers."
+)
 public class ReportControllerWeb {
 
     private final ReportService service;
 
     @GetMapping("/trial-balance")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get the trial balance",
+            description = "Returns the trial balance as of the given date: every account with its debit "
+                    + "and credit totals, and whether the ledger balances."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Trial balance computed and returned"),
+            @ApiResponse(responseCode = "400", description = "asOfDate is missing or not a valid ISO date"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public TrialBalanceReport trialBalance(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate asOfDate
             ) {
@@ -31,6 +52,16 @@ public class ReportControllerWeb {
 
     @GetMapping("/profit-and-loss")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get the profit and loss statement",
+            description = "Returns income and expense account totals between fromDate and toDate, and the "
+                    + "resulting net profit."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Profit and loss statement computed and returned"),
+            @ApiResponse(responseCode = "400", description = "fromDate or toDate is missing, not a valid ISO date, or fromDate is after toDate"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ProfitAndLossReport profitAndLoss(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
@@ -39,6 +70,16 @@ public class ReportControllerWeb {
 
     @GetMapping("/balance-sheet")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get the balance sheet",
+            description = "Returns assets, liabilities and equity as of the given date, with their totals "
+                    + "and whether the balance sheet balances."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Balance sheet computed and returned"),
+            @ApiResponse(responseCode = "400", description = "asOfDate is missing or not a valid ISO date"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public BalanceSheetReport balanceSheet(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate asOfDate) {
         return service.balanceSheet(asOfDate);

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.goodsReceivedNote;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +21,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/grns/web")
 @Validated
+@Tag(
+        name = "Goods Received Notes (Web)",
+        description = "Goods received notes (GRNs) record materials received against a vendor, capturing "
+                + "the delivery and its line items. This is the web-console API, restricted to the "
+                + "system-admin role for the current tenant rather than flat authorities. Endpoints "
+                + "cover creating, browsing, filtering by vendor or date range, and updating GRNs."
+)
 public class GoodsReceivedNoteControllerWeb {
 
     private final GoodsReceivedNoteService goodsReceivedNoteService;
@@ -28,6 +38,15 @@ public class GoodsReceivedNoteControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a goods received note",
+            description = "Creates a GRN recording materials received against a vendor with its line items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Goods received note created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> createGrn(@Valid @RequestBody GoodsReceivedNoteCreationDto creationDto) {
         GoodsReceivedNoteDto created = goodsReceivedNoteService.createGoodsReceivedNote(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -35,6 +54,15 @@ public class GoodsReceivedNoteControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a goods received note by id",
+            description = "Returns a single GRN."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received note found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No goods received note with the given id")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> getGrnById(@PathVariable Long id) {
         GoodsReceivedNoteDto grn = goodsReceivedNoteService.getGrnById(id);
         return ResponseEntity.ok(grn);
@@ -42,6 +70,14 @@ public class GoodsReceivedNoteControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List goods received notes",
+            description = "Returns every GRN in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received notes returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getAllGrns() {
         List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns();
         return ResponseEntity.ok(grns);
@@ -49,6 +85,14 @@ public class GoodsReceivedNoteControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List goods received notes (paged)",
+            description = "Returns a single page of GRNs controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of goods received notes returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<GoodsReceivedNoteDto>> getAllGrnsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -59,6 +103,14 @@ public class GoodsReceivedNoteControllerWeb {
 
     @GetMapping("/vendor/{vendorId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List goods received notes for a vendor",
+            description = "Returns the GRNs recorded against the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received notes returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getGrnsByVendor(@PathVariable Long vendorId) {
         List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getGrnsByVendor(vendorId);
         return ResponseEntity.ok(grns);
@@ -66,6 +118,16 @@ public class GoodsReceivedNoteControllerWeb {
 
     @PatchMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a goods received note",
+            description = "Applies an update to the GRN identified in the request body."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received note updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No goods received note with the given id")
+    })
     public ResponseEntity<GoodsReceivedNoteDto> updateGrn(@Valid @RequestBody GoodsReceivedNoteUpdateDto updateDto) {
         GoodsReceivedNoteDto updated = goodsReceivedNoteService.updateGoodsReceivedNote(updateDto);
         return ResponseEntity.ok(updated);
@@ -73,6 +135,15 @@ public class GoodsReceivedNoteControllerWeb {
 
     @GetMapping("/date-range")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List goods received notes by date range",
+            description = "Returns the GRNs recorded between the given start and end date-times."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received notes returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A date parameter is missing or malformed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getGrnsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.indent;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +21,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/indents")
 @Validated
+@Tag(
+        name = "Indents",
+        description = "Material indents raised on a project, the request that a purchase order is later "
+                + "converted from. An indent carries a status and a list of requested material items. "
+                + "Access is gated by the indent authorities, with an admin authority that grants all "
+                + "operations."
+)
 public class IndentController {
 
     private final IndentService indentService;
@@ -30,12 +40,29 @@ public class IndentController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('indent:create') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Create an indent",
+            description = "Creates a material indent for a project, along with its requested items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent create or admin authority")
+    })
     public ResponseEntity<IndentDto> createIndent(@Valid @RequestBody IndentCreationDto indentCreationDto) {
         return new ResponseEntity<>(indentService.addIndent(indentCreationDto), HttpStatus.CREATED);
     }
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('indent:read') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "List indents, paginated",
+            description = "Returns a single page of indents. The pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of indents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority")
+    })
     public ResponseEntity<List<IndentDto>> getAllIndents(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -45,18 +72,44 @@ public class IndentController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('indent:read') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "List all indents",
+            description = "Returns every indent for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority")
+    })
     public ResponseEntity<List<IndentDto>> getAllIndents() {
         return new ResponseEntity<>(indentService.getAllIndents(), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('indent:read') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Get an indent by id",
+            description = "Returns a single indent, including its creator, project and requested items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<IndentDto> getAnIndent(@PathVariable Long id) {
         return new ResponseEntity<>(indentService.getAnIndent(id), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('indent:delete') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Delete an indent",
+            description = "Deletes the indent with the given id, along with its items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteIndent(@PathVariable Long id) {
         indentService.deleteIndent(id);
         return ResponseEntity.ok(new ApiResponse("Indent with id: " + id + " deleted successfully"));
@@ -66,12 +119,31 @@ public class IndentController {
 
     @GetMapping("/{indentId}/items")
     @PreAuthorize("hasAuthority('indent:read') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "List items on an indent",
+            description = "Returns every requested item on the given indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<List<IndentItemDto>> getItems(@PathVariable Long indentId) {
         return ResponseEntity.ok(indentService.getItemsByIndentId(indentId));
     }
 
     @PostMapping("/{indentId}/items")
     @PreAuthorize("hasAuthority('indent:update') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Add an item to an indent",
+            description = "Adds a requested material item to an existing indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent item added"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<IndentItemDto> addItem(
             @PathVariable Long indentId,
             @Valid @RequestBody IndentItemCreationDto dto
@@ -81,6 +153,16 @@ public class IndentController {
 
     @PatchMapping("/{indentId}/items/{itemId}")
     @PreAuthorize("hasAuthority('indent:update') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Update an item on an indent",
+            description = "Applies a partial update to a requested item's material, quantity or remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent or indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> updateItem(
             @PathVariable Long indentId,
             @PathVariable Long itemId,
@@ -91,6 +173,15 @@ public class IndentController {
 
     @DeleteMapping("/{indentId}/items/{itemId}")
     @PreAuthorize("hasAuthority('indent:delete') or hasAuthority('indent:admin')")
+    @Operation(
+            summary = "Delete an item from an indent",
+            description = "Deletes the given item from the indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent or indent item with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteItem(
             @PathVariable Long indentId,
             @PathVariable Long itemId

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.indent;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +20,12 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/indents/web")
+@Tag(
+        name = "Indents (Web)",
+        description = "Web-console mirror of the indent endpoints, with an additional partial-update "
+                + "operation not exposed on the mobile API. Access is gated by the web app's org-role "
+                + "check instead of point authorities."
+)
 public class IndentControllerWeb {
 
     private final IndentService indentService;
@@ -29,12 +38,29 @@ public class IndentControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create an indent",
+            description = "Creates a material indent for a project, along with its requested items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<IndentDto> createIndent(@Valid @RequestBody IndentCreationDto indentCreationDto) {
         return new ResponseEntity<>(indentService.addIndent(indentCreationDto), HttpStatus.CREATED);
     }
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List indents, paginated",
+            description = "Returns a single page of indents. The pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of indents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentDto>> getAllIndents(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -44,18 +70,46 @@ public class IndentControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all indents",
+            description = "Returns every indent for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentDto>> getAllIndents() {
         return new ResponseEntity<>(indentService.getAllIndents(), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get an indent by id",
+            description = "Returns a single indent, including its creator, project and requested items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<IndentDto> getAnIndent(@PathVariable Long id) {
         return new ResponseEntity<>(indentService.getAnIndent(id), HttpStatus.OK);
     }
 
     @PatchMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update an indent",
+            description = "Applies a partial update to an indent's number, project, status, expected date "
+                    + "or remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<IndentDto> UpdateAnIndent(
             @PathVariable Long id,
             @Valid @RequestBody IndentUpdateDto updateDto
@@ -66,6 +120,15 @@ public class IndentControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete an indent",
+            description = "Deletes the indent with the given id, along with its items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteIndent(@PathVariable Long id) {
         indentService.deleteIndent(id);
         return ResponseEntity.ok(new ApiResponse("Indent with id: " + id + " deleted successfully"));
@@ -75,12 +138,31 @@ public class IndentControllerWeb {
 
     @GetMapping("/{indentId}/items")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items on an indent",
+            description = "Returns every requested item on the given indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<List<IndentItemDto>> getItems(@PathVariable Long indentId) {
         return ResponseEntity.ok(indentService.getItemsByIndentId(indentId));
     }
 
     @PostMapping("/{indentId}/items")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Add an item to an indent",
+            description = "Adds a requested material item to an existing indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent item added"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent with the given id")
+    })
     public ResponseEntity<IndentItemDto> addItem(
             @PathVariable Long indentId,
             @Valid @RequestBody IndentItemCreationDto dto
@@ -90,6 +172,16 @@ public class IndentControllerWeb {
 
     @PatchMapping("/{indentId}/items/{itemId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update an item on an indent",
+            description = "Applies a partial update to a requested item's material, quantity or remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent or indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> updateItem(
             @PathVariable Long indentId,
             @PathVariable Long itemId,
@@ -100,6 +192,15 @@ public class IndentControllerWeb {
 
     @DeleteMapping("/{indentId}/items/{itemId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete an item from an indent",
+            description = "Deletes the given item from the indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent or indent item with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteItem(
             @PathVariable Long indentId,
             @PathVariable Long itemId

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.indent.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,26 +11,34 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Payload to raise a material indent on a project, with its requested items.")
 @Data
 public class IndentCreationDto {
 
+    @Schema(description = "Indent number, unique per organization.", example = "IND-2026-0015")
     @NotBlank(message = "indentNumber is required(type: String)")
     @Size(min = 1, max = 50, message = "indentNumber must be between 1 and 50 characters")
     private String indentNumber;
 
+    @Schema(description = "Id of the project the indent is raised for.", example = "3")
     @NotNull(message = "project ID is required")
     private Long projectId;
 
+    @Schema(description = "Id of the employee raising the indent.", example = "8")
     @NotNull(message = "createdBy is required(type: Long)")
     private Long createdByEmployeeId;
 
+    @Schema(description = "Lifecycle status of the indent.", example = "PENDING")
     @NotBlank(message = "status is required(type: String)")
     private String status;
 
+    @Schema(description = "Date the materials are expected on site.", example = "2026-02-05T00:00:00")
     private LocalDateTime expectedOn;
 
+    @Schema(description = "Free-text remarks on the indent.", example = "Required before slab pour on 2026-02-08")
     private String remarks;
 
+    @Schema(description = "Material items being requested.")
     @Valid
     private List<IndentItemCreationDto> items;
 }

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.indent.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -8,16 +9,36 @@ import org.tornotron.echno_backend.indent.enums.IndentStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A material indent with its creator, project and requested items.")
 @Data
 public class IndentDto {
+    @Schema(description = "Indent id.", example = "42")
     private Long id;
+
+    @Schema(description = "Indent number.", example = "IND-2026-0015")
     private String indentNumber;
+
+    @Schema(description = "Timestamp the indent was created.", example = "2026-01-15T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Employee who raised the indent.")
     private EmployeeDto createdBy;
+
+    @Schema(description = "Id of the project the indent is raised for.", example = "3")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
     private String projectName;
+
+    @Schema(description = "Current lifecycle status of the indent.", example = "PENDING")
     private IndentStatus status;
+
+    @Schema(description = "Date the materials are expected on site.", example = "2026-02-05T00:00:00")
     private LocalDateTime expectedOn;
+
+    @Schema(description = "Free-text remarks on the indent.", example = "Required before slab pour on 2026-02-08")
     private String remarks;
+
+    @Schema(description = "Requested items on the indent.")
     private List<IndentItemDto> items;
 }

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentUpdateDto.java
@@ -1,15 +1,28 @@
 package org.tornotron.echno_backend.indent.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to partially update an indent's number, project, status, expected date or remarks.")
 @Data
 public class IndentUpdateDto {
+    @Schema(description = "Updated indent number.", example = "IND-2026-0015")
     private String indentNumber;
+
+    @Schema(description = "Id of the employee who raised the indent.", example = "8")
     private Long createdByemployeeId;
+
+    @Schema(description = "Id of the project the indent is raised for.", example = "3")
     private Long projectId;
+
+    @Schema(description = "Updated lifecycle status.", example = "ORDERED")
     private String status;
+
+    @Schema(description = "Updated expected delivery date.", example = "2026-02-08T00:00:00")
     private LocalDateTime expectedOn;
+
+    @Schema(description = "Updated remarks.", example = "Vendor confirmed dispatch for 2026-02-06")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.indentItem;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/indent-items")
 @Validated
+@Tag(
+        name = "Indent Items",
+        description = "Requested material items belonging to an indent: material, quantity requested and "
+                + "ordered, and whether the item has been converted into a purchase order line. Items can "
+                + "be looked up by indent, by material, or by conversion status. Access is gated by the "
+                + "indent-item authorities, with an admin authority that grants all operations."
+)
 public class IndentItemController {
 
     private final IndentItemService indentItemService;
@@ -25,6 +35,15 @@ public class IndentItemController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('indent-item:create') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "Create an indent item",
+            description = "Adds a requested material item to an indent, independently of the indent create call."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent item created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item create or admin authority")
+    })
     public ResponseEntity<IndentItemDto> createIndentItem(@Valid @RequestBody IndentItemCreationDto creationDto) {
         IndentItemDto created = indentItemService.createIndentItem(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -32,6 +51,15 @@ public class IndentItemController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "Get an indent item by id",
+            description = "Returns a single indent item, including its material and conversion status."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> getIndentItemById(@PathVariable Long id) {
         IndentItemDto indentItem = indentItemService.getIndentItemById(id);
         return ResponseEntity.ok(indentItem);
@@ -39,6 +67,14 @@ public class IndentItemController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "List all indent items",
+            description = "Returns every indent item for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
+    })
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
         List<IndentItemDto> indentItems = indentItemService.getAllIndentItems();
         return ResponseEntity.ok(indentItems);
@@ -46,6 +82,14 @@ public class IndentItemController {
 
     @GetMapping("/indent/{indentId}")
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "List items for an indent",
+            description = "Returns every item belonging to the given indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByIndentId(@PathVariable Long indentId) {
         List<IndentItemDto> indentItems = indentItemService.getIndentItemsByIndentId(indentId);
         return ResponseEntity.ok(indentItems);
@@ -53,6 +97,14 @@ public class IndentItemController {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "List items for a material",
+            description = "Returns every indent item that requests the given material, across all indents."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByMaterialId(@PathVariable Long materialId) {
         List<IndentItemDto> indentItems = indentItemService.getIndentItemsByMaterialId(materialId);
         return ResponseEntity.ok(indentItems);
@@ -60,6 +112,15 @@ public class IndentItemController {
 
     @GetMapping("/conversion-status")
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "List items by conversion status",
+            description = "Returns every indent item whose converted-to-purchase-order flag matches the "
+                    + "given value."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByConversionStatus(
             @RequestParam Boolean converted
     ) {
@@ -69,6 +130,16 @@ public class IndentItemController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('indent-item:update') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "Update an indent item",
+            description = "Replaces an indent item's material, quantities and remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> updateIndentItem(
             @PathVariable Long id,
             @Valid @RequestBody IndentItemCreationDto updateDto
@@ -79,6 +150,17 @@ public class IndentItemController {
 
     @PutMapping("/{id}/mark-converted")
     @PreAuthorize("hasAuthority('indent-item:update') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "Mark an indent item as converted",
+            description = "Marks an indent item as converted to a purchase order and records the linked "
+                    + "purchase order number."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item marked converted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The indent item is already marked as converted")
+    })
     public ResponseEntity<IndentItemDto> markAsConverted(
             @PathVariable Long id,
             @RequestParam String purchaseOrderNumber
@@ -89,6 +171,15 @@ public class IndentItemController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('indent-item:delete') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "Delete an indent item",
+            description = "Deletes the indent item with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteIndentItem(@PathVariable Long id) {
         indentItemService.deleteIndentItem(id);
         return ResponseEntity.ok(new ApiResponse("IndentItem with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.indentItem;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +16,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/indent-items/web")
+@Tag(
+        name = "Indent Items (Web)",
+        description = "Web-console mirror of the indent item endpoints. Same requested-item operations as "
+                + "the mobile API, gated by the web app's org-role check instead of point authorities."
+)
 public class IndentItemControllerWeb {
 
     private final IndentItemService indentItemService;
@@ -23,6 +31,15 @@ public class IndentItemControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create an indent item",
+            description = "Adds a requested material item to an indent, independently of the indent create call."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Indent item created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<IndentItemDto> createIndentItem(@Valid @RequestBody IndentItemCreationDto creationDto) {
         IndentItemDto created = indentItemService.createIndentItem(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -30,6 +47,15 @@ public class IndentItemControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get an indent item by id",
+            description = "Returns a single indent item, including its material and conversion status."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> getIndentItemById(@PathVariable Long id) {
         IndentItemDto indentItem = indentItemService.getIndentItemById(id);
         return ResponseEntity.ok(indentItem);
@@ -37,6 +63,14 @@ public class IndentItemControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all indent items",
+            description = "Returns every indent item for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
         List<IndentItemDto> indentItems = indentItemService.getAllIndentItems();
         return ResponseEntity.ok(indentItems);
@@ -44,6 +78,14 @@ public class IndentItemControllerWeb {
 
     @GetMapping("/indent/{indentId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items for an indent",
+            description = "Returns every item belonging to the given indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByIndentId(@PathVariable Long indentId) {
         List<IndentItemDto> indentItems = indentItemService.getIndentItemsByIndentId(indentId);
         return ResponseEntity.ok(indentItems);
@@ -51,6 +93,14 @@ public class IndentItemControllerWeb {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items for a material",
+            description = "Returns every indent item that requests the given material, across all indents."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByMaterialId(@PathVariable Long materialId) {
         List<IndentItemDto> indentItems = indentItemService.getIndentItemsByMaterialId(materialId);
         return ResponseEntity.ok(indentItems);
@@ -58,6 +108,15 @@ public class IndentItemControllerWeb {
 
     @GetMapping("/conversion-status")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items by conversion status",
+            description = "Returns every indent item whose converted-to-purchase-order flag matches the "
+                    + "given value."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IndentItemDto>> getIndentItemsByConversionStatus(
             @RequestParam Boolean converted
     ) {
@@ -67,6 +126,16 @@ public class IndentItemControllerWeb {
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update an indent item",
+            description = "Replaces an indent item's material, quantities and remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<IndentItemDto> updateIndentItem(
             @PathVariable Long id,
             @Valid @RequestBody IndentItemCreationDto updateDto
@@ -77,6 +146,17 @@ public class IndentItemControllerWeb {
 
     @PutMapping("/{id}/mark-converted")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Mark an indent item as converted",
+            description = "Marks an indent item as converted to a purchase order and records the linked "
+                    + "purchase order number."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item marked converted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The indent item is already marked as converted")
+    })
     public ResponseEntity<IndentItemDto> markAsConverted(
             @PathVariable Long id,
             @RequestParam String purchaseOrderNumber
@@ -87,6 +167,15 @@ public class IndentItemControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete an indent item",
+            description = "Deletes the indent item with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No indent item with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteIndentItem(@PathVariable Long id) {
         indentItemService.deleteIndentItem(id);
         return ResponseEntity.ok(new ApiResponse("IndentItem with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/indentItem/dto/IndentItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/dto/IndentItemCreationDto.java
@@ -1,24 +1,32 @@
 package org.tornotron.echno_backend.indentItem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
+@Schema(description = "Payload to request a material item on an indent.")
 @Data
 public class IndentItemCreationDto {
 
+    @Schema(description = "Id of the indent this item belongs to.", example = "42")
     private Long indentId;
 
+    @Schema(description = "Id of the material being requested.", example = "44")
     @NotNull(message = "Material ID is required")
     private Long materialId;
 
+    @Schema(description = "Additional specifications for the material.", example = "IS 1786 grade Fe 500D")
     private String additionalSpecifications;
 
+    @Schema(description = "Quantity requested.", example = "500")
     @NotNull(message = "Requested quantity is required")
     @Positive(message = "Requested quantity must be positive")
     private Integer requestedQuantity;
 
+    @Schema(description = "Quantity actually ordered, once a purchase order is raised.", example = "500")
     private Integer orderedQuantity;
 
+    @Schema(description = "Free-text remarks on this item.", example = "Needed before slab pour on 2026-02-08")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,24 +18,44 @@ import java.util.List;
  * accepted here. The summary counts are computed from the supplied check items
  * and defects.
  */
+@Schema(description = "Payload to schedule a new inspection, with its checklist items and any defects already known at scheduling time.")
 public record CreateInspectionRequest(
+        @Schema(description = "Short title of the inspection.", example = "Foundation Pour - Block C")
         @NotBlank @Size(max = 200) String title,
+        @Schema(description = "Category of inspection.", example = "SAFETY")
         @NotNull InspectionType type,
+        @Schema(description = "Id of the project this inspection is against.", example = "14")
         Long projectId,
+        @Schema(description = "Site or building location of the inspection.", example = "Block C, Ground Floor")
         @Size(max = 300) String location,
+        @Schema(description = "Specific area inspected within the location.", example = "Column grid C3-C6")
         @Size(max = 300) String areaInspected,
+        @Schema(description = "Reference to the drawing used during the inspection.", example = "DWG-STR-014 Rev C")
         @Size(max = 200) String drawingReference,
+        @Schema(description = "Date the inspection is scheduled for.", example = "2026-08-25")
         @NotNull LocalDate scheduledDate,
+        @Schema(description = "Scheduled time of day.", example = "10:00")
         @Size(max = 20) String scheduledTime,
+        @Schema(description = "Actual start time of the inspection, once carried out.", example = "2026-08-25T10:05:00")
         LocalDateTime actualStartTime,
+        @Schema(description = "Actual end time of the inspection, once carried out.", example = "2026-08-25T11:20:00")
         LocalDateTime actualEndTime,
+        @Schema(description = "Duration of the inspection in minutes.", example = "75")
         @PositiveOrZero Integer duration,
+        @Schema(description = "Id of the employee performing the inspection.", example = "8")
         @NotNull Long inspectorId,
+        @Schema(description = "Id of the contractor whose work is being inspected, if applicable.", example = "3")
         Long contractorId,
+        @Schema(description = "Name of the client's representative present at the inspection.", example = "K. Suresh")
         @Size(max = 200) String clientRepresentative,
+        @Schema(description = "Names of other attendees present.", example = "[\"Ravi Kumar\", \"Priya Nair\"]")
         List<@Size(max = 200) String> attendees,
+        @Schema(description = "Weather conditions at the time of inspection.", example = "Clear, dry")
         @Size(max = 200) String weatherConditions,
+        @Schema(description = "Ambient temperature at the time of inspection.", example = "31C")
         @Size(max = 50) String temperature,
+        @Schema(description = "Checklist items covered by the inspection.")
         @Valid List<InspectionCheckItemRequest> checkItems,
+        @Schema(description = "Defects identified during the inspection.")
         @Valid List<InspectionDefectRequest> defects
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
@@ -1,10 +1,12 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.inspection.CheckItemStatus;
 
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A checklist item within an inspection, as returned by the API.")
 public record InspectionCheckItemDto(
         UUID id,
         String category,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -12,15 +13,26 @@ import java.util.List;
  * passed, failed and total counts are derived server-side from the supplied
  * check items; the client does not set them.
  */
+@Schema(description = "A single checklist item within an inspection.")
 public record InspectionCheckItemRequest(
+        @Schema(description = "Grouping the check point belongs to.", example = "Reinforcement")
         @NotBlank @Size(max = 200) String category,
+        @Schema(description = "What is being checked.", example = "Rebar spacing matches drawing")
         @NotBlank @Size(max = 500) String checkPoint,
+        @Schema(description = "Reference specification or tolerance for the check point.", example = "150mm c/c +/- 10mm")
         @Size(max = 1000) String specification,
+        @Schema(description = "Result of the check.", example = "PASS")
         @NotNull CheckItemStatus status,
+        @Schema(description = "Free-text remarks recorded against the check point.", example = "Minor deviation at grid line C4, within tolerance")
         @Size(max = 1000) String remarks,
+        @Schema(description = "Whether supporting photos are required for this check point.", example = "true")
         boolean photosRequired,
+        @Schema(description = "URLs or references of photos attached to this check point.")
         List<@Size(max = 500) String> photos,
+        @Schema(description = "Measured value recorded on site.", example = "148mm")
         @Size(max = 200) String measurement,
+        @Schema(description = "Value expected per specification.", example = "150mm")
         @Size(max = 200) String expectedValue,
+        @Schema(description = "Priority of this check point.", example = "high")
         @Size(max = 20) String priority
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
@@ -1,9 +1,12 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "A defect identified during an inspection, as returned by the API.")
 public record InspectionDefectDto(
         UUID id,
         String category,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -10,15 +11,26 @@ import java.util.List;
  * Defect payload shared by the create and update requests. The number of defects
  * recorded feeds the inspection's {@code defectsFound} count, computed server-side.
  */
+@Schema(description = "A defect identified during an inspection, with its corrective action and resolution tracking.")
 public record InspectionDefectRequest(
+        @Schema(description = "Grouping the defect belongs to.", example = "Structural")
         @Size(max = 200) String category,
+        @Schema(description = "Description of the defect.", example = "Honeycombing observed on column C4 at ground level")
         @NotBlank @Size(max = 1000) String description,
+        @Schema(description = "Severity of the defect.", example = "major")
         @Size(max = 20) String severity,
+        @Schema(description = "Location of the defect within the inspected area.", example = "Column C4, ground floor")
         @Size(max = 300) String location,
+        @Schema(description = "URLs or references of photos attached to this defect.")
         List<@Size(max = 500) String> photos,
+        @Schema(description = "Action required to correct the defect.", example = "Chip out and re-pour affected section")
         @NotBlank @Size(max = 1000) String correctiveAction,
+        @Schema(description = "Party responsible for carrying out the corrective action.", example = "ABC Contractors")
         @Size(max = 200) String responsibleParty,
+        @Schema(description = "Target date for resolving the defect.", example = "2026-09-01")
         LocalDate targetDate,
+        @Schema(description = "Current resolution status of the defect.", example = "open")
         @Size(max = 20) String status,
+        @Schema(description = "Date the defect was actually resolved, if closed.", example = "null")
         LocalDate resolvedDate
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.compliance.CompliancePhase;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "An inspection as returned by the API, including its checklist items, defects and summary counts.")
 public record InspectionDto(
         UUID id,
         String inspectionNumber,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,26 +19,48 @@ import java.util.List;
  * optional (set once the inspection is concluded). The check items and defects
  * are rebuilt from the payload and the summary counts recomputed from them.
  */
+@Schema(description = "Payload to fully replace an existing inspection, including its status, result, checklist items and defects.")
 public record UpdateInspectionRequest(
+        @Schema(description = "Short title of the inspection.", example = "Foundation Pour - Block C")
         @NotBlank @Size(max = 200) String title,
+        @Schema(description = "Category of inspection.", example = "SAFETY")
         @NotNull InspectionType type,
+        @Schema(description = "Current lifecycle status of the inspection.", example = "COMPLETED")
         @NotNull InspectionStatus status,
+        @Schema(description = "Overall result once the inspection is concluded.", example = "PASSED")
         InspectionResult result,
+        @Schema(description = "Id of the project this inspection is against.", example = "14")
         Long projectId,
+        @Schema(description = "Site or building location of the inspection.", example = "Block C, Ground Floor")
         @Size(max = 300) String location,
+        @Schema(description = "Specific area inspected within the location.", example = "Column grid C3-C6")
         @Size(max = 300) String areaInspected,
+        @Schema(description = "Reference to the drawing used during the inspection.", example = "DWG-STR-014 Rev C")
         @Size(max = 200) String drawingReference,
+        @Schema(description = "Date the inspection is scheduled for.", example = "2026-08-25")
         @NotNull LocalDate scheduledDate,
+        @Schema(description = "Scheduled time of day.", example = "10:00")
         @Size(max = 20) String scheduledTime,
+        @Schema(description = "Actual start time of the inspection.", example = "2026-08-25T10:05:00")
         LocalDateTime actualStartTime,
+        @Schema(description = "Actual end time of the inspection.", example = "2026-08-25T11:20:00")
         LocalDateTime actualEndTime,
+        @Schema(description = "Duration of the inspection in minutes.", example = "75")
         @PositiveOrZero Integer duration,
+        @Schema(description = "Id of the employee performing the inspection.", example = "8")
         @NotNull Long inspectorId,
+        @Schema(description = "Id of the contractor whose work is being inspected, if applicable.", example = "3")
         Long contractorId,
+        @Schema(description = "Name of the client's representative present at the inspection.", example = "K. Suresh")
         @Size(max = 200) String clientRepresentative,
+        @Schema(description = "Names of other attendees present.", example = "[\"Ravi Kumar\", \"Priya Nair\"]")
         List<@Size(max = 200) String> attendees,
+        @Schema(description = "Weather conditions at the time of inspection.", example = "Clear, dry")
         @Size(max = 200) String weatherConditions,
+        @Schema(description = "Ambient temperature at the time of inspection.", example = "31C")
         @Size(max = 50) String temperature,
+        @Schema(description = "Checklist items, replacing any previously recorded for this inspection.")
         @Valid List<InspectionCheckItemRequest> checkItems,
+        @Schema(description = "Defects, replacing any previously recorded for this inspection.")
         @Valid List<InspectionDefectRequest> defects
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.inspection.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,24 +25,61 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/inspections/web")
 @RequiredArgsConstructor
+@Tag(
+        name = "Inspections",
+        description = "Site inspections carried out against a project, covering routine, safety and "
+                + "compliance types. An inspection tracks its checklist items, defects, result and status. "
+                + "All endpoints are tenant scoped and limited to system administrators and project "
+                + "managers."
+)
 public class InspectionControllerWeb {
 
     private final InspectionService service;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create an inspection",
+            description = "Creates a new inspection for a project, including its checklist items."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Inspection created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+    })
     public ResponseEntity<InspectionDto> create(@Valid @RequestBody CreateInspectionRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get an inspection by id",
+            description = "Returns a single inspection including its checklist items and any recorded "
+                    + "defects."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Inspection found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
     public InspectionDto get(@PathVariable UUID id) {
         return service.findById(id);
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List inspections",
+            description = "Returns a page of inspections in the current tenant. The projectId, status, "
+                    + "type and result parameters are optional filters; omitting all of them returns every "
+                    + "inspection, subject to paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching inspections"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public Page<InspectionDto> list(@RequestParam(required = false) Long projectId,
                                     @RequestParam(required = false) InspectionStatus status,
                                     @RequestParam(required = false) InspectionType type,
@@ -49,6 +90,17 @@ public class InspectionControllerWeb {
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update an inspection",
+            description = "Updates the status, result, checklist items and defects of an existing "
+                    + "inspection identified by id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Inspection updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
     public InspectionDto update(@PathVariable UUID id,
                                 @Valid @RequestBody UpdateInspectionRequest req) {
         return service.update(id, req);

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.inventoryTransaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,14 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/inventory-transactions/web")
+@Tag(
+        name = "Inventory Transactions (Web)",
+        description = "Movements of material stock, such as receipts, issues and usage, together with "
+                + "derived stock levels by storage location or material. This is the web-console API, "
+                + "restricted to the system-admin role for the current tenant. Endpoints are read-only "
+                + "and cover fetching a transaction, browsing and filtering by material, project, type, "
+                + "date range, storage location or task, and reading current stock and task usage totals."
+)
 public class InventoryTransactionControllerWeb {
     private final InventoryTransactionService inventoryTransactionService;
     private final InventoryService inventoryService;
@@ -28,6 +39,15 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get an inventory transaction by id",
+            description = "Returns a single inventory transaction."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transaction found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No inventory transaction with the given id")
+    })
     public ResponseEntity<InventoryTransactionDto> getTransactionById(@PathVariable Long id) {
         InventoryTransactionDto transaction = inventoryTransactionService.getTransactionById(id);
         return ResponseEntity.ok(transaction);
@@ -35,6 +55,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions",
+            description = "Returns every inventory transaction in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getAllTransactions() {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions();
         return ResponseEntity.ok(transactions);
@@ -42,6 +70,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions (paged)",
+            description = "Returns a single page of inventory transactions controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<InventoryTransactionDto>> getAllTransactionsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -52,6 +88,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions for a material",
+            description = "Returns the inventory transactions recorded for the given material."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByMaterial(@PathVariable Long materialId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByMaterial(materialId);
         return ResponseEntity.ok(transactions);
@@ -59,6 +103,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions for a project",
+            description = "Returns the inventory transactions recorded for the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByProject(@PathVariable Long projectId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByProject(projectId);
         return ResponseEntity.ok(transactions);
@@ -66,6 +118,15 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/type/{transactionType}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions by type",
+            description = "Returns the inventory transactions of the given transaction type."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The transaction type is not a recognized value"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByType(@PathVariable InventoryTransactionType transactionType) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByType(transactionType);
         return ResponseEntity.ok(transactions);
@@ -73,6 +134,15 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/date-range")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions by date range",
+            description = "Returns the inventory transactions recorded between the given start and end date-times."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A date parameter is missing or malformed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
@@ -83,6 +153,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/storage-location/{storageLocationId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions for a storage location",
+            description = "Returns the inventory transactions recorded at the given storage location."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByStorageLocation(
             @PathVariable Long storageLocationId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByStorageLocation(storageLocationId);
@@ -91,6 +169,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/storage-location/{storageLocationId}/material/{materialId}/project/{projectId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions for a location, material and project",
+            description = "Returns the inventory transactions matching the given storage location, material and project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByStorageLocationMaterialAndProject(
             @PathVariable Long storageLocationId,
             @PathVariable Long materialId,
@@ -102,6 +188,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/storage-location/{storageLocationId}/stock")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get stock at a storage location",
+            description = "Returns the current material stock levels at the given storage location."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<InventoryMaterialStockDto> getStockByStorageLocation(
             @PathVariable Long storageLocationId) {
         InventoryMaterialStockDto stock = inventoryService.getStockByStorageLocation(storageLocationId);
@@ -110,6 +204,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/material/{materialId}/stock")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get stock for a material",
+            description = "Returns the current stock levels of the given material across storage locations."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<MaterialLocationStockDto> getStockByMaterial(
             @PathVariable Long materialId) {
         MaterialLocationStockDto stock = inventoryService.getStockByMaterial(materialId);
@@ -118,6 +220,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/task/{taskId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List inventory transactions for a task",
+            description = "Returns the inventory transactions recorded for the given task."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByTask(@PathVariable Long taskId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByTask(taskId);
         return ResponseEntity.ok(transactions);
@@ -125,6 +235,14 @@ public class InventoryTransactionControllerWeb {
 
     @GetMapping("/project/{projectId}/task-summary")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get task material usage summary for a project",
+            description = "Returns a per-task summary of material usage for the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task material usage summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<TaskMaterialUsageDto>> getTaskMaterialUsageSummary(@PathVariable Long projectId) {
         List<TaskMaterialUsageDto> summary = inventoryTransactionService.getTaskMaterialUsageSummary(projectId);
         return ResponseEntity.ok(summary);

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -22,6 +25,13 @@ import java.util.Map;
 @RestController
 @Validated
 @RequestMapping("/api/v1/issues")
+@Tag(
+        name = "Issues",
+        description = "A problem or defect raised against a task, optionally with attachments and "
+                + "comments. Endpoints cover reading a single issue, creating one with attachments, "
+                + "partial updates and deletion. Access is gated by the issue authorities, with an "
+                + "admin authority that grants all operations."
+)
 public class IssueController {
 
     private final IssueService issueService;
@@ -45,6 +55,15 @@ public class IssueController {
 
     @GetMapping("{id}")
     @PreAuthorize("hasAuthority('issue:read') or hasAuthority('issue:admin')")
+    @Operation(
+            summary = "Get an issue by id",
+            description = "Returns a single issue including its comments and attachments."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueDto> readAnIssue(@PathVariable Long id) {
         IssueDto issue = issueService.getAnIssue(id);
         return new ResponseEntity<>(issue, HttpStatus.OK);
@@ -52,6 +71,17 @@ public class IssueController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('issue:create') or hasAuthority('issue:admin')")
+    @Operation(
+            summary = "Create an issue",
+            description = "Creates an issue from a multipart request. The data part carries the issue "
+                    + "details as JSON and the optional attachments part carries supporting files. Returns "
+                    + "the created issue as a simple view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority")
+    })
     public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") @Valid String data,
                                                       @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         IssueCreationDto dto = objectMapper.readValue(data, IssueCreationDto.class);
@@ -61,6 +91,18 @@ public class IssueController {
 
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('issue:update') or hasAuthority('issue:admin')")
+    @Operation(
+            summary = "Partially update an issue",
+            description = "Applies field updates from a multipart request. The data part carries the "
+                    + "changed fields as JSON and the optional attachments part adds files under the "
+                    + "given entityType."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueSimpleDto> partialUpdateAnIssue(
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
@@ -74,6 +116,15 @@ public class IssueController {
 
     @DeleteMapping("{id}")
     @PreAuthorize("hasAuthority('issue:delete') or hasAuthority('issue:admin')")
+    @Operation(
+            summary = "Delete an issue",
+            description = "Deletes the issue with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnIssue(@PathVariable Long id) {
         issueService.deleteAnIssue(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Issue with id: " + id + " has been deleted"));

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -23,6 +26,14 @@ import java.util.Map;
 @RestController
 @Validated
 @RequestMapping("/api/v1/issues/web")
+@Tag(
+        name = "Issues",
+        description = "Web-client twin of the issue endpoints. Adds unpaginated and paginated listing "
+                + "with search/status/type filters, dashboard stats, and lookups by project or task, "
+                + "alongside the same create, update and delete operations as the base issue API. "
+                + "Access is gated by tenant membership, with update and delete restricted to a "
+                + "system admin or project manager."
+)
 public class IssueControllerWeb {
 
     private final IssueService issueService;
@@ -35,6 +46,14 @@ public class IssueControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List all issues",
+            description = "Returns every issue in the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issues returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<IssueDto>> readAllIssues() {
         List<IssueDto> issues = issueService.getAllIssues();
         return new ResponseEntity<>(issues, HttpStatus.OK);
@@ -42,6 +61,15 @@ public class IssueControllerWeb {
 
     @GetMapping("/paginated")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List issues, paginated and filtered",
+            description = "Returns a single page of issues, optionally filtered by project, a free-text "
+                    + "search on title and description, status, or type."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of issues returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<IssueDto>> readAllIssuesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
@@ -55,6 +83,16 @@ public class IssueControllerWeb {
 
     @GetMapping("/stats")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get issue counts",
+            description = "Returns the total matching issue count and a per-status breakdown, computed "
+                    + "over the same project/search/type filters as the paginated listing, so the "
+                    + "dashboard stats stay accurate under server-side paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stats returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<IssueStatsDto> readIssueStats(
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String search,
@@ -64,12 +102,30 @@ public class IssueControllerWeb {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List issues for a project",
+            description = "Returns every issue raised against tasks belonging to the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issues returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<IssueDto>> readAllIssuesOfProject(@PathVariable Long projectId){
         return ResponseEntity.status(HttpStatus.OK).body(issueService.getAllIssuesByProjectId(projectId));
     }
 
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an issue by id",
+            description = "Returns a single issue including its comments and attachments."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueDto> readAnIssue(@PathVariable Long id) {
         IssueDto issue = issueService.getAnIssue(id);
         return new ResponseEntity<>(issue, HttpStatus.OK);
@@ -77,6 +133,17 @@ public class IssueControllerWeb {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Create an issue",
+            description = "Creates an issue from a multipart request. The data part carries the issue "
+                    + "details as JSON and the optional attachments part carries supporting files. Returns "
+                    + "the created issue as a simple view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") @Valid String data,
                                                       @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         IssueCreationDto dto = objectMapper.readValue(data, IssueCreationDto.class);
@@ -86,6 +153,18 @@ public class IssueControllerWeb {
 
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Partially update an issue",
+            description = "Applies field updates from a multipart request. The data part carries the "
+                    + "changed fields as JSON and the optional attachments part adds files under the "
+                    + "given entityType."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<IssueSimpleDto> partialUpdateAnIssue(
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
@@ -99,12 +178,30 @@ public class IssueControllerWeb {
 
     @GetMapping("/taskId/{taskId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List issues for a task",
+            description = "Returns every issue raised against the given task."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issues returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<List<IssueDto>> readAllIssuesForTask(@PathVariable Long taskId){
         return ResponseEntity.status(HttpStatus.OK).body(issueService.getAllIssuesByTaskId(taskId));
     }
 
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete an issue",
+            description = "Deletes the issue with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issue deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnIssue(@PathVariable Long id) {
         issueService.deleteAnIssue(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Issue with id: " + id + " has been deleted"));

--- a/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
+++ b/src/main/java/org/tornotron/echno_backend/keycloak/KeycloakManagementController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.keycloak;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -14,6 +17,12 @@ import java.util.Map;
 @RestController
 @RequestMapping("api/v1/keycloak")
 @Validated
+@Tag(
+        name = "Keycloak Management",
+        description = "Low-level Keycloak administration: registering clients, realm and client roles, "
+                + "authorization services, resources, policies and permissions. These calls talk "
+                + "directly to the Keycloak admin API and are restricted to a system admin."
+)
 public class KeycloakManagementController {
 
     private final KeycloakManagementService keycloakManagementService;
@@ -24,6 +33,15 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients")
+    @Operation(
+            summary = "Create a Keycloak client",
+            description = "Registers a new confidential client in Keycloak from the given definition."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Client created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ApiResponse> createClient(@Valid @RequestBody ClientCreationDto dto) {
         String id = keycloakManagementService.createClient(dto);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -32,6 +50,16 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/roles")
+    @Operation(
+            summary = "Add a client role",
+            description = "Creates a new role scoped to the given Keycloak client."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Role added"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> addClientRole(@PathVariable String clientId, @Valid @RequestBody RoleCreationDto dto) {
         keycloakManagementService.addClientRole(clientId, dto);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -40,6 +68,15 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/authorization")
+    @Operation(
+            summary = "Toggle client authorization services",
+            description = "Enables or disables fine-grained authorization services on the given client."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Authorization services updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> enableAuthorization(@PathVariable String clientId, @RequestParam boolean enabled) {
         keycloakManagementService.enableAuthorizationServices(clientId, enabled);
         return ResponseEntity.status(HttpStatus.OK)
@@ -48,6 +85,15 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/users/{userId}/roles")
+    @Operation(
+            summary = "Assign a client role to a user",
+            description = "Grants the named client role to the given Keycloak user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Role assigned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client, user or role with the given identifiers")
+    })
     public ResponseEntity<ApiResponse> assignRoleToUser(@PathVariable String userId,@PathVariable String clientId, @RequestParam String roleName) {
         keycloakManagementService.assignClientRoleToUser(userId, clientId, roleName);
         return ResponseEntity.status(HttpStatus.OK)
@@ -57,6 +103,16 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/resources")
+    @Operation(
+            summary = "Add an authorization resource",
+            description = "Registers a protected resource under the client's authorization services."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Resource created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> addResource(@PathVariable String clientId,@Valid @RequestBody ResourceDefinitionDto dto) {
         keycloakManagementService.createResource(clientId,dto);
         return ResponseEntity.status(HttpStatus.OK)
@@ -65,6 +121,16 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/policies")
+    @Operation(
+            summary = "Add a role-based authorization policy",
+            description = "Registers a policy that grants access to callers holding the given roles."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> addPolicy(@PathVariable String clientId,@Valid @RequestBody RolePolicyDefinitionDto dto) {
         keycloakManagementService.createRolePolicy(clientId,dto);
         return ResponseEntity.status(HttpStatus.OK)
@@ -73,6 +139,16 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/policies/js")
+    @Operation(
+            summary = "Add a JS-scripted authorization policy",
+            description = "Registers a policy whose decision logic is a JavaScript rule evaluated by Keycloak."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> addJsPolicy(@PathVariable String clientId, @Valid @RequestBody JsPolicyDefinitionDto dto) {
         keycloakManagementService.createJsPolicy(clientId, dto);
         return ResponseEntity.status(HttpStatus.OK)
@@ -81,6 +157,16 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/permissions")
+    @Operation(
+            summary = "Add an authorization permission",
+            description = "Ties a resource to one or more policies to form an enforceable permission."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Permission created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> addPermission(@PathVariable String clientId, @Valid @RequestBody PermissionDefinitionDto dto) {
         keycloakManagementService.createPermission(clientId,dto);
         return ResponseEntity.status(HttpStatus.OK)
@@ -89,6 +175,17 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/clients/{clientId}/authorization-setup")
+    @Operation(
+            summary = "Create a full authorization setup",
+            description = "Creates resources, policies and permissions for a client in one call, from a "
+                    + "single combined definition."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Authorization setup created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No client with the given id")
+    })
     public ResponseEntity<ApiResponse> createWholeAuthorizationSetup(@PathVariable String clientId,@Valid @RequestBody AuthorizationSetupDto dto) {
         keycloakManagementService.configureAuthorization(clientId,dto);
         return ResponseEntity.status(HttpStatus.OK)
@@ -97,6 +194,14 @@ public class KeycloakManagementController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping("/roles")
+    @Operation(
+            summary = "Add realm roles",
+            description = "Creates one or more realm-level roles from a map of role name to description."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Realm roles added"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ApiResponse> addRealmRoles(@RequestBody Map<String, String> roles) {
         keycloakManagementService.addRealmRoles(roles);
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/org/tornotron/echno_backend/labour/LabourControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/LabourControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.labour;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/labour/web")
 @Validated
+@Tag(
+        name = "Labour",
+        description = "Contract and daily-wage workforce records for the organization: masons, bar "
+                + "benders, electricians and similar site labour, with employment type, skill level, "
+                + "pay rate and bank details. Endpoints cover creating a labour record, listing, lookup "
+                + "by id, partial update and deletion, all restricted to admin and HR roles."
+)
 public class LabourControllerWeb {
 
     private final LabourService labourService;
@@ -27,12 +37,31 @@ public class LabourControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Create a labour record",
+            description = "Adds a new labour record to the current tenant organization, for example a "
+                    + "mason or bar bender engaged on daily wage or contract terms."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Labour record created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<LabourSimpleDto> createLabour(@Valid @RequestBody LabourCreationDto labourCreationDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(labourService.createLabour(labourCreationDto));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List labour records",
+            description = "Returns a single page of labour records. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of labour records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<LabourDto>> getAllLabours(@RequestParam(defaultValue = "0") int pageNo,
                                                          @RequestParam(defaultValue = "10") int pageSize) {
         return ResponseEntity.status(HttpStatus.OK).body(labourService.getAllLabours(pageNo, pageSize).getContent());
@@ -40,12 +69,32 @@ public class LabourControllerWeb {
 
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a labour record by id",
+            description = "Returns a single labour record with its employment, pay and bank detail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Labour record found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No labour record with the given id")
+    })
     public ResponseEntity<LabourDto> getALabour(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(labourService.getALabour(id));
     }
 
     @PatchMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Partially update a labour record",
+            description = "Applies the supplied fields as a partial update to an existing labour record. "
+                    + "Fields left null in the request body are left unchanged."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Labour record updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No labour record with the given id")
+    })
     public ResponseEntity<ApiResponse> partialUpdateALabour(@Valid @RequestBody LabourUpdateDto updates, @PathVariable Long id) {
         labourService.partialUpdateALabour(updates, id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Labour with id: " + id + " updated"));
@@ -53,6 +102,15 @@ public class LabourControllerWeb {
 
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Delete a labour record",
+            description = "Deletes the labour record with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Labour record deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No labour record with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteALabour(@PathVariable Long id) {
         labourService.deleteALabour(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Labour with id: " + id + " has been deleted"));

--- a/src/main/java/org/tornotron/echno_backend/labour/dto/LabourCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/dto/LabourCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.labour.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
@@ -8,68 +9,89 @@ import lombok.Data;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "Payload to create a labour record for a worker engaged on daily wage, monthly, "
+        + "contract or piece-rate terms.")
 @Data
 public class LabourCreationDto {
 
+    @Schema(description = "Organization-assigned labour code.", example = "LAB-0087")
     @NotBlank(message = "'LabourID'(String) is required")
     @Size(max = 15,message = "must not exceed 15 characters")
     private String labourID;
 
+    @Schema(description = "Full name of the worker.", example = "Suresh Pillai")
     @NotBlank(message = "'fullName'(String) is required")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String fullName;
 
+    @Schema(description = "Contact email address.", example = "suresh.pillai@example.com")
     @Email
     @Size(max = 255, message = "must not exceed 255 characters")
     private String email;
 
+    @Schema(description = "Postal address of the worker.", example = "12 Kaloor, Kochi")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String address;
 
+    @Schema(description = "Ten-digit contact phone number.", example = "9847098470")
     @NotBlank(message = "'phoneNumber'(String) is required")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String phoneNumber;
 
+    @Schema(description = "Name of the emergency contact.", example = "Latha Pillai")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String emergencyContactName;
 
+    @Schema(description = "Ten-digit phone number of the emergency contact.", example = "9846012345")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String emergencyContactPhone;
 
+    @Schema(description = "Trade or skill specialization.", example = "Bar Bender")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String specialization;
 
+    @Schema(description = "Employment arrangement. One of DAILY_WAGE, MONTHLY, CONTRACT, PIECE_RATE.", example = "DAILY_WAGE")
     @NotBlank(message = "'employmentType'(String) is required")
     @Size(max = 255, message = "must not exceed 255 characters")
     @Enumerated(EnumType.STRING)
     private String employmentType;
 
+    @Schema(description = "Skill level. One of SKILLED, SEMI_SKILLED, HIGHLY_SKILLED, UNSKILLED.", example = "SKILLED")
     @NotBlank(message = "'skillLevel'(String) is required")
     @Size(max = 255, message = "must not exceed 255 characters")
     @Enumerated(EnumType.STRING)
     private String skillLevel;
 
+    @Schema(description = "Employment status. One of ACTIVE, INACTIVE, ON_LEAVE, TERMINATED.", example = "ACTIVE")
     @NotBlank(message = "'status'(String) is required")
     @Size(max = 255, message = "must not exceed 255 characters")
     @Enumerated(EnumType.STRING)
     private String status;
 
+    @Schema(description = "Date the worker joined. Must be in the past.", example = "2026-01-15")
     @NotNull(message = "'joiningDate'(LocalDate) is required")
     @Past(message = "joiningDate must be in the past")
     private LocalDate joiningDate;
 
+    @Schema(description = "Id of the project the worker is currently assigned to.", example = "4")
     private Long currentProjectId;
 
+    @Schema(description = "Daily wage rate.", example = "850.00")
     private BigDecimal dailyRate;
 
+    @Schema(description = "Overtime rate per hour.", example = "120.00")
     private BigDecimal overTimeRate;
 
+    @Schema(description = "Bank account number for wage payment.", example = "50100234567890")
     private String bankAccountNumber;
 
+    @Schema(description = "Name of the bank.", example = "State Bank of India")
     private String bankName;
 
+    @Schema(description = "Bank IFSC code.", example = "SBIN0001234")
     private String ifscCode;
 
+    @Schema(description = "Free-text notes about the worker.", example = "Certified for tower crane rigging support.")
     private String additionalNotes;
 
 }

--- a/src/main/java/org/tornotron/echno_backend/labour/dto/LabourDto.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/dto/LabourDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.labour.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.labour.enums.EmploymentType;
 import org.tornotron.echno_backend.labour.enums.SkillLevel;
@@ -8,25 +9,45 @@ import org.tornotron.echno_backend.labour.enums.Status;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "A labour record for a worker engaged on daily wage, monthly, contract or piece-rate terms.")
 @Data
 public class LabourDto {
+    @Schema(description = "Database id of the labour record.", example = "18")
     private Long id;
+    @Schema(description = "Organization-assigned labour code.", example = "LAB-0087")
     private String labourID;
+    @Schema(description = "Full name of the worker.", example = "Suresh Pillai")
     private String fullName;
+    @Schema(description = "Contact email address.", example = "suresh.pillai@example.com")
     private String email;
+    @Schema(description = "Postal address of the worker.", example = "12 Kaloor, Kochi")
     private String address;
+    @Schema(description = "Ten-digit contact phone number.", example = "9847098470")
     private String phoneNumber;
+    @Schema(description = "Name of the emergency contact.", example = "Latha Pillai")
     private String emergencyContactName;
+    @Schema(description = "Ten-digit phone number of the emergency contact.", example = "9846012345")
     private String emergencyContactNumber;
+    @Schema(description = "Trade or skill specialization.", example = "Bar Bender")
     private String specialization;
+    @Schema(description = "Employment arrangement.", example = "DAILY_WAGE")
     private EmploymentType employmentType;
+    @Schema(description = "Skill level.", example = "SKILLED")
     private SkillLevel skillLevel;
+    @Schema(description = "Employment status.", example = "ACTIVE")
     private Status status;
+    @Schema(description = "Date the worker joined.", example = "2026-01-15")
     private LocalDate joiningDate;
+    @Schema(description = "Daily wage rate.", example = "850.00")
     private BigDecimal dailyRate;
+    @Schema(description = "Overtime rate per hour.", example = "120.00")
     private BigDecimal overTimeRate;
+    @Schema(description = "Bank account number for wage payment.", example = "50100234567890")
     private String bankAccountNumber;
+    @Schema(description = "Name of the bank.", example = "State Bank of India")
     private String bankName;
+    @Schema(description = "Bank IFSC code.", example = "SBIN0001234")
     private String ifscCode;
+    @Schema(description = "Free-text notes about the worker.", example = "Certified for tower crane rigging support.")
     private String additionalNotes;
 }

--- a/src/main/java/org/tornotron/echno_backend/labour/dto/LabourSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/dto/LabourSimpleDto.java
@@ -1,34 +1,59 @@
 package org.tornotron.echno_backend.labour.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "A terse view of a labour record, returned after creation, without the resolved project relation expanded beyond its name and id.")
 @Data
 public class LabourSimpleDto {
 
+    @Schema(description = "Database id of the labour record.", example = "18")
     private Long id;
+    @Schema(description = "Organization-assigned labour code.", example = "LAB-0087")
     private String labourId;
+    @Schema(description = "Id of the organization the worker belongs to.", example = "1")
     private Long organizationId;
+    @Schema(description = "Name of the organization the worker belongs to.", example = "Asset Homes")
     private String organizationName;
+    @Schema(description = "Full name of the worker.", example = "Suresh Pillai")
     private String fullName;
+    @Schema(description = "Contact email address.", example = "suresh.pillai@example.com")
     private String email;
+    @Schema(description = "Postal address of the worker.", example = "12 Kaloor, Kochi")
     private String address;
+    @Schema(description = "Ten-digit contact phone number.", example = "9847098470")
     private String phoneNumber;
+    @Schema(description = "Name of the emergency contact.", example = "Latha Pillai")
     private String emergencyContactName;
+    @Schema(description = "Ten-digit phone number of the emergency contact.", example = "9846012345")
     private String emergencyContactNumber;
+    @Schema(description = "Trade or skill specialization.", example = "Bar Bender")
     private String specialization;
+    @Schema(description = "Employment arrangement.", example = "DAILY_WAGE")
     private String employmentType;
+    @Schema(description = "Skill level.", example = "SKILLED")
     private String skillLevel;
+    @Schema(description = "Employment status.", example = "ACTIVE")
     private String status;
+    @Schema(description = "Date the worker joined.", example = "2026-01-15")
     private LocalDate joiningDate;
+    @Schema(description = "Name of the project the worker is currently assigned to.", example = "Marina Heights Towers")
     private String currentProjectName;
+    @Schema(description = "Id of the project the worker is currently assigned to.", example = "4")
     private String currentProjectId;
+    @Schema(description = "Daily wage rate.", example = "850.00")
     private BigDecimal dailyRate;
+    @Schema(description = "Overtime rate per hour.", example = "120.00")
     private BigDecimal overTimeRate;
+    @Schema(description = "Bank account number for wage payment.", example = "50100234567890")
     private String bankAccountNumber;
+    @Schema(description = "Name of the bank.", example = "State Bank of India")
     private String bankName;
+    @Schema(description = "Bank IFSC code.", example = "SBIN0001234")
     private String ifscCode;
+    @Schema(description = "Free-text notes about the worker.", example = "Certified for tower crane rigging support.")
     private String additionalNotes;
 }

--- a/src/main/java/org/tornotron/echno_backend/labour/dto/LabourUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/dto/LabourUpdateDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.labour.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
@@ -11,54 +12,74 @@ import org.tornotron.echno_backend.labour.enums.Status;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "Payload to partially update a labour record. Only the fields supplied in the request are changed; the rest are left as they are.")
 @Data
 public class LabourUpdateDto {
 
+    @Schema(description = "Organization-assigned labour code.", example = "LAB-0087")
     @Size(max = 15, message = "must not exceed 15 characters")
     private String labourID;
 
+    @Schema(description = "Full name of the worker.", example = "Suresh Pillai")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String fullName;
 
+    @Schema(description = "Contact email address.", example = "suresh.pillai@example.com")
     @Email
     @Size(max = 255, message = "must not exceed 255 characters")
     private String email;
 
+    @Schema(description = "Postal address of the worker.", example = "12 Kaloor, Kochi")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String address;
 
+    @Schema(description = "Ten-digit contact phone number.", example = "9847098470")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String phoneNumber;
 
+    @Schema(description = "Name of the emergency contact.", example = "Latha Pillai")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String emergencyContactName;
 
+    @Schema(description = "Ten-digit phone number of the emergency contact.", example = "9846012345")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String emergencyContactPhone;
 
+    @Schema(description = "Trade or skill specialization.", example = "Bar Bender")
     @Size(max = 255, message = "must not exceed 255 characters")
     private String specialization;
 
+    @Schema(description = "Employment arrangement.", example = "DAILY_WAGE")
     private EmploymentType employmentType;
 
+    @Schema(description = "Skill level.", example = "SKILLED")
     private SkillLevel skillLevel;
 
+    @Schema(description = "Employment status.", example = "ACTIVE")
     private Status status;
 
+    @Schema(description = "Date the worker joined. Must be in the past.", example = "2026-01-15")
     @Past(message = "joiningDate must be in the past")
     private LocalDate joiningDate;
 
+    @Schema(description = "Id of the project the worker is currently assigned to.", example = "4")
     private Long currentProjectId;
 
+    @Schema(description = "Daily wage rate.", example = "850.00")
     private BigDecimal dailyRate;
 
+    @Schema(description = "Overtime rate per hour.", example = "120.00")
     private BigDecimal overTimeRate;
 
+    @Schema(description = "Bank account number for wage payment.", example = "50100234567890")
     private String bankAccountNumber;
 
+    @Schema(description = "Name of the bank.", example = "State Bank of India")
     private String bankName;
 
+    @Schema(description = "Bank IFSC code.", example = "SBIN0001234")
     private String ifscCode;
 
+    @Schema(description = "Free-text notes about the worker.", example = "Certified for tower crane rigging support.")
     private String additionalNotes;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,6 +18,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-approvals")
 @Validated
+@Tag(
+        name = "Leave Approvals",
+        description = "Actions on the approval workflow of a submitted leave request: approve, reject, "
+                + "delegate to another approver, and read the approval history or the full approval chain. "
+                + "Approving is gated to the system-admin or hr-admin role in the caller's tenant; reject, "
+                + "delegate and the read endpoints are gated by the leave approve, read or admin authority."
+)
 public class LeaveApprovalController {
 
     private final LeaveApprovalService approvalService;
@@ -26,6 +36,17 @@ public class LeaveApprovalController {
     @PostMapping("/requests/{requestId}/approve")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Approve a leave request",
+            description = "Records an approval for the given request at its current approval level and "
+                    + "advances the workflow. Returns the request with its updated status and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> approve(
             @PathVariable Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -34,6 +55,17 @@ public class LeaveApprovalController {
 
     @PostMapping("/requests/{requestId}/reject")
     @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Reject a leave request",
+            description = "Records a rejection for the given request, stopping the approval workflow. "
+                    + "Returns the request with its updated status and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> reject(
             @PathVariable Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -42,6 +74,17 @@ public class LeaveApprovalController {
 
     @PostMapping("/requests/{requestId}/delegate")
     @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Delegate a pending approval",
+            description = "Reassigns the current approval step for the given request to the delegate named "
+                    + "in the payload. Returns the request with its updated approver and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> delegate(
             @PathVariable Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -50,6 +93,16 @@ public class LeaveApprovalController {
 
     @GetMapping("/requests/{requestId}/history")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get the approval history of a request",
+            description = "Returns every approval action recorded against the given leave request, in the "
+                    + "order they occurred."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalHistory(
             @PathVariable Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalHistory(requestId));
@@ -57,6 +110,16 @@ public class LeaveApprovalController {
 
     @GetMapping("/requests/{requestId}/chain")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get the approval chain of a request",
+            description = "Returns the ordered sequence of approvers configured for the given leave request, "
+                    + "including steps not yet acted on."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval chain returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalChain(
             @PathVariable Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalChain(requestId));
@@ -64,6 +127,16 @@ public class LeaveApprovalController {
 
     @GetMapping("/requests/{requestId}/can-approve")
     @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Check whether an employee can approve a request",
+            description = "Returns whether the given employee is the current approver for the given leave "
+                    + "request, as a single boolean flag."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Eligibility flag returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<Map<String, Boolean>> canApprove(
             @PathVariable Long requestId,
             @RequestParam Long employeeId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,6 +18,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-approvals/web")
 @Validated
+@Tag(
+        name = "Leave Approvals (Web)",
+        description = "Web-console equivalent of the leave approval endpoints, addressing the request by a "
+                + "requestId query parameter instead of a path segment. Covers approve, reject, delegate, "
+                + "approval history and chain, and the can-approve check. All endpoints are gated to the "
+                + "system-admin or hr-admin role in the caller's tenant."
+)
 public class LeaveApprovalControllerWeb {
 
     private final LeaveApprovalService approvalService;
@@ -25,6 +35,17 @@ public class LeaveApprovalControllerWeb {
 
     @PostMapping("/approve")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Approve a leave request",
+            description = "Records an approval for the given request at its current approval level and "
+                    + "advances the workflow. Returns the request with its updated status and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> approve(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -33,6 +54,17 @@ public class LeaveApprovalControllerWeb {
 
     @PostMapping("/reject")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Reject a leave request",
+            description = "Records a rejection for the given request, stopping the approval workflow. "
+                    + "Returns the request with its updated status and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> reject(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -41,6 +73,17 @@ public class LeaveApprovalControllerWeb {
 
     @PostMapping("/delegate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Delegate a pending approval",
+            description = "Reassigns the current approval step for the given request to the delegate named "
+                    + "in the payload. Returns the request with its updated approver and approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> delegate(
             @RequestParam Long requestId,
             @Valid @RequestBody LeaveApprovalActionDto dto) {
@@ -49,6 +92,16 @@ public class LeaveApprovalControllerWeb {
 
     @GetMapping("/history")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get the approval history of a request",
+            description = "Returns every approval action recorded against the given leave request, in the "
+                    + "order they occurred."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalHistory(
             @RequestParam Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalHistory(requestId));
@@ -56,6 +109,16 @@ public class LeaveApprovalControllerWeb {
 
     @GetMapping("/chain")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get the approval chain of a request",
+            description = "Returns the ordered sequence of approvers configured for the given leave request, "
+                    + "including steps not yet acted on."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval chain returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalChain(
             @RequestParam Long requestId) {
         return ResponseEntity.ok(approvalService.getApprovalChain(requestId));
@@ -63,6 +126,16 @@ public class LeaveApprovalControllerWeb {
 
     @GetMapping("/can-approve")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Check whether an employee can approve a request",
+            description = "Returns whether the given employee is the current approver for the given leave "
+                    + "request, as a single boolean flag."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Eligibility flag returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<Map<String, Boolean>> canApprove(
             @RequestParam Long requestId,
             @RequestParam Long employeeId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,6 +19,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/leave-balances")
 @Validated
+@Tag(
+        name = "Leave Balances",
+        description = "Per-employee, per-policy leave balances for a year: opening balance, accrued, used, "
+                + "pending and available days, plus the transaction ledger behind them. Endpoints cover "
+                + "reading balances and summaries, recalculating and manually adjusting a balance, and "
+                + "reading the transaction history. Reads that target another employee are gated to the "
+                + "system-admin or hr-admin role, or to the caller acting on their own record."
+)
 public class LeaveBalanceController {
 
     private final LeaveBalanceService balanceService;
@@ -27,6 +38,16 @@ public class LeaveBalanceController {
     @GetMapping("/employee/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's leave balances",
+            description = "Returns every leave policy balance held by the employee for the given year, "
+                    + "defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -37,6 +58,16 @@ public class LeaveBalanceController {
     @GetMapping("/employee/{employeeId}/policy/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get an employee's balance for one policy",
+            description = "Returns, or calculates on demand, the employee's balance under the given leave "
+                    + "policy for the given year, defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balance returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
+    })
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
             @PathVariable Long employeeId,
             @PathVariable Long policyId,
@@ -48,6 +79,16 @@ public class LeaveBalanceController {
     @GetMapping("/employee/{employeeId}/summary")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an employee's balance summary",
+            description = "Returns the employee's balances for the given year together with totals for "
+                    + "available, used and pending days across all policies."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -58,6 +99,16 @@ public class LeaveBalanceController {
     @PostMapping("/employee/{employeeId}/recalculate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Recalculate an employee's leave balances",
+            description = "Recomputes every policy balance held by the employee for the given year and "
+                    + "returns the refreshed list, defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances recalculated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveBalanceDto>> recalculateBalances(
             @PathVariable Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -68,6 +119,17 @@ public class LeaveBalanceController {
     @PostMapping("/adjust")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Manually adjust a leave balance",
+            description = "Applies a signed day adjustment to an employee's balance under the given policy "
+                    + "and records the reason. Returns the resulting transaction."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Adjustment applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The adjustment payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
+    })
     public ResponseEntity<LeaveTransactionDto> adjustBalance(
             @Valid @RequestBody LeaveBalanceAdjustmentDto dto) {
         return ResponseEntity.ok(balanceService.adjustBalance(dto));
@@ -76,6 +138,16 @@ public class LeaveBalanceController {
     @GetMapping("/employee/{employeeId}/transactions")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Get an employee's transaction history",
+            description = "Returns every leave balance transaction recorded for the employee, across all "
+                    + "policies, in chronological order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transaction history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(
             @PathVariable Long employeeId) {
         return ResponseEntity.ok(balanceService.getTransactionHistory(employeeId));
@@ -84,6 +156,16 @@ public class LeaveBalanceController {
     @GetMapping("/{balanceId}/transactions")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get transactions for one balance",
+            description = "Returns every transaction recorded against the given leave balance record, in "
+                    + "chronological order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave balance with the given id")
+    })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionsByBalance(
             @PathVariable Long balanceId) {
         return ResponseEntity.ok(balanceService.getTransactionsByBalance(balanceId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,6 +19,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/leave-balances/web")
 @Validated
+@Tag(
+        name = "Leave Balances (Web)",
+        description = "Web-console equivalent of the leave balance endpoints, addressing the employee and "
+                + "policy by query parameters instead of path segments. Covers reading balances and "
+                + "summaries, recalculating and manually adjusting a balance, and reading the transaction "
+                + "history. Reads that target another employee are gated to the system-admin or hr-admin "
+                + "role, or to the caller acting on their own record."
+)
 public class LeaveBalanceControllerWeb {
 
     private final LeaveBalanceService balanceService;
@@ -26,6 +37,16 @@ public class LeaveBalanceControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's leave balances",
+            description = "Returns every leave policy balance held by the employee for the given year, "
+                    + "defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveBalanceDto>> getEmployeeBalances(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -35,6 +56,16 @@ public class LeaveBalanceControllerWeb {
 
     @GetMapping("/specific")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get an employee's balance for one policy",
+            description = "Returns, or calculates on demand, the employee's balance under the given leave "
+                    + "policy for the given year, defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balance returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
+    })
     public ResponseEntity<LeaveBalanceDto> getSpecificBalance(
             @RequestParam Long employeeId,
             @RequestParam Long policyId,
@@ -45,6 +76,16 @@ public class LeaveBalanceControllerWeb {
 
     @GetMapping("/summary")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get an employee's balance summary",
+            description = "Returns the employee's balances for the given year together with totals for "
+                    + "available, used and pending days across all policies."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<LeaveBalanceSummaryDto> getBalanceSummary(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -54,6 +95,16 @@ public class LeaveBalanceControllerWeb {
 
     @PostMapping("/recalculate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Recalculate an employee's leave balances",
+            description = "Recomputes every policy balance held by the employee for the given year and "
+                    + "returns the refreshed list, defaulting to the current year when none is given."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Balances recalculated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveBalanceDto>> recalculateBalances(
             @RequestParam Long employeeId,
             @RequestParam(required = false) Integer year) {
@@ -63,6 +114,17 @@ public class LeaveBalanceControllerWeb {
 
     @PostMapping("/adjust")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Manually adjust a leave balance",
+            description = "Applies a signed day adjustment to an employee's balance under the given policy "
+                    + "and records the reason. Returns the resulting transaction."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Adjustment applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The adjustment payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee or leave policy with the given id")
+    })
     public ResponseEntity<LeaveTransactionDto> adjustBalance(
             @Valid @RequestBody LeaveBalanceAdjustmentDto dto) {
         return ResponseEntity.ok(balanceService.adjustBalance(dto));
@@ -70,6 +132,16 @@ public class LeaveBalanceControllerWeb {
 
     @GetMapping("/transactions")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Get an employee's transaction history",
+            description = "Returns every leave balance transaction recorded for the employee, across all "
+                    + "policies, in chronological order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transaction history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionHistory(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(balanceService.getTransactionHistory(employeeId));
@@ -77,6 +149,16 @@ public class LeaveBalanceControllerWeb {
 
     @GetMapping("/transactions-by-balance")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get transactions for one balance",
+            description = "Returns every transaction recorded against the given leave balance record, in "
+                    + "chronological order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transactions returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave balance with the given id")
+    })
     public ResponseEntity<List<LeaveTransactionDto>> getTransactionsByBalance(
             @RequestParam Long balanceId) {
         return ResponseEntity.ok(balanceService.getTransactionsByBalance(balanceId));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +16,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-calendar")
 @Validated
+@Tag(
+        name = "Leave Calendar",
+        description = "Day-by-day view of who is on leave, built from approved leave requests. Endpoints "
+                + "cover the whole organization, a single department, a single employee or a manager's "
+                + "team, over a given date range, plus a grouped-by-date view and a headcount for a single "
+                + "day. Access is gated by the leave read or admin authority."
+)
 public class LeaveCalendarController {
 
     private final LeaveCalendarService calendarService;
@@ -23,6 +33,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/organization/{organizationId}")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get an organization's leave calendar",
+            description = "Returns every leave calendar entry for the organization between startDate and "
+                    + "endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getOrganizationCalendar(
             @PathVariable Long organizationId,
             @RequestParam LocalDate startDate,
@@ -33,6 +53,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/organization/{organizationId}/department")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get a department's leave calendar",
+            description = "Returns every leave calendar entry for the named department within the "
+                    + "organization between startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getDepartmentCalendar(
             @PathVariable Long organizationId,
             @RequestParam String department,
@@ -44,6 +74,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/employee/{employeeId}")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get an employee's leave calendar",
+            description = "Returns every leave calendar entry for the employee between startDate and "
+                    + "endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getEmployeeCalendar(
             @PathVariable Long employeeId,
             @RequestParam LocalDate startDate,
@@ -54,6 +94,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/team")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get a manager's team leave calendar",
+            description = "Returns every leave calendar entry for the direct reports of the given manager "
+                    + "between startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getTeamCalendar(
             @RequestParam Long managerId,
             @RequestParam LocalDate startDate,
@@ -64,6 +114,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/organization/{organizationId}/grouped")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Get an organization's leave calendar grouped by date",
+            description = "Returns the organization's leave calendar entries between startDate and endDate, "
+                    + "inclusive, keyed by date for a day-by-day view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grouped calendar returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<Map<LocalDate, List<LeaveCalendarDto>>> getCalendarGroupedByDate(
             @PathVariable Long organizationId,
             @RequestParam LocalDate startDate,
@@ -74,6 +134,16 @@ public class LeaveCalendarController {
 
     @GetMapping("/organization/{organizationId}/count")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Count employees on leave for a day",
+            description = "Returns the number of employees in the organization who are on leave on the "
+                    + "given date."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<Map<String, Long>> getEmployeesOnLeaveCount(
             @PathVariable Long organizationId,
             @RequestParam LocalDate date) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +16,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-calendar/web")
 @Validated
+@Tag(
+        name = "Leave Calendar (Web)",
+        description = "Web-console equivalent of the leave calendar endpoints, addressing the organization, "
+                + "department, employee or manager by query parameters instead of path segments. Covers "
+                + "the organization, department, employee, team, grouped-by-date and headcount views. All "
+                + "endpoints are gated to the system-admin or hr-admin role in the caller's tenant."
+)
 public class LeaveCalendarControllerWeb {
 
     private final LeaveCalendarService calendarService;
@@ -23,6 +33,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/organization")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get an organization's leave calendar",
+            description = "Returns every leave calendar entry for the organization between startDate and "
+                    + "endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getOrganizationCalendar(
             @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
@@ -33,6 +53,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/department")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a department's leave calendar",
+            description = "Returns every leave calendar entry for the named department within the "
+                    + "organization between startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getDepartmentCalendar(
             @RequestParam Long organizationId,
             @RequestParam String department,
@@ -44,6 +74,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/employee")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get an employee's leave calendar",
+            description = "Returns every leave calendar entry for the employee between startDate and "
+                    + "endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getEmployeeCalendar(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -54,6 +94,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/team")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a manager's team leave calendar",
+            description = "Returns every leave calendar entry for the direct reports of the given manager "
+                    + "between startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
+    })
     public ResponseEntity<List<LeaveCalendarDto>> getTeamCalendar(
             @RequestParam Long managerId,
             @RequestParam LocalDate startDate,
@@ -64,6 +114,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/grouped")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get an organization's leave calendar grouped by date",
+            description = "Returns the organization's leave calendar entries between startDate and endDate, "
+                    + "inclusive, keyed by date for a day-by-day view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grouped calendar returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<Map<LocalDate, List<LeaveCalendarDto>>> getCalendarGroupedByDate(
             @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
@@ -74,6 +134,16 @@ public class LeaveCalendarControllerWeb {
 
     @GetMapping("/count")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Count employees on leave for a day",
+            description = "Returns the number of employees in the organization who are on leave on the "
+                    + "given date."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<Map<String, Long>> getEmployeesOnLeaveCount(
             @RequestParam Long organizationId,
             @RequestParam LocalDate date) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,14 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-policies")
 @Validated
+@Tag(
+        name = "Leave Policies",
+        description = "Leave types configured per organization: annual quota, accrual rate, carry-forward "
+                + "rule, half-day and attachment rules. Endpoints cover creating, reading, updating, "
+                + "deactivating, reactivating and duplicating a policy into another organization. Creation, "
+                + "updates and lifecycle changes are gated to the system-admin or hr-admin role in the "
+                + "caller's tenant."
+)
 public class LeavePolicyController {
 
     private final LeavePolicyService policyService;
@@ -27,6 +38,16 @@ public class LeavePolicyController {
     @PostMapping
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a leave policy",
+            description = "Creates a leave policy for an organization from the given quota, accrual and "
+                    + "eligibility rules. Returns the created policy."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The policy payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<LeavePolicyDto> createPolicy(
             @Valid @RequestBody LeavePolicyCreationDto dto) {
         LeavePolicyDto created = policyService.createPolicy(dto);
@@ -36,18 +57,45 @@ public class LeavePolicyController {
     @GetMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a leave policy by id",
+            description = "Returns a single leave policy with its quota, accrual and eligibility rules."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> getPolicy(@PathVariable Long policyId) {
         return ResponseEntity.ok(policyService.getPolicy(policyId));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List all leave policies",
+            description = "Returns every leave policy across all organizations, regardless of active status."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policies returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<LeavePolicyDto>> getAllPolicies() {
         return ResponseEntity.status(HttpStatus.OK).body(policyService.getAllPolicies());
     }
 
     @GetMapping("/organization/{organizationId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an organization's leave policies",
+            description = "Returns the leave policies configured for the organization. Active policies "
+                    + "only by default; pass includeInactive=true to also return deactivated ones."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policies returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<List<LeavePolicyDto>> getPoliciesByOrganization(
             @PathVariable Long organizationId,
             @RequestParam(required = false, defaultValue = "false") Boolean includeInactive) {
@@ -60,6 +108,16 @@ public class LeavePolicyController {
     @GetMapping("/employee/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "List policies applicable to an employee",
+            description = "Returns the leave policies the employee is eligible for, filtered by their "
+                    + "organization, gender and length of service against each policy's rules."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Applicable policies returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(
             @PathVariable Long employeeId) {
         return ResponseEntity.ok(policyService.getApplicablePoliciesForEmployee(employeeId));
@@ -68,6 +126,16 @@ public class LeavePolicyController {
     @PatchMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Partially update a leave policy",
+            description = "Applies the given field updates to the policy and returns the updated record."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @PathVariable Long policyId,
             @RequestBody Map<String, Object> updates) {
@@ -77,6 +145,16 @@ public class LeavePolicyController {
     @DeleteMapping("/{policyId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Deactivate a leave policy",
+            description = "Marks the policy inactive so it stops applying to new leave requests. Existing "
+                    + "balances and requests already raised against it are unaffected."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy deactivated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<ApiResponse> deactivatePolicy(@PathVariable Long policyId) {
         policyService.deactivatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy deactivated successfully"));
@@ -85,6 +163,16 @@ public class LeavePolicyController {
     @PostMapping("/{policyId}/activate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Reactivate a leave policy",
+            description = "Marks a previously deactivated policy active again so it resumes applying to "
+                    + "new leave requests."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy activated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<ApiResponse> activatePolicy(@PathVariable Long policyId) {
         policyService.activatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
@@ -93,6 +181,16 @@ public class LeavePolicyController {
     @PostMapping("/{policyId}/duplicate")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Duplicate a leave policy into another organization",
+            description = "Copies the policy's quota, accrual and eligibility rules into a new policy owned "
+                    + "by the target organization. Returns the newly created policy."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @PathVariable Long policyId,
             @RequestParam Long targetOrganizationId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-policies/web")
 @Validated
+@Tag(
+        name = "Leave Policies (Web)",
+        description = "Web-console equivalent of the leave policy endpoints, addressing a policy by a "
+                + "policyId query parameter instead of a path segment. Covers creating, reading, updating, "
+                + "deactivating, reactivating and duplicating a policy. Creation, updates and lifecycle "
+                + "changes are gated to the system-admin or hr-admin role in the caller's tenant."
+)
 public class LeavePolicyControllerWeb {
 
     private final LeavePolicyService policyService;
@@ -26,6 +36,16 @@ public class LeavePolicyControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a leave policy",
+            description = "Creates a leave policy for an organization from the given quota, accrual and "
+                    + "eligibility rules. Returns the created policy."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The policy payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<LeavePolicyDto> createPolicy(
             @Valid @RequestBody LeavePolicyCreationDto dto) {
         LeavePolicyDto created = policyService.createPolicy(dto);
@@ -34,12 +54,29 @@ public class LeavePolicyControllerWeb {
 
     @GetMapping("/policy")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a leave policy by id",
+            description = "Returns a single leave policy with its quota, accrual and eligibility rules."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> getPolicy(@RequestParam Long policyId) {
         return ResponseEntity.ok(policyService.getPolicy(policyId));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List all leave policies",
+            description = "Returns every leave policy across all organizations, regardless of active status."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policies returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<LeavePolicyDto>> getAllPolicies() {
         return ResponseEntity.status(HttpStatus.OK).body(policyService.getAllPolicies());
     }
@@ -57,6 +94,16 @@ public class LeavePolicyControllerWeb {
 
     @GetMapping("/employee")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "List policies applicable to an employee",
+            description = "Returns the leave policies the employee is eligible for, filtered by their "
+                    + "organization, gender and length of service against each policy's rules."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Applicable policies returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeavePolicyDto>> getApplicablePoliciesForEmployee(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(policyService.getApplicablePoliciesForEmployee(employeeId));
@@ -64,6 +111,16 @@ public class LeavePolicyControllerWeb {
 
     @PatchMapping("/update")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Partially update a leave policy",
+            description = "Applies the given field updates to the policy and returns the updated record."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @RequestParam Long policyId,
             @RequestBody Map<String, Object> updates) {
@@ -72,6 +129,16 @@ public class LeavePolicyControllerWeb {
 
     @DeleteMapping("/deactivate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Deactivate a leave policy",
+            description = "Marks the policy inactive so it stops applying to new leave requests. Existing "
+                    + "balances and requests already raised against it are unaffected."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy deactivated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<ApiResponse> deactivatePolicy(@RequestParam Long policyId) {
         policyService.deactivatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy deactivated successfully"));
@@ -79,6 +146,16 @@ public class LeavePolicyControllerWeb {
 
     @PostMapping("/activate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Reactivate a leave policy",
+            description = "Marks a previously deactivated policy active again so it resumes applying to "
+                    + "new leave requests."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Policy activated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy with the given id")
+    })
     public ResponseEntity<ApiResponse> activatePolicy(@RequestParam Long policyId) {
         policyService.activatePolicy(policyId);
         return ResponseEntity.ok(new ApiResponse("Leave policy activated successfully"));
@@ -86,6 +163,16 @@ public class LeavePolicyControllerWeb {
 
     @PostMapping("/duplicate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Duplicate a leave policy into another organization",
+            description = "Copies the policy's quota, accrual and eligibility rules into a new policy owned "
+                    + "by the target organization. Returns the newly created policy."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Policy duplicated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave policy or target organization with the given id")
+    })
     public ResponseEntity<LeavePolicyDto> duplicatePolicy(
             @RequestParam Long policyId,
             @RequestParam Long targetOrganizationId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +23,14 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-requests")
 @Validated
+@Tag(
+        name = "Leave Requests",
+        description = "The leave request lifecycle: draft creation, submission for approval, cancellation "
+                + "and withdrawal, plus reads by request id, employee, status, organization or approver, "
+                + "conflict checking and total-days calculation. Reads and updates on another employee's "
+                + "requests are gated to the system-admin or hr-admin role; actions on a caller's own "
+                + "request are gated to the caller being that employee."
+)
 public class LeaveRequestController {
 
     private final LeaveRequestService requestService;
@@ -31,6 +42,18 @@ public class LeaveRequestController {
     @PostMapping
 //    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Create a leave request",
+            description = "Creates a leave request for the given employee from the dates, policy and reason "
+                    + "in the payload. Submitted immediately for approval when submitImmediately is true, "
+                    + "otherwise saved as a draft."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Request created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request payload failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The requested dates overlap an existing leave request, or the balance is insufficient")
+    })
     public ResponseEntity<LeaveRequestDto> createRequest(
             @RequestParam Long employeeId,
             @Valid @RequestBody LeaveRequestCreationDto dto) {
@@ -41,6 +64,15 @@ public class LeaveRequestController {
     @GetMapping("/requestId/{requestId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a leave request by id",
+            description = "Returns a single leave request with its approval trail."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> getRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.getRequest(requestId));
     }
@@ -48,6 +80,15 @@ public class LeaveRequestController {
     @GetMapping("/employeeId/{employeeId}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "List an employee's leave requests",
+            description = "Returns a page of leave requests raised by the employee, across all statuses."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of requests returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<Page<LeaveRequestDto>> getEmployeeRequests(
             @PathVariable Long employeeId,
             Pageable pageable) {
@@ -57,6 +98,16 @@ public class LeaveRequestController {
     @GetMapping("/employeeId/{employeeId}/status/{status}")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's leave requests by status",
+            description = "Returns the employee's leave requests filtered to the given status, for "
+                    + "example PENDING_APPROVAL or APPROVED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Requests returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequestsByStatus(
             @PathVariable Long employeeId,
             @PathVariable LeaveStatus status) {
@@ -66,6 +117,14 @@ public class LeaveRequestController {
     @GetMapping("/organizationId/{organizationId}")
 //    @PreAuthorize("hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List the current tenant's leave requests",
+            description = "Returns every leave request raised within the caller's current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Requests returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
         return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
@@ -73,6 +132,15 @@ public class LeaveRequestController {
     @GetMapping("/pending-approvals")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List requests pending an approver's action",
+            description = "Returns the leave requests currently awaiting action from the given approver."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pending requests returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No approver with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
             @RequestParam Long approverId) {
         return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
@@ -81,6 +149,16 @@ public class LeaveRequestController {
     @GetMapping("/pending-approvals/count")
 //    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Count requests pending an approver's action",
+            description = "Returns the number of leave requests currently awaiting action from the given "
+                    + "approver."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No approver with the given id")
+    })
     public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
             @RequestParam Long approverId) {
         long count = requestService.getPendingApprovalCount(approverId);
@@ -90,6 +168,18 @@ public class LeaveRequestController {
     @PatchMapping("requestId/{requestId}")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Partially update a leave request",
+            description = "Applies the given field updates to a draft leave request and returns the "
+                    + "updated record."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The updated dates overlap an existing leave request, or the request is no longer editable")
+    })
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @PathVariable Long requestId,
             @RequestBody Map<String, Object> updates) {
@@ -99,6 +189,17 @@ public class LeaveRequestController {
     @PostMapping("/requestId/{requestId}/submit")
 //    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Submit a leave request for approval",
+            description = "Moves a draft leave request into the approval workflow, assigning the first "
+                    + "approver in the chain."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request submitted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a submittable state, or the balance is insufficient")
+    })
     public ResponseEntity<LeaveRequestDto> submitRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.submitRequest(requestId));
     }
@@ -106,6 +207,17 @@ public class LeaveRequestController {
     @PostMapping("/requestId/{requestId}/cancel")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Cancel a leave request",
+            description = "Cancels an already-approved leave request and records the given reason, "
+                    + "reversing any balance already deducted."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request cancelled"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a cancellable state")
+    })
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @PathVariable Long requestId,
             @RequestBody Map<String, String> body) {
@@ -116,6 +228,17 @@ public class LeaveRequestController {
     @PostMapping("/requestId/{requestId}/withdraw")
 //    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Withdraw a leave request",
+            description = "Withdraws a leave request that is still pending approval, before any approver "
+                    + "has acted on it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request withdrawn"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a withdrawable state")
+    })
     public ResponseEntity<LeaveRequestDto> withdrawRequest(@PathVariable Long requestId) {
         return ResponseEntity.ok(requestService.withdrawRequest(requestId));
     }
@@ -123,6 +246,16 @@ public class LeaveRequestController {
     @GetMapping("/conflicts")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Get conflicting leave dates",
+            description = "Returns the dates within the given range that already fall inside another leave "
+                    + "request for the employee."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Conflicting dates returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LocalDate>> getConflictingDates(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -133,6 +266,16 @@ public class LeaveRequestController {
     @PostMapping("/calculate-days")
 //    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Calculate total leave days",
+            description = "Calculates the number of leave days between startDate and endDate, accounting "
+                    + "for the optional half-day type at either end."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Total days calculated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid date"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<Map<String, Double>> calculateDays(
             @RequestBody Map<String, String> body) {
         LocalDate startDate = LocalDate.parse(body.get("startDate"));

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +23,15 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/leave-requests/web")
 @Validated
+@Tag(
+        name = "Leave Requests (Web)",
+        description = "Web-console equivalent of the leave request endpoints, addressing the request and "
+                + "employee by query parameters instead of path segments, plus a lookup of requests by "
+                + "approver. Covers creation, submission, cancellation, withdrawal, reads and conflict and "
+                + "total-days calculation. Reads and updates on another employee's requests are gated to "
+                + "the system-admin or hr-admin role; actions on a caller's own request are gated to the "
+                + "caller being that employee."
+)
 public class LeaveRequestControllerWeb {
 
     private final LeaveRequestService requestService;
@@ -30,6 +43,18 @@ public class LeaveRequestControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Create a leave request",
+            description = "Creates a leave request for the given employee from the dates, policy and reason "
+                    + "in the payload. Submitted immediately for approval when submitImmediately is true, "
+                    + "otherwise saved as a draft."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Request created"),
+            @ApiResponse(responseCode = "400", description = "The request payload failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "409", description = "The requested dates overlap an existing leave request, or the balance is insufficient")
+    })
     public ResponseEntity<LeaveRequestDto> createRequest(
             @RequestParam Long employeeId,
             @Valid @RequestBody LeaveRequestCreationDto dto) {
@@ -39,12 +64,31 @@ public class LeaveRequestControllerWeb {
 
     @GetMapping("/request")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Get a leave request by id",
+            description = "Returns a single leave request with its approval trail."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No leave request with the given id")
+    })
     public ResponseEntity<LeaveRequestDto> getRequest(@RequestParam Long requestId) {
         return ResponseEntity.ok(requestService.getRequest(requestId));
     }
 
     @GetMapping("/employee")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "List an employee's leave requests",
+            description = "Returns the leave requests raised by the employee, across all statuses, as a "
+                    + "flat list."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequests(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -53,6 +97,16 @@ public class LeaveRequestControllerWeb {
 
     @GetMapping("/employee-by-status")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's leave requests by status",
+            description = "Returns the employee's leave requests filtered to the given status, for "
+                    + "example PENDING_APPROVAL or APPROVED."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getEmployeeRequestsByStatus(
             @RequestParam Long employeeId,
             @RequestParam LeaveStatus status) {
@@ -61,12 +115,30 @@ public class LeaveRequestControllerWeb {
 
     @GetMapping("/organization")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List the current tenant's leave requests",
+            description = "Returns every leave request raised within the caller's current tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getOrganizationRequests() {
         return ResponseEntity.ok(requestService.getRequestsByOrganization());
     }
 
     @GetMapping("/approver")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List requests routed to an approver",
+            description = "Returns the leave requests, across all statuses, that name the given employee "
+                    + "as an approver at any level of the approval chain."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getRequestsByApprover(
             @RequestParam Long approverId) {
         return ResponseEntity.ok(requestService.getRequestsByApprover(approverId));
@@ -74,6 +146,15 @@ public class LeaveRequestControllerWeb {
 
     @GetMapping("/pending-approvals")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List requests pending an approver's action",
+            description = "Returns the leave requests currently awaiting action from the given approver."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Pending requests returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+    })
     public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
             @RequestParam Long approverId) {
         return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
@@ -81,6 +162,16 @@ public class LeaveRequestControllerWeb {
 
     @GetMapping("/pending-approvals/count")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Count requests pending an approver's action",
+            description = "Returns the number of leave requests currently awaiting action from the given "
+                    + "approver."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Count returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+    })
     public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
             @RequestParam Long approverId) {
         long count = requestService.getPendingApprovalCount(approverId);
@@ -89,6 +180,18 @@ public class LeaveRequestControllerWeb {
 
     @PatchMapping("/update")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Partially update a leave request",
+            description = "Applies the given field updates to a draft leave request and returns the "
+                    + "updated record."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request updated"),
+            @ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @ApiResponse(responseCode = "409", description = "The updated dates overlap an existing leave request, or the request is no longer editable")
+    })
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @RequestParam Long requestId,
             @RequestParam Long employeeId,
@@ -98,12 +201,34 @@ public class LeaveRequestControllerWeb {
 
     @PostMapping("employeeId/{employeeId}/submit")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Submit a leave request for approval",
+            description = "Moves a draft leave request into the approval workflow, assigning the first "
+                    + "approver in the chain."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request submitted"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @ApiResponse(responseCode = "409", description = "The request is not in a submittable state, or the balance is insufficient")
+    })
     public ResponseEntity<LeaveRequestDto> submitRequest(@RequestParam Long requestId,@PathVariable Long employeeId) {
         return ResponseEntity.ok(requestService.submitRequest(requestId));
     }
 
     @PostMapping("/cancel")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Cancel a leave request",
+            description = "Cancels an already-approved leave request and records the given reason, "
+                    + "reversing any balance already deducted."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request cancelled"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @ApiResponse(responseCode = "409", description = "The request is not in a cancellable state")
+    })
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @RequestParam Long requestId,
             @RequestParam Long employeeId,
@@ -114,12 +239,33 @@ public class LeaveRequestControllerWeb {
 
     @PostMapping("employeeId/{employeeId}/withdraw")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Withdraw a leave request",
+            description = "Withdraws a leave request that is still pending approval, before any approver "
+                    + "has acted on it."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request withdrawn"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
+            @ApiResponse(responseCode = "409", description = "The request is not in a withdrawable state")
+    })
     public ResponseEntity<LeaveRequestDto> withdrawRequest(@RequestParam Long requestId,@PathVariable Long employeeId) {
         return ResponseEntity.ok(requestService.withdrawRequest(requestId));
     }
 
     @GetMapping("/conflicts")
     @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @Operation(
+            summary = "Get conflicting leave dates",
+            description = "Returns the dates within the given range that already fall inside another leave "
+                    + "request for the employee."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Conflicting dates returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<LocalDate>> getConflictingDates(
             @RequestParam Long employeeId,
             @RequestParam LocalDate startDate,
@@ -129,6 +275,16 @@ public class LeaveRequestControllerWeb {
 
     @PostMapping("/calculate-days")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Calculate total leave days",
+            description = "Calculates the number of leave days between startDate and endDate, accounting "
+                    + "for the optional half-day type at either end."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Total days calculated"),
+            @ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid date"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<Map<String, Double>> calculateDays(
             @RequestBody Map<String, String> body) {
         LocalDate startDate = LocalDate.parse(body.get("startDate"));

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/notifications")
 @Validated
+@Tag(
+        name = "Notifications",
+        description = "In-app notifications raised by the leave workflow, such as a request being "
+                + "submitted, approved, rejected or delegated. Endpoints cover reading a page of "
+                + "notifications, listing or counting the unread ones, and marking one or all as read. "
+                + "Access is gated by the leave read or admin authority."
+)
 public class NotificationController {
 
     private final NotificationService notificationService;
@@ -25,6 +35,14 @@ public class NotificationController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "List an employee's notifications",
+            description = "Returns a page of notifications addressed to the given employee, newest first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of notifications returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+    })
     public ResponseEntity<Page<NotificationDto>> getNotifications(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -33,6 +51,15 @@ public class NotificationController {
 
     @GetMapping("/unread")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "List an employee's unread notifications",
+            description = "Returns every notification addressed to the given employee that has not yet "
+                    + "been marked read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Unread notifications returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+    })
     public ResponseEntity<List<NotificationDto>> getUnreadNotifications(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(notificationService.getUnreadNotifications(employeeId));
@@ -40,6 +67,15 @@ public class NotificationController {
 
     @GetMapping("/unread-count")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Count an employee's unread notifications",
+            description = "Returns the number of notifications addressed to the given employee that have "
+                    + "not yet been marked read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+    })
     public ResponseEntity<Map<String, Long>> getUnreadCount(
             @RequestParam Long employeeId) {
         long count = notificationService.getUnreadCount(employeeId);
@@ -48,6 +84,15 @@ public class NotificationController {
 
     @PatchMapping("/{notificationId}/read")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Mark a notification as read",
+            description = "Marks the given notification read and records the time it was read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notification marked as read"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id")
+    })
     public ResponseEntity<ApiResponse> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);
         return ResponseEntity.ok(new ApiResponse("Notification marked as read"));
@@ -55,6 +100,15 @@ public class NotificationController {
 
     @PostMapping("/mark-all-read")
     @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @Operation(
+            summary = "Mark all of an employee's notifications as read",
+            description = "Marks every unread notification addressed to the given employee as read and "
+                    + "returns how many were updated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notifications marked as read"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+    })
     public ResponseEntity<Map<String, Integer>> markAllAsRead(
             @RequestParam Long employeeId) {
         int count = notificationService.markAllAsRead(employeeId);

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/notifications/web")
 @Validated
+@Tag(
+        name = "Notifications (Web)",
+        description = "Web-console equivalent of the notification endpoints, addressing a notification by "
+                + "a notificationId query parameter instead of a path segment. Covers reading a page of "
+                + "notifications, listing or counting the unread ones, and marking one or all as read. "
+                + "All endpoints are gated to the system-admin or hr-admin role in the caller's tenant."
+)
 public class NotificationControllerWeb {
 
     private final NotificationService notificationService;
@@ -25,6 +35,14 @@ public class NotificationControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's notifications",
+            description = "Returns a page of notifications addressed to the given employee, newest first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of notifications returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<NotificationDto>> getNotifications(
             @RequestParam Long employeeId,
             Pageable pageable) {
@@ -33,6 +51,15 @@ public class NotificationControllerWeb {
 
     @GetMapping("/unread")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List an employee's unread notifications",
+            description = "Returns every notification addressed to the given employee that has not yet "
+                    + "been marked read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Unread notifications returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<NotificationDto>> getUnreadNotifications(
             @RequestParam Long employeeId) {
         return ResponseEntity.ok(notificationService.getUnreadNotifications(employeeId));
@@ -40,6 +67,15 @@ public class NotificationControllerWeb {
 
     @GetMapping("/unread-count")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Count an employee's unread notifications",
+            description = "Returns the number of notifications addressed to the given employee that have "
+                    + "not yet been marked read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Map<String, Long>> getUnreadCount(
             @RequestParam Long employeeId) {
         long count = notificationService.getUnreadCount(employeeId);
@@ -48,6 +84,15 @@ public class NotificationControllerWeb {
 
     @PatchMapping("/read")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Mark a notification as read",
+            description = "Marks the given notification read and records the time it was read."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notification marked as read"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id")
+    })
     public ResponseEntity<ApiResponse> markAsRead(@RequestParam Long notificationId) {
         notificationService.markAsRead(notificationId);
         return ResponseEntity.ok(new ApiResponse("Notification marked as read"));
@@ -55,6 +100,15 @@ public class NotificationControllerWeb {
 
     @PostMapping("/mark-all-read")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Mark all of an employee's notifications as read",
+            description = "Marks every unread notification addressed to the given employee as read and "
+                    + "returns how many were updated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notifications marked as read"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Map<String, Integer>> markAllAsRead(
             @RequestParam Long employeeId) {
         int count = notificationService.markAllAsRead(employeeId);

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalActionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalActionDto.java
@@ -1,17 +1,23 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload for an approve, reject or delegate action on a leave request.")
 @Data
 public class LeaveApprovalActionDto {
 
+    @Schema(description = "Id of the employee performing the action.", example = "5")
     @NotNull(message = "Approver ID is required")
     private Long approverId;
 
+    @Schema(description = "Comments on the action.", example = "Approved, please plan handover before you leave")
     @Size(max = 1000, message = "Comments must not exceed 1000 characters")
     private String comments;
 
+    @Schema(description = "Id of the employee to delegate the approval to. Required for a delegate action, "
+            + "ignored otherwise.", example = "9")
     private Long delegateToId;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalDto.java
@@ -1,22 +1,47 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.ApprovalAction;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "One approval action recorded against a leave request.")
 @Data
 public class LeaveApprovalDto {
+    @Schema(description = "Id of the approval record.", example = "612")
     private Long id;
+
+    @Schema(description = "Id of the leave request this action was taken on.", example = "241")
     private Long leaveRequestId;
+
+    @Schema(description = "Id of the employee who took the action.", example = "5")
     private Long approverId;
+
+    @Schema(description = "Name of the employee who took the action.", example = "Anitha Menon")
     private String approverName;
+
+    @Schema(description = "Job title of the employee who took the action.", example = "Site Manager")
     private String approverDesignation;
+
+    @Schema(description = "Approval level this action was taken at.", example = "1")
     private Integer approvalLevel;
+
+    @Schema(description = "The action taken.", example = "APPROVED")
     private ApprovalAction action;
+
+    @Schema(description = "Comments on the action.", example = "Approved, please plan handover before you leave")
     private String comments;
+
+    @Schema(description = "Id of the approver this action was delegated from, if any.", example = "3")
     private Long delegatedFromId;
+
+    @Schema(description = "Name of the approver this action was delegated from, if any.", example = "Suresh Pillai")
     private String delegatedFromName;
+
+    @Schema(description = "Time the action was taken.", example = "2026-08-31T10:05:00")
     private LocalDateTime actionAt;
+
+    @Schema(description = "Time this approval record was created.", example = "2026-08-31T10:05:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceAdjustmentDto.java
@@ -1,26 +1,34 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to manually adjust an employee's leave balance under one policy, for "
+        + "example a correction or a one-off grant.")
 @Data
 public class LeaveBalanceAdjustmentDto {
 
+    @Schema(description = "Id of the employee whose balance is being adjusted.", example = "18")
     @NotNull(message = "Employee ID is required")
     private Long employeeId;
 
+    @Schema(description = "Id of the leave policy the balance is tracked under.", example = "3")
     @NotNull(message = "Leave policy ID is required")
     private Long leavePolicyId;
 
+    @Schema(description = "Signed number of days to add or subtract.", example = "2.0")
     @NotNull(message = "Days is required")
     private Double days;
 
+    @Schema(description = "Reason for the adjustment.", example = "Correcting a missed accrual for July 2026")
     @NotBlank(message = "Reason is required")
     @Size(max = 500, message = "Reason must not exceed 500 characters")
     private String reason;
 
+    @Schema(description = "Id of the employee making the adjustment.", example = "2")
     @NotNull(message = "Adjusted by ID is required")
     private Long adjustedById;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceDto.java
@@ -1,24 +1,53 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Schema(description = "An employee's leave balance under one policy for one year.")
 @Data
 public class LeaveBalanceDto {
+    @Schema(description = "Id of the balance record.", example = "88")
     private Long id;
+
+    @Schema(description = "Id of the employee this balance belongs to.", example = "18")
     private Long employeeId;
+
+    @Schema(description = "Name of the employee this balance belongs to.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Leave policy this balance is tracked under.")
     private LeavePolicySimpleDto leavePolicy;
+
+    @Schema(description = "Calendar year this balance applies to.", example = "2026")
     private Integer year;
+
+    @Schema(description = "Balance carried into the year before any accrual.", example = "2.0")
     private Double openingBalance;
+
+    @Schema(description = "Days accrued so far this year.", example = "9.0")
     private Double accrued;
+
+    @Schema(description = "Days already used this year.", example = "3.5")
     private Double used;
+
+    @Schema(description = "Days locked in pending, not-yet-approved requests.", example = "1.0")
     private Double pending;
+
+    @Schema(description = "Days available, after used and pending are deducted.", example = "6.5")
     private Double available;
+
+    @Schema(description = "Days that can still be booked, respecting per-request limits.", example = "6.5")
     private Double bookable;
+
+    @Schema(description = "Days carried forward from the previous year.", example = "1.5")
     private Double carryForwardFromPrevious;
+
+    @Schema(description = "Date the carried-forward days expire, if the policy sets one.", example = "2026-03-31")
     private LocalDate carryForwardExpiryDate;
+
+    @Schema(description = "Time this balance was last recalculated.", example = "2026-08-20T02:00:00")
     private LocalDateTime lastCalculatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveBalanceSummaryDto.java
@@ -1,16 +1,31 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
 
+@Schema(description = "An employee's leave balances across all policies for one year, with totals.")
 @Data
 public class LeaveBalanceSummaryDto {
+    @Schema(description = "Id of the employee this summary belongs to.", example = "18")
     private Long employeeId;
+
+    @Schema(description = "Name of the employee this summary belongs to.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Calendar year this summary applies to.", example = "2026")
     private Integer year;
+
+    @Schema(description = "Per-policy balances making up this summary.")
     private List<LeaveBalanceDto> balances;
+
+    @Schema(description = "Total days available across all policies.", example = "14.5")
     private Double totalAvailable;
+
+    @Schema(description = "Total days used across all policies.", example = "6.0")
     private Double totalUsed;
+
+    @Schema(description = "Total days pending across all policies.", example = "1.0")
     private Double totalPending;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCalendarDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCalendarDto.java
@@ -1,20 +1,41 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.HalfDayType;
 
 import java.time.LocalDate;
 
+@Schema(description = "One day of leave for one employee, as shown on the leave calendar.")
 @Data
 public class LeaveCalendarDto {
+    @Schema(description = "Id of the calendar entry.", example = "9021")
     private Long id;
+
+    @Schema(description = "Id of the organization the employee belongs to.", example = "2")
     private Long organizationId;
+
+    @Schema(description = "Id of the employee on leave.", example = "18")
     private Long employeeId;
+
+    @Schema(description = "Name of the employee on leave.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Department of the employee on leave.", example = "Civil")
     private String department;
+
+    @Schema(description = "Id of the leave request this entry comes from.", example = "241")
     private Long leaveRequestId;
+
+    @Schema(description = "The date this entry covers.", example = "2026-09-15")
     private LocalDate leaveDate;
+
+    @Schema(description = "Whether the day is a full day or a half day of leave.", example = "FULL_DAY")
     private HalfDayType dayType;
+
+    @Schema(description = "Short code of the leave type taken.", example = "CL")
     private String leaveTypeCode;
+
+    @Schema(description = "Display name of the leave type taken.", example = "Casual Leave")
     private String leaveTypeName;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyCreationDto.java
@@ -1,55 +1,79 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to create a leave policy for an organization, with its quota, accrual and "
+        + "eligibility rules.")
 @Data
 public class LeavePolicyCreationDto {
 
+    @Schema(description = "Id of the organization the policy belongs to.", example = "2")
     @NotNull(message = "Organization ID is required")
     private Long organizationId;
 
+    @Schema(description = "Short code identifying the leave type.", example = "CL")
     @NotBlank(message = "Leave type code is required")
     @Size(max = 50, message = "Leave type code must not exceed 50 characters")
     private String leaveTypeCode;
 
+    @Schema(description = "Display name of the leave type.", example = "Casual Leave")
     @NotBlank(message = "Leave type name is required")
     @Size(max = 100, message = "Leave type name must not exceed 100 characters")
     private String leaveTypeName;
 
+    @Schema(description = "Description of the leave type and when it applies.", example = "Short-notice "
+            + "leave for personal matters, not carried forward beyond the configured limit")
     @Size(max = 500, message = "Description must not exceed 500 characters")
     private String description;
 
+    @Schema(description = "Total days granted per year under this policy.", example = "12.0")
     @NotNull(message = "Annual quota is required")
     @Positive(message = "Annual quota must be positive")
     private Double annualQuota;
 
+    @Schema(description = "Days accrued per completed month, for policies that accrue monthly instead of "
+            + "granting the full quota upfront.", example = "1.0")
     private Double accrualRatePerMonth;
 
+    @Schema(description = "Maximum days that can be carried forward into the next year.", example = "5.0")
     private Double carryForwardLimit;
 
+    @Schema(description = "Number of months into the next year before carried-forward days expire.", example = "3")
     private Integer carryForwardExpiryMonths;
 
+    @Schema(description = "Smallest number of days that can be requested at once.", example = "0.5")
     private Double minDaysPerRequest = 0.5;
 
+    @Schema(description = "Largest number of days that can be requested at once.", example = "15.0")
     private Double maxDaysPerRequest;
 
+    @Schema(description = "Minimum number of days' notice required before the leave starts.", example = "2")
     private Integer advanceNoticeDays = 0;
 
+    @Schema(description = "Whether a supporting attachment is required for requests under this policy.", example = "false")
     private Boolean requiresAttachment = false;
 
+    @Schema(description = "Number of consecutive days after which an attachment becomes required, when "
+            + "requiresAttachment is true.", example = "3")
     private Integer attachmentRequiredAfterDays;
 
+    @Schema(description = "Genders this policy applies to.", example = "ALL")
     private String applicableGenders = "ALL";
 
+    @Schema(description = "Minimum months of service before an employee becomes eligible.", example = "6")
     private Integer minServiceMonths = 0;
 
+    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
     private Boolean allowHalfDay = true;
 
+    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
     private Boolean isPaid = true;
 
+    @Schema(description = "Order this policy is shown in, relative to the organization's other policies.", example = "1")
     private Integer displayOrder = 0;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
@@ -1,32 +1,80 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "A leave policy with its quota, accrual and eligibility rules.")
 @Data
 public class LeavePolicyDto {
+    @Schema(description = "Id of the policy.", example = "3")
     private Long id;
+
+    @Schema(description = "Id of the organization the policy belongs to.", example = "2")
     private Long organizationId;
+
+    @Schema(description = "Name of the organization the policy belongs to.", example = "Asset Homes")
     private String organizationName;
+
+    @Schema(description = "Short code identifying the leave type.", example = "CL")
     private String leaveTypeCode;
+
+    @Schema(description = "Display name of the leave type.", example = "Casual Leave")
     private String leaveTypeName;
+
+    @Schema(description = "Description of the leave type and when it applies.", example = "Short-notice "
+            + "leave for personal matters, not carried forward beyond the configured limit")
     private String description;
+
+    @Schema(description = "Total days granted per year under this policy.", example = "12.0")
     private Double annualQuota;
+
+    @Schema(description = "Days accrued per completed month, for policies that accrue monthly.", example = "1.0")
     private Double accrualRatePerMonth;
+
+    @Schema(description = "Maximum days that can be carried forward into the next year.", example = "5.0")
     private Double carryForwardLimit;
+
+    @Schema(description = "Number of months into the next year before carried-forward days expire.", example = "3")
     private Integer carryForwardExpiryMonths;
+
+    @Schema(description = "Smallest number of days that can be requested at once.", example = "0.5")
     private Double minDaysPerRequest;
+
+    @Schema(description = "Largest number of days that can be requested at once.", example = "15.0")
     private Double maxDaysPerRequest;
+
+    @Schema(description = "Minimum number of days' notice required before the leave starts.", example = "2")
     private Integer advanceNoticeDays;
+
+    @Schema(description = "Whether a supporting attachment is required for requests under this policy.", example = "false")
     private Boolean requiresAttachment;
+
+    @Schema(description = "Number of consecutive days after which an attachment becomes required.", example = "3")
     private Integer attachmentRequiredAfterDays;
+
+    @Schema(description = "Genders this policy applies to.", example = "ALL")
     private String applicableGenders;
+
+    @Schema(description = "Minimum months of service before an employee becomes eligible.", example = "6")
     private Integer minServiceMonths;
+
+    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
     private Boolean allowHalfDay;
+
+    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
     private Boolean isPaid;
+
+    @Schema(description = "Whether the policy is currently active.", example = "true")
     private Boolean isActive;
+
+    @Schema(description = "Order this policy is shown in, relative to the organization's other policies.", example = "1")
     private Integer displayOrder;
+
+    @Schema(description = "Time the policy was created.", example = "2026-01-05T10:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Time the policy was last updated.", example = "2026-07-01T08:30:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicySimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicySimpleDto.java
@@ -1,13 +1,27 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Condensed view of a leave policy, used when embedding it inside a request or "
+        + "balance record.")
 @Data
 public class LeavePolicySimpleDto {
+    @Schema(description = "Id of the policy.", example = "3")
     private Long id;
+
+    @Schema(description = "Short code identifying the leave type.", example = "CL")
     private String leaveTypeCode;
+
+    @Schema(description = "Display name of the leave type.", example = "Casual Leave")
     private String leaveTypeName;
+
+    @Schema(description = "Total days granted per year under this policy.", example = "12.0")
     private Double annualQuota;
+
+    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
     private Boolean allowHalfDay;
+
+    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
     private Boolean isPaid;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,33 +9,47 @@ import org.tornotron.echno_backend.leave.enums.HalfDayType;
 
 import java.time.LocalDate;
 
+@Schema(description = "Payload to raise a leave request against a leave policy, optionally submitting it "
+        + "for approval immediately.")
 @Data
 public class LeaveRequestCreationDto {
 
+    @Schema(description = "Id of the leave policy the request is raised under.", example = "3")
     @NotNull(message = "Leave policy ID is required")
     private Long leavePolicyId;
 
+    @Schema(description = "First day of leave.", example = "2026-09-14")
     @NotNull(message = "Start date is required")
     private LocalDate startDate;
 
+    @Schema(description = "Whether the start date is a full day or a half day.", example = "FULL_DAY")
     private HalfDayType startHalfDayType;
 
+    @Schema(description = "Last day of leave.", example = "2026-09-16")
     @NotNull(message = "End date is required")
     private LocalDate endDate;
 
+    @Schema(description = "Whether the end date is a full day or a half day.", example = "SECOND_HALF")
     private HalfDayType endHalfDayType;
 
+    @Schema(description = "Reason for the leave.", example = "Attending sister's wedding in Coimbatore")
     @NotBlank(message = "Reason is required")
     @Size(max = 1000, message = "Reason must not exceed 1000 characters")
     private String reason;
 
+    @Schema(description = "Contact number or address reachable during the leave.", example = "9847012345")
     @Size(max = 100, message = "Contact during leave must not exceed 100 characters")
     private String contactDuringLeave;
 
+    @Schema(description = "Id of the employee handling handover during the leave, if any.", example = "12")
     private Long handoverToId;
 
+    @Schema(description = "Notes for the person receiving the handover.", example = "Site inspection at "
+            + "Asset Homes Chennai is due on 2026-09-15, please coordinate with the QA team")
     @Size(max = 500, message = "Handover notes must not exceed 500 characters")
     private String handoverNotes;
 
+    @Schema(description = "When true, submits the request for approval immediately instead of saving it "
+            + "as a draft.", example = "true")
     private Boolean submitImmediately = false;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.HalfDayType;
 import org.tornotron.echno_backend.leave.enums.LeaveStatus;
@@ -8,33 +9,88 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A leave request with its dates, current approval state and approval trail.")
 @Data
 public class LeaveRequestDto {
+    @Schema(description = "Id of the leave request.", example = "241")
     private Long id;
+
+    @Schema(description = "Human-readable request number.", example = "LR-2026-0241")
     private String requestNumber;
+
+    @Schema(description = "Id of the employee who raised the request.", example = "18")
     private Long employeeId;
+
+    @Schema(description = "Name of the employee who raised the request.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Department of the employee who raised the request.", example = "Civil")
     private String department;
+
+    @Schema(description = "Id of the organization the employee belongs to.", example = "2")
     private Long organizationId;
+
+    @Schema(description = "Leave policy the request is raised under.")
     private LeavePolicySimpleDto leavePolicy;
+
+    @Schema(description = "First day of leave.", example = "2026-09-14")
     private LocalDate startDate;
+
+    @Schema(description = "Whether the start date is a full day or a half day.", example = "FULL_DAY")
     private HalfDayType startHalfDayType;
+
+    @Schema(description = "Last day of leave.", example = "2026-09-16")
     private LocalDate endDate;
+
+    @Schema(description = "Whether the end date is a full day or a half day.", example = "SECOND_HALF")
     private HalfDayType endHalfDayType;
+
+    @Schema(description = "Total leave days, accounting for any half days.", example = "2.5")
     private Double totalDays;
+
+    @Schema(description = "Reason for the leave.", example = "Attending sister's wedding in Coimbatore")
     private String reason;
+
+    @Schema(description = "Current status of the request.", example = "PENDING_APPROVAL")
     private LeaveStatus status;
+
+    @Schema(description = "Id of the employee who must act next in the approval chain.", example = "5")
     private Long currentApproverId;
+
+    @Schema(description = "Name of the employee who must act next in the approval chain.", example = "Anitha Menon")
     private String currentApproverName;
+
+    @Schema(description = "The approval level currently pending action.", example = "1")
     private Integer currentApprovalLevel;
+
+    @Schema(description = "The highest approval level configured for this request.", example = "2")
     private Integer maxApprovalLevel;
+
+    @Schema(description = "Contact number or address reachable during the leave.", example = "9847012345")
     private String contactDuringLeave;
+
+    @Schema(description = "Id of the employee handling handover during the leave, if any.", example = "12")
     private Long handoverToId;
+
+    @Schema(description = "Name of the employee handling handover during the leave, if any.", example = "Deepak Nair")
     private String handoverToName;
+
+    @Schema(description = "Notes for the person receiving the handover.", example = "Site inspection at "
+            + "Asset Homes Chennai is due on 2026-09-15, please coordinate with the QA team")
     private String handoverNotes;
+
+    @Schema(description = "Time the request was cancelled, if it was.", example = "2026-09-10T11:20:00")
     private LocalDateTime cancelledAt;
+
+    @Schema(description = "Reason the request was cancelled, if it was.", example = "Wedding postponed to next month")
     private String cancellationReason;
+
+    @Schema(description = "Time the request was created.", example = "2026-08-30T09:15:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Time the request was last updated.", example = "2026-09-01T14:05:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "Approval actions recorded against this request, in the order they occurred.")
     private List<LeaveApprovalDto> approvals;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestSimpleDto.java
@@ -1,20 +1,39 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.LeaveStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Schema(description = "Condensed view of a leave request, used in list and summary contexts.")
 @Data
 public class LeaveRequestSimpleDto {
+    @Schema(description = "Id of the leave request.", example = "241")
     private Long id;
+
+    @Schema(description = "Human-readable request number.", example = "LR-2026-0241")
     private String requestNumber;
+
+    @Schema(description = "Name of the employee who raised the request.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Name of the leave type the request is raised under.", example = "Casual Leave")
     private String leaveTypeName;
+
+    @Schema(description = "First day of leave.", example = "2026-09-14")
     private LocalDate startDate;
+
+    @Schema(description = "Last day of leave.", example = "2026-09-16")
     private LocalDate endDate;
+
+    @Schema(description = "Total leave days, accounting for any half days.", example = "2.5")
     private Double totalDays;
+
+    @Schema(description = "Current status of the request.", example = "PENDING_APPROVAL")
     private LeaveStatus status;
+
+    @Schema(description = "Time the request was created.", example = "2026-08-30T09:15:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveTransactionDto.java
@@ -1,29 +1,67 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.TransactionType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Schema(description = "One entry in an employee's leave balance ledger, such as an accrual, deduction "
+        + "or manual adjustment.")
 @Data
 public class LeaveTransactionDto {
+    @Schema(description = "Id of the transaction.", example = "5031")
     private Long id;
+
+    @Schema(description = "Id of the employee this transaction belongs to.", example = "18")
     private Long employeeId;
+
+    @Schema(description = "Name of the employee this transaction belongs to.", example = "Ravi Kumar")
     private String employeeName;
+
+    @Schema(description = "Id of the leave balance this transaction was posted against.", example = "88")
     private Long leaveBalanceId;
+
+    @Schema(description = "Name of the leave type the balance is tracked under.", example = "Casual Leave")
     private String leaveTypeName;
+
+    @Schema(description = "Id of the leave request this transaction is linked to, if any.", example = "241")
     private Long leaveRequestId;
+
+    @Schema(description = "Request number of the linked leave request, if any.", example = "LR-2026-0241")
     private String requestNumber;
+
+    @Schema(description = "Type of the transaction.", example = "DEDUCTION")
     private TransactionType transactionType;
+
+    @Schema(description = "Signed number of days moved by this transaction.", example = "-2.5")
     private Double days;
+
+    @Schema(description = "Balance immediately before this transaction.", example = "9.0")
     private Double balanceBefore;
+
+    @Schema(description = "Balance immediately after this transaction.", example = "6.5")
     private Double balanceAfter;
+
+    @Schema(description = "Date the transaction is effective.", example = "2026-09-14")
     private LocalDate transactionDate;
+
+    @Schema(description = "Month the transaction is attributed to, for accrual transactions.", example = "9")
     private Integer referenceMonth;
+
+    @Schema(description = "Year the transaction is attributed to.", example = "2026")
     private Integer referenceYear;
+
+    @Schema(description = "Description of the transaction.", example = "Deduction for leave request LR-2026-0241")
     private String description;
+
+    @Schema(description = "Id of the employee who created the transaction, for manual adjustments.", example = "2")
     private Long createdById;
+
+    @Schema(description = "Name of the employee who created the transaction, for manual adjustments.", example = "Anand Rajan")
     private String createdByName;
+
+    @Schema(description = "Time the transaction was recorded.", example = "2026-09-14T09:30:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/NotificationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/NotificationDto.java
@@ -1,21 +1,45 @@
 package org.tornotron.echno_backend.leave.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.leave.enums.NotificationType;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "An in-app notification raised by an event in the leave workflow.")
 @Data
 public class NotificationDto {
+    @Schema(description = "Id of the notification.", example = "7710")
     private Long id;
+
+    @Schema(description = "Id of the employee the notification is addressed to.", example = "5")
     private Long recipientId;
+
+    @Schema(description = "Type of event that raised the notification.", example = "LEAVE_PENDING_APPROVAL")
     private NotificationType notificationType;
+
+    @Schema(description = "Short title of the notification.", example = "Leave request pending your approval")
     private String title;
+
+    @Schema(description = "Full notification message.", example = "Ravi Kumar has requested 2.5 days of "
+            + "Casual Leave from 2026-09-14 to 2026-09-16")
     private String message;
+
+    @Schema(description = "Type of the entity this notification refers to.", example = "LEAVE_REQUEST")
     private String entityType;
+
+    @Schema(description = "Id of the entity this notification refers to.", example = "241")
     private Long entityId;
+
+    @Schema(description = "URL the client should navigate to when the notification is opened.", example = "/leave-requests/241")
     private String actionUrl;
+
+    @Schema(description = "Whether the notification has been read.", example = "false")
     private Boolean isRead;
+
+    @Schema(description = "Time the notification was read, if it has been.", example = "2026-08-31T09:10:00")
     private LocalDateTime readAt;
+
+    @Schema(description = "Time the notification was created.", example = "2026-08-30T09:16:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.material;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/materials")
 @Validated
+@Tag(
+        name = "Materials",
+        description = "Materials tracked in the inventory catalogue, such as cement, TMT bars and sand. "
+                + "A material carries an SKU, unit of measure, reorder thresholds and optional opening "
+                + "stock at a project and storage location. Endpoints cover creating, browsing, searching "
+                + "and updating materials, and reading their current stock at organization, project or "
+                + "storage-location level."
+)
 public class MaterialController {
 
     private final MaterialService materialService;
@@ -27,6 +38,18 @@ public class MaterialController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('material:create') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Create a material",
+            description = "Creates a material with its SKU, unit and reorder thresholds. If an opening "
+                    + "stock, project and storage location are supplied, an opening stock entry is "
+                    + "recorded for that location as well."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Material created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, such as a missing material name or unit"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A material with the given SKU already exists in this organization")
+    })
     public ResponseEntity<MaterialDto> createMaterial(@Valid @RequestBody MaterialCreationDto creationDto) {
         MaterialDto created = materialService.createMaterial(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -34,6 +57,15 @@ public class MaterialController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Get a material by id",
+            description = "Returns a single material with its creator and current aggregate stock value."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<MaterialDto> getMaterialById(@PathVariable Long id) {
         MaterialDto material = materialService.getMaterialById(id);
         return ResponseEntity.ok(material);
@@ -41,6 +73,14 @@ public class MaterialController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "List all materials",
+            description = "Returns every material in the organization's catalogue, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority")
+    })
     public ResponseEntity<List<MaterialDto>> getAllMaterials() {
         List<MaterialDto> materials = materialService.getAllMaterials();
         return ResponseEntity.ok(materials);
@@ -48,6 +88,15 @@ public class MaterialController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "List materials, paginated",
+            description = "Returns a single page of materials. The pageNo and pageSize parameters "
+                    + "control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority")
+    })
     public ResponseEntity<Page<MaterialDto>> getAllMaterialsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -58,6 +107,15 @@ public class MaterialController {
 
     @GetMapping("/search")
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Search materials by name",
+            description = "Returns materials whose name matches the given search term, such as \"Cement\" "
+                    + "or \"TMT\"."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Matching materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority")
+    })
     public ResponseEntity<List<MaterialDto>> searchMaterials(@RequestParam String name) {
         List<MaterialDto> materials = materialService.searchMaterialsByName(name);
         return ResponseEntity.ok(materials);
@@ -65,6 +123,18 @@ public class MaterialController {
 
     @GetMapping("/{id}/stock")
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Get a material with its current stock",
+            description = "Returns a material along with its current stock. When projectId and "
+                    + "storageLocationId are both given, stock is scoped to that storage location; when "
+                    + "only projectId is given, stock is scoped to that project; when neither is given, "
+                    + "the aggregate stock across the organization is returned."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material with stock returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material, project or storage location with the given id")
+    })
     public ResponseEntity<MaterialWithStockDto> getMaterialWithStock(
             @PathVariable Long id,
             @RequestParam(required = false) Long projectId,
@@ -82,6 +152,18 @@ public class MaterialController {
 
     @PatchMapping("/{id}")
     @PreAuthorize("hasAuthority('material:update') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Update a material",
+            description = "Applies a partial update to a material's SKU, name, unit or reorder thresholds. "
+                    + "Fields left null in the request are left unchanged."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Another material already has the given SKU")
+    })
     public ResponseEntity<MaterialDto> updateMaterial(
             @PathVariable Long id,
             @Valid @RequestBody org.tornotron.echno_backend.material.dto.MaterialUpdateDto updateDto
@@ -92,6 +174,15 @@ public class MaterialController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('material:delete') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Delete a material",
+            description = "Deletes the material with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteMaterial(@PathVariable Long id) {
         materialService.deleteMaterial(id);
         return ResponseEntity.ok(new ApiResponse("Material with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.material;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/materials/web")
 @Validated
+@Tag(
+        name = "Materials (Web)",
+        description = "Web-console counterpart of the materials API, restricted to the system-admin "
+                + "role for the current tenant. Covers the same create, browse, search, update, stock "
+                + "lookup and delete operations as the standard materials endpoints, for use from the "
+                + "admin web console rather than the mobile app."
+)
 public class MaterialControllerWeb {
 
     private final MaterialService materialService;
@@ -27,6 +37,18 @@ public class MaterialControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a material",
+            description = "Creates a material with its SKU, unit and reorder thresholds. If an opening "
+                    + "stock, project and storage location are supplied, an opening stock entry is "
+                    + "recorded for that location as well."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Material created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, such as a missing material name or unit"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A material with the given SKU already exists in this organization")
+    })
     public ResponseEntity<MaterialDto> createMaterial(@Valid @RequestBody MaterialCreationDto creationDto) {
         MaterialDto created = materialService.createMaterial(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -34,6 +56,15 @@ public class MaterialControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a material by id",
+            description = "Returns a single material with its creator and current aggregate stock value."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<MaterialDto> getMaterialById(@PathVariable Long id) {
         MaterialDto material = materialService.getMaterialById(id);
         return ResponseEntity.ok(material);
@@ -41,6 +72,14 @@ public class MaterialControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all materials",
+            description = "Returns every material in the organization's catalogue, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<MaterialDto>> getAllMaterials() {
         List<MaterialDto> materials = materialService.getAllMaterials();
         return ResponseEntity.ok(materials);
@@ -48,6 +87,15 @@ public class MaterialControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List materials, paginated",
+            description = "Returns a single page of materials. The pageNo and pageSize parameters "
+                    + "control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<MaterialDto>> getAllMaterialsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -58,6 +106,15 @@ public class MaterialControllerWeb {
 
     @GetMapping("/search")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Search materials by name",
+            description = "Returns materials whose name matches the given search term, such as \"Cement\" "
+                    + "or \"TMT\"."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Matching materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<MaterialDto>> searchMaterials(@RequestParam String name) {
         List<MaterialDto> materials = materialService.searchMaterialsByName(name);
         return ResponseEntity.ok(materials);
@@ -65,6 +122,18 @@ public class MaterialControllerWeb {
 
     @GetMapping("/{id}/stock")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a material with its current stock",
+            description = "Returns a material along with its current stock. When projectId and "
+                    + "storageLocationId are both given, stock is scoped to that storage location; when "
+                    + "only projectId is given, stock is scoped to that project; when neither is given, "
+                    + "the aggregate stock across the organization is returned."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material with stock returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material, project or storage location with the given id")
+    })
     public ResponseEntity<MaterialWithStockDto> getMaterialWithStock(
             @PathVariable Long id,
             @RequestParam(required = false) Long projectId,
@@ -82,6 +151,18 @@ public class MaterialControllerWeb {
 
     @PatchMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a material",
+            description = "Applies a partial update to a material's SKU, name, unit or reorder thresholds. "
+                    + "Fields left null in the request are left unchanged."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Another material already has the given SKU")
+    })
     public ResponseEntity<MaterialDto> updateMaterial(
             @PathVariable Long id,
             @Valid @RequestBody org.tornotron.echno_backend.material.dto.MaterialUpdateDto updateDto
@@ -92,6 +173,15 @@ public class MaterialControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a material",
+            description = "Deletes the material with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Material deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteMaterial(@PathVariable Long id) {
         materialService.deleteMaterial(id);
         return ResponseEntity.ok(new ApiResponse("Material with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.material.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,43 +8,61 @@ import lombok.Data;
 import java.math.BigDecimal;
 import org.tornotron.echno_backend.common.customAnnotation.ValidOpeningStock;
 
+@Schema(description = "Payload to create a material in the inventory catalogue, optionally with an "
+        + "opening stock at a project and storage location.")
 @Data
 @ValidOpeningStock
 public class MaterialCreationDto {
 
+    @Schema(description = "Stock keeping unit code, unique within the organization.", example = "CEM-OPC53-001")
     @Size(max = 50, message = "SKU must not exceed 50 characters")
     private String sku;
 
+    @Schema(description = "Name of the material.", example = "OPC 53 Grade Cement")
     @NotBlank(message = "material name is required")
     @Size(min = 1, max = 100, message = "material name must be between 1 and 100 characters")
     private String materialName;
 
+    @Schema(description = "Unit of measure for the material.", example = "bags")
     @NotBlank(message = "unit is required")
     @Size(min = 1, max = 20, message = "unit must be between 1 and 20 characters")
     private String unit;
 
+    @Schema(description = "Id of the employee creating this material.", example = "5")
     @NotNull(message = "created by employee id is required")
     private Long createdBy;
 
+    @Schema(description = "Free-text description of the material.", example = "OPC 53 Grade cement, 50 kg bags")
     private String description;
 
+    @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
 
+    @Schema(description = "Opening stock quantity to record when the material is created. Requires "
+            + "projectId and storageLocationId to also be set.", example = "500")
     private Double openingStock;
 
+    @Schema(description = "Id of the project the opening stock is recorded against.", example = "3")
     private Long projectId;
 
+    @Schema(description = "Id of the storage location the opening stock is recorded at.", example = "2")
     private Long storageLocationId;
 
+    @Schema(description = "Minimum order quantity from the supplier.", example = "100")
     private Double moq;
 
+    @Schema(description = "Minimum stock level before the material is considered low.", example = "200")
     private Double minStock;
 
+    @Schema(description = "Maximum stock level to hold at any storage location.", example = "2000")
     private Double maxStock;
 
+    @Schema(description = "Safety stock buffer kept in reserve below the minimum stock level.", example = "50")
     private Double safetyStock;
 
+    @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
 
+    @Schema(description = "Cost per unit of the material.", example = "410.50")
     private BigDecimal unitCost;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
@@ -1,24 +1,41 @@
 package org.tornotron.echno_backend.material.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import java.math.BigDecimal;
 
+@Schema(description = "A material in the inventory catalogue, with its current aggregate stock.")
 @Data
 public class MaterialDto {
+    @Schema(description = "Material id.", example = "12")
     private Long id;
+    @Schema(description = "Stock keeping unit code.", example = "CEM-OPC53-001")
     private String sku;
+    @Schema(description = "Name of the material.", example = "OPC 53 Grade Cement")
     private String materialName;
+    @Schema(description = "Unit of measure for the material.", example = "bags")
     private String unit;
+    @Schema(description = "Employee who created this material.")
     private EmployeeDto createdBy;
+    @Schema(description = "Free-text description of the material.", example = "OPC 53 Grade cement, 50 kg bags")
     private String description;
+    @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
+    @Schema(description = "Opening stock quantity recorded when the material was created.", example = "500")
     private Double openingStock;
+    @Schema(description = "Current aggregate stock across all projects and storage locations.", example = "340")
     private Double currentStock;
+    @Schema(description = "Minimum order quantity from the supplier.", example = "100")
     private Double moq;
+    @Schema(description = "Minimum stock level before the material is considered low.", example = "200")
     private Double minStock;
+    @Schema(description = "Maximum stock level to hold at any storage location.", example = "2000")
     private Double maxStock;
+    @Schema(description = "Safety stock buffer kept in reserve below the minimum stock level.", example = "50")
     private Double safetyStock;
+    @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
+    @Schema(description = "Current stock valued at unit cost.", example = "139570.00")
     private BigDecimal stockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
@@ -1,31 +1,43 @@
 package org.tornotron.echno_backend.material.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to partially update a material. Fields left null are left unchanged.")
 @Data
 public class MaterialUpdateDto {
 
+    @Schema(description = "Stock keeping unit code, unique within the organization.", example = "CEM-OPC53-001")
     @Size(max = 50, message = "SKU must not exceed 50 characters")
     private String sku;
 
+    @Schema(description = "Name of the material.", example = "OPC 53 Grade Cement")
     @Size(min = 1, max = 100, message = "material name must be between 1 and 100 characters")
     private String materialName;
 
+    @Schema(description = "Unit of measure for the material.", example = "bags")
     @Size(min = 1, max = 20, message = "unit must be between 1 and 20 characters")
     private String unit;
 
+    @Schema(description = "Free-text description of the material.", example = "OPC 53 Grade cement, 50 kg bags")
     private String description;
 
+    @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
 
+    @Schema(description = "Minimum order quantity from the supplier.", example = "100")
     private Double moq;
 
+    @Schema(description = "Minimum stock level before the material is considered low.", example = "200")
     private Double minStock;
 
+    @Schema(description = "Maximum stock level to hold at any storage location.", example = "2000")
     private Double maxStock;
 
+    @Schema(description = "Safety stock buffer kept in reserve below the minimum stock level.", example = "50")
     private Double safetyStock;
 
+    @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialWithStockDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialWithStockDto.java
@@ -1,15 +1,24 @@
 package org.tornotron.echno_backend.material.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import java.math.BigDecimal;
 
+@Schema(description = "A material with its stock scoped to the organization, a project or a storage "
+        + "location, depending on which lookup was used.")
 @Data
 public class MaterialWithStockDto {
 
+    @Schema(description = "Material id.", example = "12")
     private Long id;
+    @Schema(description = "Stock keeping unit code.", example = "TMT-12MM-001")
     private String sku;
+    @Schema(description = "Name of the material.", example = "TMT Bar 12mm")
     private String materialName;
+    @Schema(description = "Unit of measure for the material.", example = "kg")
     private String unit;
+    @Schema(description = "Current stock at the requested scope.", example = "1250")
     private Double currentStock;
+    @Schema(description = "Current stock valued at unit cost.", example = "78125.00")
     private BigDecimal stockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.materialConsumption;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +22,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/material-consumptions")
 @Validated
+@Tag(
+        name = "Material Consumptions",
+        description = "Records of material drawn out of stock against a project, optionally a storage "
+                + "location and a task. Each consumption reduces the material's current stock, so "
+                + "creating one checks that sufficient stock is available first. Endpoints cover "
+                + "recording a consumption and reading consumptions by id, material, type, date range or task."
+)
 public class MaterialConsumptionController {
 
     private final MaterialConsumptionService materialConsumptionService;
@@ -28,6 +39,19 @@ public class MaterialConsumptionController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('material-consumption:create') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "Record a material consumption",
+            description = "Records material consumed against a project, and optionally a storage "
+                    + "location and task, after checking that enough stock is available at the relevant "
+                    + "level."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Consumption recorded"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation, such as a missing material id or a non-positive quantity"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption create or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No material, employee, project, storage location or task with the given id"),
+            @ApiResponse(responseCode = "409", description = "Insufficient stock at the relevant material, project or storage location for the requested quantity")
+    })
     public ResponseEntity<MaterialConsumptionDto> createMaterialConsumption(
             @Valid @RequestBody MaterialConsumptionCreationDto creationDto) {
         MaterialConsumptionDto created = materialConsumptionService.createMaterialConsumption(creationDto);
@@ -36,6 +60,16 @@ public class MaterialConsumptionController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "Get a material consumption by id",
+            description = "Returns a single material consumption record with its material, project, "
+                    + "storage location, task and creator resolved."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumption found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No material consumption with the given id")
+    })
     public ResponseEntity<MaterialConsumptionDto> getMaterialConsumptionById(@PathVariable Long id) {
         MaterialConsumptionDto consumption = materialConsumptionService.getMaterialConsumptionById(id);
         return ResponseEntity.ok(consumption);
@@ -43,6 +77,14 @@ public class MaterialConsumptionController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List all material consumptions",
+            description = "Returns every material consumption record in the organization, unpaginated."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getAllMaterialConsumptions() {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions();
         return ResponseEntity.ok(consumptions);
@@ -50,6 +92,15 @@ public class MaterialConsumptionController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List material consumptions, paginated",
+            description = "Returns a single page of material consumption records. The pageNo and "
+                    + "pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
+    })
     public ResponseEntity<Page<MaterialConsumptionDto>> getAllMaterialConsumptionsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -60,6 +111,16 @@ public class MaterialConsumptionController {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List consumptions for a material",
+            description = "Returns every consumption record for the given material, such as all draws "
+                    + "of TMT Bar 12mm across every project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByMaterial(@PathVariable Long materialId) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByMaterial(materialId);
         return ResponseEntity.ok(consumptions);
@@ -67,6 +128,15 @@ public class MaterialConsumptionController {
 
     @GetMapping("/type/{consumptionType}")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List consumptions by type",
+            description = "Returns every consumption record of the given consumption type, such as "
+                    + "wastage or normal usage."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByType(@PathVariable MaterialConsumptionType consumptionType) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByType(consumptionType);
         return ResponseEntity.ok(consumptions);
@@ -74,6 +144,16 @@ public class MaterialConsumptionController {
 
     @GetMapping("/date-range")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List consumptions in a date range",
+            description = "Returns every consumption record whose consumption date falls between "
+                    + "startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid ISO date-time"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
@@ -84,6 +164,15 @@ public class MaterialConsumptionController {
 
     @GetMapping("/task/{taskId}")
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
+    @Operation(
+            summary = "List consumptions for a task",
+            description = "Returns every consumption record linked to the given task."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByTask(@PathVariable Long taskId) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByTask(taskId);
         return ResponseEntity.ok(consumptions);

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.materialConsumption;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +22,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/material-consumptions/web")
 @Validated
+@Tag(
+        name = "Material Consumptions (Web)",
+        description = "Web-console counterpart of the material consumptions API, restricted to the "
+                + "system-admin role for the current tenant. Covers the same recording and lookup "
+                + "operations as the standard material consumption endpoints, for use from the admin "
+                + "web console rather than the mobile app."
+)
 public class MaterialConsumptionControllerWeb {
 
     private final MaterialConsumptionService materialConsumptionService;
@@ -28,6 +39,19 @@ public class MaterialConsumptionControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Record a material consumption",
+            description = "Records material consumed against a project, and optionally a storage "
+                    + "location and task, after checking that enough stock is available at the relevant "
+                    + "level."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Consumption recorded"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation, such as a missing material id or a non-positive quantity"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No material, employee, project, storage location or task with the given id"),
+            @ApiResponse(responseCode = "409", description = "Insufficient stock at the relevant material, project or storage location for the requested quantity")
+    })
     public ResponseEntity<MaterialConsumptionDto> createMaterialConsumption(
             @Valid @RequestBody MaterialConsumptionCreationDto creationDto) {
         MaterialConsumptionDto created = materialConsumptionService.createMaterialConsumption(creationDto);
@@ -36,6 +60,16 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a material consumption by id",
+            description = "Returns a single material consumption record with its material, project, "
+                    + "storage location, task and creator resolved."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumption found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No material consumption with the given id")
+    })
     public ResponseEntity<MaterialConsumptionDto> getMaterialConsumptionById(@PathVariable Long id) {
         MaterialConsumptionDto consumption = materialConsumptionService.getMaterialConsumptionById(id);
         return ResponseEntity.ok(consumption);
@@ -43,6 +77,14 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all material consumptions",
+            description = "Returns every material consumption record in the organization, unpaginated."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getAllMaterialConsumptions() {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions();
         return ResponseEntity.ok(consumptions);
@@ -50,6 +92,15 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List material consumptions, paginated",
+            description = "Returns a single page of material consumption records. The pageNo and "
+                    + "pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<MaterialConsumptionDto>> getAllMaterialConsumptionsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -60,6 +111,16 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List consumptions for a material",
+            description = "Returns every consumption record for the given material, such as all draws "
+                    + "of TMT Bar 12mm across every project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByMaterial(@PathVariable Long materialId) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByMaterial(materialId);
         return ResponseEntity.ok(consumptions);
@@ -67,6 +128,15 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/type/{consumptionType}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List consumptions by type",
+            description = "Returns every consumption record of the given consumption type, such as "
+                    + "wastage or normal usage."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByType(@PathVariable MaterialConsumptionType consumptionType) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByType(consumptionType);
         return ResponseEntity.ok(consumptions);
@@ -74,6 +144,16 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/date-range")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List consumptions in a date range",
+            description = "Returns every consumption record whose consumption date falls between "
+                    + "startDate and endDate, inclusive."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "400", description = "startDate or endDate is missing or not a valid ISO date-time"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
@@ -84,6 +164,15 @@ public class MaterialConsumptionControllerWeb {
 
     @GetMapping("/task/{taskId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List consumptions for a task",
+            description = "Returns every consumption record linked to the given task."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Consumptions returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<List<MaterialConsumptionDto>> getConsumptionsByTask(@PathVariable Long taskId) {
         List<MaterialConsumptionDto> consumptions = materialConsumptionService.getConsumptionsByTask(taskId);
         return ResponseEntity.ok(consumptions);

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/dto/MaterialConsumptionCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/dto/MaterialConsumptionCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.materialConsumption.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -8,32 +9,43 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to record material consumed against a project. Stock sufficiency is "
+        + "checked at the material and project level, or at the storage location level when one is given.")
 @Data
 public class MaterialConsumptionCreationDto {
 
+    @Schema(description = "Date and time the material was consumed.", example = "2026-01-15T00:00:00")
     @NotNull(message = "consumption date is required")
     private LocalDateTime consumptionDate;
 
+    @Schema(description = "Id of the material consumed.", example = "12")
     @NotNull(message = "material ID is required")
     private Long materialId;
 
+    @Schema(description = "Quantity consumed, in the material's unit of measure.", example = "50")
     @NotNull(message = "quantity is required")
     @Min(value = 1, message = "quantity must be at least 1")
     private Integer quantity;
 
+    @Schema(description = "Type of consumption.", example = "NORMAL_USAGE")
     @NotBlank(message = "consumption type is required")
     private String consumptionType;
 
+    @Schema(description = "Free-text note about the consumption.", example = "Used for column casting at 3rd floor")
     @Size(max = 500, message = "details must not exceed 500 characters")
     private String details;
 
+    @Schema(description = "Id of the project the material was consumed against.", example = "3")
     @NotNull(message = "project ID is required")
     private Long projectId;
 
+    @Schema(description = "Id of the storage location the material was drawn from, if applicable.", example = "2")
     private Long storageLocationId;
 
+    @Schema(description = "Id of the task the consumption is linked to, if applicable.", example = "45")
     private Long taskId;
 
+    @Schema(description = "Id of the employee recording this consumption.", example = "5")
     @NotNull(message = "created by employee id is required")
     private Long createdBy;
 }

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/dto/MaterialConsumptionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/dto/MaterialConsumptionDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.materialConsumption.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType;
@@ -7,21 +8,37 @@ import org.tornotron.echno_backend.user.dto.UserDto;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "A recorded material consumption, with its material, project, storage location "
+        + "and task resolved to names.")
 @Data
 public class MaterialConsumptionDto {
 
+    @Schema(description = "Consumption record id.", example = "78")
     private Long id;
+    @Schema(description = "Date and time the material was consumed.", example = "2026-01-15T00:00:00")
     private LocalDateTime consumptionDate;
+    @Schema(description = "Id of the material consumed.", example = "12")
     private Long materialId;
+    @Schema(description = "Name of the material consumed.", example = "OPC 53 Grade Cement")
     private String materialName;
+    @Schema(description = "Quantity consumed, in the material's unit of measure.", example = "50")
     private Integer quantity;
+    @Schema(description = "Type of consumption.", example = "NORMAL_USAGE")
     private MaterialConsumptionType consumptionType;
+    @Schema(description = "Free-text note about the consumption.", example = "Used for column casting at 3rd floor")
     private String details;
+    @Schema(description = "Id of the project the material was consumed against.", example = "3")
     private Long projectId;
+    @Schema(description = "Name of the project the material was consumed against.", example = "Asset Homes - Kochi Phase 2")
     private String projectName;
+    @Schema(description = "Id of the storage location the material was drawn from, if applicable.", example = "2")
     private Long storageLocationId;
+    @Schema(description = "Name of the storage location the material was drawn from, if applicable.", example = "Main Site Store")
     private String storageLocationName;
+    @Schema(description = "Id of the task the consumption is linked to, if applicable.", example = "45")
     private Long taskId;
+    @Schema(description = "Title of the task the consumption is linked to, if applicable.", example = "Column casting - Block A")
     private String taskTitle;
+    @Schema(description = "Employee who recorded this consumption.")
     private EmployeeDto createdBy;
 }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.organization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -29,6 +32,14 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/organization")
 @Validated
+@Tag(
+        name = "Organizations (Platform Admin)",
+        description = "Platform-level organization management, used by platform administrators to look up "
+                + "and manage organizations across tenants rather than within the caller's own tenant. "
+                + "Companies such as Asset Homes are represented as an organization, each with its own "
+                + "members, projects and subscription. Tenant-scoped organization access lives on the "
+                + "sibling /organization/web endpoints."
+)
 public class OrganizationController {
 
     private final OrganizationService service;
@@ -52,6 +63,17 @@ public class OrganizationController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('organization:create') or hasAuthority('organization:admin')")
     @RequireSubscription(feature = "CREATE_ORGANIZATION", recordUsage = true)
+    @Operation(
+            summary = "Create an organization",
+            description = "Creates an organization from a multipart request. The data part carries the "
+                    + "organization details as JSON and the optional attachments part carries supporting "
+                    + "files such as a logo. Counts against the CREATE_ORGANIZATION subscription feature."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Organization created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid organization JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the organization create or admin authority")
+    })
     public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
@@ -85,6 +107,16 @@ public class OrganizationController {
     // which is filtered to their memberships.
     @GetMapping("/creator/{creatorId}")
     @PreAuthorize("hasAuthority('organization:admin')")
+    @Operation(
+            summary = "List organizations by creator",
+            description = "Returns every organization created by the given user id. Platform-admin only, "
+                    + "since it can enumerate another user's organizations regardless of the caller's own "
+                    + "memberships."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of organizations created by the given user"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the organization admin authority")
+    })
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsByCreatorId(@PathVariable Integer creatorId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganizationsByCreatorId(creatorId));
     }
@@ -97,6 +129,15 @@ public class OrganizationController {
      */
     @GetMapping("{id}")
     @PreAuthorize("(hasAuthority('organization:read') and @orgSecurity.isMember(#id)) or hasAuthority('organization:admin')")
+    @Operation(
+            summary = "Get an organization by id",
+            description = "Returns a single organization by its numeric id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the organization read authority as a member of the organization, or the organization admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<?> readAnOrganization(@PathVariable Long id) {
         OrganizationDto organization = service.getAnOrganization(id);
         return new ResponseEntity<>(organization, HttpStatus.OK);
@@ -123,6 +164,16 @@ public class OrganizationController {
      */
     @PatchMapping("/batch")
     @PreAuthorize("hasAuthority('organization:update') or hasAuthority('organization:admin')")
+    @Operation(
+            summary = "Batch update organizations",
+            description = "Applies partial updates to several organizations in one call. Each entry names "
+                    + "an organization id and the fields to change on it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the organization update or admin authority")
+    })
     public ResponseEntity<ApiResponse> batchUpdateOrganizations(@Valid @RequestBody List<OrganizationPatchDto> updates) {
         service.batchUpdateOrganization(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Organizations updated successfully"));
@@ -136,6 +187,15 @@ public class OrganizationController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasOrgRole(#id, 'system-admin') or (hasAuthority('organization:delete') and @orgSecurity.isMember(#id)) or hasAuthority('organization:admin')")
+    @Operation(
+            summary = "Delete an organization",
+            description = "Deletes the organization with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin role in the organization, the organization delete authority as a member, or the organization admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteOrganization(@PathVariable Long id) {
         service.deleteAnOrganization(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Organization with id: " + id + " deleted"));

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -3,6 +3,9 @@ package org.tornotron.echno_backend.organization;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -23,6 +26,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/organization/web")
 @Validated
+@Tag(
+        name = "Organizations",
+        description = "Tenant-scoped organization access for the current user: creating an organization, "
+                + "listing and reading the organizations the caller is a member of, and updating or "
+                + "deleting an organization the caller administers. Companies such as Asset Homes are "
+                + "represented as an organization."
+)
 public class OrganizationWebController {
 
     private final OrganizationService service;
@@ -41,6 +51,18 @@ public class OrganizationWebController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @RequireSubscription(feature = "CREATE_ORGANIZATION",recordUsage = true)
     @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "Create an organization",
+            description = "Creates an organization from a multipart request. The data part carries the "
+                    + "organization details as JSON and the optional attachments part carries supporting "
+                    + "files such as a logo. The caller becomes the organization's initial member. Counts "
+                    + "against the CREATE_ORGANIZATION subscription feature."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Organization created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid organization JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
+    })
     public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
@@ -55,6 +77,15 @@ public class OrganizationWebController {
      */
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List the current user's organizations",
+            description = "Returns the organizations the caller is a member of, filtered to those where "
+                    + "the caller holds an organization membership authority for the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of the caller's organizations"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<OrganizationDto>> readAllOrganizations() {
         return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganization());
     }
@@ -68,6 +99,15 @@ public class OrganizationWebController {
      */
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOrAdmin(#id)")
+    @Operation(
+            summary = "Get an organization by id",
+            description = "Returns a single organization by its numeric id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the organization nor a platform admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<?> readAnOrganization(@PathVariable Long id) {
         OrganizationDto organization = service.getAnOrganization(id);
         return new ResponseEntity<>(organization, HttpStatus.OK);
@@ -82,6 +122,19 @@ public class OrganizationWebController {
      */
     @PatchMapping(value = "{id}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRole(#id, 'system-admin', 'hr-admin')")
+    @Operation(
+            summary = "Partially update an organization",
+            description = "Applies the given field updates to the organization, from a multipart request. "
+                    + "The optional data part carries the fields to change as JSON; the optional attachments "
+                    + "part carries a replacement file for the given entityType, such as the organization "
+                    + "logo."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin or hr-admin role in the organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<OrganizationSimpleDto> partialUpdateAnOrganization(
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
@@ -101,6 +154,15 @@ public class OrganizationWebController {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasOrgRole(#id, 'system-admin')")
+    @Operation(
+            summary = "Delete an organization",
+            description = "Deletes the organization with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin role in the organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteOrganization(@PathVariable Long id) {
         service.deleteAnOrganization(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Organization with id: " + id + " deleted"));

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.payable;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/payables")
 @Validated
+@Tag(
+        name = "Payables",
+        description = "Amounts owed to vendors, tracked from creation through to settlement. A payable "
+                + "carries its vendor, amount and outstanding balance, and accepts payment records that "
+                + "reduce that balance. Endpoints cover creating payables, recording payments, browsing "
+                + "and filtering by vendor, and listing outstanding items. Access is tenant scoped and "
+                + "gated by the payable authorities, with an admin authority that grants all operations."
+)
 public class PayableController {
 
     private final PayableService payableService;
@@ -26,6 +37,15 @@ public class PayableController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('payable:create') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "Create a payable",
+            description = "Creates a payable owed to a vendor with its amount and details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Payable created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable create or admin authority")
+    })
     public ResponseEntity<PayableDto> createPayable(@Valid @RequestBody PayableCreationDto creationDto) {
         PayableDto created = payableService.createPayable(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -33,6 +53,16 @@ public class PayableController {
 
     @PostMapping("/{id}/payments")
     @PreAuthorize("hasAuthority('payable:update') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "Record a payment",
+            description = "Records a payment against the given payable, reducing its outstanding balance."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No payable with the given id")
+    })
     public ResponseEntity<PayableDto> recordPayment(
             @PathVariable Long id,
             @Valid @RequestBody PaymentRecordDto paymentDto
@@ -43,6 +73,15 @@ public class PayableController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "Get a payable by id",
+            description = "Returns a single payable."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payable found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No payable with the given id")
+    })
     public ResponseEntity<PayableDto> getPayableById(@PathVariable Long id) {
         PayableDto payable = payableService.getPayableById(id);
         return ResponseEntity.ok(payable);
@@ -50,6 +89,14 @@ public class PayableController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "List payables",
+            description = "Returns every payable in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
+    })
     public ResponseEntity<List<PayableDto>> getAllPayables() {
         List<PayableDto> payables = payableService.getAllPayables();
         return ResponseEntity.ok(payables);
@@ -57,6 +104,14 @@ public class PayableController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "List payables (paged)",
+            description = "Returns a single page of payables controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
+    })
     public ResponseEntity<Page<PayableDto>> getAllPayablesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -67,6 +122,14 @@ public class PayableController {
 
     @GetMapping("/vendor/{vendorId}")
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "List payables for a vendor",
+            description = "Returns the payables owed to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
+    })
     public ResponseEntity<List<PayableDto>> getPayablesByVendor(@PathVariable Long vendorId) {
         List<PayableDto> payables = payableService.getPayablesByVendor(vendorId);
         return ResponseEntity.ok(payables);
@@ -74,6 +137,14 @@ public class PayableController {
 
     @GetMapping("/outstanding")
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
+    @Operation(
+            summary = "List outstanding payables",
+            description = "Returns the payables that still have an outstanding balance."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Outstanding payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
+    })
     public ResponseEntity<List<PayableDto>> getOutstandingPayables() {
         List<PayableDto> payables = payableService.getOutstandingPayables();
         return ResponseEntity.ok(payables);

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.payable;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/payables/web")
 @Validated
+@Tag(
+        name = "Payables (Web)",
+        description = "Web-console counterpart of the payables API, restricted to the system-admin role "
+                + "for the current tenant instead of the flat payable authorities used by the mobile "
+                + "variant. Covers the same create, payment-recording, browse, filter-by-vendor and "
+                + "outstanding-list operations, for use from the admin web console."
+)
 public class PayableControllerWeb {
 
     private final PayableService payableService;
@@ -26,6 +36,15 @@ public class PayableControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a payable",
+            description = "Creates a payable owed to a vendor with its amount and details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Payable created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<PayableDto> createPayable(@Valid @RequestBody PayableCreationDto creationDto) {
         PayableDto created = payableService.createPayable(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -33,6 +52,16 @@ public class PayableControllerWeb {
 
     @PostMapping("/{id}/payments")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Record a payment",
+            description = "Records a payment against the given payable, reducing its outstanding balance."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No payable with the given id")
+    })
     public ResponseEntity<PayableDto> recordPayment(
             @PathVariable Long id,
             @Valid @RequestBody PaymentRecordDto paymentDto
@@ -43,6 +72,15 @@ public class PayableControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a payable by id",
+            description = "Returns a single payable."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payable found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No payable with the given id")
+    })
     public ResponseEntity<PayableDto> getPayableById(@PathVariable Long id) {
         PayableDto payable = payableService.getPayableById(id);
         return ResponseEntity.ok(payable);
@@ -50,6 +88,14 @@ public class PayableControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List payables",
+            description = "Returns every payable in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PayableDto>> getAllPayables() {
         List<PayableDto> payables = payableService.getAllPayables();
         return ResponseEntity.ok(payables);
@@ -57,6 +103,14 @@ public class PayableControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List payables (paged)",
+            description = "Returns a single page of payables controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<PayableDto>> getAllPayablesPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -67,6 +121,14 @@ public class PayableControllerWeb {
 
     @GetMapping("/vendor/{vendorId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List payables for a vendor",
+            description = "Returns the payables owed to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PayableDto>> getPayablesByVendor(@PathVariable Long vendorId) {
         List<PayableDto> payables = payableService.getPayablesByVendor(vendorId);
         return ResponseEntity.ok(payables);
@@ -74,6 +136,14 @@ public class PayableControllerWeb {
 
     @GetMapping("/outstanding")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List outstanding payables",
+            description = "Returns the payables that still have an outstanding balance."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Outstanding payables returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PayableDto>> getOutstandingPayables() {
         List<PayableDto> payables = payableService.getOutstandingPayables();
         return ResponseEntity.ok(payables);

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
@@ -2,6 +2,10 @@ package org.tornotron.echno_backend.pdfGeneration;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -23,6 +27,12 @@ import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1/generate-report")
+@Tag(
+        name = "PDF Reports",
+        description = "Generates a consolidated PDF report covering tasks, task status counts, projects "
+                + "and indents. The report is rendered from a Thymeleaf template and returned as a "
+                + "downloadable file."
+)
 public class ReportController {
 
     private final OrganizationService organizationService;
@@ -67,6 +77,16 @@ public class ReportController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @GetMapping("/pdf")
+    @Operation(
+            summary = "Generate a PDF report",
+            description = "Renders and returns a PDF covering all tasks, their status breakdown, projects "
+                    + "and indents in the current tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "PDF report generated and returned as an attachment"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "500", description = "PDF rendering failed")
+    })
     public ResponseEntity<byte[]> pdfReport() {
         Context ctx = populateContext();
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -3,6 +3,9 @@ package org.tornotron.echno_backend.project;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +29,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/project/web")
 @Validated
+@Tag(
+        name = "Projects",
+        description = "Web-client twin of the project endpoints. Adds employee membership management "
+                + "(add/remove/list by project or by employee) alongside the same create, read, "
+                + "update and delete operations as the base project API. Access is gated by tenant "
+                + "membership, with mutations restricted to a system admin or project manager."
+)
 public class ProjectControllerWeb {
 
     private final ProjectService service;
@@ -53,6 +63,17 @@ public class ProjectControllerWeb {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create a project",
+            description = "Creates a project from a multipart request. The data part carries the "
+                    + "project details as JSON and the optional attachments part carries supporting "
+                    + "files. Returns the created project as a simple view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Project created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") @Valid String data,
                                                           @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         ProjectCreationDto dto = objectMapper.readValue(data, ProjectCreationDto.class);
@@ -67,6 +88,15 @@ public class ProjectControllerWeb {
      */
     @GetMapping()
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List projects",
+            description = "Returns a single page of projects. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of projects returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<ProjectDto>> readAllProjects(@RequestParam(defaultValue = "0") int pageNo,
                                                             @RequestParam(defaultValue = "10") int pageSize) {
         Page<ProjectDto> projects = service.getAllProjects(pageNo,pageSize);
@@ -82,6 +112,15 @@ public class ProjectControllerWeb {
      */
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Get a project by id",
+            description = "Returns a single project including its assigned employees and attachments."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<?> readAProject(@PathVariable Long id) {
         ProjectDto project = service.getAProject(id);
         return new ResponseEntity<>(project,HttpStatus.OK);
@@ -95,6 +134,18 @@ public class ProjectControllerWeb {
      */
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Partially update a project",
+            description = "Applies field updates from a multipart request. The data part carries the "
+                    + "changed fields as JSON and the optional attachments part adds files under the "
+                    + "given entityType."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<ProjectSimpleDto> partialUpdateAProject(
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
@@ -126,6 +177,15 @@ public class ProjectControllerWeb {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete a project",
+            description = "Deletes the project with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Project deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteProject(@PathVariable Long id) {
         service.deleteAProject(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Project with id: "+id+" has been deleted"));
@@ -133,12 +193,30 @@ public class ProjectControllerWeb {
 
     @PostMapping("{projectId}/employees/{employeeId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Add an employee to a project",
+            description = "Assigns the given employee to the given project's team."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee added, updated project team returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or employee with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> addEmployeeToProject(@PathVariable Long projectId, @PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.addEmployeeToProject(projectId, employeeId));
     }
 
     @DeleteMapping("{projectId}/employees/{employeeId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Remove an employee from a project",
+            description = "Removes the given employee from the given project's team."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee removed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or employee with the given id")
+    })
     public ResponseEntity<ApiResponse> removeEmployeeFromProject(@PathVariable Long projectId, @PathVariable Long employeeId) {
         service.removeEmployeeFromProject(projectId, employeeId);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee removed from project"));
@@ -146,12 +224,30 @@ public class ProjectControllerWeb {
 
     @GetMapping("{projectId}/employees")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List a project's employees",
+            description = "Returns every employee assigned to the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<EmployeeDto>> getEmployeesByProjectId(@PathVariable Long projectId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getEmployeesByProjectId(projectId));
     }
 
     @GetMapping("employees/{employeeId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List an employee's projects",
+            description = "Returns every project the given employee is assigned to."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Projects returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+    })
     public ResponseEntity<List<ProjectDto>> getProjectsByEmployeeId(@PathVariable Long employeeId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getProjectsByEmployeeId(employeeId));
     }

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.projectInviteCode;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +24,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/invitation/web")
 @Validated
+@Tag(
+        name = "Project Invite Codes",
+        description = "Invite codes that let users join an organization or project. A code carries a "
+                + "usage limit, current usage count and an active flag. Endpoints cover listing an "
+                + "organization's codes, generating a code, validating a code to join, and patching a "
+                + "code's limits or active state. This is the web-console API, gated by organization "
+                + "roles for the current tenant; validation additionally allows the user acting on "
+                + "their own account."
+)
 public class ProjectInviteCodeController {
 
     private final ProjectInviteCodeService projectInviteCodeService;
@@ -36,6 +48,14 @@ public class ProjectInviteCodeController {
 
     @GetMapping("/organizationId/{organizationId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "List invite codes for an organization",
+            description = "Returns every invite code generated for the given organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Invite codes returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<ProjectInviteCodeDto>> readAllInviteCodes(@PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.OK).body(projectInviteCodeService.readAllProjectInviteCodes(organizationId));
     }
@@ -48,6 +68,16 @@ public class ProjectInviteCodeController {
      */
     @PostMapping("/generateCode/organizationId/{organizationId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Generate an invite code",
+            description = "Generates a new invite code for the given organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Invite code created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+    })
     public ResponseEntity<ProjectInviteCodeDto> createInviteCode(@Valid @RequestBody InviteCodeGenerationDto inviteCodeGenerationDto,
                                                                  @PathVariable Long organizationId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(projectInviteCodeService.generateInviteCode(inviteCodeGenerationDto,organizationId));
@@ -61,6 +91,17 @@ public class ProjectInviteCodeController {
      */
     @PostMapping("/validate/userId/{userId}")
     @PreAuthorize("@orgSecurity.isSelfUser(#userId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Validate and use an invite code",
+            description = "Validates the supplied invite code and joins the user to the organization it "
+                    + "grants access to."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Invite code accepted and organization joined"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation or the code is invalid or expired"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the target user nor a role holder in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<OrganizationDto> validateInviteCode(@Valid @RequestBody InviteCodeValidationDto inviteCodeValidationDto,
                                                               @PathVariable Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(projectInviteCodeService.validateAndUseInviteCode(inviteCodeValidationDto,userId));
@@ -76,6 +117,17 @@ public class ProjectInviteCodeController {
      */
     @PatchMapping("/{inviteCodeId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @Operation(
+            summary = "Update an invite code",
+            description = "Applies a partial update to an invite code, adjusting its usage limit, current "
+                    + "usage count or active state."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Invite code updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No invite code with the given id")
+    })
     public ResponseEntity<ProjectInviteCodeDto> patchInviteCode(@PathVariable Long inviteCodeId,
                                                                  @Valid @RequestBody InviteCodePatchDto patchDto) {
         return ResponseEntity.ok(projectInviteCodeService.patchInviteCode(inviteCodeId, patchDto));

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.purchaseOrder;
 
 import org.springframework.security.access.prepost.PreAuthorize;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -18,6 +21,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/purchase-orders")
 @Validated
+@Tag(
+        name = "Purchase Orders",
+        description = "Purchase orders raised against a vendor, optionally converted from an indent. A "
+                + "purchase order carries line items, a status lifecycle from draft through fully "
+                + "received or cancelled, and the totals used for payables. Access is restricted to the "
+                + "system-admin role for the current tenant."
+)
 public class PurchaseOrderController {
 
     private final PurchaseOrderService purchaseOrderService;
@@ -28,6 +38,16 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
+    @Operation(
+            summary = "Create a purchase order",
+            description = "Creates a purchase order for a vendor, with an optional link back to the indent "
+                    + "it was raised from, and its line items in one call."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Purchase order created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<PurchaseOrderDto> createPurchaseOrder(@Valid @RequestBody PurchaseOrderCreationDto creationDto) {
         PurchaseOrderDto created = purchaseOrderService.createPurchaseOrder(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -35,6 +55,15 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a purchase order by id",
+            description = "Returns a single purchase order including its vendor, indent link, items and totals."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+    })
     public ResponseEntity<PurchaseOrderDto> getPurchaseOrderById(@PathVariable Long id) {
         PurchaseOrderDto purchaseOrder = purchaseOrderService.getPurchaseOrderById(id);
         return ResponseEntity.ok(purchaseOrder);
@@ -42,6 +71,14 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping
+    @Operation(
+            summary = "List all purchase orders",
+            description = "Returns every purchase order for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getAllPurchaseOrders() {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
         return ResponseEntity.ok(purchaseOrders);
@@ -49,6 +86,15 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/all")
+    @Operation(
+            summary = "List purchase orders, paginated",
+            description = "Returns a single page of purchase orders. The pageNo and pageSize parameters "
+                    + "control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<PurchaseOrderDto>> getAllPurchaseOrdersPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -59,6 +105,15 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/vendor/{vendorId}")
+    @Operation(
+            summary = "List purchase orders for a vendor",
+            description = "Returns every purchase order raised against the given vendor, for example every "
+                    + "PO placed with Sri Balaji Steel Traders."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByVendor(@PathVariable Long vendorId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByVendor(vendorId);
         return ResponseEntity.ok(purchaseOrders);
@@ -66,6 +121,14 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/indent/{indentId}")
+    @Operation(
+            summary = "List purchase orders for an indent",
+            description = "Returns every purchase order that was raised from the given material indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByIndent(@PathVariable Long indentId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByIndent(indentId);
         return ResponseEntity.ok(purchaseOrders);
@@ -73,6 +136,16 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/status/{status}")
+    @Operation(
+            summary = "List purchase orders by status",
+            description = "Returns every purchase order currently in the given lifecycle status, such as "
+                    + "SENT_TO_VENDOR or FULLY_RECEIVED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "status is not a recognised purchase order status"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByStatus(@PathVariable PurchaseOrderStatus status) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByStatus(status);
         return ResponseEntity.ok(purchaseOrders);
@@ -80,6 +153,17 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping
+    @Operation(
+            summary = "Update a purchase order",
+            description = "Applies a partial update to a purchase order's status, expected delivery date, "
+                    + "remarks or total amount."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+    })
     public ResponseEntity<PurchaseOrderDto> updatePurchaseOrder(@Valid @RequestBody PurchaseOrderUpdateDto updateDto) {
         PurchaseOrderDto updated = purchaseOrderService.updatePurchaseOrder(updateDto);
         return ResponseEntity.ok(updated);
@@ -87,6 +171,17 @@ public class PurchaseOrderController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/{id}/status")
+    @Operation(
+            summary = "Update a purchase order's status",
+            description = "Transitions a purchase order to the given status, for example from APPROVED to "
+                    + "SENT_TO_VENDOR."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The requested transition is not valid from the purchase order's current status, for example cancelling an already fully received order")
+    })
     public ResponseEntity<ApiResponse> updatePurchaseOrderStatus(
             @PathVariable Long id,
             @RequestParam PurchaseOrderStatus status

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.purchaseOrder;
 
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +21,12 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/purchase-orders/web")
 @Validated
+@Tag(
+        name = "Purchase Orders (Web)",
+        description = "Web-console mirror of the purchase order endpoints. Same purchase order lifecycle "
+                + "as the mobile API, but gated by the web app's org-role check instead of point "
+                + "authorities."
+)
 public class PurchaseOrderControllerWeb {
 
     private final PurchaseOrderService purchaseOrderService;
@@ -28,6 +37,16 @@ public class PurchaseOrderControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a purchase order",
+            description = "Creates a purchase order for a vendor, with an optional link back to the indent "
+                    + "it was raised from, and its line items in one call."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Purchase order created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<PurchaseOrderDto> createPurchaseOrder(@Valid @RequestBody PurchaseOrderCreationDto creationDto) {
         PurchaseOrderDto created = purchaseOrderService.createPurchaseOrder(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -35,6 +54,15 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a purchase order by id",
+            description = "Returns a single purchase order including its vendor, indent link, items and totals."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+    })
     public ResponseEntity<PurchaseOrderDto> getPurchaseOrderById(@PathVariable Long id) {
         PurchaseOrderDto purchaseOrder = purchaseOrderService.getPurchaseOrderById(id);
         return ResponseEntity.ok(purchaseOrder);
@@ -42,6 +70,14 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all purchase orders",
+            description = "Returns every purchase order for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getAllPurchaseOrders() {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
         return ResponseEntity.ok(purchaseOrders);
@@ -49,6 +85,15 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase orders, paginated",
+            description = "Returns a single page of purchase orders. The pageNo and pageSize parameters "
+                    + "control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<PurchaseOrderDto>> getAllPurchaseOrdersPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -59,6 +104,15 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping("/vendor/{vendorId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase orders for a vendor",
+            description = "Returns every purchase order raised against the given vendor, for example every "
+                    + "PO placed with Sri Balaji Steel Traders."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByVendor(@PathVariable Long vendorId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByVendor(vendorId);
         return ResponseEntity.ok(purchaseOrders);
@@ -66,6 +120,14 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping("/indent/{indentId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase orders for an indent",
+            description = "Returns every purchase order that was raised from the given material indent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByIndent(@PathVariable Long indentId) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByIndent(indentId);
         return ResponseEntity.ok(purchaseOrders);
@@ -73,6 +135,16 @@ public class PurchaseOrderControllerWeb {
 
     @GetMapping("/status/{status}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase orders by status",
+            description = "Returns every purchase order currently in the given lifecycle status, such as "
+                    + "SENT_TO_VENDOR or FULLY_RECEIVED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "status is not a recognised purchase order status"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderDto>> getPurchaseOrdersByStatus(@PathVariable PurchaseOrderStatus status) {
         List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getPurchaseOrdersByStatus(status);
         return ResponseEntity.ok(purchaseOrders);
@@ -80,6 +152,17 @@ public class PurchaseOrderControllerWeb {
 
     @PatchMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a purchase order",
+            description = "Applies a partial update to a purchase order's status, expected delivery date, "
+                    + "remarks or total amount."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+    })
     public ResponseEntity<PurchaseOrderDto> updatePurchaseOrder(@Valid @RequestBody PurchaseOrderUpdateDto updateDto) {
         PurchaseOrderDto updated = purchaseOrderService.updatePurchaseOrder(updateDto);
         return ResponseEntity.ok(updated);
@@ -87,6 +170,17 @@ public class PurchaseOrderControllerWeb {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a purchase order's status",
+            description = "Transitions a purchase order to the given status, for example from APPROVED to "
+                    + "SENT_TO_VENDOR."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The requested transition is not valid from the purchase order's current status, for example cancelling an already fully received order")
+    })
     public ResponseEntity<ApiResponse> updatePurchaseOrderStatus(
             @PathVariable Long id,
             @RequestParam PurchaseOrderStatus status

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrder.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,33 +12,44 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Payload to raise a purchase order against a vendor, with its line items.")
 @Data
 public class PurchaseOrderCreationDto {
 
+    @Schema(description = "Purchase order number, unique per organization.", example = "PO-2026-0042")
     @NotBlank(message = "PO number is required")
     @Size(min = 1, max = 50, message = "PO number must be between 1 and 50 characters")
     private String poNumber;
 
+    @Schema(description = "Id of the vendor the order is raised against.", example = "12")
     @NotNull(message = "vendor ID is required")
     private Long vendorId;
 
+    @Schema(description = "Id of the indent this order was converted from, if any.", example = "7")
     private Long indentId;
 
+    @Schema(description = "Lifecycle status of the purchase order.", example = "DRAFT")
     @NotBlank(message = "status is required")
     private String status;
 
+    @Schema(description = "Id of the project the materials are for.", example = "3")
     @NotNull(message = "project ID is required")
     private Long projectId;
 
+    @Schema(description = "Id of the employee raising the purchase order.", example = "8")
     @NotNull(message = "created by employee id is required")
     private Long createdBy;
 
+    @Schema(description = "Date the vendor is expected to deliver by.", example = "2026-02-10T00:00:00")
     private LocalDateTime expectedDeliveryDate;
 
+    @Schema(description = "Free-text remarks on the order.", example = "Deliver to Perumbavoor site, second gate")
     private String remarks;
 
+    @Schema(description = "Total value of the purchase order in INR.", example = "485000.00")
     private BigDecimal totalAmount;
 
+    @Schema(description = "Line items being ordered.")
     @Valid
     private List<PurchaseOrderItemCreationDto> items;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrder.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
@@ -9,22 +10,52 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A purchase order with its vendor, indent link, line items and totals.")
 @Data
 public class PurchaseOrderDto {
 
+    @Schema(description = "Purchase order id.", example = "204")
     private Long id;
+
+    @Schema(description = "Purchase order number.", example = "PO-2026-0042")
     private String poNumber;
+
+    @Schema(description = "Id of the vendor the order is raised against.", example = "12")
     private Long vendorId;
+
+    @Schema(description = "Name of the vendor.", example = "Sri Balaji Steel Traders")
     private String vendorName;
+
+    @Schema(description = "Id of the indent this order was converted from, if any.", example = "7")
     private Long indentId;
+
+    @Schema(description = "Number of the source indent, if any.", example = "IND-2026-0015")
     private String indentNumber;
+
+    @Schema(description = "Id of the project the materials are for.", example = "3")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
     private String projectName;
+
+    @Schema(description = "Current lifecycle status of the purchase order.", example = "SENT_TO_VENDOR")
     private PurchaseOrderStatus status;
+
+    @Schema(description = "Timestamp the purchase order was created.", example = "2026-01-15T10:30:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Employee who raised the purchase order.")
     private EmployeeDto createdBy;
+
+    @Schema(description = "Date the vendor is expected to deliver by.", example = "2026-02-10T00:00:00")
     private LocalDateTime expectedDeliveryDate;
+
+    @Schema(description = "Free-text remarks on the order.", example = "Deliver to Perumbavoor site, second gate")
     private String remarks;
+
+    @Schema(description = "Line items on the order.")
     private List<PurchaseOrderItemDto> items;
+
+    @Schema(description = "Total value of the purchase order in INR.", example = "485000.00")
     private BigDecimal totalAmount;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderItemDto.java
@@ -1,32 +1,43 @@
 package org.tornotron.echno_backend.purchaseOrder.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "A purchase order line item as embedded in a purchase order response.")
 @Data
 public class PurchaseOrderItemDto {
 
+    @Schema(description = "Purchase order item id.", example = "512")
     private Long id;
 
+    @Schema(description = "Id of the material being ordered.", example = "44")
     @NotNull(message = "material ID is required")
     private Long materialId;
 
+    @Schema(description = "Name of the material.", example = "TMT Bar Fe 500D, 12mm")
     private String materialName;
 
+    @Schema(description = "Id of the source indent item this line was converted from, if any.", example = "31")
     private Long indentItemId;
 
+    @Schema(description = "Quantity ordered.", example = "500")
     @NotNull(message = "ordered quantity is required")
     @Min(value = 1, message = "ordered quantity must be at least 1")
     private Integer orderedQuantity;
 
+    @Schema(description = "Quantity received against this line so far.", example = "0")
     private Integer receivedQuantity;
 
+    @Schema(description = "Unit price in INR.", example = "62.50")
     private BigDecimal unitPrice;
 
+    @Schema(description = "Total price for this line in INR.", example = "31250.00")
     private BigDecimal totalPrice;
 
+    @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderUpdateDto.java
@@ -1,22 +1,29 @@
 package org.tornotron.echno_backend.purchaseOrder.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
+@Schema(description = "Payload to update a purchase order's status, delivery date, remarks or total.")
 @Data
 public class PurchaseOrderUpdateDto {
 
+    @Schema(description = "Id of the purchase order to update.", example = "204")
     @NotNull(message = "Purchase Order ID is required")
     private Long id;
 
+    @Schema(description = "New lifecycle status.", example = "APPROVED")
     private String status;
 
+    @Schema(description = "Updated expected delivery date.", example = "2026-02-14T00:00:00")
     private LocalDateTime expectedDeliveryDate;
 
+    @Schema(description = "Updated remarks.", example = "Vendor confirmed dispatch for 2026-02-12")
     private String remarks;
 
+    @Schema(description = "Updated total value in INR.", example = "492500.00")
     private BigDecimal totalAmount;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
 import org.springframework.security.access.prepost.PreAuthorize;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/purchase-order-items")
 @Validated
+@Tag(
+        name = "Purchase Order Items",
+        description = "Line items belonging to a purchase order: the material, ordered and received "
+                + "quantities, unit price and totals. Items can be created independently of the parent "
+                + "order create call and looked up by purchase order or by material. Access is restricted "
+                + "to the system-admin role for the current tenant."
+)
 public class PurchaseOrderItemController {
 
     private final PurchaseOrderItemService purchaseOrderItemService;
@@ -26,6 +36,16 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PostMapping
+    @Operation(
+            summary = "Create a purchase order item",
+            description = "Adds a line item to an existing purchase order, naming the material, ordered "
+                    + "quantity and unit price."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Purchase order item created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> createPurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemCreationDto creationDto) {
         PurchaseOrderItemResponseDto created = purchaseOrderItemService.createPurchaseOrderItem(creationDto);
@@ -34,6 +54,15 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a purchase order item by id",
+            description = "Returns a single purchase order line item, including ordered and received quantities."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> getPurchaseOrderItemById(@PathVariable Long id) {
         PurchaseOrderItemResponseDto item = purchaseOrderItemService.getPurchaseOrderItemById(id);
         return ResponseEntity.ok(item);
@@ -41,6 +70,14 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping
+    @Operation(
+            summary = "List all purchase order items",
+            description = "Returns every purchase order line item for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getAllPurchaseOrderItems();
         return ResponseEntity.ok(items);
@@ -48,6 +85,15 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/purchase-order/{purchaseOrderId}")
+    @Operation(
+            summary = "List items for a purchase order",
+            description = "Returns every line item belonging to the given purchase order, for example all "
+                    + "items on PO-2026-0042."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByPurchaseOrderId(
             @PathVariable Long purchaseOrderId) {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getItemsByPurchaseOrderId(purchaseOrderId);
@@ -56,6 +102,15 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/material/{materialId}")
+    @Operation(
+            summary = "List items for a material",
+            description = "Returns every purchase order line item that orders the given material, across "
+                    + "all purchase orders."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByMaterialId(@PathVariable Long materialId) {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getItemsByMaterialId(materialId);
         return ResponseEntity.ok(items);
@@ -63,6 +118,16 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PutMapping
+    @Operation(
+            summary = "Update a purchase order item",
+            description = "Replaces a line item's ordered quantity, unit price and remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> updatePurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemUpdateDto updateDto) {
         PurchaseOrderItemResponseDto updated = purchaseOrderItemService.updatePurchaseOrderItem(updateDto);
@@ -71,6 +136,15 @@ public class PurchaseOrderItemController {
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a purchase order item",
+            description = "Deletes the purchase order line item with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<ApiResponse> deletePurchaseOrderItem(@PathVariable Long id) {
         purchaseOrderItemService.deletePurchaseOrderItem(id);
         return ResponseEntity.ok(new ApiResponse("PurchaseOrderItem with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +17,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/purchase-order-items/web")
+@Tag(
+        name = "Purchase Order Items (Web)",
+        description = "Web-console mirror of the purchase order item endpoints. Same line-item operations "
+                + "as the mobile API, gated by the web app's org-role check instead of point authorities."
+)
 public class PurchaseOrderItemControllerWeb {
 
     private final PurchaseOrderItemService purchaseOrderItemService;
@@ -24,6 +32,16 @@ public class PurchaseOrderItemControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a purchase order item",
+            description = "Adds a line item to an existing purchase order, naming the material, ordered "
+                    + "quantity and unit price."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Purchase order item created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> createPurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemCreationDto creationDto) {
         PurchaseOrderItemResponseDto created = purchaseOrderItemService.createPurchaseOrderItem(creationDto);
@@ -32,6 +50,15 @@ public class PurchaseOrderItemControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a purchase order item by id",
+            description = "Returns a single purchase order line item, including ordered and received quantities."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> getPurchaseOrderItemById(@PathVariable Long id) {
         PurchaseOrderItemResponseDto item = purchaseOrderItemService.getPurchaseOrderItemById(id);
         return ResponseEntity.ok(item);
@@ -39,6 +66,14 @@ public class PurchaseOrderItemControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all purchase order items",
+            description = "Returns every purchase order line item for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getAllPurchaseOrderItems();
         return ResponseEntity.ok(items);
@@ -46,6 +81,15 @@ public class PurchaseOrderItemControllerWeb {
 
     @GetMapping("/purchase-order/{purchaseOrderId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items for a purchase order",
+            description = "Returns every line item belonging to the given purchase order, for example all "
+                    + "items on PO-2026-0042."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByPurchaseOrderId(
             @PathVariable Long purchaseOrderId) {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getItemsByPurchaseOrderId(purchaseOrderId);
@@ -54,6 +98,15 @@ public class PurchaseOrderItemControllerWeb {
 
     @GetMapping("/material/{materialId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List items for a material",
+            description = "Returns every purchase order line item that orders the given material, across "
+                    + "all purchase orders."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getItemsByMaterialId(@PathVariable Long materialId) {
         List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getItemsByMaterialId(materialId);
         return ResponseEntity.ok(items);
@@ -61,6 +114,16 @@ public class PurchaseOrderItemControllerWeb {
 
     @PatchMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a purchase order item",
+            description = "Replaces a line item's ordered quantity, unit price and remarks."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<PurchaseOrderItemResponseDto> updatePurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemUpdateDto updateDto) {
         PurchaseOrderItemResponseDto updated = purchaseOrderItemService.updatePurchaseOrderItem(updateDto);
@@ -69,6 +132,15 @@ public class PurchaseOrderItemControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a purchase order item",
+            description = "Deletes the purchase order line item with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+    })
     public ResponseEntity<ApiResponse> deletePurchaseOrderItem(@PathVariable Long id) {
         purchaseOrderItemService.deletePurchaseOrderItem(id);
         return ResponseEntity.ok(new ApiResponse("PurchaseOrderItem with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemCreationDto.java
@@ -1,28 +1,37 @@
 package org.tornotron.echno_backend.purchaseOrderItem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Payload to add a line item to a purchase order.")
 @Data
 public class PurchaseOrderItemCreationDto {
 
+    @Schema(description = "Id of the purchase order this item belongs to.", example = "204")
     private Long purchaseOrderId;
 
+    @Schema(description = "Id of the material being ordered.", example = "44")
     @NotNull(message = "Material ID is required")
     private Long materialId;
 
+    @Schema(description = "Id of the source indent item this line was converted from, if any.", example = "31")
     private Long indentItemId;
 
+    @Schema(description = "Quantity ordered.", example = "500")
     @NotNull(message = "Ordered quantity is required")
     @Min(value = 1, message = "Ordered quantity must be at least 1")
     private Integer orderedQuantity;
 
+    @Schema(description = "Unit price in INR.", example = "62.50")
     private BigDecimal unitPrice;
 
+    @Schema(description = "Total price for this line in INR.", example = "31250.00")
     private BigDecimal totalPrice;
 
+    @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemResponseDto.java
@@ -1,21 +1,44 @@
 package org.tornotron.echno_backend.purchaseOrderItem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "A purchase order line item, returned standalone by the item endpoints.")
 @Data
 public class PurchaseOrderItemResponseDto {
 
+    @Schema(description = "Purchase order item id.", example = "512")
     private Long id;
+
+    @Schema(description = "Id of the purchase order this item belongs to.", example = "204")
     private Long purchaseOrderId;
+
+    @Schema(description = "Number of the parent purchase order.", example = "PO-2026-0042")
     private String poNumber;
+
+    @Schema(description = "Id of the material being ordered.", example = "44")
     private Long materialId;
+
+    @Schema(description = "Name of the material.", example = "TMT Bar Fe 500D, 12mm")
     private String materialName;
+
+    @Schema(description = "Id of the source indent item this line was converted from, if any.", example = "31")
     private Long indentItemId;
+
+    @Schema(description = "Quantity ordered.", example = "500")
     private Integer orderedQuantity;
+
+    @Schema(description = "Quantity received against this line so far.", example = "0")
     private Integer receivedQuantity;
+
+    @Schema(description = "Unit price in INR.", example = "62.50")
     private BigDecimal unitPrice;
+
+    @Schema(description = "Total price for this line in INR.", example = "31250.00")
     private BigDecimal totalPrice;
+
+    @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemUpdateDto.java
@@ -1,19 +1,25 @@
 package org.tornotron.echno_backend.purchaseOrderItem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Payload to update a purchase order line item's quantity, price or remarks.")
 @Data
 public class PurchaseOrderItemUpdateDto {
 
+    @Schema(description = "Id of the item to update.", example = "512")
     @NotNull(message = "Item ID is required")
     private Long id;
 
+    @Schema(description = "Updated ordered quantity.", example = "450")
     private Integer orderedQuantity;
 
+    @Schema(description = "Updated unit price in INR.", example = "64.00")
     private BigDecimal unitPrice;
 
+    @Schema(description = "Updated remarks.", example = "Vendor revised rate for February delivery")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.siteTransfer;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/site-transfers")
 @Validated
+@Tag(
+        name = "Site Transfers",
+        description = "Movement of materials between two projects, and optionally between specific storage "
+                + "locations within them. A site transfer records the sending person, the items and "
+                + "quantities being moved, and its own status as it progresses. Creating a transfer checks "
+                + "that the sending location holds enough stock before the items are recorded. Access is "
+                + "gated by the site-transfer authorities, with an admin authority that grants all operations."
+)
 public class SiteTransferController {
 
     private final SiteTransferService siteTransferService;
@@ -27,6 +38,20 @@ public class SiteTransferController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('site-transfer:create') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "Create a site transfer",
+            description = "Creates a site transfer moving materials from a sending project, and optionally a "
+                    + "specific storage location within it, to a receiving project. Validates that the "
+                    + "sending location holds enough stock for every item before the transfer is recorded, "
+                    + "then publishes an event so inventory is updated automatically."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Site transfer created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing, or an item failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "The sending person, sending project, receiving project, a referenced storage location, or a material on one of the items was not found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A site transfer with the given transfer number already exists, or the sending location does not hold enough stock for one or more items")
+    })
     public ResponseEntity<SiteTransferDto> createSiteTransfer(@Valid @RequestBody SiteTransferCreationDto creationDto) {
         SiteTransferDto created = siteTransferService.createSiteTransfer(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -34,6 +59,16 @@ public class SiteTransferController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "Get a site transfer by id",
+            description = "Returns a single site transfer including its sending and receiving projects, "
+                    + "storage locations, sending person, and line items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
     public ResponseEntity<SiteTransferDto> getSiteTransferById(@PathVariable Long id) {
         SiteTransferDto transfer = siteTransferService.getSiteTransferById(id);
         return ResponseEntity.ok(transfer);
@@ -41,6 +76,14 @@ public class SiteTransferController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "List all site transfers",
+            description = "Returns every site transfer in the organization, without pagination."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
+    })
     public ResponseEntity<List<SiteTransferDto>> getAllSiteTransfers() {
         List<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers();
         return ResponseEntity.ok(transfers);
@@ -48,6 +91,15 @@ public class SiteTransferController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "List site transfers, paginated",
+            description = "Returns a single page of site transfers ordered by issue date, most recent first. "
+                    + "The pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
+    })
     public ResponseEntity<Page<SiteTransferDto>> getAllSiteTransfersPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -58,6 +110,15 @@ public class SiteTransferController {
 
     @GetMapping("/status/{status}")
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "List site transfers by status",
+            description = "Returns every site transfer currently in the given status, for example PENDING, "
+                    + "IN_TRANSIT or COMPLETED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersByStatus(@PathVariable SiteTransferStatus status) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersByStatus(status);
         return ResponseEntity.ok(transfers);
@@ -65,6 +126,14 @@ public class SiteTransferController {
 
     @GetMapping("/sending-project/{projectId}")
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "List site transfers sent from a project",
+            description = "Returns every site transfer whose sending project is the given project id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersBySendingProject(@PathVariable Long projectId) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersBySendingProject(projectId);
         return ResponseEntity.ok(transfers);
@@ -72,6 +141,14 @@ public class SiteTransferController {
 
     @GetMapping("/receiving-project/{projectId}")
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "List site transfers received by a project",
+            description = "Returns every site transfer whose receiving project is the given project id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersByReceivingProject(@PathVariable Long projectId) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersByReceivingProject(projectId);
         return ResponseEntity.ok(transfers);
@@ -79,6 +156,16 @@ public class SiteTransferController {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasAuthority('site-transfer:update') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "Update a site transfer's status",
+            description = "Sets the status of an existing site transfer, for example moving it from PENDING "
+                    + "to IN_TRANSIT or COMPLETED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
     public ResponseEntity<ApiResponse> updateSiteTransferStatus(
             @PathVariable Long id,
             @RequestParam SiteTransferStatus status

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.siteTransfer;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/site-transfers/web")
 @Validated
+@Tag(
+        name = "Site Transfers (Web)",
+        description = "Web-app view of site transfers: the same movement of materials between two projects "
+                + "and their storage locations as the mobile-facing site-transfer endpoints, restricted to "
+                + "the system-admin role for the caller's current tenant. Creating a transfer checks that "
+                + "the sending location holds enough stock before the items are recorded."
+)
 public class SiteTransferControllerWeb {
 
     private final SiteTransferService siteTransferService;
@@ -27,6 +37,20 @@ public class SiteTransferControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a site transfer",
+            description = "Creates a site transfer moving materials from a sending project, and optionally a "
+                    + "specific storage location within it, to a receiving project. Validates that the "
+                    + "sending location holds enough stock for every item before the transfer is recorded, "
+                    + "then publishes an event so inventory is updated automatically."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Site transfer created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing, or an item failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "The sending person, sending project, receiving project, a referenced storage location, or a material on one of the items was not found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A site transfer with the given transfer number already exists, or the sending location does not hold enough stock for one or more items")
+    })
     public ResponseEntity<SiteTransferDto> createSiteTransfer(@Valid @RequestBody SiteTransferCreationDto creationDto) {
         SiteTransferDto created = siteTransferService.createSiteTransfer(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -34,6 +58,16 @@ public class SiteTransferControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a site transfer by id",
+            description = "Returns a single site transfer including its sending and receiving projects, "
+                    + "storage locations, sending person, and line items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
     public ResponseEntity<SiteTransferDto> getSiteTransferById(@PathVariable Long id) {
         SiteTransferDto transfer = siteTransferService.getSiteTransferById(id);
         return ResponseEntity.ok(transfer);
@@ -41,6 +75,14 @@ public class SiteTransferControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all site transfers",
+            description = "Returns every site transfer in the organization, without pagination."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SiteTransferDto>> getAllSiteTransfers() {
         List<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers();
         return ResponseEntity.ok(transfers);
@@ -48,6 +90,15 @@ public class SiteTransferControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List site transfers, paginated",
+            description = "Returns a single page of site transfers ordered by issue date, most recent first. "
+                    + "The pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<SiteTransferDto>> getAllSiteTransfersPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -58,6 +109,15 @@ public class SiteTransferControllerWeb {
 
     @GetMapping("/status/{status}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List site transfers by status",
+            description = "Returns every site transfer currently in the given status, for example PENDING, "
+                    + "IN_TRANSIT or COMPLETED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersByStatus(@PathVariable SiteTransferStatus status) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersByStatus(status);
         return ResponseEntity.ok(transfers);
@@ -65,6 +125,14 @@ public class SiteTransferControllerWeb {
 
     @GetMapping("/sending-project/{projectId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List site transfers sent from a project",
+            description = "Returns every site transfer whose sending project is the given project id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersBySendingProject(@PathVariable Long projectId) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersBySendingProject(projectId);
         return ResponseEntity.ok(transfers);
@@ -72,6 +140,14 @@ public class SiteTransferControllerWeb {
 
     @GetMapping("/receiving-project/{projectId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List site transfers received by a project",
+            description = "Returns every site transfer whose receiving project is the given project id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SiteTransferDto>> getSiteTransfersByReceivingProject(@PathVariable Long projectId) {
         List<SiteTransferDto> transfers = siteTransferService.getSiteTransfersByReceivingProject(projectId);
         return ResponseEntity.ok(transfers);
@@ -79,6 +155,16 @@ public class SiteTransferControllerWeb {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a site transfer's status",
+            description = "Sets the status of an existing site transfer, for example moving it from PENDING "
+                    + "to IN_TRANSIT or COMPLETED."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
     public ResponseEntity<ApiResponse> updateSiteTransferStatus(
             @PathVariable Long id,
             @RequestParam SiteTransferStatus status

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.siteTransfer.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -10,32 +11,46 @@ import lombok.Data;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Payload to create a site transfer moving materials from a sending project to a receiving project.")
 @Data
 public class SiteTransferCreationDto {
 
+    @Schema(description = "Unique transfer document number.", example = "ST-2026-0031")
     @NotBlank(message = "transfer number is required")
     @Size(min = 1, max = 50, message = "transfer number must be between 1 and 50 characters")
     private String transferNumber;
 
+    @Schema(description = "Date and time the transfer was issued.", example = "2026-01-15T09:30:00")
     @NotNull(message = "issue date is required")
     private LocalDateTime issueDate;
 
+    @Schema(description = "Id of the employee handing over the materials at the sending project.", example = "12")
     @NotNull(message = "sending person employee id is required")
     private Long sendingPerson;
 
+    @Schema(description = "Id of the project the materials are being sent from.", example = "4")
     @NotNull(message = "sending project ID is required")
     private Long sendingProjectId;
 
+    @Schema(description = "Id of the specific storage location within the sending project to draw stock "
+            + "from, for example Main Site Store. Optional; when omitted, stock is validated at the "
+            + "project level instead of a single location.", example = "7")
     private Long sendingStorageLocationId;
 
+    @Schema(description = "Id of the project the materials are being sent to.", example = "9")
     @NotNull(message = "receiving project ID is required")
     private Long receivingProjectId;
 
+    @Schema(description = "Id of the specific storage location within the receiving project to credit the "
+            + "materials to, for example Site B Yard. Optional.", example = "15")
     private Long receivingStorageLocationId;
 
+    @Schema(description = "Initial status of the transfer.", example = "PENDING")
     @NotBlank(message = "status is required")
     private String status;
 
+    @Schema(description = "Line items listing each material and quantity being transferred. Must contain "
+            + "at least one item.")
     @NotEmpty(message = "items list cannot be empty")
     @Valid
     private List<SiteTransferItemDto> items;

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.siteTransfer.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
@@ -7,21 +8,49 @@ import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A site transfer of materials between two projects, with resolved names for the projects and storage locations involved.")
 @Data
 public class SiteTransferDto {
 
+    @Schema(description = "Id of the site transfer.", example = "31")
     private Long id;
+
+    @Schema(description = "Unique transfer document number.", example = "ST-2026-0031")
     private String transferNumber;
+
+    @Schema(description = "Date and time the transfer was issued.", example = "2026-01-15T09:30:00")
     private LocalDateTime issueDate;
+
+    @Schema(description = "Employee who handed over the materials at the sending project.")
     private EmployeeDto sendingPerson;
+
+    @Schema(description = "Id of the sending project.", example = "4")
     private Long sendingProjectId;
+
+    @Schema(description = "Name of the sending project.", example = "Asset Homes - Kochi Phase 2")
     private String sendingProjectName;
+
+    @Schema(description = "Id of the sending storage location, if one was specified.", example = "7")
     private Long sendingStorageLocationId;
+
+    @Schema(description = "Name of the sending storage location.", example = "Main Site Store")
     private String sendingStorageLocationName;
+
+    @Schema(description = "Id of the receiving project.", example = "9")
     private Long receivingProjectId;
+
+    @Schema(description = "Name of the receiving project.", example = "Asset Homes - Coimbatore Villas")
     private String receivingProjectName;
+
+    @Schema(description = "Id of the receiving storage location, if one was specified.", example = "15")
     private Long receivingStorageLocationId;
+
+    @Schema(description = "Name of the receiving storage location.", example = "Site B Yard")
     private String receivingStorageLocationName;
+
+    @Schema(description = "Current status of the transfer.", example = "IN_TRANSIT")
     private SiteTransferStatus status;
+
+    @Schema(description = "Line items listing each material and quantity being transferred.")
     private List<SiteTransferItemDto> items;
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferItemDto.java
@@ -1,22 +1,29 @@
 package org.tornotron.echno_backend.siteTransfer.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+@Schema(description = "A single material line on a site transfer, naming the material and the quantity sent.")
 @Data
 public class SiteTransferItemDto {
 
+    @Schema(description = "Id of the transfer item.", example = "84")
     private Long id;
 
+    @Schema(description = "Id of the material being transferred.", example = "21")
     @NotNull(message = "material ID is required")
     private Long materialId;
 
+    @Schema(description = "Name of the material being transferred.", example = "TMT Bar 12mm")
     private String materialName;
 
+    @Schema(description = "Quantity sent, in the material's unit.", example = "500")
     @NotNull(message = "sent quantity is required")
     @Min(value = 1, message = "sent quantity must be at least 1")
     private Integer sentQuantity;
 
+    @Schema(description = "Optional remarks for this line item.", example = "For column casting, Block C")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.stockAdjustment;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,14 @@ import java.util.List;
 @RestController
 @Validated
 @RequestMapping("/api/v1/stock-adjustments/web")
+@Tag(
+        name = "Stock Adjustments (Web)",
+        description = "Documents that correct the recorded on-hand quantity of materials at a storage "
+                + "location against a physical count, capturing the variance, its reason and justification "
+                + "per line item. Endpoints cover creating, updating, browsing and deleting stock "
+                + "adjustment documents for the caller's current tenant. Read endpoints require tenant "
+                + "membership; write endpoints require the system-admin or project-manager role."
+)
 public class StockAdjustmentControllerWeb {
 
     private final StockAdjustmentService stockAdjustmentService;
@@ -26,12 +37,30 @@ public class StockAdjustmentControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List all stock adjustments",
+            description = "Returns every stock adjustment document recorded for the organization, without "
+                    + "pagination."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<List<StockAdjustmentDto>> readAllStockAdjustments() {
         return new ResponseEntity<>(stockAdjustmentService.getAll(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List stock adjustments, paginated",
+            description = "Returns a single page of stock adjustments ordered by creation time, most recent "
+                    + "first. The pageNo and pageSize parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of stock adjustments returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
     public ResponseEntity<Page<StockAdjustmentDto>> readAllStockAdjustmentsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
@@ -40,18 +69,52 @@ public class StockAdjustmentControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a stock adjustment by id",
+            description = "Returns a single stock adjustment document, including its header fields and line "
+                    + "items."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
+    })
     public ResponseEntity<StockAdjustmentDto> readAStockAdjustment(@PathVariable Long id) {
         return new ResponseEntity<>(stockAdjustmentService.getById(id), HttpStatus.OK);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create a stock adjustment",
+            description = "Records a stock adjustment document capturing the counted and system quantities, "
+                    + "variance and justification for one or more materials at a location. In the current "
+                    + "scope the document is persisted as a record only; it does not yet post inventory "
+                    + "transactions or change the current stock balance."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Stock adjustment created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "The referenced location or project, or a material on one of the line items, was not found")
+    })
     public ResponseEntity<StockAdjustmentDto> createStockAdjustment(@Valid @RequestBody StockAdjustmentCreationDto creationDto) {
         return new ResponseEntity<>(stockAdjustmentService.create(creationDto), HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Update a stock adjustment",
+            description = "Replaces the header fields and line items of an existing stock adjustment with "
+                    + "the given values."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A required field is missing or failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id, or the referenced location, project, or a material on one of the line items was not found")
+    })
     public ResponseEntity<StockAdjustmentDto> updateStockAdjustment(@PathVariable Long id,
                                                                     @Valid @RequestBody StockAdjustmentCreationDto creationDto) {
         return new ResponseEntity<>(stockAdjustmentService.update(id, creationDto), HttpStatus.OK);
@@ -59,6 +122,15 @@ public class StockAdjustmentControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete a stock adjustment",
+            description = "Deletes the stock adjustment with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteStockAdjustment(@PathVariable Long id) {
         stockAdjustmentService.delete(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.stockAdjustment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -7,26 +8,56 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Payload to create or update a stock adjustment document correcting on-hand quantities of materials against a physical count.")
 @Data
 public class StockAdjustmentCreationDto {
 
+    @Schema(description = "Unique adjustment document number.", example = "SA-2026-0014")
     private String adjustmentNumber;
+
+    @Schema(description = "Type of adjustment.", example = "PHYSICAL_COUNT")
     private String type;
+
+    @Schema(description = "Status of the adjustment document.", example = "DRAFT")
     private String status;
+
+    @Schema(description = "Id of the storage location the adjustment applies to.", example = "7")
     private Long locationId;
+
+    @Schema(description = "Id of the project the adjustment applies to.", example = "4")
     private Long projectId;
+
+    @Schema(description = "Date the adjustment document was raised.", example = "2026-01-15")
     private LocalDate adjustmentDate;
+
+    @Schema(description = "Date the adjustment takes effect on the stock ledger.", example = "2026-01-15")
     private LocalDate effectiveDate;
 
+    @Schema(description = "Justification for the adjustment.", example = "Quarterly physical count found a shortfall in River Sand at Main Site Store")
     @NotBlank
     private String justification;
 
+    @Schema(description = "Primary reason category for the adjustment.", example = "PHYSICAL_COUNT_VARIANCE")
     private String primaryReason;
+
+    @Schema(description = "Total monetary value of the adjustment across all line items.", example = "18500.00")
     private BigDecimal totalAdjustmentValue;
+
+    @Schema(description = "Date the physical count was performed.", example = "2026-01-14")
     private LocalDate physicalCountDate;
+
+    @Schema(description = "Id of the employee who performed the physical count.", example = "18")
     private Long physicalCountBy;
+
+    @Schema(description = "Method used to perform the physical count.", example = "FULL_COUNT")
     private String countMethod;
+
+    @Schema(description = "Id of the employee who submitted the adjustment.", example = "18")
     private Long submittedBy;
+
+    @Schema(description = "Total variance quantity across all line items.", example = "-120.0")
     private Double totalVarianceQuantity;
+
+    @Schema(description = "Line items, one per material, listing the system quantity, the counted quantity, and the variance.")
     private List<StockAdjustmentLineItemCreationDto> lineItems;
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.stockAdjustment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -7,36 +8,96 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A stock adjustment document correcting on-hand quantities of materials against a physical count, with its workflow and audit fields.")
 @Data
 public class StockAdjustmentDto {
+    @Schema(description = "Id of the stock adjustment.", example = "14")
     private Long id;
+
+    @Schema(description = "Unique adjustment document number.", example = "SA-2026-0014")
     private String adjustmentNumber;
+
+    @Schema(description = "Type of adjustment.", example = "PHYSICAL_COUNT")
     private String type;
+
+    @Schema(description = "Status of the adjustment document.", example = "APPROVED")
     private String status;
+
+    @Schema(description = "Id of the storage location the adjustment applies to.", example = "7")
     private Long locationId;
+
+    @Schema(description = "Name of the storage location.", example = "Main Site Store")
     private String locationName;
+
+    @Schema(description = "Id of the project the adjustment applies to.", example = "4")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes - Kochi Phase 2")
     private String projectName;
+
+    @Schema(description = "Id of the owning organization.", example = "1")
     private Long organizationId;
+
+    @Schema(description = "Date the adjustment document was raised.", example = "2026-01-15")
     private LocalDate adjustmentDate;
+
+    @Schema(description = "Date the adjustment takes effect on the stock ledger.", example = "2026-01-15")
     private LocalDate effectiveDate;
+
+    @Schema(description = "Total monetary value of the adjustment across all line items.", example = "18500.00")
     private BigDecimal totalAdjustmentValue;
+
+    @Schema(description = "Primary reason category for the adjustment.", example = "PHYSICAL_COUNT_VARIANCE")
     private String primaryReason;
+
+    @Schema(description = "Justification for the adjustment.", example = "Quarterly physical count found a shortfall in River Sand at Main Site Store")
     private String justification;
+
+    @Schema(description = "Date the physical count was performed.", example = "2026-01-14")
     private LocalDate physicalCountDate;
+
+    @Schema(description = "Id of the employee who performed the physical count.", example = "18")
     private Long physicalCountBy;
+
+    @Schema(description = "Method used to perform the physical count.", example = "FULL_COUNT")
     private String countMethod;
+
+    @Schema(description = "Id of the employee who submitted the adjustment.", example = "18")
     private Long submittedBy;
+
+    @Schema(description = "Date and time the adjustment was submitted.", example = "2026-01-15T10:00:00")
     private LocalDateTime submittedAt;
+
+    @Schema(description = "Id of the employee who approved the adjustment.", example = "3")
     private Long approvedBy;
+
+    @Schema(description = "Date and time the adjustment was approved.", example = "2026-01-16T09:00:00")
     private LocalDateTime approvedAt;
+
+    @Schema(description = "Id of the employee who rejected the adjustment, if it was rejected.", example = "3")
     private Long rejectedBy;
+
+    @Schema(description = "Date and time the adjustment was rejected, if it was rejected.", example = "2026-01-16T09:00:00")
     private LocalDateTime rejectedAt;
+
+    @Schema(description = "Reason given for rejecting the adjustment.", example = "Variance not supported by the count sheet")
     private String rejectionReason;
+
+    @Schema(description = "Id of the employee who processed the adjustment.", example = "3")
     private Long processedBy;
+
+    @Schema(description = "Date and time the adjustment was processed.", example = "2026-01-16T11:00:00")
     private LocalDateTime processedAt;
+
+    @Schema(description = "Total variance quantity across all line items.", example = "-120.0")
     private Double totalVarianceQuantity;
+
+    @Schema(description = "Line items, one per material, listing the system quantity, the counted quantity, and the variance.")
     private List<StockAdjustmentLineItemDto> lineItems;
+
+    @Schema(description = "Date and time the record was created.", example = "2026-01-15T09:45:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Date and time the record was last updated.", example = "2026-01-16T11:00:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
@@ -1,22 +1,49 @@
 package org.tornotron.echno_backend.stockAdjustment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "A single material line on a stock adjustment, comparing the system quantity to the physically counted quantity.")
 @Data
 public class StockAdjustmentLineItemCreationDto {
+    @Schema(description = "Id of the material being adjusted.", example = "21")
     private Long materialId;
+
+    @Schema(description = "Free-text description of the line item.", example = "OPC 53 Grade Cement, damaged bags found during count")
     private String description;
+
+    @Schema(description = "Quantity on record before the adjustment.", example = "480.0")
     private Double systemQuantity;
+
+    @Schema(description = "Quantity found during the physical count.", example = "460.0")
     private Double physicalQuantity;
+
+    @Schema(description = "Adjustment quantity (physical minus system).", example = "-20.0")
     private Double adjustmentQuantity;
+
+    @Schema(description = "Unit of measure for the quantities.", example = "bags")
     private String unit;
+
+    @Schema(description = "Value per unit.", example = "380.00")
     private BigDecimal unitValue;
+
+    @Schema(description = "Total monetary value of this line's adjustment.", example = "-7600.00")
     private BigDecimal totalAdjustmentValue;
+
+    @Schema(description = "Reason category for this line's variance.", example = "DAMAGE")
     private String reason;
+
+    @Schema(description = "Additional detail on the reason.", example = "Bags damaged by moisture ingress near the store roof")
     private String reasonDetails;
+
+    @Schema(description = "Id of the storage location this line item was counted at.", example = "7")
     private Long locationId;
+
+    @Schema(description = "Bin or rack location within the storage location.", example = "Rack B-3")
     private String binLocation;
+
+    @Schema(description = "Additional notes for this line item.", example = "Photos attached to the count sheet")
     private String notes;
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
@@ -1,25 +1,58 @@
 package org.tornotron.echno_backend.stockAdjustment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Schema(description = "A single material line on a stock adjustment, comparing the system quantity to the physically counted quantity.")
 @Data
 public class StockAdjustmentLineItemDto {
+    @Schema(description = "Id of the line item.", example = "56")
     private Long id;
+
+    @Schema(description = "Id of the material being adjusted.", example = "21")
     private Long materialId;
+
+    @Schema(description = "Name of the material.", example = "OPC 53 Grade Cement")
     private String materialName;
+
+    @Schema(description = "Free-text description of the line item.", example = "Damaged bags found during count")
     private String description;
+
+    @Schema(description = "Quantity on record before the adjustment.", example = "480.0")
     private Double systemQuantity;
+
+    @Schema(description = "Quantity found during the physical count.", example = "460.0")
     private Double physicalQuantity;
+
+    @Schema(description = "Adjustment quantity (physical minus system).", example = "-20.0")
     private Double adjustmentQuantity;
+
+    @Schema(description = "Unit of measure for the quantities.", example = "bags")
     private String unit;
+
+    @Schema(description = "Value per unit.", example = "380.00")
     private BigDecimal unitValue;
+
+    @Schema(description = "Total monetary value of this line's adjustment.", example = "-7600.00")
     private BigDecimal totalAdjustmentValue;
+
+    @Schema(description = "Reason category for this line's variance.", example = "DAMAGE")
     private String reason;
+
+    @Schema(description = "Additional detail on the reason.", example = "Bags damaged by moisture ingress near the store roof")
     private String reasonDetails;
+
+    @Schema(description = "Id of the storage location this line item was counted at.", example = "7")
     private Long locationId;
+
+    @Schema(description = "Name of the storage location.", example = "Main Site Store")
     private String locationName;
+
+    @Schema(description = "Bin or rack location within the storage location.", example = "Rack B-3")
     private String binLocation;
+
+    @Schema(description = "Additional notes for this line item.", example = "Photos attached to the count sheet")
     private String notes;
 }

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
@@ -1,5 +1,9 @@
 package org.tornotron.echno_backend.storageLocation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/storage-locations")
 @Validated
+@Tag(
+        name = "Storage Locations",
+        description = "Physical places where inventory is held, such as a site store, a central warehouse "
+                + "or a godown. A location carries a name, type, optional project link and coordinates. "
+                + "Endpoints cover creating a location and listing or looking one up by id, project or "
+                + "type. Access is gated by the storage-location authorities, with an admin authority "
+                + "that grants all operations."
+)
 public class StorageLocationController {
 
     private final StorageLocationService storageLocationService;
@@ -26,6 +38,18 @@ public class StorageLocationController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "Create a storage location",
+            description = "Creates a storage location, such as \"Central Warehouse - Chennai\" or "
+                    + "\"Site B Yard\". The project link is optional since a central warehouse or godown "
+                    + "can serve more than one project."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Storage location created"),
+            @ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location admin authority"),
+            @ApiResponse(responseCode = "409", description = "A storage location with the same name already exists in the organization")
+    })
     public ResponseEntity<StorageLocationDto> createStorageLocation(
             @Valid @RequestBody StorageLocationCreationDto creationDto) {
         StorageLocationDto storageLocation = storageLocationService.createStorageLocation(creationDto);
@@ -34,6 +58,16 @@ public class StorageLocationController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "Get a storage location by id",
+            description = "Returns a single storage location, including its resolved project name and "
+                    + "current stored-items count."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Storage location found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority"),
+            @ApiResponse(responseCode = "404", description = "No storage location with the given id")
+    })
     public ResponseEntity<StorageLocationDto> getStorageLocationById(@PathVariable Long id) {
         StorageLocationDto storageLocation = storageLocationService.getStorageLocationById(id);
         return ResponseEntity.ok(storageLocation);
@@ -41,6 +75,14 @@ public class StorageLocationController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "List all storage locations",
+            description = "Returns every storage location in the caller's organization, unpaginated."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
+    })
     public ResponseEntity<List<StorageLocationDto>> getAllStorageLocations() {
         List<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations();
         return ResponseEntity.ok(storageLocations);
@@ -48,6 +90,15 @@ public class StorageLocationController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "List storage locations, paginated",
+            description = "Returns a single page of storage locations. The pageNo and pageSize "
+                    + "parameters control paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of storage locations returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
+    })
     public ResponseEntity<Page<StorageLocationDto>> getAllStorageLocationsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
@@ -57,6 +108,15 @@ public class StorageLocationController {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "List storage locations for a project",
+            description = "Returns the storage locations linked to the given project id, for example the "
+                    + "site stores serving a particular construction site."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
+    })
     public ResponseEntity<List<StorageLocationDto>> getStorageLocationsByProject(@PathVariable Long projectId) {
         List<StorageLocationDto> storageLocations = storageLocationService.getStorageLocationsByProject(projectId);
         return ResponseEntity.ok(storageLocations);
@@ -64,6 +124,16 @@ public class StorageLocationController {
 
     @GetMapping("/type/{locationType}")
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
+    @Operation(
+            summary = "List storage locations by type",
+            description = "Returns the storage locations of the given type, for example all WAREHOUSE "
+                    + "locations across the organization."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @ApiResponse(responseCode = "400", description = "locationType is not a recognized storage location type"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
+    })
     public ResponseEntity<List<StorageLocationDto>> getStorageLocationsByType(
             @PathVariable StorageLocationType locationType) {
         List<StorageLocationDto> storageLocations = storageLocationService.getStorageLocationsByType(locationType);

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.storageLocation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -18,6 +21,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/storage-locations/web")
 @Validated
+@Tag(
+        name = "Storage Locations (Web)",
+        description = "Web-console counterpart of the storage location API, gated by organization role "
+                + "instead of a flat authority. Covers the same create, read and lookup operations as the "
+                + "mobile API plus partial update and delete, which the mobile API does not expose. Every "
+                + "operation requires the system-admin role in the caller's current tenant."
+)
 public class StorageLocationControllerWeb {
 
     private final StorageLocationService storageLocationService;
@@ -28,6 +38,18 @@ public class StorageLocationControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a storage location",
+            description = "Creates a storage location, such as \"Central Warehouse - Chennai\" or "
+                    + "\"Site B Yard\". The project link is optional since a central warehouse or godown "
+                    + "can serve more than one project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Storage location created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "A storage location with the same name already exists in the organization")
+    })
     public ResponseEntity<StorageLocationDto> createStorageLocation(
             @Valid @RequestBody StorageLocationCreationDto creationDto) {
         StorageLocationDto storageLocation = storageLocationService.createStorageLocation(creationDto);
@@ -36,6 +58,16 @@ public class StorageLocationControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a storage location by id",
+            description = "Returns a single storage location, including its resolved project name and "
+                    + "current stored-items count."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage location found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No storage location with the given id")
+    })
     public ResponseEntity<StorageLocationDto> getStorageLocationById(@PathVariable Long id) {
         StorageLocationDto storageLocation = storageLocationService.getStorageLocationById(id);
         return ResponseEntity.ok(storageLocation);
@@ -43,6 +75,14 @@ public class StorageLocationControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List all storage locations",
+            description = "Returns every storage location in the caller's organization, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<StorageLocationDto>> getAllStorageLocations() {
         List<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations();
         return ResponseEntity.ok(storageLocations);
@@ -50,6 +90,15 @@ public class StorageLocationControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List storage locations, paginated",
+            description = "Returns a single page of storage locations. The pageNo and pageSize "
+                    + "parameters control paging."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of storage locations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<StorageLocationDto>> getAllStorageLocationsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
@@ -59,6 +108,15 @@ public class StorageLocationControllerWeb {
 
     @GetMapping("/project/{projectId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List storage locations for a project",
+            description = "Returns the storage locations linked to the given project id, for example the "
+                    + "site stores serving a particular construction site."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<StorageLocationDto>> getStorageLocationsByProject(@PathVariable Long projectId) {
         List<StorageLocationDto> storageLocations = storageLocationService.getStorageLocationsByProject(projectId);
         return ResponseEntity.ok(storageLocations);
@@ -66,6 +124,16 @@ public class StorageLocationControllerWeb {
 
     @GetMapping("/type/{locationType}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List storage locations by type",
+            description = "Returns the storage locations of the given type, for example all WAREHOUSE "
+                    + "locations across the organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage locations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "locationType is not a recognized storage location type"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<StorageLocationDto>> getStorageLocationsByType(
             @PathVariable StorageLocationType locationType) {
         List<StorageLocationDto> storageLocations = storageLocationService.getStorageLocationsByType(locationType);
@@ -74,6 +142,19 @@ public class StorageLocationControllerWeb {
 
     @PatchMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a storage location",
+            description = "Applies a partial update to a storage location. Only the fields present in the "
+                    + "request body are changed; a location name change is checked against other "
+                    + "locations in the organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage location updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No storage location with the given id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Another storage location already uses the requested name")
+    })
     public ResponseEntity<StorageLocationDto> updateStorageLocation(
             @PathVariable Long id,
             @Valid @RequestBody StorageLocationUpdateDto updateDto) {
@@ -83,6 +164,15 @@ public class StorageLocationControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a storage location",
+            description = "Deletes the storage location with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage location deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No storage location with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteStorageLocation(@PathVariable Long id) {
         storageLocationService.deleteStorageLocation(id);
         return ResponseEntity.ok(new ApiResponse("Storage location with id: " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
@@ -1,30 +1,43 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to create a storage location where inventory is held, such as a site "
+        + "store, a central warehouse or a godown.")
 @Data
 public class StorageLocationCreationDto {
 
+    @Schema(description = "Name of the storage location.", example = "Central Warehouse - Chennai")
     @NotBlank(message = "location name is required")
     @Size(min = 1, max = 100, message = "location name must be between 1 and 100 characters")
     private String locationName;
 
+    @Schema(description = "Type of storage location. One of PROJECT_SITE, WAREHOUSE, GODOWN, "
+            + "HEAD_OFFICE, PROCESSING_PLANT or OTHERS.", example = "WAREHOUSE")
     @NotBlank(message = "location type is required")
     private String locationType;
 
+    @Schema(description = "Postal address of the storage location.", example = "Plot 14, Ambattur Industrial Estate, Chennai")
     @Size(max = 255, message = "address must not exceed 255 characters")
     private String address;
 
+    @Schema(description = "Storage capacity, free text since units vary by material.", example = "5000 sq ft")
     private String capacity;
 
+    @Schema(description = "Whether the storage location is currently active.", example = "true")
     private boolean isActive;
 
+    @Schema(description = "Id of the project this location serves. Optional, a central warehouse or "
+            + "godown may serve more than one project.", example = "12")
     private Long projectId;
 
+    @Schema(description = "Latitude of the storage location.", example = "13.0827")
     private Float latitude;
 
+    @Schema(description = "Longitude of the storage location.", example = "80.2707")
     private Float longitude;
 }

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationDto.java
@@ -1,20 +1,44 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
 
+@Schema(description = "Storage location where inventory is held, such as a site store, a central "
+        + "warehouse or a godown.")
 @Data
 public class StorageLocationDto {
 
+    @Schema(description = "Id of the storage location.", example = "18")
     private Long id;
+
+    @Schema(description = "Name of the storage location.", example = "Central Warehouse - Chennai")
     private String locationName;
+
+    @Schema(description = "Type of storage location.", example = "WAREHOUSE")
     private StorageLocationType locationType;
+
+    @Schema(description = "Postal address of the storage location.", example = "Plot 14, Ambattur Industrial Estate, Chennai")
     private String address;
+
+    @Schema(description = "Id of the project this location serves, if any.", example = "12")
     private Long projectId;
+
+    @Schema(description = "Name of the project this location serves, if any.", example = "Asset Homes - Site B")
     private String projectName;
+
+    @Schema(description = "Storage capacity, free text since units vary by material.", example = "5000 sq ft")
     private String capacity;
+
+    @Schema(description = "Whether the storage location is currently active.", example = "true")
     private boolean isActive;
+
+    @Schema(description = "Count of distinct items currently stocked at this location.", example = "42")
     private Long storageItemsCount;
+
+    @Schema(description = "Latitude of the storage location.", example = "13.0827")
     private Float latitude;
+
+    @Schema(description = "Longitude of the storage location.", example = "80.2707")
     private Float longitude;
 }

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
@@ -1,26 +1,38 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "Payload to partially update a storage location. Only the fields present in the "
+        + "request are changed.")
 @Data
 public class StorageLocationUpdateDto {
 
+    @Schema(description = "New name for the storage location.", example = "Central Warehouse - Chennai")
     @Size(min = 1, max = 100, message = "location name must be between 1 and 100 characters")
     private String locationName;
 
+    @Schema(description = "New type for the storage location. One of PROJECT_SITE, WAREHOUSE, GODOWN, "
+            + "HEAD_OFFICE, PROCESSING_PLANT or OTHERS.", example = "GODOWN")
     private String locationType;
 
+    @Schema(description = "New postal address for the storage location.", example = "Plot 14, Ambattur Industrial Estate, Chennai")
     @Size(max = 255, message = "address must not exceed 255 characters")
     private String address;
 
+    @Schema(description = "New storage capacity, free text since units vary by material.", example = "6000 sq ft")
     private String capacity;
 
+    @Schema(description = "New active status for the storage location.", example = "true")
     private Boolean isActive;
 
+    @Schema(description = "New latitude of the storage location.", example = "13.0827")
     private Float latitude;
 
+    @Schema(description = "New longitude of the storage location.", example = "80.2707")
     private Float longitude;
 
+    @Schema(description = "New project id this location serves.", example = "12")
     private Long projectId;
 }

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.subcontract;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,13 @@ import java.util.List;
 @RestController
 @Validated
 @RequestMapping("/api/v1/sub-contracts/web")
+@Tag(
+        name = "Subcontracts",
+        description = "Contracts placed with subcontractors for labor, material supply, equipment rental "
+                + "or services on a project, including payment milestones, ratings and completion "
+                + "tracking. Read access requires tenant membership; creating, updating and deleting are "
+                + "restricted to system-admin or project-manager."
+)
 public class SubContractControllerWeb {
 
     private final SubContractService subContractService;
@@ -26,12 +36,29 @@ public class SubContractControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List all subcontracts",
+            description = "Returns every subcontract for the current tenant, unpaginated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subcontracts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<SubContractDto>> readAllSubContracts() {
         return new ResponseEntity<>(subContractService.getAll(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List subcontracts, paginated and filterable",
+            description = "Returns a single page of subcontracts. Supports a free-text search over "
+                    + "contract and contractor name, and filtering by status or contract type."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of subcontracts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<SubContractDto>> readAllSubContractsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
@@ -43,18 +70,47 @@ public class SubContractControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a subcontract by id",
+            description = "Returns a single subcontract, including its milestones, ratings and payment totals."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subcontract found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No subcontract with the given id")
+    })
     public ResponseEntity<SubContractDto> readASubContract(@PathVariable Long id) {
         return new ResponseEntity<>(subContractService.getById(id), HttpStatus.OK);
     }
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create a subcontract",
+            description = "Creates a subcontract with a contractor, its scope of work, contract value, "
+                    + "payment terms and optional milestones."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Subcontract created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "contractName or contractorName is missing"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<SubContractDto> createSubContract(@Valid @RequestBody SubContractCreationDto creationDto) {
         return new ResponseEntity<>(subContractService.create(creationDto), HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Update a subcontract",
+            description = "Replaces the subcontract's details, including its milestone list, with the given payload."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subcontract updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "contractName or contractorName is missing"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No subcontract with the given id")
+    })
     public ResponseEntity<SubContractDto> updateSubContract(@PathVariable Long id,
                                                             @Valid @RequestBody SubContractCreationDto creationDto) {
         return new ResponseEntity<>(subContractService.update(id, creationDto), HttpStatus.OK);
@@ -62,6 +118,15 @@ public class SubContractControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete a subcontract",
+            description = "Deletes the subcontract with the given id, along with its milestones."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subcontract deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No subcontract with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteSubContract(@PathVariable Long id) {
         subContractService.delete(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/ContractMilestoneDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/ContractMilestoneDto.java
@@ -1,18 +1,35 @@
 package org.tornotron.echno_backend.subcontract.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "A payment milestone within a subcontract.")
 @Data
 public class ContractMilestoneDto {
+    @Schema(description = "Milestone id.", example = "51")
     private Long id;
+
+    @Schema(description = "Name of the milestone.", example = "Ground floor slab casting")
     private String name;
+
+    @Schema(description = "Description of the work due at this milestone.", example = "Shuttering, reinforcement and concreting of the ground floor slab")
     private String description;
+
+    @Schema(description = "Planned completion date.", example = "2026-03-15")
     private LocalDate targetDate;
+
+    @Schema(description = "Actual completion date, once reached.", example = "2026-03-20")
     private LocalDate completionDate;
+
+    @Schema(description = "Percentage of the contract value released at this milestone.", example = "20.00")
     private BigDecimal paymentPercentage;
+
+    @Schema(description = "Payment amount for this milestone in INR.", example = "640000.00")
     private BigDecimal amount;
+
+    @Schema(description = "Status of the milestone.", example = "PENDING")
     private String status;
 }

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.subcontract.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -7,66 +8,138 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(description = "Payload to create or fully update a subcontract with a contractor.")
 @Data
 public class SubContractCreationDto {
 
+    @Schema(description = "Human-readable contract reference, if different from the generated id.", example = "SC-2026-0011")
     private String contractId;
 
+    @Schema(description = "Name of the contract.", example = "Structural steel fabrication, Block C")
     @NotBlank
     private String contractName;
 
+    @Schema(description = "Description of the work covered by the contract.", example = "Fabrication and erection of structural steel for Block C, ground plus four floors")
     private String workDescription;
+
+    @Schema(description = "Detailed scope of work.", example = "Includes shop drawings, fabrication, transport and site erection; excludes painting")
     private String scopeOfWork;
 
+    @Schema(description = "Name of the contracting firm or individual.", example = "Muthoot Structural Contractors")
     @NotBlank
     private String contractorName;
 
+    @Schema(description = "Contact person at the contractor.", example = "Sunil Muthoot")
     private String contractorContactPerson;
+
+    @Schema(description = "Contractor's phone number.", example = "9847098470")
     private String contractorPhone;
+
+    @Schema(description = "Contractor's email address.", example = "sunil@muthootstructural.in")
     private String contractorEmail;
+
+    @Schema(description = "Contractor's registered address.", example = "Industrial Estate, Kalamassery, Kochi")
     private String contractorAddress;
+
+    @Schema(description = "Contractor's GST registration number.", example = "32AAECM1234F1Z5")
     private String contractorGst;
+
+    @Schema(description = "Contractor's PAN.", example = "AAECM1234F")
     private String contractorPan;
+
+    @Schema(description = "Contractor's trade or work license number.", example = "KL/STL/2024/0087")
     private String contractorLicense;
 
+    @Schema(description = "Type of subcontract.", example = "LABOR_CONTRACT")
     private String type;
+
+    @Schema(description = "Lifecycle status of the subcontract.", example = "ACTIVE")
     private String status;
 
+    @Schema(description = "Total contract value in INR.", example = "3200000.00")
     private BigDecimal contractValue;
+
+    @Schema(description = "Currency code for the contract value.", example = "INR")
     private String currency;
+
+    @Schema(description = "Mobilization advance paid upfront, in INR.", example = "320000.00")
     private BigDecimal mobilizationAdvance;
+
+    @Schema(description = "Retention percentage held back from each payment.", example = "5.00")
     private BigDecimal retentionPercentage;
+
+    @Schema(description = "Total amount paid to the contractor so far, in INR.", example = "1200000.00")
     private BigDecimal totalPaid;
+
+    @Schema(description = "Total amount still due to the contractor, in INR.", example = "2000000.00")
     private BigDecimal totalDue;
+
+    @Schema(description = "Agreed payment terms.", example = "30 percent advance, balance against milestone certification")
     private String paymentTerms;
 
+    @Schema(description = "Contract start date.", example = "2026-01-15")
     private LocalDate startDate;
+
+    @Schema(description = "Contract end date.", example = "2026-06-30")
     private LocalDate endDate;
+
+    @Schema(description = "Actual completion date, once finished.", example = "2026-07-05")
     private LocalDate actualCompletionDate;
+
+    @Schema(description = "Percentage of work completed.", example = "45.00")
     private BigDecimal completionPercentage;
 
+    @Schema(description = "Id of the project this subcontract belongs to.", example = "3")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
     private String projectName;
 
+    @Schema(description = "Quality rating out of 5.", example = "4.20")
     private BigDecimal qualityRating;
+
+    @Schema(description = "Timeliness rating out of 5.", example = "3.80")
     private BigDecimal timelinessRating;
+
+    @Schema(description = "Safety rating out of 5.", example = "4.50")
     private BigDecimal safetyRating;
+
+    @Schema(description = "Overall rating out of 5.", example = "4.20")
     private BigDecimal overallRating;
 
+    @Schema(description = "Name of the insurance provider covering the work.", example = "New India Assurance")
     private String insuranceProvider;
+
+    @Schema(description = "Insurance policy number.", example = "NIA-CAR-2026-44210")
     private String insurancePolicyNumber;
+
+    @Schema(description = "Insurance expiry date.", example = "2026-12-31")
     private LocalDate insuranceExpiry;
 
+    @Schema(description = "Contractor's bank name for payments.", example = "Federal Bank")
     private String bankName;
+
+    @Schema(description = "Contractor's bank account number.", example = "15920100012345")
     private String bankAccountNumber;
+
+    @Schema(description = "Contractor's bank IFSC code.", example = "FDRL0001592")
     private String bankIfsc;
 
+    @Schema(description = "Id of the employee supervising the contract on site.", example = "9")
     private Long supervisorId;
+
+    @Schema(description = "Id of the employee handling the contract's payments.", example = "11")
     private Long accountManagerId;
 
+    @Schema(description = "Penalty clause for delay or non-performance.", example = "0.5 percent of contract value per week of delay, capped at 5 percent")
     private String penaltyClause;
+
+    @Schema(description = "Warranty or defect liability period.", example = "12 months from completion")
     private String warrantyPeriod;
+
+    @Schema(description = "Free-text notes.", example = "Contractor previously worked on Phase 1 tower")
     private String notes;
 
+    @Schema(description = "Payment milestones for the contract.")
     private List<ContractMilestoneDto> milestones;
 }

--- a/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractDto.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/dto/SubContractDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.subcontract.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -7,65 +8,147 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A subcontract with the contractor, terms, milestones and ratings.")
 @Data
 public class SubContractDto {
+    @Schema(description = "Subcontract id.", example = "18")
     private Long id;
+
+    @Schema(description = "Human-readable contract reference.", example = "SC-2026-0011")
     private String contractId;
+
+    @Schema(description = "Name of the contract.", example = "Structural steel fabrication, Block C")
     private String contractName;
+
+    @Schema(description = "Description of the work covered by the contract.", example = "Fabrication and erection of structural steel for Block C, ground plus four floors")
     private String workDescription;
+
+    @Schema(description = "Detailed scope of work.", example = "Includes shop drawings, fabrication, transport and site erection; excludes painting")
     private String scopeOfWork;
 
+    @Schema(description = "Name of the contracting firm or individual.", example = "Muthoot Structural Contractors")
     private String contractorName;
+
+    @Schema(description = "Contact person at the contractor.", example = "Sunil Muthoot")
     private String contractorContactPerson;
+
+    @Schema(description = "Contractor's phone number.", example = "9847098470")
     private String contractorPhone;
+
+    @Schema(description = "Contractor's email address.", example = "sunil@muthootstructural.in")
     private String contractorEmail;
+
+    @Schema(description = "Contractor's registered address.", example = "Industrial Estate, Kalamassery, Kochi")
     private String contractorAddress;
+
+    @Schema(description = "Contractor's GST registration number.", example = "32AAECM1234F1Z5")
     private String contractorGst;
+
+    @Schema(description = "Contractor's PAN.", example = "AAECM1234F")
     private String contractorPan;
+
+    @Schema(description = "Contractor's trade or work license number.", example = "KL/STL/2024/0087")
     private String contractorLicense;
 
+    @Schema(description = "Type of subcontract.", example = "LABOR_CONTRACT")
     private String type;
+
+    @Schema(description = "Lifecycle status of the subcontract.", example = "ACTIVE")
     private String status;
 
+    @Schema(description = "Total contract value in INR.", example = "3200000.00")
     private BigDecimal contractValue;
+
+    @Schema(description = "Currency code for the contract value.", example = "INR")
     private String currency;
+
+    @Schema(description = "Mobilization advance paid upfront, in INR.", example = "320000.00")
     private BigDecimal mobilizationAdvance;
+
+    @Schema(description = "Retention percentage held back from each payment.", example = "5.00")
     private BigDecimal retentionPercentage;
+
+    @Schema(description = "Total amount paid to the contractor so far, in INR.", example = "1200000.00")
     private BigDecimal totalPaid;
+
+    @Schema(description = "Total amount still due to the contractor, in INR.", example = "2000000.00")
     private BigDecimal totalDue;
+
+    @Schema(description = "Agreed payment terms.", example = "30 percent advance, balance against milestone certification")
     private String paymentTerms;
 
+    @Schema(description = "Contract start date.", example = "2026-01-15")
     private LocalDate startDate;
+
+    @Schema(description = "Contract end date.", example = "2026-06-30")
     private LocalDate endDate;
+
+    @Schema(description = "Actual completion date, once finished.", example = "2026-07-05")
     private LocalDate actualCompletionDate;
+
+    @Schema(description = "Percentage of work completed.", example = "45.00")
     private BigDecimal completionPercentage;
 
+    @Schema(description = "Id of the project this subcontract belongs to.", example = "3")
     private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
     private String projectName;
 
+    @Schema(description = "Quality rating out of 5.", example = "4.20")
     private BigDecimal qualityRating;
+
+    @Schema(description = "Timeliness rating out of 5.", example = "3.80")
     private BigDecimal timelinessRating;
+
+    @Schema(description = "Safety rating out of 5.", example = "4.50")
     private BigDecimal safetyRating;
+
+    @Schema(description = "Overall rating out of 5.", example = "4.20")
     private BigDecimal overallRating;
 
+    @Schema(description = "Name of the insurance provider covering the work.", example = "New India Assurance")
     private String insuranceProvider;
+
+    @Schema(description = "Insurance policy number.", example = "NIA-CAR-2026-44210")
     private String insurancePolicyNumber;
+
+    @Schema(description = "Insurance expiry date.", example = "2026-12-31")
     private LocalDate insuranceExpiry;
 
+    @Schema(description = "Contractor's bank name for payments.", example = "Federal Bank")
     private String bankName;
+
+    @Schema(description = "Contractor's bank account number.", example = "15920100012345")
     private String bankAccountNumber;
+
+    @Schema(description = "Contractor's bank IFSC code.", example = "FDRL0001592")
     private String bankIfsc;
 
+    @Schema(description = "Id of the employee supervising the contract on site.", example = "9")
     private Long supervisorId;
+
+    @Schema(description = "Id of the employee handling the contract's payments.", example = "11")
     private Long accountManagerId;
 
+    @Schema(description = "Penalty clause for delay or non-performance.", example = "0.5 percent of contract value per week of delay, capped at 5 percent")
     private String penaltyClause;
+
+    @Schema(description = "Warranty or defect liability period.", example = "12 months from completion")
     private String warrantyPeriod;
+
+    @Schema(description = "Free-text notes.", example = "Contractor previously worked on Phase 1 tower")
     private String notes;
 
+    @Schema(description = "Id of the owning organization.", example = "1")
     private Long organizationId;
+
+    @Schema(description = "Payment milestones for the contract.")
     private List<ContractMilestoneDto> milestones;
 
+    @Schema(description = "Timestamp the subcontract was created.", example = "2026-01-15T09:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "Timestamp the subcontract was last updated.", example = "2026-03-02T14:20:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -3,6 +3,9 @@ package org.tornotron.echno_backend.task;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +30,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/tasks/web")
 @Validated
+@Tag(
+        name = "Tasks",
+        description = "Web-client twin of the task endpoints. Adds listing tasks by project, alongside "
+                + "the same create, read, batch update and delete operations as the base task API. "
+                + "Access is gated by tenant membership, with mutations restricted to a system admin "
+                + "or project manager."
+)
 public class TaskControllerWeb {
 
     private final TaskService service;
@@ -52,6 +62,17 @@ public class TaskControllerWeb {
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Create a task",
+            description = "Creates a task from a multipart request. The data part carries the task "
+                    + "details as JSON and the optional attachments part carries supporting files. "
+                    + "Returns the created task as a simple view."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Task created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data,
                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
@@ -67,6 +88,15 @@ public class TaskControllerWeb {
      */
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List tasks",
+            description = "Returns a single page of tasks. The pageNo and pageSize parameters control "
+                    + "paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of tasks returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<TaskDto>> readAllTasks(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<TaskDto> tasks = service.getAllTasks(pageNo, pageSize);
@@ -76,6 +106,15 @@ public class TaskControllerWeb {
 
     @GetMapping("/projectId/{projectId}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List tasks for a project",
+            description = "Returns every task belonging to the given project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tasks returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
     public ResponseEntity<List<TaskDto>> readAllTasksForProject(@PathVariable Long projectId) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getTasksByProjectId(projectId));
     }
@@ -88,6 +127,16 @@ public class TaskControllerWeb {
      */
     @GetMapping("{id}")
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a task by id",
+            description = "Returns a single task including its creator, assignees, category, issues and "
+                    + "attachments."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<?> readATask(@PathVariable Long id) {
         TaskDto taskDto = service.getATask(id);
         return new ResponseEntity<>(taskDto, HttpStatus.OK);
@@ -101,6 +150,18 @@ public class TaskControllerWeb {
      */
     @PatchMapping(value = "{id}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Partially update a task",
+            description = "Applies field updates from a multipart request. The data part carries the "
+                    + "changed fields as JSON and the optional attachments part adds files under the "
+                    + "given entityType."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestPart(value = "data", required = false) String data,
                                                             @PathVariable Long id,
                                                             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
@@ -119,6 +180,16 @@ public class TaskControllerWeb {
      */
     @PatchMapping("/batch")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Batch update tasks",
+            description = "Applies partial updates to several tasks in one call. Each entry names a "
+                    + "task id and the map of fields to change on that task."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ApiResponse> batchUpdateTasks(@Valid @RequestBody List<TaskPatchDto> updates) {
         service.batchUpdateTasks(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -132,6 +203,15 @@ public class TaskControllerWeb {
      */
     @DeleteMapping("{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Delete a task",
+            description = "Deletes the task with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Task deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteATask(@PathVariable Long id) {
         service.deleteATask(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Task with id: " + id + " deleted"));

--- a/src/main/java/org/tornotron/echno_backend/user/UserController.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.user;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -24,6 +27,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/user")
 @Validated
+@Tag(
+        name = "Users",
+        description = "The platform account behind an employee, keyed to a Keycloak identity. Endpoints "
+                + "cover reading the caller's own profile, listing users and their organizations, "
+                + "batch and partial updates, and deletion. Most operations are restricted to a "
+                + "system or HR admin, except reads of one's own record."
+)
 public class UserController {
 
     private final UserService userService;
@@ -47,6 +57,15 @@ public class UserController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     @GetMapping("/all")
+    @Operation(
+            summary = "List users",
+            description = "Returns a single page of user accounts. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of users returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<UserDto> users = userService.getAllUsers(pageNo,pageSize);
@@ -61,6 +80,16 @@ public class UserController {
      */
     @PreAuthorize("@orgSecurity.isSelfUser(#userId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{userId}/organizations")
+    @Operation(
+            summary = "List a user's organizations",
+            description = "Returns every organization the given user belongs to. Callable by the user "
+                    + "themselves or by a system admin."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organizations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the user nor a system admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsForCurrentUser(@PathVariable Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getOrganizationsForCurrentUser(userId));
     }
@@ -72,6 +101,15 @@ public class UserController {
      */
     @PreAuthorize("isAuthenticated()")
     @GetMapping
+    @Operation(
+            summary = "Get the current user",
+            description = "Resolves the caller's user record from the subject claim of their access token."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Caller is not authenticated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user matches the token subject")
+    })
     public ResponseEntity<UserDto> readAnUser(JwtAuthenticationToken authenticationToken) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getAnUser(authenticationToken.getToken().getClaimAsString("sub")));
     }
@@ -85,6 +123,17 @@ public class UserController {
      */
     @PreAuthorize("@orgSecurity.isSelfUser(#id) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("{id}")
+    @Operation(
+            summary = "Partially update a user",
+            description = "Applies the given field updates to the user with the given id. Callable by the "
+                    + "user themselves or by a system admin."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the updated fields failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the user nor a system admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<UserDto> partialUpdateAUser(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.partialUpdateAnUser(updates, id));
     }
@@ -97,6 +146,16 @@ public class UserController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/batch")
+    @Operation(
+            summary = "Batch update users",
+            description = "Applies partial updates to several users in one call. Each entry names a user "
+                    + "id and the map of fields to change on that user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ApiResponse> batchUpdateUsers(@Valid @RequestBody List<UserPatchDto> updates) {
         userService.batchUpdateUser(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -110,6 +169,15 @@ public class UserController {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("{id}")
+    @Operation(
+            summary = "Delete a user",
+            description = "Deletes the user account with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnUser(@PathVariable Long id) {
         userService.deleteAnUser(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User with ID " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -3,6 +3,9 @@ package org.tornotron.echno_backend.user;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -24,6 +27,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/user/web")
 @Validated
+@Tag(
+        name = "Users",
+        description = "Web-client twin of the user endpoints. Adds the current-user shortcut, the "
+                + "employee memberships of the caller, and a multipart profile-update path for the "
+                + "profile picture and CV, alongside the same listing, batch update and delete "
+                + "operations as the base user API."
+)
 public class UserControllerWeb {
 
     private final UserService userService;
@@ -62,6 +72,15 @@ public class UserControllerWeb {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
     @GetMapping("/all")
+    @Operation(
+            summary = "List users",
+            description = "Returns a single page of user accounts. The pageNo and pageSize parameters "
+                    + "control paging; only the page content is returned, without paging metadata."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of users returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
                                                       @RequestParam(defaultValue = "10") int pageSize) {
         Page<UserDto> users = userService.getAllUsers(pageNo,pageSize);
@@ -76,6 +95,16 @@ public class UserControllerWeb {
      */
     @PreAuthorize("@orgSecurity.isSelfUser(#userId) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @GetMapping("/{userId}/organizations")
+    @Operation(
+            summary = "List a user's organizations",
+            description = "Returns every organization the given user belongs to. Callable by the user "
+                    + "themselves or by a system admin."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organizations returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the user nor a system admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<List<OrganizationDto>> readAllOrganizationsForCurrentUser(@PathVariable Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getOrganizationsForCurrentUser(userId));
     }
@@ -92,6 +121,15 @@ public class UserControllerWeb {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping
+    @Operation(
+            summary = "Get the current user",
+            description = "Resolves the caller's user record from their Keycloak identity."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Caller is not authenticated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user matches the caller's Keycloak identity")
+    })
     public ResponseEntity<UserDto> getCurrentUser() {
         String keycloakId = userContextService.getCurrentKeycloakId();
         return ResponseEntity.ok(userService.getCurrentUserDto(keycloakId));
@@ -99,6 +137,15 @@ public class UserControllerWeb {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/employees")
+    @Operation(
+            summary = "List the current user's employee records",
+            description = "Returns every employee record linked to the caller's user account, across "
+                    + "the organizations they belong to."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employee records returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Caller is not authenticated")
+    })
     public ResponseEntity<List<EmployeeDto>> getEmployeesForCurrentUser() {
         String keycloakId = userContextService.getCurrentKeycloakId();
         List<EmployeeDto> employees = userService.getEmployeesForUser(keycloakId);
@@ -116,6 +163,18 @@ public class UserControllerWeb {
      */
     @PreAuthorize("@orgSecurity.isSelfUser(#id) or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping(value = "{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "Partially update a user",
+            description = "Applies field updates from a multipart request. The data part carries the "
+                    + "changed fields as JSON, and the optional profilePicture and cv parts replace those "
+                    + "files. Callable by the user themselves or by a system admin."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the user nor a system admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<UserDto> partialUpdateAUser(
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
@@ -135,6 +194,16 @@ public class UserControllerWeb {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @PatchMapping("/batch")
+    @Operation(
+            summary = "Batch update users",
+            description = "Applies partial updates to several users in one call. Each entry names a user "
+                    + "id and the map of fields to change on that user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch update applied"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update entries failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<ApiResponse> batchUpdateUsers(@Valid @RequestBody List<UserPatchDto> updates) {
         userService.batchUpdateUser(updates);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Batch update successful"));
@@ -148,6 +217,15 @@ public class UserControllerWeb {
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @DeleteMapping("{id}")
+    @Operation(
+            summary = "Delete a user",
+            description = "Deletes the user account with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteAnUser(@PathVariable Long id) {
         userService.deleteAnUser(id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("User with ID " + id + " deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.vendor;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -15,6 +18,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/vendors")
 @Validated
+@Tag(
+        name = "Vendors",
+        description = "Suppliers that materials are purchased from, along with their contacts, tax "
+                + "identifiers, bank accounts and payment terms. A vendor carries a name and the nested "
+                + "records used for procurement and payables. Endpoints cover creating, browsing, "
+                + "searching, updating and deleting vendors and their sub-records, and reading a vendor "
+                + "summary. Access is tenant scoped and gated by the vendor authorities, with an admin "
+                + "authority that grants all operations."
+)
 public class VendorController {
 
     private final VendorService vendorService;
@@ -29,6 +41,15 @@ public class VendorController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('vendor:create') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Create a vendor",
+            description = "Creates a vendor record in the current tenant with its identifying details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Vendor created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor create or admin authority")
+    })
     public ResponseEntity<VendorDto> createVendor(@Valid @RequestBody VendorCreationDto creationDto) {
         VendorDto created = vendorService.createVendor(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -36,6 +57,15 @@ public class VendorController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Get a vendor by id",
+            description = "Returns a single vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorDto> getVendorById(@PathVariable Long id) {
         VendorDto vendor = vendorService.getVendorById(id);
         return ResponseEntity.ok(vendor);
@@ -43,6 +73,14 @@ public class VendorController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "List vendors",
+            description = "Returns every vendor in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority")
+    })
     public ResponseEntity<List<VendorDto>> getAllVendors() {
         List<VendorDto> vendors = vendorService.getAllVendors();
         return ResponseEntity.ok(vendors);
@@ -50,6 +88,14 @@ public class VendorController {
 
     @GetMapping("/all")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "List vendors (paged)",
+            description = "Returns a single page of vendors controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority")
+    })
     public ResponseEntity<Page<VendorDto>> getAllVendorsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -60,6 +106,14 @@ public class VendorController {
 
     @GetMapping("/search")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Search vendors by name",
+            description = "Returns vendors whose name matches the given search term."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Matching vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority")
+    })
     public ResponseEntity<List<VendorDto>> searchVendors(@RequestParam String name) {
         List<VendorDto> vendors = vendorService.searchVendorsByName(name);
         return ResponseEntity.ok(vendors);
@@ -67,6 +121,16 @@ public class VendorController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Update a vendor",
+            description = "Replaces the details of the vendor with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorDto> updateVendor(
             @PathVariable Long id,
             @Valid @RequestBody VendorCreationDto updateDto
@@ -77,6 +141,15 @@ public class VendorController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('vendor:delete') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Delete a vendor",
+            description = "Deletes the vendor with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteVendor(@PathVariable Long id) {
         vendorService.deleteVendor(id);
         return ResponseEntity.ok(new ApiResponse("Vendor with id: " + id + " deleted successfully"));
@@ -86,6 +159,15 @@ public class VendorController {
 
     @GetMapping("/{vendorId}/summary")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Get a vendor summary",
+            description = "Returns aggregated summary figures for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorSummaryDto> getVendorSummary(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorSummaryService.getVendorSummary(vendorId));
     }
@@ -94,12 +176,31 @@ public class VendorController {
 
     @GetMapping("/{vendorId}/contacts")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "List vendor contacts",
+            description = "Returns the contacts recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contacts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorContactDto>> getContacts(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getContactsByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/contacts")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Add a vendor contact",
+            description = "Adds a contact to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Contact created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorContactDto> addContact(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorContactCreationDto dto
@@ -109,6 +210,16 @@ public class VendorController {
 
     @PutMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Update a vendor contact",
+            description = "Replaces the details of a contact belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contact updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or contact with the given id")
+    })
     public ResponseEntity<VendorContactDto> updateContact(
             @PathVariable Long vendorId,
             @PathVariable Long contactId,
@@ -119,6 +230,15 @@ public class VendorController {
 
     @DeleteMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("hasAuthority('vendor:delete') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Delete a vendor contact",
+            description = "Deletes a contact belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contact deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or contact with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteContact(
             @PathVariable Long vendorId,
             @PathVariable Long contactId
@@ -131,12 +251,31 @@ public class VendorController {
 
     @GetMapping("/{vendorId}/tax-identifiers")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "List vendor tax identifiers",
+            description = "Returns the tax identifiers recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifiers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorTaxIdentifierDto>> getTaxIdentifiers(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getTaxIdentifiersByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/tax-identifiers")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Add a vendor tax identifier",
+            description = "Adds a tax identifier to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Tax identifier created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorTaxIdentifierDto> addTaxIdentifier(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorTaxIdentifierCreationDto dto
@@ -146,6 +285,16 @@ public class VendorController {
 
     @PutMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Update a vendor tax identifier",
+            description = "Replaces the details of a tax identifier belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifier updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or tax identifier with the given id")
+    })
     public ResponseEntity<VendorTaxIdentifierDto> updateTaxIdentifier(
             @PathVariable Long vendorId,
             @PathVariable Long taxIdId,
@@ -156,6 +305,15 @@ public class VendorController {
 
     @DeleteMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("hasAuthority('vendor:delete') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Delete a vendor tax identifier",
+            description = "Deletes a tax identifier belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifier deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or tax identifier with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteTaxIdentifier(
             @PathVariable Long vendorId,
             @PathVariable Long taxIdId
@@ -168,12 +326,31 @@ public class VendorController {
 
     @GetMapping("/{vendorId}/bank-accounts")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "List vendor bank accounts",
+            description = "Returns the bank accounts recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank accounts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorBankAccountDto>> getBankAccounts(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getBankAccountsByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/bank-accounts")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Add a vendor bank account",
+            description = "Adds a bank account to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Bank account created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorBankAccountDto> addBankAccount(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorBankAccountCreationDto dto
@@ -183,6 +360,16 @@ public class VendorController {
 
     @PutMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Update a vendor bank account",
+            description = "Replaces the details of a bank account belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank account updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or bank account with the given id")
+    })
     public ResponseEntity<VendorBankAccountDto> updateBankAccount(
             @PathVariable Long vendorId,
             @PathVariable Long accountId,
@@ -193,6 +380,15 @@ public class VendorController {
 
     @DeleteMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("hasAuthority('vendor:delete') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Delete a vendor bank account",
+            description = "Deletes a bank account belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank account deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or bank account with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteBankAccount(
             @PathVariable Long vendorId,
             @PathVariable Long accountId
@@ -205,12 +401,31 @@ public class VendorController {
 
     @GetMapping("/{vendorId}/payment-terms")
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Get vendor payment terms",
+            description = "Returns the payment terms recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorPaymentTermsDto> getPaymentTerms(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getPaymentTermsByVendorId(vendorId));
     }
 
     @PutMapping("/{vendorId}/payment-terms")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Set vendor payment terms",
+            description = "Sets or replaces the payment terms for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms set"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorPaymentTermsDto> setPaymentTerms(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorPaymentTermsCreationDto dto
@@ -220,6 +435,15 @@ public class VendorController {
 
     @DeleteMapping("/{vendorId}/payment-terms")
     @PreAuthorize("hasAuthority('vendor:delete') or hasAuthority('vendor:admin')")
+    @Operation(
+            summary = "Delete vendor payment terms",
+            description = "Deletes the payment terms recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor delete or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<ApiResponse> deletePaymentTerms(@PathVariable Long vendorId) {
         vendorService.deletePaymentTerms(vendorId);
         return ResponseEntity.ok(new ApiResponse("Payment terms deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.vendor;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -15,6 +18,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/vendors/web")
 @Validated
+@Tag(
+        name = "Vendors (Web)",
+        description = "Web-console counterpart of the vendors API, restricted to the system-admin role "
+                + "for the current tenant instead of the flat vendor authorities used by the mobile "
+                + "variant. Covers the same create, browse, search, update, delete and summary "
+                + "operations for vendors and their contacts, tax identifiers, bank accounts and "
+                + "payment terms, for use from the admin web console."
+)
 public class VendorControllerWeb {
 
     private final VendorService vendorService;
@@ -29,6 +40,15 @@ public class VendorControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a vendor",
+            description = "Creates a vendor record in the current tenant with its identifying details."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Vendor created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<VendorDto> createVendor(@Valid @RequestBody VendorCreationDto creationDto) {
         VendorDto created = vendorService.createVendor(creationDto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
@@ -36,6 +56,15 @@ public class VendorControllerWeb {
 
     @GetMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a vendor by id",
+            description = "Returns a single vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorDto> getVendorById(@PathVariable Long id) {
         VendorDto vendor = vendorService.getVendorById(id);
         return ResponseEntity.ok(vendor);
@@ -43,6 +72,14 @@ public class VendorControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List vendors",
+            description = "Returns every vendor in the current tenant."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<VendorDto>> getAllVendors() {
         List<VendorDto> vendors = vendorService.getAllVendors();
         return ResponseEntity.ok(vendors);
@@ -50,6 +87,14 @@ public class VendorControllerWeb {
 
     @GetMapping("/all")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List vendors (paged)",
+            description = "Returns a single page of vendors controlled by the pageNo and pageSize parameters."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<Page<VendorDto>> getAllVendorsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize
@@ -60,6 +105,14 @@ public class VendorControllerWeb {
 
     @GetMapping("/search")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Search vendors by name",
+            description = "Returns vendors whose name matches the given search term."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Matching vendors returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
     public ResponseEntity<List<VendorDto>> searchVendors(@RequestParam String name) {
         List<VendorDto> vendors = vendorService.searchVendorsByName(name);
         return ResponseEntity.ok(vendors);
@@ -67,6 +120,16 @@ public class VendorControllerWeb {
 
     @PutMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a vendor",
+            description = "Replaces the details of the vendor with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorDto> updateVendor(
             @PathVariable Long id,
             @Valid @RequestBody VendorCreationDto updateDto
@@ -77,6 +140,15 @@ public class VendorControllerWeb {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a vendor",
+            description = "Deletes the vendor with the given id."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteVendor(@PathVariable Long id) {
         vendorService.deleteVendor(id);
         return ResponseEntity.ok(new ApiResponse("Vendor with id: " + id + " deleted successfully"));
@@ -86,6 +158,15 @@ public class VendorControllerWeb {
 
     @GetMapping("/{vendorId}/summary")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a vendor summary",
+            description = "Returns aggregated summary figures for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendor summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorSummaryDto> getVendorSummary(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorSummaryService.getVendorSummary(vendorId));
     }
@@ -94,12 +175,31 @@ public class VendorControllerWeb {
 
     @GetMapping("/{vendorId}/contacts")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List vendor contacts",
+            description = "Returns the contacts recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contacts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorContactDto>> getContacts(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getContactsByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/contacts")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Add a vendor contact",
+            description = "Adds a contact to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Contact created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorContactDto> addContact(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorContactCreationDto dto
@@ -109,6 +209,16 @@ public class VendorControllerWeb {
 
     @PutMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a vendor contact",
+            description = "Replaces the details of a contact belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contact updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or contact with the given id")
+    })
     public ResponseEntity<VendorContactDto> updateContact(
             @PathVariable Long vendorId,
             @PathVariable Long contactId,
@@ -119,6 +229,15 @@ public class VendorControllerWeb {
 
     @DeleteMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a vendor contact",
+            description = "Deletes a contact belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Contact deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or contact with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteContact(
             @PathVariable Long vendorId,
             @PathVariable Long contactId
@@ -131,12 +250,31 @@ public class VendorControllerWeb {
 
     @GetMapping("/{vendorId}/tax-identifiers")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List vendor tax identifiers",
+            description = "Returns the tax identifiers recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifiers returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorTaxIdentifierDto>> getTaxIdentifiers(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getTaxIdentifiersByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/tax-identifiers")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Add a vendor tax identifier",
+            description = "Adds a tax identifier to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Tax identifier created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorTaxIdentifierDto> addTaxIdentifier(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorTaxIdentifierCreationDto dto
@@ -146,6 +284,16 @@ public class VendorControllerWeb {
 
     @PutMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a vendor tax identifier",
+            description = "Replaces the details of a tax identifier belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifier updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or tax identifier with the given id")
+    })
     public ResponseEntity<VendorTaxIdentifierDto> updateTaxIdentifier(
             @PathVariable Long vendorId,
             @PathVariable Long taxIdId,
@@ -156,6 +304,15 @@ public class VendorControllerWeb {
 
     @DeleteMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a vendor tax identifier",
+            description = "Deletes a tax identifier belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tax identifier deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or tax identifier with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteTaxIdentifier(
             @PathVariable Long vendorId,
             @PathVariable Long taxIdId
@@ -168,12 +325,31 @@ public class VendorControllerWeb {
 
     @GetMapping("/{vendorId}/bank-accounts")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List vendor bank accounts",
+            description = "Returns the bank accounts recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank accounts returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<List<VendorBankAccountDto>> getBankAccounts(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getBankAccountsByVendorId(vendorId));
     }
 
     @PostMapping("/{vendorId}/bank-accounts")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Add a vendor bank account",
+            description = "Adds a bank account to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Bank account created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorBankAccountDto> addBankAccount(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorBankAccountCreationDto dto
@@ -183,6 +359,16 @@ public class VendorControllerWeb {
 
     @PutMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a vendor bank account",
+            description = "Replaces the details of a bank account belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank account updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or bank account with the given id")
+    })
     public ResponseEntity<VendorBankAccountDto> updateBankAccount(
             @PathVariable Long vendorId,
             @PathVariable Long accountId,
@@ -193,6 +379,15 @@ public class VendorControllerWeb {
 
     @DeleteMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a vendor bank account",
+            description = "Deletes a bank account belonging to the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Bank account deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor or bank account with the given id")
+    })
     public ResponseEntity<ApiResponse> deleteBankAccount(
             @PathVariable Long vendorId,
             @PathVariable Long accountId
@@ -205,12 +400,31 @@ public class VendorControllerWeb {
 
     @GetMapping("/{vendorId}/payment-terms")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get vendor payment terms",
+            description = "Returns the payment terms recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorPaymentTermsDto> getPaymentTerms(@PathVariable Long vendorId) {
         return ResponseEntity.ok(vendorService.getPaymentTermsByVendorId(vendorId));
     }
 
     @PutMapping("/{vendorId}/payment-terms")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Set vendor payment terms",
+            description = "Sets or replaces the payment terms for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms set"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<VendorPaymentTermsDto> setPaymentTerms(
             @PathVariable Long vendorId,
             @Valid @RequestBody VendorPaymentTermsCreationDto dto
@@ -220,6 +434,15 @@ public class VendorControllerWeb {
 
     @DeleteMapping("/{vendorId}/payment-terms")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete vendor payment terms",
+            description = "Deletes the payment terms recorded for the given vendor."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payment terms deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No vendor with the given id")
+    })
     public ResponseEntity<ApiResponse> deletePaymentTerms(@PathVariable Long vendorId) {
         vendorService.deletePaymentTerms(vendorId);
         return ResponseEntity.ok(new ApiResponse("Payment terms deleted successfully"));

--- a/src/main/java/org/tornotron/echno_backend/wbs/WbsElementController.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/WbsElementController.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.wbs;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +19,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/project/{projectId}/wbs")
 @Validated
+@Tag(
+        name = "WBS Elements",
+        description = "Work breakdown structure elements for a project, arranged as a tree of phases and "
+                + "activities such as Foundation Works or RCC Column Casting - Block A. Endpoints cover "
+                + "creating a single element or a batch, reading the tree or a flat list, updating and "
+                + "deleting an element, moving an element under a different parent, and recalculating "
+                + "rolled-up cost and progress. Every endpoint is restricted to the system-admin role for "
+                + "the caller's current tenant."
+)
 public class WbsElementController {
 
     private final WbsElementService service;
@@ -27,6 +39,20 @@ public class WbsElementController {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a WBS element",
+            description = "Creates a single work breakdown structure element under the given project, "
+                    + "for example \"RCC Column Casting - Block A\" with wbsCode \"1.2.3\". Pass parentId "
+                    + "to nest the element under an existing one; the wbsCode must be unique within the "
+                    + "project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "WBS element created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request body failed validation, or the parent element belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project, or no parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "wbsCode already exists in this project")
+    })
     public ResponseEntity<WbsElementDto> createWbsElement(
             @PathVariable Long projectId,
             @Valid @RequestBody WbsElementCreationDto dto) {
@@ -37,6 +63,20 @@ public class WbsElementController {
 
     @PostMapping("/bulk")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Bulk create WBS elements",
+            description = "Creates a batch of work breakdown structure elements under the given project "
+                    + "in one call, for example seeding \"Foundation Works\", \"Electrical First Fix\" and "
+                    + "their sub-activities together. Each entry is created the same way as the single "
+                    + "create endpoint and is validated the same way."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "WBS elements created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The elements list is missing or one entry failed validation, or a parent element belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project, or no parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "wbsCode already exists in this project for one of the entries")
+    })
     public ResponseEntity<List<WbsElementDto>> bulkCreateWbsElements(
             @PathVariable Long projectId,
             @Valid @RequestBody WbsBulkCreateDto dto) {
@@ -47,6 +87,16 @@ public class WbsElementController {
 
     @GetMapping("/tree")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get the WBS tree",
+            description = "Returns the project's work breakdown structure as a tree, starting from the "
+                    + "root elements with their children nested underneath in sort order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS tree returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementDto>> getWbsTree(@PathVariable Long projectId) {
         List<WbsElementDto> tree = service.getWbsTree(projectId);
         return ResponseEntity.ok(tree);
@@ -54,6 +104,16 @@ public class WbsElementController {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List WBS elements",
+            description = "Returns every WBS element in the project as a flat list ordered by wbsCode, "
+                    + "without the parent/child nesting used by the tree endpoint."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS elements returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementFlatDto>> getWbsFlatList(@PathVariable Long projectId) {
         List<WbsElementFlatDto> elements = service.getWbsFlatList(projectId);
         return ResponseEntity.ok(elements);
@@ -61,6 +121,16 @@ public class WbsElementController {
 
     @GetMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a WBS element by id",
+            description = "Returns a single WBS element and its children, for example the \"Foundation "
+                    + "Works\" node together with its \"Excavation\" and \"PCC\" sub-elements."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> getWbsElementById(@PathVariable Long projectId,
                                                             @PathVariable Long elementId) {
         WbsElementDto element = service.getWbsElementById(elementId);
@@ -69,6 +139,18 @@ public class WbsElementController {
 
     @PutMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a WBS element",
+            description = "Applies a partial update to a WBS element: only the fields present in the "
+                    + "request body are changed. Setting progress is only allowed on a leaf element; "
+                    + "setting it on a leaf recalculates the progress rolled up to its ancestors."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request body failed validation, or progress was set on an element that is not a leaf"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> updateWbsElement(@PathVariable Long projectId,
                                                            @PathVariable Long elementId,
                                                            @Valid @RequestBody WbsElementUpdateDto dto) {
@@ -79,6 +161,17 @@ public class WbsElementController {
 
     @DeleteMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a WBS element",
+            description = "Deletes the WBS element with the given id. If it was the last remaining child "
+                    + "of its parent, the parent is marked as a leaf again and its progress is "
+                    + "recalculated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<ApiResponse> deleteWbsElement(@PathVariable Long projectId,
                                                          @PathVariable Long elementId) {
         service.deleteWbsElement(elementId);
@@ -88,6 +181,19 @@ public class WbsElementController {
 
     @PostMapping("/{elementId}/move")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Move a WBS element",
+            description = "Reparents a WBS element under a different parent (or to the project root when "
+                    + "newParentId is omitted), and optionally reassigns its wbsCode and sortOrder in the "
+                    + "same call. Levels are recalculated down through the element's own descendants."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element moved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The new parent belongs to a different project, or the move would place the element under its own descendant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element, or no new parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "newWbsCode already exists in this project on a different element")
+    })
     public ResponseEntity<WbsElementDto> moveWbsElement(@PathVariable Long projectId,
                                                          @PathVariable Long elementId,
                                                          @Valid @RequestBody WbsMoveDto dto) {
@@ -98,6 +204,16 @@ public class WbsElementController {
 
     @GetMapping("/leaves")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List leaf WBS elements",
+            description = "Returns the leaf elements of the project's WBS, the elements with no children, "
+                    + "ordered by wbsCode. These are the elements progress can be set on directly."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Leaf WBS elements returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementFlatDto>> getLeafElements(@PathVariable Long projectId) {
         List<WbsElementFlatDto> leaves = service.getLeafElements(projectId);
         return ResponseEntity.ok(leaves);
@@ -105,6 +221,17 @@ public class WbsElementController {
 
     @PostMapping("/{elementId}/recalculate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Recalculate a WBS element",
+            description = "Recomputes the actual cost and progress of a non-leaf WBS element from its "
+                    + "descendants, cost by summing and progress by weighted average, and saves the "
+                    + "result."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element recalculated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> recalculateElement(@PathVariable Long projectId,
                                                              @PathVariable Long elementId) {
         WbsElementDto recalculated = service.recalculateElement(elementId);

--- a/src/main/java/org/tornotron/echno_backend/wbs/WbsElementControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/WbsElementControllerWeb.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.wbs;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +19,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/project/{projectId}/wbs/web")
 @Validated
+@Tag(
+        name = "WBS Elements (Web)",
+        description = "Web-client counterpart of the WBS Elements endpoints, serving the same work "
+                + "breakdown structure operations under the /web path segment: create single or batch "
+                + "elements, read the tree or a flat list, update, delete, move an element under a "
+                + "different parent, and recalculate rolled-up cost and progress. Restricted to the "
+                + "system-admin role for the caller's current tenant."
+)
 public class WbsElementControllerWeb {
 
     private final WbsElementService service;
@@ -27,6 +38,20 @@ public class WbsElementControllerWeb {
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Create a WBS element",
+            description = "Creates a single work breakdown structure element under the given project, "
+                    + "for example \"RCC Column Casting - Block A\" with wbsCode \"1.2.3\". Pass parentId "
+                    + "to nest the element under an existing one; the wbsCode must be unique within the "
+                    + "project."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "WBS element created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request body failed validation, or the parent element belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project, or no parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "wbsCode already exists in this project")
+    })
     public ResponseEntity<WbsElementDto> createWbsElement(
             @PathVariable Long projectId,
             @Valid @RequestBody WbsElementCreationDto dto) {
@@ -37,6 +62,20 @@ public class WbsElementControllerWeb {
 
     @PostMapping("/bulk")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Bulk create WBS elements",
+            description = "Creates a batch of work breakdown structure elements under the given project "
+                    + "in one call, for example seeding \"Foundation Works\", \"Electrical First Fix\" and "
+                    + "their sub-activities together. Each entry is created the same way as the single "
+                    + "create endpoint and is validated the same way."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "WBS elements created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The elements list is missing or one entry failed validation, or a parent element belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project, or no parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "wbsCode already exists in this project for one of the entries")
+    })
     public ResponseEntity<List<WbsElementDto>> bulkCreateWbsElements(
             @PathVariable Long projectId,
             @Valid @RequestBody WbsBulkCreateDto dto) {
@@ -47,6 +86,16 @@ public class WbsElementControllerWeb {
 
     @GetMapping("/tree")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get the WBS tree",
+            description = "Returns the project's work breakdown structure as a tree, starting from the "
+                    + "root elements with their children nested underneath in sort order."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS tree returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementDto>> getWbsTree(@PathVariable Long projectId) {
         List<WbsElementDto> tree = service.getWbsTree(projectId);
         return ResponseEntity.ok(tree);
@@ -54,6 +103,16 @@ public class WbsElementControllerWeb {
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List WBS elements",
+            description = "Returns every WBS element in the project as a flat list ordered by wbsCode, "
+                    + "without the parent/child nesting used by the tree endpoint."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS elements returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementFlatDto>> getWbsFlatList(@PathVariable Long projectId) {
         List<WbsElementFlatDto> elements = service.getWbsFlatList(projectId);
         return ResponseEntity.ok(elements);
@@ -61,6 +120,16 @@ public class WbsElementControllerWeb {
 
     @GetMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a WBS element by id",
+            description = "Returns a single WBS element and its children, for example the \"Foundation "
+                    + "Works\" node together with its \"Excavation\" and \"PCC\" sub-elements."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> getWbsElementById(@PathVariable Long projectId,
                                                            @PathVariable Long elementId) {
         WbsElementDto element = service.getWbsElementById(elementId);
@@ -69,6 +138,18 @@ public class WbsElementControllerWeb {
 
     @PutMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update a WBS element",
+            description = "Applies a partial update to a WBS element: only the fields present in the "
+                    + "request body are changed. Setting progress is only allowed on a leaf element; "
+                    + "setting it on a leaf recalculates the progress rolled up to its ancestors."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request body failed validation, or progress was set on an element that is not a leaf"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> updateWbsElement(@PathVariable Long projectId,
                                                           @PathVariable Long elementId,
                                                           @Valid @RequestBody WbsElementUpdateDto dto) {
@@ -79,6 +160,17 @@ public class WbsElementControllerWeb {
 
     @DeleteMapping("/{elementId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Delete a WBS element",
+            description = "Deletes the WBS element with the given id. If it was the last remaining child "
+                    + "of its parent, the parent is marked as a leaf again and its progress is "
+                    + "recalculated."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<ApiResponse> deleteWbsElement(@PathVariable Long projectId,
                                                         @PathVariable Long elementId) {
         service.deleteWbsElement(elementId);
@@ -88,6 +180,19 @@ public class WbsElementControllerWeb {
 
     @PostMapping("/{elementId}/move")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Move a WBS element",
+            description = "Reparents a WBS element under a different parent (or to the project root when "
+                    + "newParentId is omitted), and optionally reassigns its wbsCode and sortOrder in the "
+                    + "same call. Levels are recalculated down through the element's own descendants."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element moved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The new parent belongs to a different project, or the move would place the element under its own descendant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element, or no new parent element, with the given id in this organization"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "newWbsCode already exists in this project on a different element")
+    })
     public ResponseEntity<WbsElementDto> moveWbsElement(@PathVariable Long projectId,
                                                         @PathVariable Long elementId,
                                                         @Valid @RequestBody WbsMoveDto dto) {
@@ -98,6 +203,16 @@ public class WbsElementControllerWeb {
 
     @GetMapping("/leaves")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List leaf WBS elements",
+            description = "Returns the leaf elements of the project's WBS, the elements with no children, "
+                    + "ordered by wbsCode. These are the elements progress can be set on directly."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Leaf WBS elements returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id in this organization")
+    })
     public ResponseEntity<List<WbsElementFlatDto>> getLeafElements(@PathVariable Long projectId) {
         List<WbsElementFlatDto> leaves = service.getLeafElements(projectId);
         return ResponseEntity.ok(leaves);
@@ -105,6 +220,17 @@ public class WbsElementControllerWeb {
 
     @PostMapping("/{elementId}/recalculate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Recalculate a WBS element",
+            description = "Recomputes the actual cost and progress of a non-leaf WBS element from its "
+                    + "descendants, cost by summing and progress by weighted average, and saves the "
+                    + "result."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "WBS element recalculated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No WBS element with the given id in this organization")
+    })
     public ResponseEntity<WbsElementDto> recalculateElement(@PathVariable Long projectId,
                                                             @PathVariable Long elementId) {
         WbsElementDto recalculated = service.recalculateElement(elementId);

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsBulkCreateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsBulkCreateDto.java
@@ -1,14 +1,20 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
+@Schema(description = "Payload to create a batch of WBS elements for a project in one call, for example "
+        + "seeding \"Foundation Works\", \"RCC Column Casting - Block A\" and \"Electrical First Fix\" "
+        + "together. Each entry is validated and created the same way as the single-element create "
+        + "endpoint.")
 @Data
 public class WbsBulkCreateDto {
 
+    @Schema(description = "WBS elements to create, in the order they should be created.")
     @NotNull(message = "elements is required(type: List<WbsElementCreationDto>)")
     @Valid
     private List<WbsElementCreationDto> elements;

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -7,32 +8,45 @@ import lombok.Data;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "Payload to create a WBS element under a project, optionally nested under a "
+        + "parent element.")
 @Data
 public class WbsElementCreationDto {
 
+    @Schema(description = "Project-unique code identifying this element's position in the WBS hierarchy.", example = "1.2.3")
     @NotBlank(message = "wbsCode is required")
     @Size(max = 50, message = "wbsCode must not exceed 50 characters")
     private String wbsCode;
 
+    @Schema(description = "Name of the WBS element.", example = "RCC Column Casting - Block A")
     @NotBlank(message = "title is required")
     @Size(max = 255, message = "title must not exceed 255 characters")
     private String title;
 
+    @Schema(description = "Free-text description of the scope of work covered by this element.", example = "Column casting for grid lines A1 to A6, M25 grade concrete")
     private String description;
 
+    @Schema(description = "Id of the parent WBS element to nest this element under. Omit to create a root element.", example = "12")
     private Long parentId;
 
+    @Schema(description = "Display order among sibling elements. Defaults to 0 when omitted.", example = "1")
     private Integer sortOrder;
 
+    @Schema(description = "Initial status of the element. See WbsStatus for the allowed values.", example = "NOT_STARTED")
     private String status;
 
+    @Schema(description = "Planned start date.", example = "2026-01-15")
     private LocalDate startDate;
 
+    @Schema(description = "Planned end date.", example = "2026-02-28")
     private LocalDate endDate;
 
+    @Schema(description = "Budgeted cost for this element, in the project's base currency.", example = "850000.00")
     private BigDecimal budgetedCost;
 
+    @Schema(description = "Relative weight of this element among its siblings, used to roll up progress to the parent.", example = "1.5")
     private Double weight;
 
+    @Schema(description = "Id of the employee creating this element.", example = "5")
     private Long createdBy;
 }

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.wbs.enums.WbsStatus;
@@ -9,30 +10,55 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "A WBS element with its resolved parent, creator and, on tree responses, nested children.")
 @Data
 public class WbsElementDto {
+    @Schema(description = "Unique id of the WBS element.", example = "42")
     private Long id;
+    @Schema(description = "Project-unique code identifying this element's position in the WBS hierarchy.", example = "1.2.3")
     private String wbsCode;
+    @Schema(description = "Name of the WBS element.", example = "RCC Column Casting - Block A")
     private String title;
+    @Schema(description = "Free-text description of the scope of work.", example = "Column casting for grid lines A1 to A6, M25 grade concrete")
     private String description;
+    @Schema(description = "Depth of this element in the WBS tree, with 0 for a root element.", example = "2")
     private Integer level;
+    @Schema(description = "Display order among sibling elements.", example = "1")
     private Integer sortOrder;
+    @Schema(description = "Current status of the element.", example = "IN_PROGRESS")
     private WbsStatus status;
+    @Schema(description = "Planned start date.", example = "2026-01-15")
     private LocalDate startDate;
+    @Schema(description = "Planned end date.", example = "2026-02-28")
     private LocalDate endDate;
+    @Schema(description = "Actual start date recorded on site.", example = "2026-01-18")
     private LocalDate actualStartDate;
+    @Schema(description = "Actual end date recorded on site.", example = "2026-03-02")
     private LocalDate actualEndDate;
+    @Schema(description = "Budgeted cost for this element, in the project's base currency.", example = "850000.00")
     private BigDecimal budgetedCost;
+    @Schema(description = "Actual cost incurred for this element, summed from its descendants if it is not a leaf.", example = "612340.50")
     private BigDecimal actualCost;
+    @Schema(description = "Completion percentage, from 0 to 100, weighted from children if this element is not a leaf.", example = "62.5")
     private Double progress;
+    @Schema(description = "Relative weight of this element among its siblings, used to roll up progress to the parent.", example = "1.5")
     private Double weight;
+    @Schema(description = "Whether this element has no children.", example = "false")
     private Boolean isLeaf;
+    @Schema(description = "Id of the project this element belongs to.", example = "7")
     private Long projectId;
+    @Schema(description = "Name of the project this element belongs to.", example = "Asset Homes - Kochi Riverside Phase 2")
     private String projectName;
+    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12")
     private Long parentId;
+    @Schema(description = "wbsCode of the parent WBS element, or null for a root element.", example = "1.2")
     private String parentWbsCode;
+    @Schema(description = "Employee who created this element.")
     private EmployeeDto createdBy;
+    @Schema(description = "Timestamp the element was created.", example = "2026-01-10T09:30:00")
     private LocalDateTime createdAt;
+    @Schema(description = "Timestamp the element was last updated.", example = "2026-02-05T14:12:00")
     private LocalDateTime updatedAt;
+    @Schema(description = "Child elements, present on tree responses; empty or null on other reads.")
     private List<WbsElementDto> children;
 }

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementFlatDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementFlatDto.java
@@ -1,21 +1,34 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.wbs.enums.WbsStatus;
 
 import java.math.BigDecimal;
 
+@Schema(description = "Terse view of a WBS element for flat listings, without the nested children or resolved parent/creator carried by WbsElementDto.")
 @Data
 public class WbsElementFlatDto {
+    @Schema(description = "Unique id of the WBS element.", example = "42")
     private Long id;
+    @Schema(description = "Project-unique code identifying this element's position in the WBS hierarchy.", example = "1.2.3")
     private String wbsCode;
+    @Schema(description = "Name of the WBS element.", example = "RCC Column Casting - Block A")
     private String title;
+    @Schema(description = "Depth of this element in the WBS tree, with 0 for a root element.", example = "2")
     private Integer level;
+    @Schema(description = "Display order among sibling elements.", example = "1")
     private Integer sortOrder;
+    @Schema(description = "Current status of the element.", example = "IN_PROGRESS")
     private WbsStatus status;
+    @Schema(description = "Budgeted cost for this element, in the project's base currency.", example = "850000.00")
     private BigDecimal budgetedCost;
+    @Schema(description = "Actual cost incurred for this element.", example = "612340.50")
     private BigDecimal actualCost;
+    @Schema(description = "Completion percentage, from 0 to 100.", example = "62.5")
     private Double progress;
+    @Schema(description = "Whether this element has no children.", example = "true")
     private Boolean isLeaf;
+    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12")
     private Long parentId;
 }

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementUpdateDto.java
@@ -1,34 +1,48 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Schema(description = "Partial update for a WBS element. Only the fields present in the request are "
+        + "changed; progress may only be set on a leaf element.")
 @Data
 public class WbsElementUpdateDto {
 
+    @Schema(description = "New name of the WBS element.", example = "RCC Column Casting - Block A")
     @Size(max = 255, message = "title must not exceed 255 characters")
     private String title;
 
+    @Schema(description = "New free-text description of the scope of work.", example = "Column casting for grid lines A1 to A6, M25 grade concrete")
     private String description;
 
+    @Schema(description = "New status of the element. See WbsStatus for the allowed values.", example = "IN_PROGRESS")
     private String status;
 
+    @Schema(description = "New planned start date.", example = "2026-01-15")
     private LocalDate startDate;
 
+    @Schema(description = "New planned end date.", example = "2026-02-28")
     private LocalDate endDate;
 
+    @Schema(description = "Actual start date recorded on site.", example = "2026-01-18")
     private LocalDate actualStartDate;
 
+    @Schema(description = "Actual end date recorded on site.", example = "2026-03-02")
     private LocalDate actualEndDate;
 
+    @Schema(description = "New budgeted cost for this element, in the project's base currency.", example = "850000.00")
     private BigDecimal budgetedCost;
 
+    @Schema(description = "New relative weight of this element among its siblings.", example = "1.5")
     private Double weight;
 
+    @Schema(description = "New display order among sibling elements.", example = "2")
     private Integer sortOrder;
 
+    @Schema(description = "New completion percentage, from 0 to 100. Only allowed when the element is a leaf.", example = "75.0")
     private Double progress;
 }

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsMoveDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsMoveDto.java
@@ -1,10 +1,16 @@
 package org.tornotron.echno_backend.wbs.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "Payload to move a WBS element to a new parent, optionally renaming its wbsCode "
+        + "and reordering it among its new siblings in the same call.")
 @Data
 public class WbsMoveDto {
+    @Schema(description = "Id of the new parent WBS element. Omit to move the element to the project root. Must not be the element itself or one of its own descendants.", example = "18")
     private Long newParentId;
+    @Schema(description = "New wbsCode for the element, if it should change. Must stay unique within the project.", example = "2.1.4")
     private String newWbsCode;
+    @Schema(description = "New display order among the element's siblings under its new parent.", example = "3")
     private Integer newSortOrder;
 }


### PR DESCRIPTION
Completes the OpenAPI/springdoc enrichment across the rest of the API surface, extending the high-traffic pass done earlier to every remaining controller and the DTOs they exchange.

## What
- Class-level `@Tag` on every remaining controller, describing the resource and its tenant scope. Web twins note they are the org-role-gated web-console variant vs. the mobile/authority controller.
- Per-endpoint `@Operation` (summary + description) and `@ApiResponses` on each method, with response codes chosen from the actual return type, `HttpStatus`, `@Valid` usage and the `@PreAuthorize` gate.
- `@Schema` descriptions on the request/response DTO fields these controllers exchange, so the generated schema documents the contract.

Modules covered: attendance, billing, asset, issue, indent, purchase-order, category, subcontract, organization, user, material, site-transfer, stock-adjustment, material-consumption, vendor, payable, project-invite-code, goods-received-note and inventory-transaction, plus their web twins.

## Notes
- Annotations only. No logic, signatures, mappings or security expressions changed.
- Every inner `@ApiResponse` is written fully-qualified (`io.swagger.v3.oas.annotations.responses.ApiResponse`) to avoid clashing with the domain `ApiResponse` response type; only `Operation`/`ApiResponses`/`Tag` are imported.
- After this, the whole controller surface (88 controllers; the 89th is the exception-handler advice) carries an OpenAPI tag.

Compiles clean; annotation-only change with no test impact.