### PR TITLE
feat: opt-in toggle for multi-level leave approval (#249)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -68,8 +68,14 @@ public class LeaveApprovalService {
     /**
      * Builds and stores the approval chain for a submitted request and notifies the first approver.
      *
+     * <p>The applicable leave policy (the one the request was raised under) decides the shape of the
+     * chain. When {@code multiLevelApprovalEnabled} is true (the default, preserving today's
+     * behaviour) the full management line is used, so the request advances level by level. When an
+     * organization opts out by setting it false, only the direct approver is enrolled
+     * ({@code maxApprovalLevel = 1}), so a single approval finalizes the request.
+     *
      * <p>When the employee has no resolvable approvers, the request is finalized immediately
-     * instead of waiting for an approval.
+     * instead of waiting for an approval, regardless of the toggle.
      *
      * @param request The submitted leave request to route for approval.
      */
@@ -80,6 +86,12 @@ public class LeaveApprovalService {
         if (approvers.isEmpty()) {
             finalizeApproval(request);
             return;
+        }
+
+        if (!isMultiLevelApprovalEnabled(request)) {
+            // Organization opted out of multi-level approval: only the direct
+            // approver decides, so one approval finalizes the request.
+            approvers = approvers.subList(0, 1);
         }
 
         request.setMaxApprovalLevel(approvers.size());
@@ -132,6 +144,25 @@ public class LeaveApprovalService {
         }
 
         return chain;
+    }
+
+    /**
+     * Resolves whether the request's leave policy opts in to multi-level approval.
+     *
+     * <p>Reads the toggle from the policy the request was raised under (already resolved and attached
+     * to the request when it was submitted, the same policy the rest of the leave flow uses). Defaults
+     * to {@code true} when no policy or no explicit value is present, so the historical full-chain
+     * behaviour is preserved.
+     *
+     * @param request The leave request being routed for approval.
+     * @return {@code true} to build the full management-line chain; {@code false} for single-level.
+     */
+    private boolean isMultiLevelApprovalEnabled(LeaveRequest request) {
+        LeavePolicy policy = request.getLeavePolicy();
+        if (policy == null || policy.getMultiLevelApprovalEnabled() == null) {
+            return true;
+        }
+        return policy.getMultiLevelApprovalEnabled();
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicy.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicy.java
@@ -94,6 +94,9 @@ public class LeavePolicy implements TenantScopedEntity {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
 
+    @Column(name = "multi_level_approval_enabled", nullable = false)
+    private Boolean multiLevelApprovalEnabled = true;
+
     @Column(name = "display_order")
     private Integer displayOrder = 0;
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -95,6 +95,9 @@ public class LeavePolicyService {
         policy.setIsPaid(dto.getIsPaid());
         policy.setIsActive(true);
         policy.setDisplayOrder(dto.getDisplayOrder());
+        if (dto.getMultiLevelApprovalEnabled() != null) {
+            policy.setMultiLevelApprovalEnabled(dto.getMultiLevelApprovalEnabled());
+        }
 
         LeavePolicy saved = policyRepository.save(policy);
         return leavePolicyMapper.toDto(saved);
@@ -240,6 +243,7 @@ public class LeavePolicyService {
                 case "allowHalfDay" -> policy.setAllowHalfDay((Boolean) value);
                 case "isPaid" -> policy.setIsPaid((Boolean) value);
                 case "isActive" -> policy.setIsActive((Boolean) value);
+                case "multiLevelApprovalEnabled" -> policy.setMultiLevelApprovalEnabled((Boolean) value);
                 case "displayOrder" -> policy.setDisplayOrder(
                         value != null ? ((Number) value).intValue() : null);
             }
@@ -330,6 +334,7 @@ public class LeavePolicyService {
         duplicate.setIsPaid(source.getIsPaid());
         duplicate.setIsActive(true);
         duplicate.setDisplayOrder(source.getDisplayOrder());
+        duplicate.setMultiLevelApprovalEnabled(source.getMultiLevelApprovalEnabled());
 
         LeavePolicy saved = policyRepository.save(duplicate);
         return leavePolicyMapper.toDto(saved);

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyCreationDto.java
@@ -76,4 +76,9 @@ public class LeavePolicyCreationDto {
 
     @Schema(description = "Order this policy is shown in, relative to the organization's other policies.", example = "1")
     private Integer displayOrder = 0;
+
+    @Schema(description = "Whether leave requests under this policy go through the full multi-level approval "
+            + "chain (the employee's management line). Set false to opt out and let a single approval by the "
+            + "direct approver finalize the request.", example = "true")
+    private Boolean multiLevelApprovalEnabled = true;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyDto.java
@@ -69,6 +69,11 @@ public class LeavePolicyDto {
     @Schema(description = "Whether the policy is currently active.", example = "true")
     private Boolean isActive;
 
+    @Schema(description = "Whether leave requests under this policy go through the full multi-level approval "
+            + "chain (the employee's management line). When false, a single approval by the direct approver "
+            + "finalizes the request.", example = "true")
+    private Boolean multiLevelApprovalEnabled;
+
     @Schema(description = "Order this policy is shown in, relative to the organization's other policies.", example = "1")
     private Integer displayOrder;
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -256,4 +256,7 @@
     <!-- v4.0 - Backfill organization_id on legacy attachments -->
     <include file="db/changelog/v4.0/038-backfill-attachment-organization-id.xml"/>
 
+    <!-- v4.0 - Opt-in toggle for multi-level leave approval (#249) -->
+    <include file="db/changelog/v4.0/039-add-multi-level-approval-to-leave-policy.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/039-add-multi-level-approval-to-leave-policy.xml
+++ b/src/main/resources/db/changelog/v4.0/039-add-multi-level-approval-to-leave-policy.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="039-add-multi-level-approval-to-leave-policy" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="leave_policy" columnName="multi_level_approval_enabled"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Opt-in toggle for multi-level leave approval (#249). Defaults to true so existing
+            policies keep today's full management-line approval chain; an organization can set it
+            false to have a single approval by the direct approver finalize the request.
+        </comment>
+
+        <addColumn tableName="leave_policy">
+            <column name="multi_level_approval_enabled" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
@@ -1,0 +1,219 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.enums.ApprovalAction;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LeaveApprovalService#initializeApprovalChain}, covering the opt-in
+ * multi-level approval toggle on the leave policy (#249). The repositories and collaborators are
+ * mocked and the entity graph is built in memory.
+ *
+ * <p>Three shapes are exercised: a policy with the toggle enabled (the default) builds the full
+ * management-line chain as before; a policy with the toggle disabled builds a single-level chain of
+ * just the direct approver, and one approval then finalizes the request; an employee with no
+ * resolvable approvers finalizes immediately regardless of the toggle.
+ */
+@ExtendWith(MockitoExtension.class)
+class LeaveApprovalServiceTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long REQUEST_ID = 42L;
+    private static final Long POLICY_ID = 3L;
+
+    @Mock private LeaveApprovalRepository approvalRepository;
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private LeaveTransactionRepository transactionRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveCalendarService calendarService;
+    @Mock private NotificationService notificationService;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+
+    private LeaveApprovalService service() {
+        return new LeaveApprovalService(
+                approvalRepository,
+                requestRepository,
+                balanceRepository,
+                transactionRepository,
+                employeeRepository,
+                calendarService,
+                notificationService,
+                leaveRequestMapper);
+    }
+
+    private Organization organization() {
+        Organization org = new Organization();
+        org.setId(ORG_ID);
+        return org;
+    }
+
+    private Employee employee(Long id, Employee manager) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        employee.setOrganization(organization());
+        employee.setManager(manager);
+        return employee;
+    }
+
+    private LeavePolicy policy(Boolean multiLevelEnabled) {
+        LeavePolicy policy = new LeavePolicy();
+        policy.setId(POLICY_ID);
+        policy.setOrganization(organization());
+        policy.setMultiLevelApprovalEnabled(multiLevelEnabled);
+        return policy;
+    }
+
+    private LeaveRequest request(Employee applicant, LeavePolicy policy) {
+        LeaveRequest request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setOrganization(organization());
+        request.setEmployee(applicant);
+        request.setLeavePolicy(policy);
+        request.setStartDate(LocalDate.of(2026, 6, 1));
+        request.setStatus(LeaveStatus.PENDING_APPROVAL);
+        return request;
+    }
+
+    @Test
+    void multiLevelEnabled_buildsFullManagementLineChain() {
+        Employee topManager = employee(3L, null);
+        Employee lineManager = employee(2L, topManager);
+        Employee applicant = employee(1L, lineManager);
+        LeaveRequest request = request(applicant, policy(true));
+
+        service().initializeApprovalChain(request);
+
+        // Full chain: both managers in the management line become approvers.
+        assertThat(request.getMaxApprovalLevel()).isEqualTo(2);
+        assertThat(request.getCurrentApprovalLevel()).isEqualTo(1);
+        assertThat(request.getCurrentApprover()).isEqualTo(lineManager);
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.PENDING_APPROVAL);
+
+        ArgumentCaptor<LeaveApproval> captor = ArgumentCaptor.forClass(LeaveApproval.class);
+        verify(approvalRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues())
+                .extracting(LeaveApproval::getApprovalLevel)
+                .containsExactly(1, 2);
+        assertThat(captor.getAllValues())
+                .extracting(LeaveApproval::getApprover)
+                .containsExactly(lineManager, topManager);
+
+        verify(notificationService).sendApprovalRequiredNotification(request, lineManager);
+    }
+
+    @Test
+    void multiLevelDisabled_buildsSingleLevelChainOfDirectApprover() {
+        Employee topManager = employee(3L, null);
+        Employee lineManager = employee(2L, topManager);
+        Employee applicant = employee(1L, lineManager);
+        LeaveRequest request = request(applicant, policy(false));
+
+        service().initializeApprovalChain(request);
+
+        // Single-level: only the direct approver, even though a management line exists.
+        assertThat(request.getMaxApprovalLevel()).isEqualTo(1);
+        assertThat(request.getCurrentApprovalLevel()).isEqualTo(1);
+        assertThat(request.getCurrentApprover()).isEqualTo(lineManager);
+
+        ArgumentCaptor<LeaveApproval> captor = ArgumentCaptor.forClass(LeaveApproval.class);
+        verify(approvalRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getApprovalLevel()).isEqualTo(1);
+        assertThat(captor.getValue().getApprover()).isEqualTo(lineManager);
+
+        verify(notificationService).sendApprovalRequiredNotification(request, lineManager);
+    }
+
+    @Test
+    void multiLevelDisabled_singleApprovalFinalizesRequest() {
+        Employee topManager = employee(3L, null);
+        Employee lineManager = employee(2L, topManager);
+        Employee applicant = employee(1L, lineManager);
+        LeaveRequest request = request(applicant, policy(false));
+
+        LeaveApprovalService service = service();
+        service.initializeApprovalChain(request);
+
+        // The single-level chain is now in place; the direct approver approves.
+        LeaveApproval pending = new LeaveApproval();
+        pending.setLeaveRequest(request);
+        pending.setApprover(lineManager);
+        pending.setApprovalLevel(1);
+        pending.setAction(ApprovalAction.PENDING);
+
+        when(requestRepository.lockByIdAndOrganizationId(eq(REQUEST_ID), any()))
+                .thenReturn(Optional.of(request));
+        when(approvalRepository.findFirstByLeaveRequestIdAndApprovalLevelAndActionOrderByCreatedAtDesc(
+                eq(REQUEST_ID), eq(1), eq(ApprovalAction.PENDING)))
+                .thenReturn(Optional.of(pending));
+        lenient().when(balanceRepository.findByEmployeeIdAndLeavePolicyIdAndYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(Optional.empty());
+        when(leaveRequestMapper.toDto(request)).thenReturn(new LeaveRequestDto());
+
+        LeaveApprovalActionDto action = new LeaveApprovalActionDto();
+        action.setApproverId(lineManager.getId());
+
+        service.approve(REQUEST_ID, action);
+
+        // maxApprovalLevel == 1, so the first approval finalizes rather than advancing.
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.APPROVED);
+        assertThat(request.getCurrentApprover()).isNull();
+        verify(calendarService).createCalendarEntries(request);
+        verify(notificationService).sendLeaveDecisionNotification(request, ApprovalAction.APPROVED);
+    }
+
+    @Test
+    void noResolvableApprovers_finalizesImmediately() {
+        Employee applicant = employee(1L, null);
+        LeaveRequest request = request(applicant, policy(true));
+        lenient().when(balanceRepository.findByEmployeeIdAndLeavePolicyIdAndYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(Optional.empty());
+
+        service().initializeApprovalChain(request);
+
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.APPROVED);
+        assertThat(request.getCurrentApprover()).isNull();
+        verify(approvalRepository, never()).save(any());
+        verify(notificationService, never()).sendApprovalRequiredNotification(any(), any());
+        verify(notificationService).sendLeaveDecisionNotification(request, ApprovalAction.APPROVED);
+    }
+
+    @Test
+    void nullPolicyToggle_defaultsToMultiLevel() {
+        Employee topManager = employee(3L, null);
+        Employee lineManager = employee(2L, topManager);
+        Employee applicant = employee(1L, lineManager);
+        // A legacy policy with no explicit toggle value must preserve the full-chain behaviour.
+        LeaveRequest request = request(applicant, policy(null));
+
+        service().initializeApprovalChain(request);
+
+        assertThat(request.getMaxApprovalLevel()).isEqualTo(2);
+        verify(approvalRepository, times(2)).save(any());
+    }
+}


### PR DESCRIPTION
Closes #249. Leave requests always went through a multi-level approval chain (built from the management line). Small orgs want to opt out.

**Change:** a `multiLevelApprovalEnabled` boolean on `LeavePolicy` (**default true** — current behaviour is unchanged), settable via the policy DTOs/endpoints. When the applicable org's policy has it **disabled**, `LeaveApprovalService.initializeApprovalChain` builds a **single-level** chain (first approver only, maxApprovalLevel=1) so one approval finalizes the request. The existing no-approver fast-path is preserved. Migration `v4.0/039` adds the column. Unit tests cover toggle on/off and the no-approver path.

**Follow-up (not here):** echno-core `LeavePolicy` type + the web leave-policy form need the field to surface the toggle in the UI; the backend already accepts it. Full suite green on the lab CockroachDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leave policies can now control whether requests require the full management approval chain or only a direct approver.
  * Multi-level approval is enabled by default for existing and new policies.
  * Policy settings are preserved when policies are updated or duplicated.

* **Bug Fixes**
  * Leave requests without resolvable approvers are finalized immediately.
  * Single-approver workflows are finalized after one approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->