### PR TITLE
feat: vendor updates use PATCH and free-text payment terms (#266, #267)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
@@ -119,7 +119,7 @@ public class VendorController {
         return ResponseEntity.ok(vendors);
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
     @Operation(
             summary = "Update a vendor",
@@ -208,7 +208,7 @@ public class VendorController {
         return new ResponseEntity<>(vendorService.addContact(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/contacts/{contactId}")
+    @PatchMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
     @Operation(
             summary = "Update a vendor contact",
@@ -283,7 +283,7 @@ public class VendorController {
         return new ResponseEntity<>(vendorService.addTaxIdentifier(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/tax-identifiers/{taxIdId}")
+    @PatchMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
     @Operation(
             summary = "Update a vendor tax identifier",
@@ -358,7 +358,7 @@ public class VendorController {
         return new ResponseEntity<>(vendorService.addBankAccount(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/bank-accounts/{accountId}")
+    @PatchMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("hasAuthority('vendor:update') or hasAuthority('vendor:admin')")
     @Operation(
             summary = "Update a vendor bank account",

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
@@ -118,7 +118,7 @@ public class VendorControllerWeb {
         return ResponseEntity.ok(vendors);
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a vendor",
@@ -207,7 +207,7 @@ public class VendorControllerWeb {
         return new ResponseEntity<>(vendorService.addContact(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/contacts/{contactId}")
+    @PatchMapping("/{vendorId}/contacts/{contactId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a vendor contact",
@@ -282,7 +282,7 @@ public class VendorControllerWeb {
         return new ResponseEntity<>(vendorService.addTaxIdentifier(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/tax-identifiers/{taxIdId}")
+    @PatchMapping("/{vendorId}/tax-identifiers/{taxIdId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a vendor tax identifier",
@@ -357,7 +357,7 @@ public class VendorControllerWeb {
         return new ResponseEntity<>(vendorService.addBankAccount(vendorId, dto), HttpStatus.CREATED);
     }
 
-    @PutMapping("/{vendorId}/bank-accounts/{accountId}")
+    @PatchMapping("/{vendorId}/bank-accounts/{accountId}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a vendor bank account",

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorPaymentTerms.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorPaymentTerms.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Filter;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.organization.Organization;
-import org.tornotron.echno_backend.vendor.enums.PaymentTermsType;
 
 import java.math.BigDecimal;
 
@@ -26,9 +25,8 @@ public class VendorPaymentTerms extends BaseEntity implements TenantScopedEntity
     @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PaymentTermsType paymentTerms;
+    private String paymentTerms;
 
     private BigDecimal creditLimit;
     private Integer creditDays;

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorService.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorService.java
@@ -12,7 +12,6 @@ import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.vendor.dto.*;
-import org.tornotron.echno_backend.vendor.enums.PaymentTermsType;
 import org.tornotron.echno_backend.vendor.enums.TaxIdentifierType;
 import org.tornotron.echno_backend.vendor.enums.VendorStatus;
 import org.tornotron.echno_backend.vendor.enums.VendorType;
@@ -252,7 +251,7 @@ public class VendorService {
 
     private VendorPaymentTerms mapToPaymentTermsEntity(VendorPaymentTermsCreationDto dto) {
         VendorPaymentTerms terms = new VendorPaymentTerms();
-        terms.setPaymentTerms(PaymentTermsType.valueOf(dto.getPaymentTerms()));
+        terms.setPaymentTerms(dto.getPaymentTerms());
         terms.setCreditLimit(dto.getCreditLimit());
         terms.setCreditDays(dto.getCreditDays());
         return terms;

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorSubEntityService.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorSubEntityService.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.vendor.dto.*;
-import org.tornotron.echno_backend.vendor.enums.PaymentTermsType;
 import org.tornotron.echno_backend.vendor.enums.TaxIdentifierType;
 import org.tornotron.echno_backend.vendor.mapper.VendorBankAccountMapper;
 import org.tornotron.echno_backend.vendor.mapper.VendorContactMapper;
@@ -225,7 +224,7 @@ public class VendorSubEntityService {
             vendor.setPaymentTerms(terms);
             vendorRepository.save(vendor);
         } else {
-            terms.setPaymentTerms(PaymentTermsType.valueOf(dto.getPaymentTerms()));
+            terms.setPaymentTerms(dto.getPaymentTerms());
             terms.setCreditLimit(dto.getCreditLimit());
             terms.setCreditDays(dto.getCreditDays());
             vendorPaymentTermsRepository.save(terms);
@@ -279,7 +278,7 @@ public class VendorSubEntityService {
 
     private VendorPaymentTerms mapToPaymentTermsEntity(VendorPaymentTermsCreationDto dto) {
         VendorPaymentTerms terms = new VendorPaymentTerms();
-        terms.setPaymentTerms(PaymentTermsType.valueOf(dto.getPaymentTerms()));
+        terms.setPaymentTerms(dto.getPaymentTerms());
         terms.setCreditLimit(dto.getCreditLimit());
         terms.setCreditDays(dto.getCreditDays());
         return terms;

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorPaymentTermsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorPaymentTermsDto.java
@@ -1,14 +1,13 @@
 package org.tornotron.echno_backend.vendor.dto;
 
 import lombok.Data;
-import org.tornotron.echno_backend.vendor.enums.PaymentTermsType;
 
 import java.math.BigDecimal;
 
 @Data
 public class VendorPaymentTermsDto {
     private Long id;
-    private PaymentTermsType paymentTerms;
+    private String paymentTerms;
     private BigDecimal creditLimit;
     private Integer creditDays;
 }

--- a/src/main/java/org/tornotron/echno_backend/vendor/enums/PaymentTermsType.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/enums/PaymentTermsType.java
@@ -1,5 +1,0 @@
-package org.tornotron.echno_backend.vendor.enums;
-
-public enum PaymentTermsType {
-    IMMEDIATE, NET15, NET30, NET60, NET90
-}


### PR DESCRIPTION
Backend-only changes to the vendor module for #266 and #267. Both are already anticipated by the echno-core client (it calls PATCH for vendor updates and types `paymentTerms` as a raw string), so no core or web change is needed.

## #266 — vendor updates use PATCH instead of PUT
The four vendor update endpoints now use `@PatchMapping` in both `VendorController` (base) and `VendorControllerWeb` (web twin):

- update vendor (`/{id}`)
- update contact (`/{vendorId}/contacts/{contactId}`)
- update tax identifier (`/{vendorId}/tax-identifiers/{taxIdId}`)
- update bank account (`/{vendorId}/bank-accounts/{accountId}`)

The payment-terms endpoint (`PUT /{vendorId}/payment-terms`) is intentionally left on `@PutMapping`: it replaces the terms record wholesale and core still calls PUT there. Only the HTTP-method annotation changed; paths, `@PreAuthorize`, method bodies, and OpenAPI docs are untouched.

## #267 — payment terms become free-text
Organizations use many payment-term schemes beyond the fixed `IMMEDIATE/NET15/NET30/NET60/NET90` set, so `paymentTerms` is now a plain `String`:

- `VendorPaymentTerms` entity: `String` (dropped `@Enumerated`)
- `VendorPaymentTermsDto`: `String`
- `VendorPaymentTermsCreationDto`: already `String`, unchanged
- `VendorService` / `VendorSubEntityService`: drop the `PaymentTermsType.valueOf(...)` conversion
- `vendor/enums/PaymentTermsType.java`: deleted (no remaining references anywhere in the codebase)

`creditDays` and `creditLimit` are unchanged.

## Migration
None needed. The `payment_terms` column is already `VARCHAR(50)` (`@Enumerated(EnumType.STRING)` stored the name as text) with no check constraint, so a plain `String` maps to the same column.

## Verification
Compiled and ran the full test suite on the lab box: `./gradlew --no-daemon compileJava test` — BUILD SUCCESSFUL.

Closes #266
Closes #267