### PR TITLE
feat: material movement-history endpoint (#256)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryMaterialStockDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialLocationStockDto;
+import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialMovementHistoryDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.TaskMaterialUsageDto;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 
@@ -109,6 +110,28 @@ public class InventoryTransactionController {
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByMaterial(@PathVariable Long materialId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByMaterial(materialId);
         return ResponseEntity.ok(transactions);
+    }
+
+    @GetMapping("/material/{materialId}/history")
+    @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
+    @Operation(
+            summary = "Get a material's movement history (timeline, paginated)",
+            description = "Returns the material's stock movements as a timeline, oldest movement first, one "
+                    + "page at a time. Each entry carries the storage location, project, movement type and its "
+                    + "stock direction, the quantity changed, the timestamp and the source reference, so a "
+                    + "caller can show where the material has been, when, and how much."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of movement-history entries for the material"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
+    })
+    public ResponseEntity<Page<MaterialMovementHistoryDto>> getMaterialMovementHistory(
+            @PathVariable Long materialId,
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageNo, pageSize);
+        return ResponseEntity.ok(history);
     }
 
     @GetMapping("/project/{projectId}")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryMaterialStockDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialLocationStockDto;
+import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialMovementHistoryDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.TaskMaterialUsageDto;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 
@@ -99,6 +100,28 @@ public class InventoryTransactionControllerWeb {
     public ResponseEntity<List<InventoryTransactionDto>> getTransactionsByMaterial(@PathVariable Long materialId) {
         List<InventoryTransactionDto> transactions = inventoryTransactionService.getTransactionsByMaterial(materialId);
         return ResponseEntity.ok(transactions);
+    }
+
+    @GetMapping("/material/{materialId}/history")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Get a material's movement history (timeline, paged)",
+            description = "Returns the material's stock movements as a timeline, oldest movement first, "
+                    + "one page at a time. Each entry carries the storage location, project, movement type "
+                    + "and its stock direction, the quantity changed, the timestamp and the source reference "
+                    + "so the caller can show where the material has been, when, and how much."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of movement-history entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<MaterialMovementHistoryDto>> getMaterialMovementHistory(
+            @PathVariable Long materialId,
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageNo, pageSize);
+        return ResponseEntity.ok(history);
     }
 
     @GetMapping("/project/{projectId}")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.inventoryTransaction;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,16 @@ public interface InventoryTransactionRepository extends JpaRepository<InventoryT
     Optional<InventoryTransaction> findByIdAndOrganization_Id(Long id, Long organizationId);
 
     List<InventoryTransaction> findByMaterialId(Long materialId);
+
+    /**
+     * A material's movement history as a page, oldest movement first so the caller reads it
+     * as a forward-running timeline. The id is a stable tie-break when two movements share a
+     * transaction date. Tenant scoping is applied by the {@code orgFilter} Hibernate filter,
+     * as with the other ledger reads.
+     */
+    @Query("SELECT it FROM InventoryTransaction it WHERE it.material.id = :materialId " +
+           "ORDER BY it.transactionDate ASC, it.id ASC")
+    Page<InventoryTransaction> findMovementHistoryByMaterial(@Param("materialId") Long materialId, Pageable pageable);
 
     List<InventoryTransaction> findByTransactionType(InventoryTransactionType transactionType);
 

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.inventoryTransaction.mapper.InventoryTransact
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
+import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialMovementHistoryDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.TaskMaterialUsageDto;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 
@@ -80,6 +81,26 @@ public class InventoryTransactionService {
         return inventoryTransactionRepository.findByMaterialId(materialId).stream()
                 .map(transaction -> inventoryTransactionMapper.toDto(transaction))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * A material's movement history as a timeline, one page at a time, oldest movement first.
+     *
+     * <p>Backs the Location module timeline (issue #256): each entry carries where the material
+     * moved (storage location), the project, when, the movement type and its stock direction,
+     * the quantity changed and the source reference. Ordered oldest-first so the page reads as a
+     * forward-running timeline, with the id as a stable tie-break within one transaction date.
+     *
+     * @param materialId The material whose movements are listed.
+     * @param pageNo Zero-based page index.
+     * @param pageSize Number of movements per page.
+     * @return A page of movement-history entries ordered by transaction date ascending.
+     */
+    @Transactional(readOnly = true)
+    public Page<MaterialMovementHistoryDto> getMaterialMovementHistory(Long materialId, int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize);
+        return inventoryTransactionRepository.findMovementHistoryByMaterial(materialId, pageable)
+                .map(inventoryTransactionMapper::toMovementHistoryDto);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.inventoryTransaction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType.StockEffect;
+
+import java.time.LocalDateTime;
+
+/**
+ * One entry in a material's movement history: a single stock movement condensed to the
+ * fields a timeline needs, namely where the material was, when, in what direction and by
+ * how much. Used by the Location module timeline (issue #256) to answer "where has this
+ * material been, when, and how much".
+ */
+@Data
+@Schema(description = "A single movement of a material for its timeline history: the storage location it "
+        + "applied to, when it happened, the movement type and its stock direction, the quantity changed "
+        + "and the source reference.")
+public class MaterialMovementHistoryDto {
+
+    @Schema(description = "Unique transaction id.", example = "5012")
+    private Long id;
+
+    @Schema(description = "When the movement was recorded.", example = "2026-08-01T10:30:00")
+    private LocalDateTime transactionDate;
+
+    @Schema(description = "Movement type, for example GRN, USE, TRANSFER_OUT, TRANSFER_IN, ADJUST or OPENING_BALANCE.",
+            example = "USE")
+    private InventoryTransactionType transactionType;
+
+    @Schema(description = "Direction the movement type moves stock in: INCREASE, DECREASE, or EITHER when the "
+            + "sign comes from the signed quantity.", example = "DECREASE")
+    private StockEffect direction;
+
+    @Schema(description = "Storage location the movement applied to.", example = "7")
+    private Long storageLocationId;
+
+    @Schema(description = "Storage location name.", example = "Site A main store")
+    private String storageLocationName;
+
+    @Schema(description = "Project the movement is booked against.", example = "42")
+    private Long projectId;
+
+    @Schema(description = "Project name.", example = "Tower B fit-out")
+    private String projectName;
+
+    @Schema(description = "Signed change applied by this movement. Positive for stock in, negative for stock out.",
+            example = "-15.0")
+    private Double quantityChanged;
+
+    @Schema(description = "Source document reference for the movement, for example a GRN or challan number.",
+            example = "GRN-2026-0042")
+    private String referenceNumber;
+}

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/mapper/InventoryTransactionMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/mapper/InventoryTransactionMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
+import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialMovementHistoryDto;
 
 /**
  * Maps {@link InventoryTransaction} to its DTO. The material/project/storage-location/
@@ -22,4 +23,16 @@ public interface InventoryTransactionMapper {
     @Mapping(source = "task.id", target = "taskId")
     @Mapping(source = "task.title", target = "taskTitle")
     InventoryTransactionDto toDto(InventoryTransaction transaction);
+
+    /**
+     * Condenses a ledger row to a movement-history timeline entry. The movement direction is
+     * read from the transaction type's {@code stockEffect}, so the sign metadata lives in one
+     * place rather than being inferred at the call site.
+     */
+    @Mapping(source = "transactionType.stockEffect", target = "direction")
+    @Mapping(source = "storageLocation.id", target = "storageLocationId")
+    @Mapping(source = "storageLocation.locationName", target = "storageLocationName")
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "project.projectName", target = "projectName")
+    MaterialMovementHistoryDto toMovementHistoryDto(InventoryTransaction transaction);
 }

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/MaterialMovementHistoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/MaterialMovementHistoryIT.java
@@ -1,0 +1,128 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType.StockEffect;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the material movement-history finder that backs the Location module timeline
+ * (issue #256): it returns only the requested material's ledger rows, oldest movement first,
+ * and each row resolves its storage location and carries a movement direction. Runs against a
+ * real CockroachDB through the shared Testcontainer.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MaterialMovementHistoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryTransactionRepository repository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void movementHistory_returnsMaterialRowsOldestFirstWithLocationAndDirection() {
+        Organization org = new Organization();
+        org.setOrganizationName("History Org");
+        org.setOrganizationAddress("addr");
+        org.setOrganizationEmail("history@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+
+        Project project = new Project();
+        project.setProjectName("Timeline Project");
+        project.setOrganization(org);
+        entityManager.persist(project);
+
+        Material cement = new Material();
+        cement.setMaterialName("Cement");
+        cement.setUnit("bag");
+        cement.setOrganization(org);
+        entityManager.persist(cement);
+
+        Material steel = new Material();
+        steel.setMaterialName("Steel");
+        steel.setUnit("ton");
+        steel.setOrganization(org);
+        entityManager.persist(steel);
+
+        StorageLocation mainStore = location(org, project, "Site A main store");
+        StorageLocation yard = location(org, project, "Site A yard");
+        entityManager.persist(mainStore);
+        entityManager.persist(yard);
+
+        // Insert out of date order to prove the query, not the insert order, decides the timeline.
+        LocalDateTime base = LocalDateTime.of(2026, 8, 1, 9, 0);
+        persistTransaction(org, project, cement, yard, InventoryTransactionType.USE, -15.0, base.plusDays(2), "USE-3");
+        persistTransaction(org, project, cement, mainStore, InventoryTransactionType.GRN, 100.0, base, "GRN-1");
+        persistTransaction(org, project, cement, mainStore, InventoryTransactionType.TRANSFER_OUT, -20.0, base.plusDays(1), "TRF-2");
+        // A different material must not leak into the history.
+        persistTransaction(org, project, steel, yard, InventoryTransactionType.GRN, 5.0, base.plusDays(1), "GRN-STEEL");
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<InventoryTransaction> page =
+                repository.findMovementHistoryByMaterial(cement.getId(), PageRequest.of(0, 10));
+
+        List<InventoryTransaction> rows = page.getContent();
+
+        // Only the cement rows, and all of them.
+        assertThat(rows).hasSize(3);
+        assertThat(rows).allSatisfy(row -> assertThat(row.getMaterial().getId()).isEqualTo(cement.getId()));
+
+        // Oldest movement first.
+        assertThat(rows).extracting(InventoryTransaction::getReferenceNumber)
+                .containsExactly("GRN-1", "TRF-2", "USE-3");
+        assertThat(rows).extracting(InventoryTransaction::getTransactionDate).isSorted();
+
+        // Storage location resolves on each row.
+        assertThat(rows).extracting(row -> row.getStorageLocation().getLocationName())
+                .containsExactly("Site A main store", "Site A main store", "Site A yard");
+
+        // Direction comes from the transaction type's stock effect.
+        assertThat(rows).extracting(row -> row.getTransactionType().getStockEffect())
+                .containsExactly(StockEffect.INCREASE, StockEffect.DECREASE, StockEffect.DECREASE);
+    }
+
+    private StorageLocation location(Organization org, Project project, String name) {
+        StorageLocation location = new StorageLocation();
+        location.setLocationName(name);
+        location.setLocationType(StorageLocationType.WAREHOUSE);
+        location.setOrganization(org);
+        location.setProject(project);
+        return location;
+    }
+
+    private void persistTransaction(Organization org, Project project, Material material,
+                                    StorageLocation location, InventoryTransactionType type,
+                                    double quantityChanged, LocalDateTime when, String reference) {
+        InventoryTransaction txn = new InventoryTransaction();
+        txn.setOrganization(org);
+        txn.setProject(project);
+        txn.setMaterial(material);
+        txn.setStorageLocation(location);
+        txn.setTransactionType(type);
+        txn.setQuantityChanged(quantityChanged);
+        txn.setTransactionDate(when);
+        txn.setReferenceNumber(reference);
+        entityManager.persist(txn);
+    }
+}


### PR DESCRIPTION
## What

Adds a time-ordered movement history for a material so the web Location module timeline (#256, Option B) can answer "where has this material been, when, and how much".

## Endpoint

`GET /api/v1/inventory-transactions/web/material/{materialId}/history` (web console, `@orgSecurity` system-admin), plus its base-controller twin `GET /api/v1/inventory-transactions/material/{materialId}/history` (`inventory-transaction:read`/`:admin`), matching the existing base/web twin pattern in this module.

The existing `/material/{materialId}` endpoint already returns a material's transactions but as an unordered, unpaged full `InventoryTransactionDto` list. Rather than change its contract (echno-web consumes it), this adds a dedicated `/history` sub-path shaped for a timeline: paged and ordered.

- **Ordering:** oldest movement first (`transactionDate ASC`, `id ASC` as a stable tie-break), so the page reads as a forward-running timeline.
- **Paging:** `pageNo`/`pageSize` request params (defaults 0/10), returning `Page<MaterialMovementHistoryDto>`, like the other paged list endpoints.
- **Tenant scoping:** the same `orgFilter` Hibernate filter that scopes the module's other ledger reads.

## DTO

`MaterialMovementHistoryDto` carries, per movement:

- `transactionType` and its `direction` (the `StockEffect` INCREASE/DECREASE/EITHER from the type, sourced via the mapper so the sign metadata stays in one place)
- `storageLocationId` + resolved `storageLocationName`
- `projectId` + `projectName`
- `quantityChanged`, `transactionDate`, `referenceNumber`, `id`

## Reuse

Builds on the existing `InventoryTransaction` ledger and `InventoryTransactionMapper`. A new repository finder `findMovementHistoryByMaterial` supplies the ordered page; the existing `findByMaterialId` was left untouched.

## Test

`MaterialMovementHistoryIT` (repository slice against the real CockroachDB Testcontainer) asserts the history returns only the requested material's rows, oldest first, with the storage location resolved and the direction derived from the transaction type.

## Verification

`./gradlew clean build` (full suite) green on the lab build box.