### PR TITLE
build: raise JaCoCo line floor to 22%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,10 @@ ext {
     // small margin for run-to-run variance; raise it as tests are added. Denominator
     // excludes generated/DTO/config classes. History: 14% at introduction (14.5%
     // measured), raised to 18% after the RBAC, billing, procurement, receipt, ledger
-    // and attendance service tests landed (18.77% measured).
-    jacocoLineFloor = 0.18
+    // and attendance service tests landed (18.77% measured), then to 22% after the
+    // consumption, transfer, adjustment, bank-account and report-service tests (22.42%
+    // measured).
+    jacocoLineFloor = 0.22
 }
 
 repositories {


### PR DESCRIPTION
The no-regression coverage gate ratchets up. Line coverage (excluded denominator: no generated/DTO/config) measured **22.42%** after the material-consumption, site-transfer, stock-adjustment, company-bank-account and report-service tests landed, up from 18.77% when the floor was last set to 18%.

Raises `jacocoLineFloor` to 0.22 to lock in the gain, keeping a small margin under the measured level for run-to-run variance. CI runs `jacocoTestCoverageVerification`, so this is enforced on every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the minimum required line-coverage threshold from 18% to 22%.
  * Updated coverage documentation to reflect expanded service testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->