### PR TITLE
feat: expand inventory transaction reasons (#258)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/enums/InventoryTransactionType.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/enums/InventoryTransactionType.java
@@ -1,10 +1,58 @@
 package org.tornotron.echno_backend.inventoryTransaction.enums;
 
+/**
+ * The reason a stock movement was recorded. Each type carries the direction its
+ * movement has on stock ({@link StockEffect}), so the sign is defined in one place
+ * rather than inferred at every call site.
+ *
+ * <p>Note on how stock is actually applied today: callers of
+ * {@code InventoryService.updateCurrentStock} pass an already-signed
+ * {@code quantityChanged} (negative for outbound movements such as USE and
+ * TRANSFER_OUT, positive for inbound ones), and the current-stock update derives
+ * its increase/decrease purely from that sign. The transaction type is stored as a
+ * label and is not consulted when the balance is changed. {@code stockEffect} is
+ * therefore authoritative metadata about each reason's direction, available for
+ * validation, reporting and future producers, but it is intentionally not wired
+ * into the existing sign application, which stays sign-driven and unchanged.</p>
+ */
 public enum InventoryTransactionType {
-    GRN,
-    USE,
-    TRANSFER_OUT,
-    TRANSFER_IN,
-    ADJUST,
-    OPENING_BALANCE
+
+    OPENING_BALANCE(StockEffect.INCREASE),
+    GRN(StockEffect.INCREASE),
+    PURCHASE_RETURN(StockEffect.DECREASE),
+    USE(StockEffect.DECREASE),
+    PRODUCTION_CONSUME(StockEffect.DECREASE),
+    PRODUCTION_OUTPUT(StockEffect.INCREASE),
+    SCRAP(StockEffect.DECREASE),
+    DAMAGE(StockEffect.DECREASE),
+    EXPIRE(StockEffect.DECREASE),
+    LOSS(StockEffect.DECREASE),
+    TRANSFER_OUT(StockEffect.DECREASE),
+    TRANSFER_IN(StockEffect.INCREASE),
+    CUSTOMER_RETURN(StockEffect.INCREASE),
+    STOCK_TAKE_GAIN(StockEffect.INCREASE),
+    STOCK_TAKE_LOSS(StockEffect.DECREASE),
+    WRITE_OFF(StockEffect.DECREASE),
+    ADJUST(StockEffect.EITHER);
+
+    private final StockEffect stockEffect;
+
+    InventoryTransactionType(StockEffect stockEffect) {
+        this.stockEffect = stockEffect;
+    }
+
+    public StockEffect getStockEffect() {
+        return stockEffect;
+    }
+
+    /**
+     * The direction a transaction type moves stock in.
+     * {@code EITHER} means the sign is not fixed by the type and comes from the
+     * signed quantity supplied by the caller (as ADJUST does today).
+     */
+    public enum StockEffect {
+        INCREASE,
+        DECREASE,
+        EITHER
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionTypeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionTypeTest.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType.StockEffect;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that every {@link InventoryTransactionType} constant carries the stock
+ * effect defined for it in issue #258, and that the full set of reasons is present.
+ */
+class InventoryTransactionTypeTest {
+
+    @Test
+    void everyTypeMapsToExpectedStockEffect() {
+        Map<InventoryTransactionType, StockEffect> expected =
+                new EnumMap<>(InventoryTransactionType.class);
+        expected.put(InventoryTransactionType.OPENING_BALANCE, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.GRN, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.PURCHASE_RETURN, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.USE, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.PRODUCTION_CONSUME, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.PRODUCTION_OUTPUT, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.SCRAP, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.DAMAGE, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.EXPIRE, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.LOSS, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.TRANSFER_OUT, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.TRANSFER_IN, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.CUSTOMER_RETURN, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.STOCK_TAKE_GAIN, StockEffect.INCREASE);
+        expected.put(InventoryTransactionType.STOCK_TAKE_LOSS, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.WRITE_OFF, StockEffect.DECREASE);
+        expected.put(InventoryTransactionType.ADJUST, StockEffect.EITHER);
+
+        // Every declared constant must have an expectation, so a newly added value
+        // without a defined effect fails the test rather than passing silently.
+        assertEquals(expected.size(), InventoryTransactionType.values().length,
+                "Every transaction type must have an expected stock effect asserted");
+
+        for (Map.Entry<InventoryTransactionType, StockEffect> entry : expected.entrySet()) {
+            assertEquals(entry.getValue(), entry.getKey().getStockEffect(),
+                    "Unexpected stock effect for " + entry.getKey());
+        }
+    }
+
+    @Test
+    void adjustIsTheOnlyEitherEffect() {
+        for (InventoryTransactionType type : InventoryTransactionType.values()) {
+            assertNotNull(type.getStockEffect(), type + " must declare a stock effect");
+            if (type.getStockEffect() == StockEffect.EITHER) {
+                assertEquals(InventoryTransactionType.ADJUST, type,
+                        "ADJUST is the only type whose sign comes from the signed quantity");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Expands `InventoryTransactionType` from the previous 6 values to the full set of stock-movement reasons requested in #258, and attaches each reason's stock direction to the enum itself.

New values added: `PURCHASE_RETURN`, `PRODUCTION_CONSUME`, `PRODUCTION_OUTPUT`, `SCRAP`, `DAMAGE`, `EXPIRE`, `LOSS`, `CUSTOMER_RETURN`, `STOCK_TAKE_GAIN`, `STOCK_TAKE_LOSS`, `WRITE_OFF`. The existing `OPENING_BALANCE`, `GRN`, `USE`, `TRANSFER_IN`, `TRANSFER_OUT`, `ADJUST` are unchanged.

Each constant now carries a `StockEffect` (`INCREASE`, `DECREASE`, `EITHER`), so a reason's direction is defined in one place instead of scattered switch statements. `ADJUST` is `EITHER`, since its sign comes from the signed quantity, as today.

## On the existing sign logic

The applied stock sign is **not** derived from the transaction type. Callers (`InventoryEventListener` for GRN/USE/transfers, `MaterialService` for opening balance) pass an already-signed `quantityChanged` to `InventoryService.updateCurrentStock` (negative for outbound such as USE and TRANSFER_OUT, positive for inbound), and the current-stock update decides increase vs decrease purely from that sign. `updateCurrentStock` never receives the type at all.

Because the type is a label and not the driver of the sign, no sign-application logic was invented or changed. `StockEffect` is additive metadata: authoritative about each reason's direction and available for validation, reporting, and future producers, but intentionally not wired into the sign-driven balance update. Behaviour for the pre-existing values is unchanged.

## DB

The column is `@Enumerated(EnumType.STRING)` mapped to `VARCHAR(50)` with only a NOT NULL constraint (no CHECK constraint on the values), and the new names are well under 50 chars, so no Liquibase changeset is needed.

## Tests

Adds `InventoryTransactionTypeTest`, asserting every constant maps to its expected `StockEffect` and that `ADJUST` is the only `EITHER`. Full `compileJava test` suite is green on the lab build box.

Closes #258.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded inventory transaction options to support returns, production usage and output, scrap, damage, expiration, loss, stock-taking adjustments, and write-offs.
  * Inventory transaction types now indicate whether they increase stock, decrease stock, or may result in either outcome, improving clarity when recording inventory movements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->