### PR TITLE
fix: attribute attendance approvals to the real approver, not "system"

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
@@ -122,6 +122,9 @@ public class Attendance implements TenantScopedEntity {
     @Column(name = "approved_by")
     private String approvedBy;
 
+    @Column(name = "approved_by_id")
+    private Long approvedById;
+
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -162,7 +162,7 @@ public class AttendanceController {
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
-        return ResponseEntity.ok(attendanceService.approveAttendance(id, dto, "system"));
+        return ResponseEntity.ok(attendanceService.approveAttendance(id, dto));
     }
 
     @PostMapping("/mark-absent")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -160,7 +160,7 @@ public class AttendanceControllerWeb {
     public ResponseEntity<AttendanceResponseDto> approve(
             @PathVariable Long id,
             @Valid @RequestBody AttendanceApprovalDto dto) {
-        return ResponseEntity.ok(attendanceService.approveAttendance(id, dto, "system"));
+        return ResponseEntity.ok(attendanceService.approveAttendance(id, dto));
     }
 
     @PostMapping("/mark-absent")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -26,6 +26,7 @@ import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -47,6 +48,9 @@ public class AttendanceService {
 
     private static final String ATTENDANCE_FOLDER = "attendance";
 
+    /** Fallback approver name stamped when no authenticated employee can be resolved (e.g. a system job). */
+    private static final String SYSTEM_APPROVER = "system";
+
     private final AttendanceRepository attendanceRepository;
     private final ShiftTimingRepository shiftTimingRepository;
     private final EmployeeRepository employeeRepository;
@@ -58,6 +62,7 @@ public class AttendanceService {
     private final AttendanceMapper attendanceMapper;
     private final AttachmentService attachmentService;
     private final FileStorageService fileStorageService;
+    private final UserContextService userContextService;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              ShiftTimingRepository shiftTimingRepository,
@@ -69,7 +74,8 @@ public class AttendanceService {
                              ClockEventSequenceValidator sequenceValidator,
                              AttendanceMapper attendanceMapper,
                              AttachmentService attachmentService,
-                             FileStorageService fileStorageService) {
+                             FileStorageService fileStorageService,
+                             UserContextService userContextService) {
         this.attendanceRepository = attendanceRepository;
         this.shiftTimingRepository = shiftTimingRepository;
         this.employeeRepository = employeeRepository;
@@ -81,6 +87,7 @@ public class AttendanceService {
         this.attendanceMapper = attendanceMapper;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
+        this.userContextService = userContextService;
     }
 
     /**
@@ -362,25 +369,53 @@ public class AttendanceService {
     /**
      * Sets the approval decision on an attendance record and stamps who approved it and when.
      *
+     * <p>The approver is resolved from the security context: the authenticated user is mapped to
+     * their {@link Employee} in the current organization, and that employee's id and name are
+     * stamped onto the record. When no employee can be resolved for the caller (for example a
+     * system or scheduled job that runs without a user principal), the record falls back to the
+     * {@code "system"} name with no approver id.
+     *
      * @param attendanceId The ID of the attendance record.
      * @param dto The approval status and optional remarks.
-     * @param approvedBy An identifier for the approving user.
      * @return The updated attendance record.
      * @throws ResourceNotFoundException if no record with the given ID exists in this organization.
      */
     @Transactional
-    public AttendanceResponseDto approveAttendance(Long attendanceId, AttendanceApprovalDto dto, String approvedBy) {
+    public AttendanceResponseDto approveAttendance(Long attendanceId, AttendanceApprovalDto dto) {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(attendanceId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Attendance record with ID " + attendanceId + " was not found"));
 
+        Employee approver = resolveCurrentEmployee();
+
         attendance.setApprovalStatus(dto.getApprovalStatus());
-        attendance.setApprovedBy(approvedBy);
+        if (approver != null) {
+            attendance.setApprovedBy(approver.getEmployeeName());
+            attendance.setApprovedById(approver.getId());
+        } else {
+            attendance.setApprovedBy(SYSTEM_APPROVER);
+            attendance.setApprovedById(null);
+        }
         attendance.setApprovedAt(LocalDateTime.now());
         if (dto.getRemarks() != null) {
             attendance.setRemarks(dto.getRemarks());
         }
 
         return attendanceMapper.toResponseDto(attendanceRepository.save(attendance),fileStorageService);
+    }
+
+    /**
+     * Resolves the authenticated caller to their {@link Employee} in the current organization,
+     * or {@code null} when there is no authenticated user or no matching employee record (for
+     * example a system or scheduled job).
+     */
+    private Employee resolveCurrentEmployee() {
+        Long userId = userContextService.getCurrentUserId();
+        if (userId == null) {
+            return null;
+        }
+        return employeeRepository
+                .findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
@@ -85,8 +85,11 @@ public class AttendanceResponseDto {
     @Schema(description = "Approval status of the record.", example = "APPROVED")
     private ApprovalStatus approvalStatus;
 
-    @Schema(description = "Name or id of the person who approved or rejected the record.", example = "Anand Rajashekar")
+    @Schema(description = "Name of the employee who approved or rejected the record.", example = "Anand Rajashekar")
     private String approvedBy;
+
+    @Schema(description = "Employee id of the person who approved or rejected the record, for filtering by approver.", example = "42")
+    private Long approvedById;
 
     @Schema(description = "Timestamp the record was approved or rejected.", example = "2026-01-16T10:15:00")
     private LocalDateTime approvedAt;

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapper.java
@@ -63,6 +63,7 @@ public class AttendanceMapper {
                         : null)
                 .approvalStatus(attendance.getApprovalStatus())
                 .approvedBy(attendance.getApprovedBy())
+                .approvedById(attendance.getApprovedById())
                 .approvedAt(attendance.getApprovedAt())
                 .remarks(attendance.getRemarks())
                 .createdAt(attendance.getCreatedAt())

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -265,4 +265,7 @@
     <include file="db/changelog/v4.0/042-add-regularization-employee-ids.xml"/>
     <include file="db/changelog/v4.0/043-backfill-regularization-employee-ids.xml"/>
 
+    <!-- v4.0 - Attribute attendance approvals to the approving employee -->
+    <include file="db/changelog/v4.0/044-add-approved-by-id-to-attendance.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/044-add-approved-by-id-to-attendance.xml
+++ b/src/main/resources/db/changelog/v4.0/044-add-approved-by-id-to-attendance.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="044-add-approved-by-id-to-attendance" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="attendance" columnName="approved_by_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Employee id of the approver on an attendance record, alongside the existing approved_by
+            name. Lets approvals be attributed to and filtered by a real employee instead of the
+            former hard-coded "system" string. Nullable, since a system or scheduled approval has
+            no employee principal.
+        </comment>
+
+        <addColumn tableName="attendance">
+            <column name="approved_by_id" type="BIGINT"/>
+        </addColumn>
+
+        <createIndex tableName="attendance" indexName="idx_attendance_approved_by_id">
+            <column name="approved_by_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -1,0 +1,131 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.dto.AttendanceApprovalDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the approval attribution in {@link AttendanceService#approveAttendance}. The focus
+ * is that an approval records the authenticated employee's id and name, rather than the former
+ * hard-coded "system" string, and that it falls back safely to "system" with no id when there is
+ * no authenticated employee (for example a system or scheduled job).
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceApprovalTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ATT_ID = 42L;
+    private static final Long USER_ID = 7L;
+    private static final Long APPROVER_EMP_ID = 55L;
+    private static final String APPROVER_NAME = "Anand Rajashekar";
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private AttendanceApprovalDto approvalDto() {
+        AttendanceApprovalDto dto = new AttendanceApprovalDto();
+        dto.setApprovalStatus(ApprovalStatus.APPROVED);
+        return dto;
+    }
+
+    private Employee approver() {
+        Employee employee = new Employee();
+        employee.setId(APPROVER_EMP_ID);
+        employee.setEmployeeName(APPROVER_NAME);
+        return employee;
+    }
+
+    @Test
+    void approvalIsAttributedToTheAuthenticatedEmployee() {
+        Attendance record = Attendance.builder().id(ATT_ID).build();
+        when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG)).thenReturn(Optional.of(record));
+        when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
+        when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG)).thenReturn(Optional.of(approver()));
+        when(attendanceRepository.save(any(Attendance.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(attendanceMapper.toResponseDto(any(Attendance.class), any(FileStorageService.class)))
+                .thenReturn(AttendanceResponseDto.builder().build());
+
+        service.approveAttendance(ATT_ID, approvalDto());
+
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        org.mockito.Mockito.verify(attendanceRepository).save(captor.capture());
+        Attendance saved = captor.getValue();
+
+        assertThat(saved.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+        assertThat(saved.getApprovedBy()).isEqualTo(APPROVER_NAME);
+        assertThat(saved.getApprovedById()).isEqualTo(APPROVER_EMP_ID);
+        assertThat(saved.getApprovedBy()).isNotEqualTo("system");
+    }
+
+    @Test
+    void approvalFallsBackToSystemWhenNoAuthenticatedEmployee() {
+        Attendance record = Attendance.builder().id(ATT_ID).build();
+        when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG)).thenReturn(Optional.of(record));
+        when(userContextService.getCurrentUserId()).thenReturn(null);
+        when(attendanceRepository.save(any(Attendance.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(attendanceMapper.toResponseDto(any(Attendance.class), any(FileStorageService.class)))
+                .thenReturn(AttendanceResponseDto.builder().build());
+
+        service.approveAttendance(ATT_ID, approvalDto());
+
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        org.mockito.Mockito.verify(attendanceRepository).save(captor.capture());
+        Attendance saved = captor.getValue();
+
+        assertThat(saved.getApprovedBy()).isEqualTo("system");
+        assertThat(saved.getApprovedById()).isNull();
+    }
+}


### PR DESCRIPTION
## Problem

The attendance approve endpoints stamped the record's `approvedBy` field with the hard-coded literal string `"system"` instead of the authenticated approver. Approvals were therefore never attributed to a real person, and there was no approver id to filter attendance by.

The `"system"` literal was passed at two call sites:

- `AttendanceController#approve` (`POST /api/v1/attendance/{id}/approve`)
- `AttendanceControllerWeb#approve` (`POST /api/v1/web/attendance/{id}/approve`)

both calling `attendanceService.approveAttendance(id, dto, "system")`.

## Change

`approveAttendance` now owns approver resolution and no longer takes an approver string. It resolves the authenticated caller to their `Employee` in the current organization using the same pattern used elsewhere in the codebase:

1. `UserContextService.getCurrentUserId()` maps the Keycloak principal to the app user id.
2. `EmployeeRepository.findByUserIdAndOrganizationId(userId, currentOrgId)` maps that user to the tenant-scoped employee.

The resolved employee's name is stamped onto `approvedBy` and its id onto the new `approvedById` field. Both controllers now call `approveAttendance(id, dto)`; neither passes a literal any more.

### New `approvedById` column

- Nullable `approved_by_id` (`BIGINT`) added to the `attendance` table in Liquibase changeset `v4.0/044-add-approved-by-id-to-attendance.xml`, with a supporting index so approvals can be filtered by approver.
- Exposed as `approvedById` on `AttendanceResponseDto` (and mapped in `AttendanceMapper`).

Note: phase 3 (#35) added `approved_by_id` only to `attendance_regularization`; the `attendance` table itself still lacked it, so this column is new.

### System / cron fallback

When no employee can be resolved for the caller (no authenticated user principal, e.g. a system or scheduled job), the record falls back to the `"system"` name with a null approver id. This keeps such non-user-driven paths safe while attributing all real, user-driven approvals to the actual approver.

## Tests

New `AttendanceServiceApprovalTest` (JUnit + Mockito) covers both paths:

- an approval by an authenticated employee records that employee's id and name (asserted not `"system"`);
- an approval with no authenticated employee falls back to `"system"` with a null id.

## Verification

Compiled and ran the full test suite on the lab build box: `BUILD SUCCESSFUL`, all 60 test classes pass (Testcontainers integration tests included); the new test reports 2 passed, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance approvals now record the approving employee’s name and ID.
  * Approval details can be filtered using the approver’s employee ID.
* **Bug Fixes**
  * Approval attribution now uses the authenticated employee instead of a generic system value.
  * Unauthenticated approvals continue to use a system fallback without an employee ID.
* **Database**
  * Added support for storing and indexing approver IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->