### PR TITLE
fix: presign against the public object-store endpoint

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/SpacesConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/SpacesConfig.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
@@ -16,6 +17,9 @@ public class SpacesConfig {
 
     @Value("${digital-ocean.uri}")
     private String spaces;
+
+    @Value("${digital-ocean.presign-endpoint}")
+    private String presignEndpoint;
 
     @Value("${digital-ocean.access-key-id}")
     private String access_key_id;
@@ -39,10 +43,19 @@ public class SpacesConfig {
                 .build();
     }
 
+    // Presigned URLs are handed to the browser, so they must be signed against the
+    // public object-store endpoint (which may differ from the internal endpoint the
+    // s3Client above uses for server-side ops). Path-style addressing is required for
+    // MinIO, which puts the bucket in the path rather than the host.
     @Bean
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
-                .endpointOverride(URI.create(spaces))
+                .endpointOverride(URI.create(presignEndpoint))
+                .serviceConfiguration(
+                        S3Configuration.builder()
+                                .pathStyleAccessEnabled(true)
+                                .build()
+                )
                 .region(Region.US_EAST_1)
                 .credentialsProvider(
                         StaticCredentialsProvider.create(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ jwt:
 
 digital-ocean:
   uri: ${DIGITAL_OCEAN_SPACES_URI}
+  presign-endpoint: ${OBJECT_STORE_PUBLIC_ENDPOINT:${DIGITAL_OCEAN_SPACES_URI}}
   access-key-id: ${DIGITAL_OCEAN_SPACES_KEY_ID}
   secret-access-key: ${DIGITAL_OCEAN_SPACES_KEY_SECRET}
   bucket-name: ${DIGITAL_OCEAN_SPACES_BUCKET_NAME}


### PR DESCRIPTION
## Problem

`SpacesConfig` built the `S3Presigner` with `endpointOverride(digital-ocean.uri)`, the same internal object-store endpoint the server-side `S3Client` uses. On the IITM/MinIO deployment that resolves to the internal docker host `http://echno-minio:9000`, so the presigned PUT/GET URLs we hand to the browser point at a host the browser cannot reach. On DigitalOcean Spaces the `uri` is already the public endpoint, so it happens to work there.

## Fix

Split the internal endpoint from the public one the presigner signs against:

- New property `digital-ocean.presign-endpoint`, driven by a new env var `OBJECT_STORE_PUBLIC_ENDPOINT` that **defaults to the existing `DIGITAL_OCEAN_SPACES_URI`** when unset. DO and local are therefore unchanged (the default equals the already-public uri); the MinIO deployment sets `OBJECT_STORE_PUBLIC_ENDPOINT` to the public MinIO host.
- `s3Presigner()` now overrides its endpoint with `presign-endpoint` and enables **path-style access**, which MinIO requires (bucket in the path, not the host). Same region and credentials as before.
- `s3Client()` is untouched: server-side operations keep using the internal endpoint, which works today.

No change to `FileStorageService` or callers. The presigner returning a public-host URL is the whole fix.

## Verification

`compileJava` + full test suite green on the lab build box: BUILD SUCCESSFUL, 262 tests, 0 failures, 0 errors. The `SpacesConfig` beans load in the application context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file access links for DigitalOcean Spaces by using the configured public endpoint.
  * Enabled path-style access to help ensure generated links work reliably across supported storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->