### PR TITLE
test: raise service coverage and ratchet the JaCoCo floor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,9 @@ ext {
     // measured), raised to 18% after the RBAC, billing, procurement, receipt, ledger
     // and attendance service tests landed (18.77% measured), then to 22% after the
     // consumption, transfer, adjustment, bank-account and report-service tests (22.42%
-    // measured).
-    jacocoLineFloor = 0.22
+    // measured), then to 25% after the leave-accrual, employee-hierarchy,
+    // attendance-regularization and project-invite-code service tests (25.50% measured).
+    jacocoLineFloor = 0.25
 }
 
 repositories {

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -1,0 +1,282 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.ValidationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRegularization;
+import org.tornotron.echno_backend.attendance.AttendanceRegularizationRepository;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AttendanceRegularizationService}. Repositories, the settings and
+ * calculation services, and the mapper are mocked. The focus is the submission and
+ * processing gates the service owns: refusing self-service when disabled, enforcing the
+ * monthly cap, blocking a duplicate pending request, choosing PENDING vs auto-APPROVED from
+ * the settings, applying corrected events only on auto-approve, and refusing to re-action a
+ * request that is no longer PENDING (recalculating attendance only on approval).
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceRegularizationServiceTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ATT_ID = 42L;
+    private static final Long REG_ID = 7L;
+    private static final String REQUESTER = "user-abc";
+    private static final String APPROVER = "manager-xyz";
+
+    @Mock private AttendanceRegularizationRepository regularizationRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private AttendanceRegularizationMapper regularizationMapper;
+
+    private AttendanceRegularizationService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
+                organizationRepository, settingsService, calculationService, regularizationMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private Organization organization() {
+        Organization org = new Organization();
+        org.setId(ORG);
+        return org;
+    }
+
+    private Attendance attendance() {
+        return Attendance.builder()
+                .id(ATT_ID)
+                .attendanceDate(LocalDate.of(2024, 5, 10))
+                .projectId(9L)
+                .build();
+    }
+
+    private AttendanceSettings settings(boolean allowSelf, boolean approvalRequired, int maxPerMonth) {
+        return AttendanceSettings.builder()
+                .allowSelfRegularization(allowSelf)
+                .regularizationApprovalRequired(approvalRequired)
+                .maxRegularizationDaysPerMonth(maxPerMonth)
+                .build();
+    }
+
+    private RegularizationRequestDto requestDto() {
+        RegularizationRequestDto dto = new RegularizationRequestDto();
+        dto.setAttendanceId(ATT_ID);
+        dto.setReason("Forgot to clock out");
+        return dto;
+    }
+
+    private void stubOrgAndAttendance(Attendance attendance) {
+        lenient().when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        lenient().when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG))
+                .thenReturn(Optional.of(attendance));
+    }
+
+    @Test
+    void submitRequest_unknownOrganization_throwsNotFound() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+    }
+
+    @Test
+    void submitRequest_unknownAttendance_throwsNotFound() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+    }
+
+    @Test
+    void submitRequest_selfRegularizationDisabled_throwsValidation() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(false, true, 3));
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRequest_monthlyLimitReached_throwsValidation() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 2));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(2L);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRequest_existingPendingRequest_throwsValidation() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(0L);
+        AttendanceRegularization pending = AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING).build();
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.of(pending));
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRequest_approvalRequired_savesAsPending() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.submitRequest(requestDto(), REQUESTER);
+
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RegularizationStatus.PENDING);
+        assertThat(captor.getValue().getRequestedBy()).isEqualTo(REQUESTER);
+    }
+
+    @Test
+    void submitRequest_autoApprove_savesApprovedAndAppliesCorrectedEvents() {
+        Attendance attendance = attendance();
+        stubOrgAndAttendance(attendance);
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, false, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.submitRequest(requestDto(), REQUESTER);
+
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+    }
+
+    @Test
+    void processRegularization_unknownRequest_throwsNotFound() {
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG)).thenReturn(Optional.empty());
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.APPROVED);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action, APPROVER));
+    }
+
+    @Test
+    void processRegularization_notPending_throwsValidation() {
+        AttendanceRegularization already = AttendanceRegularization.builder()
+                .status(RegularizationStatus.APPROVED).build();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(already));
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.APPROVED);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action, APPROVER));
+        verify(calculationService, never()).recalculate(any(), any());
+    }
+
+    @Test
+    void processRegularization_approveWithShift_recalculatesAttendance() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        AttendanceRegularization pending = AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING).attendance(attendance).build();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.APPROVED);
+
+        service.processRegularization(REG_ID, action, APPROVER);
+
+        verify(calculationService).recalculate(eq(attendance), any(ShiftTiming.class));
+        verify(attendanceRepository).save(attendance);
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+        assertThat(pending.getApprovedBy()).isEqualTo(APPROVER);
+    }
+
+    @Test
+    void processRegularization_reject_doesNotRecalculate() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        AttendanceRegularization pending = AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING).attendance(attendance).build();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.REJECTED);
+        action.setRejectionReason("Insufficient evidence");
+
+        service.processRegularization(REG_ID, action, APPROVER);
+
+        verify(calculationService, never()).recalculate(any(), any());
+        verify(attendanceRepository, never()).save(any());
+        assertThat(pending.getRejectionReason()).isEqualTo("Insufficient evidence");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeHierarchyServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeHierarchyServiceTest.java
@@ -1,0 +1,216 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link EmployeeHierarchyService}. The repository and mapper are mocked and
+ * the reporting graph is built in memory. The focus is the manager-assignment validation the
+ * service owns: rejecting a self-manager, rejecting a cross-organization manager, and
+ * detecting a cycle anywhere up the proposed manager's chain, plus the not-found guards and
+ * the null-out on manager removal.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmployeeHierarchyServiceTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private EmployeeMapper employeeMapper;
+
+    private EmployeeHierarchyService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new EmployeeHierarchyService(employeeRepository, employeeMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private Organization org(Long id) {
+        Organization organization = new Organization();
+        organization.setId(id);
+        return organization;
+    }
+
+    private Employee employee(Long id, Long orgId) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        employee.setOrganization(org(orgId));
+        return employee;
+    }
+
+    @Test
+    void validateManager_selfManager_isRejected() {
+        Employee employee = employee(5L, ORG);
+        Employee manager = employee(5L, ORG);
+
+        assertThatThrownBy(() -> service.validateManager(employee, manager))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("their own manager");
+    }
+
+    @Test
+    void validateManager_differentOrganization_isRejected() {
+        Employee employee = employee(5L, ORG);
+        Employee manager = employee(6L, 999L);
+
+        assertThatThrownBy(() -> service.validateManager(employee, manager))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("same organization");
+    }
+
+    @Test
+    void validateManager_cycleInChain_isRejected() {
+        // employee(5) -> proposed manager(6) whose chain climbs back to 5.
+        Employee employee = employee(5L, ORG);
+        Employee top = employee(5L, ORG);
+        Employee middle = employee(7L, ORG);
+        middle.setManager(top);
+        Employee manager = employee(6L, ORG);
+        manager.setManager(middle);
+
+        assertThatThrownBy(() -> service.validateManager(employee, manager))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("circular reference");
+    }
+
+    @Test
+    void validateManager_validChain_passes() {
+        Employee employee = employee(5L, ORG);
+        Employee grandManager = employee(8L, ORG);
+        Employee manager = employee(6L, ORG);
+        manager.setManager(grandManager);
+
+        // No exception expected for a manager whose chain never reaches the employee.
+        service.validateManager(employee, manager);
+    }
+
+    @Test
+    void validateManager_newEmployeeWithoutId_skipsCycleCheck() {
+        Employee employee = employee(null, ORG);
+        Employee manager = employee(6L, ORG);
+
+        // A not-yet-persisted employee (null id) cannot be in any chain, so this passes.
+        service.validateManager(employee, manager);
+    }
+
+    @Test
+    void assignManager_persistsAndMapsWhenValid() {
+        Employee employee = employee(5L, ORG);
+        Employee manager = employee(6L, ORG);
+        EmployeeDto dto = new EmployeeDto();
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(employee));
+        when(employeeRepository.findByIdAndOrganizationId(6L, ORG)).thenReturn(Optional.of(manager));
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(employeeMapper.toDto(any(Employee.class))).thenReturn(dto);
+
+        EmployeeDto result = service.assignManager(5L, 6L);
+
+        assertThat(result).isSameAs(dto);
+        assertThat(employee.getManager()).isSameAs(manager);
+        verify(employeeRepository).save(employee);
+    }
+
+    @Test
+    void assignManager_unknownEmployee_throwsNotFound() {
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.assignManager(5L, 6L));
+        verify(employeeRepository, never()).save(any());
+    }
+
+    @Test
+    void assignManager_unknownManager_throwsNotFound() {
+        Employee employee = employee(5L, ORG);
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(employee));
+        when(employeeRepository.findByIdAndOrganizationId(6L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.assignManager(5L, 6L));
+        verify(employeeRepository, never()).save(any());
+    }
+
+    @Test
+    void assignManager_invalidManager_propagatesAndDoesNotPersist() {
+        Employee employee = employee(5L, ORG);
+        Employee manager = employee(6L, 999L); // different org
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(employee));
+        when(employeeRepository.findByIdAndOrganizationId(6L, ORG)).thenReturn(Optional.of(manager));
+
+        assertThatThrownBy(() -> service.assignManager(5L, 6L))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(employeeRepository, never()).save(any());
+    }
+
+    @Test
+    void removeManager_clearsManagerAndSaves() {
+        Employee employee = employee(5L, ORG);
+        employee.setManager(employee(6L, ORG));
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(employee));
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(employeeMapper.toDto(any(Employee.class))).thenReturn(new EmployeeDto());
+
+        service.removeManager(5L);
+
+        assertThat(employee.getManager()).isNull();
+        verify(employeeRepository).save(employee);
+    }
+
+    @Test
+    void removeManager_unknownEmployee_throwsNotFound() {
+        when(employeeRepository.findByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.removeManager(5L));
+    }
+
+    @Test
+    void getDirectSubordinates_unknownManager_throwsNotFound() {
+        when(employeeRepository.existsByIdAndOrganization_Id(6L, ORG)).thenReturn(false);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.getDirectSubordinates(6L));
+    }
+
+    @Test
+    void getDirectSubordinates_mapsEachSubordinate() {
+        Employee sub1 = employee(1L, ORG);
+        Employee sub2 = employee(2L, ORG);
+        when(employeeRepository.existsByIdAndOrganization_Id(6L, ORG)).thenReturn(true);
+        when(employeeRepository.findByManager_Id(6L)).thenReturn(List.of(sub1, sub2));
+        lenient().when(employeeMapper.toDto(any(Employee.class))).thenReturn(new EmployeeDto());
+
+        List<EmployeeDto> result = service.getDirectSubordinates(6L);
+
+        assertThat(result).hasSize(2);
+        verify(employeeMapper).toDto(sub1);
+        verify(employeeMapper).toDto(sub2);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveAccrualServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveAccrualServiceTest.java
@@ -1,0 +1,299 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.leave.enums.TransactionType;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LeaveAccrualService}. All four repositories are mocked and the
+ * entity graph is built in memory. The focus is the accrual arithmetic this service owns:
+ * choosing the start month from the joining date, deriving the monthly accrual from the
+ * policy (explicit rate vs annual-quota / 12 vs nothing), prorating by attendance, capping
+ * at the annual quota, skipping months that already have an ACCRUAL transaction, and not
+ * accruing for months that have not started yet.
+ *
+ * A past year (2020) is used for the deterministic cases: when the balance year is not the
+ * current year the service walks all twelve months, so the assertions do not drift with the
+ * calendar. Rates are chosen so the prorated figure lands on a round number.
+ */
+@ExtendWith(MockitoExtension.class)
+class LeaveAccrualServiceTest {
+
+    private static final int PAST_YEAR = 2020;
+    private static final Long BALANCE_ID = 55L;
+    private static final Long EMPLOYEE_ID = 7L;
+    private static final Long POLICY_ID = 3L;
+
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private LeaveTransactionRepository transactionRepository;
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+
+    private LeaveAccrualService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeaveAccrualService(
+                balanceRepository, transactionRepository, requestRepository, attendanceRepository);
+    }
+
+    private Employee employee(LocalDateTime joiningDate) {
+        Organization org = new Organization();
+        org.setId(100L);
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE_ID);
+        employee.setOrganization(org);
+        employee.setJoiningDate(joiningDate);
+        return employee;
+    }
+
+    private LeavePolicy policy(Double ratePerMonth, Double annualQuota) {
+        LeavePolicy policy = new LeavePolicy();
+        policy.setId(POLICY_ID);
+        policy.setAccrualRatePerMonth(ratePerMonth);
+        policy.setAnnualQuota(annualQuota);
+        return policy;
+    }
+
+    private LeaveBalance balance(Employee employee, LeavePolicy policy, int year) {
+        LeaveBalance balance = new LeaveBalance();
+        balance.setId(BALANCE_ID);
+        balance.setEmployee(employee);
+        balance.setLeavePolicy(policy);
+        balance.setYear(year);
+        balance.setOpeningBalance(0.0);
+        balance.setAccrued(0.0);
+        return balance;
+    }
+
+    /** No month already accrued, and no attendance records anywhere. */
+    private void stubNoPriorAccrualsNoAttendance() {
+        lenient().when(transactionRepository
+                .existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
+                        anyLong(), eq(TransactionType.ACCRUAL), any(), any()))
+                .thenReturn(false);
+        lenient().when(attendanceRepository
+                .findByEmployeeIdAndAttendanceDateBetween(anyLong(), any(), any()))
+                .thenReturn(new ArrayList<>());
+    }
+
+    @Test
+    void recalculate_joinedBeforeYear_accruesEveryMonthAtFlatRate() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.5, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        // 12 months x 1.5 = 18.0, no quota cap
+        assertThat(balance.getAccrued()).isEqualTo(18.0);
+        verify(transactionRepository, times(12)).save(any(LeaveTransaction.class));
+        verify(balanceRepository).save(balance);
+        assertThat(balance.getLastCalculationMonth()).isEqualTo(12);
+    }
+
+    @Test
+    void recalculate_joinedMidYear_startsFromJoiningMonth() {
+        Employee employee = employee(LocalDateTime.of(PAST_YEAR, 6, 15, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        // Months 6..12 inclusive = 7 accruals x 1.0
+        assertThat(balance.getAccrued()).isEqualTo(7.0);
+        verify(transactionRepository, times(7)).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_nullJoiningDate_startsFromJanuary() {
+        Employee employee = employee(null);
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        assertThat(balance.getAccrued()).isEqualTo(12.0);
+    }
+
+    @Test
+    void recalculate_annualQuota_capsTotalAccrued() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(5.0, 20.0), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        // 12 x 5 = 60 raw, capped at the annual quota of 20
+        assertThat(balance.getAccrued()).isEqualTo(20.0);
+    }
+
+    @Test
+    void recalculate_noExplicitRate_derivesMonthlyFromAnnualQuota() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(null, 24.0), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        // 24 / 12 = 2 per month x 12 = 24, cap min(24, 24) = 24
+        assertThat(balance.getAccrued()).isEqualTo(24.0);
+        verify(transactionRepository, times(12)).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_noQuotaConfigured_accruesNothing() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(null, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        assertThat(balance.getAccrued()).isEqualTo(0.0);
+        verify(transactionRepository, never()).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_proratesByAttendanceRatio() {
+        // Joined December 2020 so exactly one month (Dec) is walked.
+        Employee employee = employee(LocalDateTime.of(PAST_YEAR, 12, 1, 0, 0));
+        // December 2020 has 23 weekdays; a rate of 23 makes accrual == effective days.
+        LeaveBalance balance = balance(employee, policy(23.0, null), PAST_YEAR);
+        lenient().when(transactionRepository
+                .existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
+                        anyLong(), eq(TransactionType.ACCRUAL), any(), any()))
+                .thenReturn(false);
+
+        List<Attendance> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            records.add(attendanceWith(AttendanceStatus.PRESENT));
+        }
+        records.add(attendanceWith(AttendanceStatus.HALF_DAY));
+        records.add(attendanceWith(AttendanceStatus.HALF_DAY));
+        when(attendanceRepository.findByEmployeeIdAndAttendanceDateBetween(anyLong(), any(), any()))
+                .thenReturn(records);
+
+        service.recalculate(balance);
+
+        // effective days = 10 + 2 * 0.5 = 11; ratio 11/23; accrual = 23 * 11/23 = 11
+        assertThat(balance.getAccrued()).isEqualTo(11.0);
+    }
+
+    @Test
+    void recalculate_allAbsentRecords_treatedAsUntracked_givesFullAccrual() {
+        Employee employee = employee(LocalDateTime.of(PAST_YEAR, 12, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(5.0, null), PAST_YEAR);
+        lenient().when(transactionRepository
+                .existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
+                        anyLong(), eq(TransactionType.ACCRUAL), any(), any()))
+                .thenReturn(false);
+
+        List<Attendance> records = new ArrayList<>();
+        records.add(attendanceWith(AttendanceStatus.ABSENT));
+        records.add(attendanceWith(AttendanceStatus.ABSENT));
+        when(attendanceRepository.findByEmployeeIdAndAttendanceDateBetween(anyLong(), any(), any()))
+                .thenReturn(records);
+
+        service.recalculate(balance);
+
+        // Every record ABSENT means attendance is not being tracked -> full monthly accrual
+        assertThat(balance.getAccrued()).isEqualTo(5.0);
+    }
+
+    @Test
+    void recalculate_existingAccrualTransaction_isCountedNotRecreated() {
+        Employee employee = employee(LocalDateTime.of(PAST_YEAR, 12, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(5.0, null), PAST_YEAR);
+        when(transactionRepository
+                .existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
+                        anyLong(), eq(TransactionType.ACCRUAL), any(), any()))
+                .thenReturn(true);
+        LeaveTransaction existing = new LeaveTransaction();
+        existing.setDays(3.5);
+        when(transactionRepository.findByBalanceAndTypeAndMonthYear(
+                eq(BALANCE_ID), eq(TransactionType.ACCRUAL), eq(12), eq(PAST_YEAR)))
+                .thenReturn(List.of(existing));
+
+        service.recalculate(balance);
+
+        assertThat(balance.getAccrued()).isEqualTo(3.5);
+        verify(transactionRepository, never()).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_futureYear_accruesNothing() {
+        int futureYear = LocalDate.now().getYear() + 1;
+        Employee employee = employee(LocalDateTime.now());
+        LeaveBalance balance = balance(employee, policy(5.0, null), futureYear);
+        lenient().when(transactionRepository
+                .existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
+                        anyLong(), eq(TransactionType.ACCRUAL), any(), any()))
+                .thenReturn(false);
+
+        service.recalculate(balance);
+
+        // Every month of next year has not started yet -> zero accrual, no transactions
+        assertThat(balance.getAccrued()).isEqualTo(0.0);
+        verify(transactionRepository, never()).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_usedAndPending_defaultToZeroWhenRepositoryReturnsNull() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(requestRepository.sumApprovedDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(null);
+        when(requestRepository.sumPendingDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(null);
+
+        service.recalculate(balance);
+
+        assertThat(balance.getUsed()).isEqualTo(0.0);
+        assertThat(balance.getPending()).isEqualTo(0.0);
+    }
+
+    @Test
+    void recalculate_usedAndPending_takenFromRepositoryWhenPresent() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(requestRepository.sumApprovedDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(4.0);
+        when(requestRepository.sumPendingDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(1.5);
+
+        service.recalculate(balance);
+
+        assertThat(balance.getUsed()).isEqualTo(4.0);
+        assertThat(balance.getPending()).isEqualTo(1.5);
+    }
+
+    private Attendance attendanceWith(AttendanceStatus status) {
+        return Attendance.builder().status(status).build();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
@@ -1,0 +1,308 @@
+package org.tornotron.echno_backend.projectInviteCode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
+import org.tornotron.echno_backend.common.exception.InvalidInviteCodeException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.organization.dto.OrganizationDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodeGenerationDto;
+import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodePatchDto;
+import org.tornotron.echno_backend.projectInviteCode.dto.InviteCodeValidationDto;
+import org.tornotron.echno_backend.projectInviteCode.dto.ProjectInviteCodeDto;
+import org.tornotron.echno_backend.projectInviteCode.mapper.ProjectInviteCodeMapper;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ProjectInviteCodeService}. Repositories, the employee service, and
+ * the mappers are mocked. The focus is the generation and redemption rules the service owns:
+ * validating the organization and (optional) manager on generation, rejecting an expired /
+ * inactive / used-up code on redemption, incrementing the use count and delegating the join,
+ * the not-persisted guard, and the selective patch that only touches the fields the DTO sets.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectInviteCodeServiceTest {
+
+    private static final Long ORG = 100L;
+    private static final Long INVITE_ID = 3L;
+    private static final Long USER_ID = 55L;
+    private static final Long MANAGER_ID = 8L;
+
+    @Mock private ProjectInviteCodeRepository inviteCodeRepository;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectInviteCodeMapper projectInviteCodeMapper;
+    @Mock private OrganizationMapper organizationMapper;
+
+    private ProjectInviteCodeService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new ProjectInviteCodeService(inviteCodeRepository, employeeService, organizationRepository,
+                fileStorageService, employeeRepository, projectInviteCodeMapper, organizationMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private Organization organization() {
+        Organization org = new Organization();
+        org.setId(ORG);
+        return org;
+    }
+
+    private InviteCodeGenerationDto generationDto() {
+        InviteCodeGenerationDto dto = new InviteCodeGenerationDto();
+        dto.setEmployeeName("Jane Doe");
+        dto.setEmail("jane@example.com");
+        dto.setDesignation("Engineer");
+        return dto;
+    }
+
+    @Test
+    void generateSecureFiveDigitNumber_alwaysFiveDigits() {
+        for (int i = 0; i < 200; i++) {
+            int code = service.generateSecureFiveDigitNumber();
+            assertThat(code).isBetween(10000, 99999);
+        }
+    }
+
+    @Test
+    void generateInviteCode_unknownOrganization_throwsNotFound() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.generateInviteCode(generationDto(), ORG));
+        verify(inviteCodeRepository, never()).save(any());
+    }
+
+    @Test
+    void generateInviteCode_managerWithoutManagerRole_throwsNotFound() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(employeeRepository.existsByIdAndOrgRolesIn(eq(MANAGER_ID), any())).thenReturn(false);
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setManagerId(MANAGER_ID);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.generateInviteCode(dto, ORG));
+        verify(inviteCodeRepository, never()).save(any());
+    }
+
+    @Test
+    void generateInviteCode_valid_persistsCodeWithExpiryAndZeroUses() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> {
+            ProjectInviteCode saved = inv.getArgument(0);
+            saved.setId(INVITE_ID);
+            return saved;
+        });
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setMaxUses(4);
+        dto.setValidityDays(10);
+
+        service.generateInviteCode(dto, ORG);
+
+        ArgumentCaptor<ProjectInviteCode> captor = ArgumentCaptor.forClass(ProjectInviteCode.class);
+        verify(inviteCodeRepository).save(captor.capture());
+        ProjectInviteCode saved = captor.getValue();
+        assertThat(saved.getCode()).isBetween(10000, 99999);
+        assertThat(saved.isActive()).isTrue();
+        assertThat(saved.getMaxUses()).isEqualTo(4);
+        assertThat(saved.getCurrentUses()).isZero();
+        assertThat(saved.getExpiryDate()).isAfter(LocalDateTime.now().plusDays(9));
+        assertThat(saved.getEmployeeDetails()).containsEntry("email", "jane@example.com");
+    }
+
+    @Test
+    void generateInviteCode_notPersisted_throwsDatabaseError() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        // save returns an entity whose id is still null -> persistence failure
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        assertThatExceptionOfType(DatabaseOperationException.class)
+                .isThrownBy(() -> service.generateInviteCode(generationDto(), ORG));
+    }
+
+    private ProjectInviteCode storedCode(boolean active, LocalDateTime expiry, int maxUses, int currentUses) {
+        ProjectInviteCode code = new ProjectInviteCode();
+        code.setId(INVITE_ID);
+        code.setCode(12345);
+        code.setActive(active);
+        code.setExpiryDate(expiry);
+        code.setMaxUses(maxUses);
+        code.setCurrentUses(currentUses);
+        code.setOrganization(organization());
+        Map<String, Object> details = new HashMap<>();
+        details.put("designation", "Engineer");
+        details.put("email", "jane@example.com");
+        code.setEmployeeDetails(details);
+        return code;
+    }
+
+    private InviteCodeValidationDto validationDto() {
+        InviteCodeValidationDto dto = new InviteCodeValidationDto();
+        dto.setCode("12345");
+        return dto;
+    }
+
+    @Test
+    void validateAndUse_unknownCode_throwsNotFound() {
+        when(inviteCodeRepository.findByCode(12345)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+    }
+
+    @Test
+    void validateAndUse_expiredCode_throwsInvalid() {
+        when(inviteCodeRepository.findByCode(12345))
+                .thenReturn(Optional.of(storedCode(true, LocalDateTime.now().minusDays(1), 5, 0)));
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void validateAndUse_inactiveCode_throwsInvalid() {
+        when(inviteCodeRepository.findByCode(12345))
+                .thenReturn(Optional.of(storedCode(false, LocalDateTime.now().plusDays(5), 5, 0)));
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void validateAndUse_maxUsesReached_throwsInvalid() {
+        when(inviteCodeRepository.findByCode(12345))
+                .thenReturn(Optional.of(storedCode(true, LocalDateTime.now().plusDays(5), 2, 2)));
+
+        assertThatExceptionOfType(InvalidInviteCodeException.class)
+                .isThrownBy(() -> service.validateAndUseInviteCode(validationDto(), USER_ID));
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void validateAndUse_valid_joinsOrgIncrementsUsesAndMapsOrganization() {
+        ProjectInviteCode code = storedCode(true, LocalDateTime.now().plusDays(5), 5, 1);
+        code.getEmployeeDetails().put("managerId", 8);
+        code.getEmployeeDetails().put("salary", 55000.0);
+        when(inviteCodeRepository.findByCode(12345)).thenReturn(Optional.of(code));
+        OrganizationDto orgDto = new OrganizationDto();
+        when(organizationMapper.toDto(any())).thenReturn(orgDto);
+
+        OrganizationDto result = service.validateAndUseInviteCode(validationDto(), USER_ID);
+
+        assertThat(result).isSameAs(orgDto);
+        assertThat(code.getCurrentUses()).isEqualTo(2);
+        ArgumentCaptor<EmployeeJoinOrgDto> captor = ArgumentCaptor.forClass(EmployeeJoinOrgDto.class);
+        verify(employeeService).joinOrganization(eq(USER_ID), eq(ORG), captor.capture());
+        EmployeeJoinOrgDto joinDto = captor.getValue();
+        assertThat(joinDto.getEmail()).isEqualTo("jane@example.com");
+        assertThat(joinDto.getManagerId()).isEqualTo(8L);
+        assertThat(joinDto.getSalary()).isEqualTo(55000.0);
+    }
+
+    @Test
+    void patchInviteCode_unknownCode_throwsNotFound() {
+        when(inviteCodeRepository.findByIdAndOrganization_Id(INVITE_ID, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.patchInviteCode(INVITE_ID, new InviteCodePatchDto()));
+    }
+
+    @Test
+    void patchInviteCode_updatesOnlyProvidedFields() {
+        ProjectInviteCode code = storedCode(true, LocalDateTime.now().plusDays(5), 5, 1);
+        when(inviteCodeRepository.findByIdAndOrganization_Id(INVITE_ID, ORG)).thenReturn(Optional.of(code));
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        InviteCodePatchDto patch = new InviteCodePatchDto();
+        patch.setIsActive(false);
+        // maxUses and currentUses left null -> must not change
+
+        service.patchInviteCode(INVITE_ID, patch);
+
+        assertThat(code.isActive()).isFalse();
+        assertThat(code.getMaxUses()).isEqualTo(5);
+        assertThat(code.getCurrentUses()).isEqualTo(1);
+    }
+
+    @Test
+    void patchInviteCode_updatesUsageCounters() {
+        ProjectInviteCode code = storedCode(true, LocalDateTime.now().plusDays(5), 5, 1);
+        when(inviteCodeRepository.findByIdAndOrganization_Id(INVITE_ID, ORG)).thenReturn(Optional.of(code));
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        InviteCodePatchDto patch = new InviteCodePatchDto();
+        patch.setMaxUses(10);
+        patch.setCurrentUses(3);
+
+        service.patchInviteCode(INVITE_ID, patch);
+
+        assertThat(code.getMaxUses()).isEqualTo(10);
+        assertThat(code.getCurrentUses()).isEqualTo(3);
+        assertThat(code.isActive()).isTrue();
+    }
+
+    // Guards against an accidental widening of the manager-role set used in generation.
+    @Test
+    void generateInviteCode_checksManagerRolesSet() {
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        Set<OrgRole> managerRoles = OrgRole.getManagerRoles();
+        lenient().when(employeeRepository.existsByIdAndOrgRolesIn(MANAGER_ID, managerRoles)).thenReturn(true);
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> {
+            ProjectInviteCode saved = inv.getArgument(0);
+            saved.setId(INVITE_ID);
+            return saved;
+        });
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setManagerId(MANAGER_ID);
+
+        service.generateInviteCode(dto, ORG);
+
+        verify(employeeRepository).existsByIdAndOrgRolesIn(MANAGER_ID, managerRoles);
+    }
+}


### PR DESCRIPTION
## What

Adds plain JUnit 5 + Mockito unit tests for four service classes whose branching business logic had no test, and ratchets the JaCoCo line floor to lock in the gain.

### Classes covered

- **LeaveAccrualService** - start-month selection from the joining date (before-year, mid-year join, null date, future year), monthly accrual derivation (explicit per-month rate vs annual-quota / 12 vs no quota), attendance proration and the all-absent = untracked fallback, the annual-quota cap, counting an existing ACCRUAL transaction instead of recreating it, and the null-vs-present used/pending figures.
- **EmployeeHierarchyService** - manager validation: self-manager, cross-organization manager, and cycle detection anywhere up the proposed manager's chain, plus the assign/remove not-found guards and the subordinate listing.
- **AttendanceRegularizationService** - submission gates (self-service disabled, monthly cap reached, duplicate pending request), PENDING vs auto-APPROVED selection from settings, and the process path that recalculates attendance only on approval and refuses to re-action a request that is no longer PENDING.
- **ProjectInviteCodeService** - generation with organization and manager-role validation and the not-persisted guard, redemption rejecting expired / inactive / used-up codes, the use-count increment plus join delegation, and the selective patch that only touches the fields the DTO sets.

All are fast unit tests with the repositories and collaborators mocked; no new integration tests were needed since none of this behaviour is DB or locking specific.

### Coverage

Measured line coverage over the gate's exclusion-adjusted denominator (generated / DTO / config / mapper classes excluded):

| | Coverage | Floor |
|---|---|---|
| Before | 22.42% | 0.22 |
| After | 25.50% | 0.25 |

`jacocoLineFloor` is set to 0.25, just under the measured 25.50% with the usual margin for run-to-run variance, and the history comment in `build.gradle` is extended. `./gradlew test jacocoTestReport jacocoTestCoverageVerification` is green.