### PR TITLE
feat: filter issues list by assignee and creator (#35 phase 2)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -64,7 +64,8 @@ public class IssueControllerWeb {
     @Operation(
             summary = "List issues, paginated and filtered",
             description = "Returns a single page of issues, optionally filtered by project, a free-text "
-                    + "search on title and description, status, or type."
+                    + "search on title and description, status, type, the assigned employee, or the "
+                    + "employee who created it."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of issues returned"),
@@ -76,8 +77,10 @@ public class IssueControllerWeb {
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status,
-            @RequestParam(required = false) String type) {
-        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize, projectId, search, status, type);
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) Long assigneeId,
+            @RequestParam(required = false) Long creatorId) {
+        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize, projectId, search, status, type, assigneeId, creatorId);
         return new ResponseEntity<>(issues, HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueRepository.java
@@ -27,6 +27,8 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
      * Paginated issue search. Every filter is optional (a null argument disables
      * that clause); the tenant orgFilter still applies. {@code search} matches
      * title, description, or the creator's name, case-insensitively.
+     * {@code assigneeId} and {@code creatorId} restrict to the issues assigned to
+     * or created by that employee.
      */
     @Query("""
             SELECT i FROM Issue i WHERE
@@ -36,13 +38,17 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
                  OR LOWER(i.description) LIKE :search
                  OR LOWER(i.createdBy.employeeName) LIKE :search) AND
               (:status IS NULL OR i.status = :status) AND
-              (:type IS NULL OR i.type = :type)
+              (:type IS NULL OR i.type = :type) AND
+              (:assigneeId IS NULL OR i.assignedTo.id = :assigneeId) AND
+              (:creatorId IS NULL OR i.createdBy.id = :creatorId)
             """)
     Page<Issue> search(
             @Param("projectId") Long projectId,
             @Param("search") String search,
             @Param("status") IssueStatus status,
             @Param("type") IssueType type,
+            @Param("assigneeId") Long assigneeId,
+            @Param("creatorId") Long creatorId,
             Pageable pageable);
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -91,9 +91,9 @@ public class IssueService {
     }
 
     @Transactional(readOnly = true)
-    public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type) {
+    public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type, Long assigneeId, Long creatorId) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return issueRepository.search(projectId, searchPattern(search), parseStatus(status), parseType(type), pageable)
+        return issueRepository.search(projectId, searchPattern(search), parseStatus(status), parseType(type), assigneeId, creatorId, pageable)
                 .map(issue -> issueMapper.toDto(issue));
     }
 

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueRepositoryIT.java
@@ -1,0 +1,149 @@
+package org.tornotron.echno_backend.issue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.enums.TaskStatus;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the paginated issue search against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Covers the two optional employee filters
+ * added for the web all-issues list (web#35 phase 2): {@code assigneeId} narrows
+ * to the issues assigned to that employee and {@code creatorId} to the ones they
+ * created, while a null argument leaves that clause off.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class IssueRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private IssueRepository issueRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void search_byAssigneeId_returnsOnlyIssuesAssignedToThatEmployee() {
+        Organization org = persistOrganization("Org A");
+        Employee alice = persistEmployee(org, "Alice");
+        Employee bob = persistEmployee(org, "Bob");
+        persistIssue(org, "Assigned to Alice", bob, alice);
+        persistIssue(org, "Assigned to Bob", bob, bob);
+        em.flush();
+        em.clear();
+
+        Page<Issue> result = issueRepository.search(
+                null, null, null, null, alice.getId(), null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Issue::getTitle)
+                .containsExactly("Assigned to Alice");
+    }
+
+    @Test
+    void search_byCreatorId_returnsOnlyIssuesCreatedByThatEmployee() {
+        Organization org = persistOrganization("Org B");
+        Employee carol = persistEmployee(org, "Carol");
+        Employee dave = persistEmployee(org, "Dave");
+        persistIssue(org, "Raised by Carol", carol, dave);
+        persistIssue(org, "Raised by Dave", dave, carol);
+        em.flush();
+        em.clear();
+
+        Page<Issue> result = issueRepository.search(
+                null, null, null, null, null, carol.getId(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Issue::getTitle)
+                .containsExactly("Raised by Carol");
+    }
+
+    @Test
+    void search_withBothEmployeeFiltersNull_returnsAll() {
+        Organization org = persistOrganization("Org C");
+        Employee eve = persistEmployee(org, "Eve");
+        persistIssue(org, "First unfiltered", eve, eve);
+        persistIssue(org, "Second unfiltered", eve, null);
+        em.flush();
+        em.clear();
+
+        Page<Issue> result = issueRepository.search(
+                null, null, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(Issue::getTitle)
+                .contains("First unfiltered", "Second unfiltered");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Employee persistEmployee(Organization org, String name) {
+        User user = new User();
+        user.setKeycloakId("kc-" + name.toLowerCase());
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase() + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+        return employee;
+    }
+
+    private void persistIssue(Organization org, String title, Employee createdBy, Employee assignedTo) {
+        Issue issue = new Issue();
+        issue.setTitle(title);
+        issue.setDescription(title + " description");
+        issue.setType(IssueType.safety);
+        issue.setStatus(IssueStatus.open);
+        issue.setOrganization(org);
+        issue.setCreatedBy(createdBy);
+        issue.setAssignedTo(assignedTo);
+        // The search query resolves i.task.project.id, an implicit inner join, so an
+        // issue only appears when it has a task on a project (as every created issue does).
+        issue.setTask(persistTask(org, title, createdBy));
+        em.persist(issue);
+    }
+
+    private Task persistTask(Organization org, String title, Employee creator) {
+        Project project = new Project();
+        project.setProjectName(title + " project");
+        project.setOrganization(org);
+        em.persist(project);
+
+        Task task = new Task();
+        task.setTitle(title + " task");
+        task.setOrganization(org);
+        task.setCreator(creator);
+        task.setProject(project);
+        task.setStatus(TaskStatus.upcoming);
+        em.persist(task);
+        return task;
+    }
+}


### PR DESCRIPTION
## What

Adds two optional filter parameters to the paginated issue list endpoint (`GET /api/v1/issues/web/paginated`) so the web global all-issues view can request issues by employee:

- **`assigneeId`** (Long, optional) — restricts to issues whose `assignedTo.id` equals the given employee id.
- **`creatorId`** (Long, optional) — restricts to issues whose `createdBy.id` (the reporter) equals the given employee id.

Both follow the existing optional-filter convention: a null/absent argument leaves the clause off, exactly like `projectId`, `search`, `status`, and `type`. The params are threaded through the same path as the current filters: web controller `@RequestParam` to the service to the repository JPQL `search` query.

## Why

The global issues list is server-paginated and its filters had no way to narrow by the assignee or the creator. The web app (echno-web) global all-issues list (web#35 phase 2) consumes these two new params to offer "assigned to / created by employee X" filtering.

## Entity associations used

- assignee: `Issue.assignedTo` (`@ManyToOne Employee`)
- creator/reporter: `Issue.createdBy` (`@ManyToOne Employee`)

## Tests

New `IssueRepositoryIT` (DataJpaTest against the CockroachDB Testcontainer) asserts `assigneeId` narrows to that assignee's issues, `creatorId` to that creator's issues, and that both-null returns all. Compile and the new tests are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional filters to issue listings for assignee and creator.
  * Issue search now includes matches based on the assigned employee and issue creator.
  * Existing pagination, sorting, status, type, and text-search options remain available.

* **Tests**
  * Added coverage verifying assignee and creator filtering, including unfiltered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->