### PR TITLE
feat: server-rendered invoice PDF endpoint

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfService.java
@@ -1,0 +1,210 @@
+package org.tornotron.echno_backend.finance.construction.pdf;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineDto;
+import org.tornotron.echno_backend.project.ProjectService;
+import org.tornotron.echno_backend.project.dto.ProjectDto;
+import org.tornotron.echno_backend.vendor.VendorService;
+import org.tornotron.echno_backend.vendor.dto.VendorDto;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Renders a construction invoice into a downloadable PDF. The invoice data is formatted
+ * into display-ready strings here (currency, dates, humanised enum labels, resolved vendor
+ * and project names) so the Thymeleaf template stays free of formatting logic, and the
+ * result is rendered with the same openhtmltopdf engine used by the site progress report.
+ */
+@Service
+public class ConstructionInvoicePdfService {
+
+    private static final String DASH = "—";
+    private static final DateTimeFormatter DATE_FMT =
+            DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.ENGLISH);
+    private static final DateTimeFormatter STAMP_FMT =
+            DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm", Locale.ENGLISH);
+
+    private final SpringTemplateEngine pdfTemplateEngine;
+    private final VendorService vendorService;
+    private final ProjectService projectService;
+
+    public ConstructionInvoicePdfService(@Qualifier("pdfTemplateEngine") SpringTemplateEngine pdfTemplateEngine,
+                                         VendorService vendorService,
+                                         ProjectService projectService) {
+        this.pdfTemplateEngine = pdfTemplateEngine;
+        this.vendorService = vendorService;
+        this.projectService = projectService;
+    }
+
+    /**
+     * Builds the invoice PDF for the given invoice.
+     *
+     * @param invoice the invoice to render, already loaded and tenant scoped by the caller
+     * @return the rendered PDF as a byte array
+     * @throws IOException if the PDF cannot be rendered
+     */
+    public byte[] render(ConstructionInvoiceDto invoice) throws IOException {
+        Context ctx = populateContext(invoice);
+        String html = pdfTemplateEngine.process("invoice/invoice", ctx);
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(html, "classpath:/templates/");
+            builder.toStream(os);
+            builder.run();
+            return os.toByteArray();
+        }
+    }
+
+    private Context populateContext(ConstructionInvoiceDto inv) {
+        Context ctx = new Context();
+        ctx.setVariable("invoiceNumber", orDash(inv.invoiceNumber()));
+        ctx.setVariable("typeLabel", humanise(inv.type() == null ? null : inv.type().name()));
+        ctx.setVariable("statusLabel", humanise(inv.status() == null ? null : inv.status().name()));
+        ctx.setVariable("paymentStatusLabel",
+                humanise(inv.paymentStatus() == null ? null : inv.paymentStatus().name()));
+
+        ctx.setVariable("vendorName", resolveVendorName(inv.vendorId()));
+        ctx.setVariable("projectName", resolveProjectName(inv.projectId()));
+
+        ctx.setVariable("issueDate", date(inv.issueDate()));
+        ctx.setVariable("dueDate", date(inv.dueDate()));
+        ctx.setVariable("paymentDate", date(inv.paymentDate()));
+
+        ctx.setVariable("gstNumber", nullToEmpty(inv.gstNumber()));
+        ctx.setVariable("taxType", nullToEmpty(inv.taxType()));
+        ctx.setVariable("paymentTerms", orDash(inv.paymentTerms()));
+        ctx.setVariable("paymentMethod", orDash(inv.paymentMethod()));
+        ctx.setVariable("notes", nullToEmpty(inv.notes()));
+        ctx.setVariable("termsAndConditions", nullToEmpty(inv.termsAndConditions()));
+
+        ctx.setVariable("subtotal", money(inv.subtotal()));
+        ctx.setVariable("taxAmount", money(inv.taxAmount()));
+        ctx.setVariable("discountAmount", money(inv.discountAmount()));
+        ctx.setVariable("totalAmount", money(inv.totalAmount()));
+        ctx.setVariable("paidAmount", money(inv.paidAmount()));
+        ctx.setVariable("balanceAmount", money(inv.balanceAmount()));
+
+        ctx.setVariable("lines", toLineRows(inv.lines()));
+        ctx.setVariable("generatedOn", STAMP_FMT.format(LocalDateTime.now()));
+        return ctx;
+    }
+
+    private List<PdfLine> toLineRows(List<ConstructionInvoiceLineDto> lines) {
+        if (lines == null) {
+            return List.of();
+        }
+        return lines.stream()
+                .map(l -> new PdfLine(
+                        orDash(l.description()),
+                        orDash(l.unit()),
+                        plain(l.quantity()),
+                        money(l.unitPrice()),
+                        percent(l.taxRate()),
+                        percent(l.discountRate()),
+                        money(l.total())))
+                .toList();
+    }
+
+    private String resolveVendorName(Long vendorId) {
+        if (vendorId == null) {
+            return DASH;
+        }
+        try {
+            VendorDto vendor = vendorService.getVendorById(vendorId);
+            if (vendor != null && vendor.getVendorName() != null && !vendor.getVendorName().isBlank()) {
+                return vendor.getVendorName();
+            }
+        } catch (RuntimeException ignored) {
+            // Fall through to a stable placeholder if the vendor cannot be resolved.
+        }
+        return "Vendor #" + vendorId;
+    }
+
+    private String resolveProjectName(Long projectId) {
+        if (projectId == null) {
+            return DASH;
+        }
+        try {
+            ProjectDto project = projectService.getAProject(projectId);
+            if (project != null && project.getProjectName() != null && !project.getProjectName().isBlank()) {
+                return project.getProjectName();
+            }
+        } catch (RuntimeException ignored) {
+            // Fall through to a stable placeholder if the project cannot be resolved.
+        }
+        return "Project #" + projectId;
+    }
+
+    private static String money(BigDecimal value) {
+        BigDecimal v = value == null ? BigDecimal.ZERO : value;
+        return "Rs. " + String.format(Locale.ENGLISH, "%,.2f", v);
+    }
+
+    private static String percent(BigDecimal value) {
+        if (value == null) {
+            return "0";
+        }
+        return value.stripTrailingZeros().toPlainString();
+    }
+
+    private static String plain(BigDecimal value) {
+        if (value == null) {
+            return DASH;
+        }
+        return value.stripTrailingZeros().toPlainString();
+    }
+
+    private static String date(LocalDate value) {
+        return value == null ? DASH : DATE_FMT.format(value);
+    }
+
+    private static String humanise(String enumName) {
+        if (enumName == null || enumName.isBlank()) {
+            return DASH;
+        }
+        String[] parts = enumName.toLowerCase(Locale.ENGLISH).split("_");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return sb.toString();
+    }
+
+    private static String orDash(String value) {
+        return value == null || value.isBlank() ? DASH : value;
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    /** Display-ready projection of a single invoice line for the template. */
+    public record PdfLine(String description,
+                          String unit,
+                          String quantity,
+                          String unitPrice,
+                          String taxRate,
+                          String discountRate,
+                          String total) {
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -8,7 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -17,8 +19,10 @@ import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.pdf.ConstructionInvoicePdfService;
 import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -35,6 +39,7 @@ import java.util.UUID;
 public class ConstructionInvoiceControllerWeb {
 
     private final ConstructionInvoiceService service;
+    private final ConstructionInvoicePdfService pdfService;
 
     @PostMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
@@ -66,6 +71,31 @@ public class ConstructionInvoiceControllerWeb {
     })
     public ConstructionInvoiceDto get(@PathVariable UUID id) {
         return service.findById(id);
+    }
+
+    @GetMapping("/{id}/pdf")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Download a construction invoice as a PDF",
+            description = "Renders the invoice, with its header, billing details and line items, into a "
+                    + "professionally formatted PDF and returns it as a downloadable attachment named "
+                    + "after the invoice number."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "PDF generated and returned as an attachment"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant"),
+            @ApiResponse(responseCode = "500", description = "PDF rendering failed")
+    })
+    public ResponseEntity<byte[]> downloadPdf(@PathVariable UUID id) throws IOException {
+        ConstructionInvoiceDto invoice = service.findById(id);
+        byte[] pdf = pdfService.render(invoice);
+        String number = invoice.invoiceNumber();
+        String filename = (number == null || number.isBlank()) ? "invoice" : number;
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + ".pdf\"")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
     }
 
     @GetMapping

--- a/src/main/resources/templates/invoice/invoice.html
+++ b/src/main/resources/templates/invoice/invoice.html
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title th:text="${invoiceNumber}">Invoice</title>
+    <style type="text/css">
+        @page {
+            size: A4;
+            margin: 28mm 18mm 24mm 18mm;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: 'Helvetica', 'Arial', sans-serif;
+            color: #1f2933;
+            font-size: 10.5px;
+            line-height: 1.45;
+            margin: 0;
+        }
+        .doc-header {
+            border-bottom: 2px solid #c2410c;
+            padding-bottom: 14px;
+            margin-bottom: 18px;
+        }
+        .doc-header .brand {
+            font-size: 22px;
+            font-weight: bold;
+            letter-spacing: 1px;
+            color: #c2410c;
+        }
+        .doc-header .doc-title {
+            font-size: 15px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: #52606d;
+            margin-top: 2px;
+        }
+        .doc-header .invoice-no {
+            font-size: 13px;
+            font-weight: bold;
+            color: #1f2933;
+            margin-top: 6px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .meta-table td {
+            vertical-align: top;
+            padding: 0 8px 8px 0;
+            width: 33%;
+        }
+        .meta-label {
+            font-size: 8.5px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: #7b8794;
+            margin-bottom: 1px;
+        }
+        .meta-value {
+            font-size: 11px;
+            font-weight: bold;
+            color: #1f2933;
+        }
+        .badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 9px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            background-color: #e4e7eb;
+            color: #3e4c59;
+        }
+        .section-title {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: #7b8794;
+            font-weight: bold;
+            margin: 20px 0 6px 0;
+            border-bottom: 1px solid #e4e7eb;
+            padding-bottom: 4px;
+        }
+        .parties td {
+            vertical-align: top;
+            width: 50%;
+            padding-right: 16px;
+        }
+        .party-name {
+            font-size: 12px;
+            font-weight: bold;
+            color: #1f2933;
+        }
+        .party-line {
+            color: #52606d;
+        }
+        .lines {
+            margin-top: 6px;
+        }
+        .lines th {
+            background-color: #f5f7fa;
+            color: #52606d;
+            text-align: left;
+            font-size: 9px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 7px 8px;
+            border-bottom: 1px solid #cbd2d9;
+        }
+        .lines td {
+            padding: 7px 8px;
+            border-bottom: 1px solid #e4e7eb;
+            vertical-align: top;
+        }
+        .num {
+            text-align: right;
+            white-space: nowrap;
+        }
+        .totals {
+            margin-top: 14px;
+        }
+        .totals td {
+            padding: 4px 8px;
+        }
+        .totals .totals-inner {
+            width: 46%;
+            margin-left: 54%;
+        }
+        .totals .totals-inner td {
+            border-bottom: 1px solid #f0f2f5;
+        }
+        .totals .label {
+            color: #52606d;
+        }
+        .totals .grand td {
+            border-top: 2px solid #c2410c;
+            border-bottom: none;
+            font-size: 13px;
+            font-weight: bold;
+            color: #1f2933;
+            padding-top: 8px;
+        }
+        .totals .balance td {
+            font-weight: bold;
+            color: #b42318;
+        }
+        .notes {
+            margin-top: 22px;
+            color: #52606d;
+        }
+        .notes .block {
+            margin-bottom: 10px;
+        }
+        .footer {
+            margin-top: 28px;
+            border-top: 1px solid #e4e7eb;
+            padding-top: 8px;
+            font-size: 8.5px;
+            color: #9aa5b1;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="doc-header">
+    <table>
+        <tr>
+            <td>
+                <div class="brand">Echno</div>
+                <div class="doc-title">Tax Invoice</div>
+            </td>
+            <td class="num">
+                <div class="invoice-no" th:text="${invoiceNumber}">CINV-2026-0000</div>
+                <div style="margin-top:4px;"><span class="badge" th:text="${statusLabel}">Status</span></div>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<table class="meta-table">
+    <tr>
+        <td>
+            <div class="meta-label">Invoice Type</div>
+            <div class="meta-value" th:text="${typeLabel}">Purchase</div>
+        </td>
+        <td>
+            <div class="meta-label">Issue Date</div>
+            <div class="meta-value" th:text="${issueDate}">-</div>
+        </td>
+        <td>
+            <div class="meta-label">Due Date</div>
+            <div class="meta-value" th:text="${dueDate}">-</div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="meta-label">Payment Status</div>
+            <div class="meta-value" th:text="${paymentStatusLabel}">Unpaid</div>
+        </td>
+        <td>
+            <div class="meta-label">Payment Terms</div>
+            <div class="meta-value" th:text="${paymentTerms}">-</div>
+        </td>
+        <td>
+            <div class="meta-label">Payment Method</div>
+            <div class="meta-value" th:text="${paymentMethod}">-</div>
+        </td>
+    </tr>
+</table>
+
+<div class="section-title">Billing Details</div>
+<table class="parties">
+    <tr>
+        <td>
+            <div class="meta-label">Vendor / Payee</div>
+            <div class="party-name" th:text="${vendorName}">Vendor</div>
+            <div class="party-line" th:if="${gstNumber != null and gstNumber != ''}">
+                GSTIN: <span th:text="${gstNumber}">-</span>
+            </div>
+            <div class="party-line" th:if="${taxType != null and taxType != ''}">
+                Tax treatment: <span th:text="${taxType}">-</span>
+            </div>
+        </td>
+        <td>
+            <div class="meta-label">Project</div>
+            <div class="party-name" th:text="${projectName}">Project</div>
+            <div class="party-line" th:if="${paymentDate != null and paymentDate != '—'}">
+                Paid on: <span th:text="${paymentDate}">-</span>
+            </div>
+        </td>
+    </tr>
+</table>
+
+<div class="section-title">Line Items</div>
+<table class="lines">
+    <thead>
+    <tr>
+        <th style="width:4%;">#</th>
+        <th style="width:34%;">Description</th>
+        <th style="width:8%;">Unit</th>
+        <th class="num" style="width:9%;">Qty</th>
+        <th class="num" style="width:13%;">Unit Price</th>
+        <th class="num" style="width:8%;">Tax %</th>
+        <th class="num" style="width:8%;">Disc %</th>
+        <th class="num" style="width:16%;">Line Total</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="line, iter : ${lines}">
+        <td th:text="${iter.count}">1</td>
+        <td th:text="${line.description}">Item</td>
+        <td th:text="${line.unit}">-</td>
+        <td class="num" th:text="${line.quantity}">0</td>
+        <td class="num" th:text="${line.unitPrice}">0.00</td>
+        <td class="num" th:text="${line.taxRate}">0</td>
+        <td class="num" th:text="${line.discountRate}">0</td>
+        <td class="num" th:text="${line.total}">0.00</td>
+    </tr>
+    <tr th:if="${#lists.isEmpty(lines)}">
+        <td colspan="8" style="text-align:center; color:#9aa5b1; padding:14px;">No line items.</td>
+    </tr>
+    </tbody>
+</table>
+
+<table class="totals">
+    <tr>
+        <td>
+            <table class="totals-inner">
+                <tr>
+                    <td class="label">Subtotal</td>
+                    <td class="num" th:text="${subtotal}">Rs. 0.00</td>
+                </tr>
+                <tr>
+                    <td class="label">Tax</td>
+                    <td class="num" th:text="${taxAmount}">Rs. 0.00</td>
+                </tr>
+                <tr>
+                    <td class="label">Discount</td>
+                    <td class="num" th:text="${discountAmount}">Rs. 0.00</td>
+                </tr>
+                <tr class="grand">
+                    <td>Total</td>
+                    <td class="num" th:text="${totalAmount}">Rs. 0.00</td>
+                </tr>
+                <tr>
+                    <td class="label">Paid</td>
+                    <td class="num" th:text="${paidAmount}">Rs. 0.00</td>
+                </tr>
+                <tr class="balance">
+                    <td>Balance Due</td>
+                    <td class="num" th:text="${balanceAmount}">Rs. 0.00</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<div class="notes">
+    <div class="block" th:if="${notes != null and notes != ''}">
+        <div class="meta-label">Notes</div>
+        <div th:text="${notes}">-</div>
+    </div>
+    <div class="block" th:if="${termsAndConditions != null and termsAndConditions != ''}">
+        <div class="meta-label">Terms &amp; Conditions</div>
+        <div th:text="${termsAndConditions}">-</div>
+    </div>
+</div>
+
+<div class="footer">
+    Generated by Echno on <span th:text="${generatedOn}">-</span>. This is a system-generated invoice.
+</div>
+</body>
+</html>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
@@ -1,0 +1,91 @@
+package org.tornotron.echno_backend.finance.construction.pdf;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.configuration.ThymeleafConfig;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineDto;
+import org.tornotron.echno_backend.project.ProjectService;
+import org.tornotron.echno_backend.project.dto.ProjectDto;
+import org.tornotron.echno_backend.vendor.VendorService;
+import org.tornotron.echno_backend.vendor.dto.VendorDto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Renders a fully populated invoice through the real openhtmltopdf pipeline and the actual
+ * Thymeleaf template, proving the template is well formed enough to produce a PDF and that
+ * the resolved vendor and project names are wired into the document.
+ */
+class ConstructionInvoicePdfServiceTest {
+
+    private final VendorService vendorService = mock(VendorService.class);
+    private final ProjectService projectService = mock(ProjectService.class);
+    private final ConstructionInvoicePdfService service =
+            new ConstructionInvoicePdfService(new ThymeleafConfig().pdfTemplateEngine(), vendorService, projectService);
+
+    @Test
+    void render_producesAPdf_forAFullyPopulatedInvoice() throws Exception {
+        VendorDto vendor = new VendorDto();
+        vendor.setId(17L);
+        vendor.setVendorName("Sri Ganesh Traders");
+        when(vendorService.getVendorById(17L)).thenReturn(vendor);
+
+        ProjectDto project = new ProjectDto();
+        project.setId(42L);
+        project.setProjectName("Tower B, Riverside Residences");
+        when(projectService.getAProject(42L)).thenReturn(project);
+
+        byte[] pdf = service.render(sampleInvoice());
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 5)).startsWith("%PDF-");
+    }
+
+    @Test
+    void render_producesAPdf_whenOptionalFieldsAndLinesAreMissing() throws Exception {
+        ConstructionInvoiceDto invoice = new ConstructionInvoiceDto(
+                UUID.randomUUID(), "CINV-2026-0002", ConstructionInvoiceType.PURCHASE,
+                ConstructionInvoiceStatus.DRAFT, ConstructionPaymentStatus.UNPAID,
+                null, null, null, null,
+                null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null,
+                null);
+
+        byte[] pdf = service.render(invoice);
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(new String(pdf, 0, 5)).startsWith("%PDF-");
+    }
+
+    private ConstructionInvoiceDto sampleInvoice() {
+        ConstructionInvoiceLineDto line = new ConstructionInvoiceLineDto(
+                UUID.randomUUID(), "OPC 53 grade cement", new BigDecimal("200"), "bag",
+                new BigDecimal("350.00"), new BigDecimal("18.0"), new BigDecimal("12600.00"),
+                new BigDecimal("5.0"), new BigDecimal("3500.00"), new BigDecimal("70000.00"),
+                new BigDecimal("79100.00"), 512L, 88L, 1204L);
+
+        return new ConstructionInvoiceDto(
+                UUID.randomUUID(), "CINV-2026-0042", ConstructionInvoiceType.PURCHASE,
+                ConstructionInvoiceStatus.PARTIALLY_PAID, ConstructionPaymentStatus.PARTIALLY_PAID,
+                42L, 17L, 108L, 231L,
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31), null,
+                new BigDecimal("67500.00"), new BigDecimal("12150.00"), new BigDecimal("3375.00"),
+                new BigDecimal("76275.00"), new BigDecimal("40000.00"), new BigDecimal("36275.00"),
+                "Net 30", "BANK_TRANSFER", "29ABCDE1234F1Z5", "CGST_SGST",
+                "Second progress claim for tower B", "Payable within 30 days of receipt.",
+                5L, null, 2L, null, 5L, UUID.randomUUID(), null,
+                List.of(line));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
@@ -1,0 +1,107 @@
+package org.tornotron.echno_backend.finance.construction.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.pdf.ConstructionInvoicePdfService;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice test for the invoice PDF download endpoint. It pins that the guard admits a
+ * caller holding an elevated role for the current tenant and forbids one with neither, and
+ * that a served PDF carries the application/pdf content type and an attachment filename
+ * derived from the invoice number. The rendering itself is stubbed; @orgSecurity is mocked.
+ */
+@WebMvcTest(ConstructionInvoiceControllerWeb.class)
+@Import(ConstructionInvoicePdfAuthzTest.TestSecurityConfig.class)
+class ConstructionInvoicePdfAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ConstructionInvoiceService invoiceService;
+
+    @MockitoBean
+    private ConstructionInvoicePdfService pdfService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @Test
+    void downloadPdf_isOk_andServesAnAttachment_forAnElevatedRoleHolder() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        when(invoiceService.findById(id)).thenReturn(stubInvoice(id));
+        when(pdfService.render(any())).thenReturn("%PDF-1.4 stub".getBytes());
+
+        mockMvc.perform(get("/api/v1/finance/construction-invoices/web/{id}/pdf", id).with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", MediaType.APPLICATION_PDF_VALUE))
+                .andExpect(header().string("Content-Disposition", "attachment; filename=\"CINV-2026-0042.pdf\""));
+    }
+
+    @Test
+    void downloadPdf_isForbidden_forACallerWithoutAnElevatedRole() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/finance/construction-invoices/web/{id}/pdf", id).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    private ConstructionInvoiceDto stubInvoice(UUID id) {
+        return new ConstructionInvoiceDto(
+                id, "CINV-2026-0042", ConstructionInvoiceType.PURCHASE,
+                ConstructionInvoiceStatus.APPROVED, ConstructionPaymentStatus.UNPAID,
+                42L, 17L, null, null,
+                null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null,
+                List.of());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a server-rendered PDF for construction invoices and exposes it as a download endpoint.

**Endpoint:** `GET /api/v1/finance/construction-invoices/web/{id}/pdf`

It loads the tenant-scoped invoice, renders it to a PDF, and returns `application/pdf` with `Content-Disposition: attachment; filename="<invoice-number>.pdf"`.

### A note on the path

The invoice detail page in `echno-web` displays a **construction** invoice (`financeConstructionInvoiceService` -> `/finance/construction-invoices/web/{id}`), so the PDF endpoint lives on `ConstructionInvoiceControllerWeb`, alongside the read it downloads from, rather than on the customer-AR `InvoiceControllerWeb`. That keeps the id space consistent: the same `{id}` the page already holds resolves here. The listed PDF fields (type, vendor, project, payment info) are construction-invoice fields.

## How it renders

Mirrors the existing site progress report pipeline:

- A Thymeleaf template `templates/invoice/invoice.html` is processed by the `pdfTemplateEngine` bean.
- `openhtmltopdf-pdfbox` (`PdfRendererBuilder`) turns the HTML into the PDF.
- `ConstructionInvoicePdfService` builds the template context: it formats currency, dates and humanised enum labels in Java (so the template holds no formatting logic) and resolves the vendor and project names, falling back to a stable placeholder if a lookup fails.

The document covers the invoice number, type, status, dates, vendor/payee, project, GST details, line items, and the subtotal / tax / discount / total / paid / balance breakdown, plus notes and terms.

## Auth

Same `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')` guard as the other invoice web reads.

## Tests

- `ConstructionInvoicePdfServiceTest` drives the real openhtmltopdf pipeline and asserts a valid PDF for both a fully populated invoice and one with only the required fields.
- `ConstructionInvoicePdfAuthzTest` (web slice) pins the role guard (200 for an elevated role, 403 otherwise) and the `application/pdf` + attachment-filename response headers.

Verified on the lab build box: `./gradlew --no-daemon --no-configuration-cache compileJava test` -> BUILD SUCCESSFUL, the four new tests green.

## Ordering

This backend endpoint must be **deployed first**. The companion `echno-web` PR that enables the "Download PDF" button depends on it being live.