### PR TITLE
feat: material GST rate + per-location thresholds (#257)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/material/Material.java
+++ b/src/main/java/org/tornotron/echno_backend/material/Material.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
 import org.tornotron.echno_backend.materialConsumption.MaterialConsumption;
 import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +51,9 @@ public class Material implements TenantScopedEntity {
 
     @Column(name = "hsn")
     private String hsn;
+
+    @Column(name = "gst_rate")
+    private BigDecimal gstRate;
 
     @Column(name = "opening_stock")
     private Double openingStock;

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
@@ -14,6 +14,9 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
+import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
 
 import java.util.List;
 
@@ -31,9 +34,12 @@ import java.util.List;
 public class MaterialController {
 
     private final MaterialService materialService;
+    private final MaterialLocationThresholdService thresholdService;
 
-    public MaterialController(MaterialService materialService) {
+    public MaterialController(MaterialService materialService,
+                             MaterialLocationThresholdService thresholdService) {
         this.materialService = materialService;
+        this.thresholdService = thresholdService;
     }
 
     @PostMapping
@@ -186,5 +192,60 @@ public class MaterialController {
     public ResponseEntity<ApiResponse> deleteMaterial(@PathVariable Long id) {
         materialService.deleteMaterial(id);
         return ResponseEntity.ok(new ApiResponse("Material with id: " + id + " deleted successfully"));
+    }
+
+    @GetMapping("/{materialId}/location-thresholds")
+    @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "List a material's per-location threshold overrides",
+            description = "Returns every storage-location override of the material's planning thresholds. "
+                    + "A location not listed here uses the material's global thresholds."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Overrides returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
+    public ResponseEntity<List<MaterialLocationThresholdDto>> getLocationThresholds(@PathVariable Long materialId) {
+        return ResponseEntity.ok(thresholdService.listForMaterial(materialId));
+    }
+
+    @PutMapping("/{materialId}/location-thresholds/{storageLocationId}")
+    @PreAuthorize("hasAuthority('material:update') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Set a material's thresholds at a storage location",
+            description = "Creates or replaces the material's threshold override at the given storage location. "
+                    + "Any field left null clears that level so the material's global threshold applies."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Override saved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material or storage location with the given id")
+    })
+    public ResponseEntity<MaterialLocationThresholdDto> upsertLocationThreshold(
+            @PathVariable Long materialId,
+            @PathVariable Long storageLocationId,
+            @Valid @RequestBody MaterialLocationThresholdUpsertDto upsertDto) {
+        return ResponseEntity.ok(thresholdService.upsert(materialId, storageLocationId, upsertDto));
+    }
+
+    @DeleteMapping("/{materialId}/location-thresholds/{storageLocationId}")
+    @PreAuthorize("hasAuthority('material:update') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "Remove a material's thresholds at a storage location",
+            description = "Deletes the material's threshold override at the given storage location, so the "
+                    + "material's global thresholds apply there again."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Override removed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No override for the given material and storage location")
+    })
+    public ResponseEntity<Void> deleteLocationThreshold(
+            @PathVariable Long materialId,
+            @PathVariable Long storageLocationId) {
+        thresholdService.delete(materialId, storageLocationId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -14,6 +14,9 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
+import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
 
 import java.util.List;
 
@@ -30,9 +33,12 @@ import java.util.List;
 public class MaterialControllerWeb {
 
     private final MaterialService materialService;
+    private final MaterialLocationThresholdService thresholdService;
 
-    public MaterialControllerWeb(MaterialService materialService) {
+    public MaterialControllerWeb(MaterialService materialService,
+                                MaterialLocationThresholdService thresholdService) {
         this.materialService = materialService;
+        this.thresholdService = thresholdService;
     }
 
     @PostMapping
@@ -185,5 +191,60 @@ public class MaterialControllerWeb {
     public ResponseEntity<ApiResponse> deleteMaterial(@PathVariable Long id) {
         materialService.deleteMaterial(id);
         return ResponseEntity.ok(new ApiResponse("Material with id: " + id + " deleted successfully"));
+    }
+
+    @GetMapping("/{materialId}/location-thresholds")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List a material's per-location threshold overrides",
+            description = "Returns every storage-location override of the material's planning thresholds. "
+                    + "A location not listed here uses the material's global thresholds."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Overrides returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material with the given id")
+    })
+    public ResponseEntity<List<MaterialLocationThresholdDto>> getLocationThresholds(@PathVariable Long materialId) {
+        return ResponseEntity.ok(thresholdService.listForMaterial(materialId));
+    }
+
+    @PutMapping("/{materialId}/location-thresholds/{storageLocationId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Set a material's thresholds at a storage location",
+            description = "Creates or replaces the material's threshold override at the given storage location. "
+                    + "Any field left null clears that level so the material's global threshold applies."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Override saved"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No material or storage location with the given id")
+    })
+    public ResponseEntity<MaterialLocationThresholdDto> upsertLocationThreshold(
+            @PathVariable Long materialId,
+            @PathVariable Long storageLocationId,
+            @Valid @RequestBody MaterialLocationThresholdUpsertDto upsertDto) {
+        return ResponseEntity.ok(thresholdService.upsert(materialId, storageLocationId, upsertDto));
+    }
+
+    @DeleteMapping("/{materialId}/location-thresholds/{storageLocationId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Remove a material's thresholds at a storage location",
+            description = "Deletes the material's threshold override at the given storage location, so the "
+                    + "material's global thresholds apply there again."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Override removed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No override for the given material and storage location")
+    })
+    public ResponseEntity<Void> deleteLocationThreshold(
+            @PathVariable Long materialId,
+            @PathVariable Long storageLocationId) {
+        thresholdService.delete(materialId, storageLocationId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
@@ -99,6 +99,7 @@ public class MaterialService {
         material.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
         material.setDescription(creationDto.getDescription());
         material.setHsn(creationDto.getHsn());
+        material.setGstRate(creationDto.getGstRate());
         material.setMoq(creationDto.getMoq());
         material.setOpeningStock(creationDto.getOpeningStock());
         material.setMinStock(creationDto.getMinStock());
@@ -237,6 +238,10 @@ public class MaterialService {
 
         if (updateDto.getHsn() != null) {
             material.setHsn(updateDto.getHsn());
+        }
+
+        if (updateDto.getGstRate() != null) {
+            material.setGstRate(updateDto.getGstRate());
         }
 
         if (updateDto.getMoq() != null) {

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
@@ -38,6 +38,9 @@ public class MaterialCreationDto {
     @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
 
+    @Schema(description = "Applicable GST percentage for the material, used on invoices.", example = "18.00")
+    private BigDecimal gstRate;
+
     @Schema(description = "Opening stock quantity to record when the material is created. Requires "
             + "projectId and storageLocationId to also be set.", example = "500")
     private Double openingStock;

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
@@ -22,6 +22,8 @@ public class MaterialDto {
     private String description;
     @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
+    @Schema(description = "Applicable GST percentage for the material, used on invoices.", example = "18.00")
+    private BigDecimal gstRate;
     @Schema(description = "Opening stock quantity recorded when the material was created.", example = "500")
     private Double openingStock;
     @Schema(description = "Current aggregate stock across all projects and storage locations.", example = "340")

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.material.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import java.math.BigDecimal;
 
 @Schema(description = "Payload to partially update a material. Fields left null are left unchanged.")
 @Data
@@ -25,6 +26,9 @@ public class MaterialUpdateDto {
 
     @Schema(description = "HSN code for the material, used on GST invoices.", example = "2523")
     private String hsn;
+
+    @Schema(description = "Applicable GST percentage for the material, used on invoices.", example = "18.00")
+    private BigDecimal gstRate;
 
     @Schema(description = "Minimum order quantity from the supplier.", example = "100")
     private Double moq;

--- a/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThreshold.java
+++ b/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThreshold.java
@@ -1,0 +1,74 @@
+package org.tornotron.echno_backend.material.threshold;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.time.LocalDateTime;
+
+/**
+ * A per-location override of a material's planning thresholds.
+ *
+ * <p>The thresholds on {@link Material} (minimum order quantity, reorder level, and safety,
+ * minimum and maximum stock) apply globally to the material. When a specific storage location
+ * needs different levels, an override is recorded here for that material and location; any field
+ * left null falls back to the material's global level. At most one override exists per
+ * material and storage location.
+ */
+@Entity
+@NoArgsConstructor
+@Data
+@Table(
+        name = "material_location_threshold",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_material_location_threshold",
+                columnNames = {"material_id", "storage_location_id"}
+        )
+)
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+public class MaterialLocationThreshold implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "material_id", nullable = false)
+    private Material material;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "storage_location_id", nullable = false)
+    private StorageLocation storageLocation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @Column(name = "min_stock")
+    private Double minStock;
+
+    @Column(name = "max_stock")
+    private Double maxStock;
+
+    @Column(name = "safety_stock")
+    private Double safetyStock;
+
+    @Column(name = "reorder_level")
+    private Double reorderLevel;
+
+    @Column(name = "moq")
+    private Double moq;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdRepository.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.material.threshold;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MaterialLocationThresholdRepository extends JpaRepository<MaterialLocationThreshold, Long> {
+
+    List<MaterialLocationThreshold> findByMaterial_IdAndOrganization_Id(Long materialId, Long organizationId);
+
+    Optional<MaterialLocationThreshold> findByMaterial_IdAndStorageLocation_IdAndOrganization_Id(
+            Long materialId, Long storageLocationId, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdService.java
@@ -1,0 +1,140 @@
+package org.tornotron.echno_backend.material.threshold;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
+import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Manages per-location overrides of a material's planning thresholds.
+ *
+ * <p>Each override lets a storage location carry its own minimum order quantity, reorder level,
+ * and safety, minimum and maximum stock, in place of the material's global levels. Every read and
+ * write is scoped to the current tenant, and both the material and storage location are checked to
+ * belong to that tenant before an override is created or changed.
+ */
+@Service
+public class MaterialLocationThresholdService {
+
+    private final MaterialLocationThresholdRepository thresholdRepository;
+    private final MaterialRepository materialRepository;
+    private final StorageLocationRepository storageLocationRepository;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    public MaterialLocationThresholdService(MaterialLocationThresholdRepository thresholdRepository,
+                                            MaterialRepository materialRepository,
+                                            StorageLocationRepository storageLocationRepository,
+                                            TenantEntityHelper tenantEntityHelper) {
+        this.thresholdRepository = thresholdRepository;
+        this.materialRepository = materialRepository;
+        this.storageLocationRepository = storageLocationRepository;
+        this.tenantEntityHelper = tenantEntityHelper;
+    }
+
+    /**
+     * Lists every per-location threshold override for a material within the current tenant.
+     *
+     * @param materialId The material whose overrides to list.
+     * @return The material's overrides as DTOs, one per storage location that has an override.
+     * @throws ResourceNotFoundException if no material with the given id exists in this organization.
+     */
+    @Transactional(readOnly = true)
+    public List<MaterialLocationThresholdDto> listForMaterial(Long materialId) {
+        materialRepository.findByIdAndOrganization_Id(materialId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Material with ID " + materialId + " was not found in this organization"));
+
+        return thresholdRepository
+                .findByMaterial_IdAndOrganization_Id(materialId, TenantContext.getCurrentOrgId())
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Creates or replaces the threshold override for a material at a storage location.
+     *
+     * <p>If an override already exists for the material and location it is updated in place;
+     * otherwise a new one is created. All five levels are set from the payload, so a field left
+     * null clears that level back to the material's global value.
+     *
+     * @param materialId The material to override thresholds for.
+     * @param storageLocationId The storage location the override applies to.
+     * @param upsertDto The threshold levels to store for the location.
+     * @return The saved override as a DTO.
+     * @throws ResourceNotFoundException if the material or storage location is not found in this organization.
+     */
+    @Transactional
+    public MaterialLocationThresholdDto upsert(Long materialId, Long storageLocationId,
+                                               MaterialLocationThresholdUpsertDto upsertDto) {
+        Long orgId = TenantContext.getCurrentOrgId();
+
+        Material material = materialRepository.findByIdAndOrganization_Id(materialId, orgId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Material with ID " + materialId + " was not found in this organization"));
+
+        StorageLocation storageLocation = storageLocationRepository.findByIdAndOrganization_Id(storageLocationId, orgId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Storage location with ID " + storageLocationId + " was not found in this organization"));
+
+        MaterialLocationThreshold threshold = thresholdRepository
+                .findByMaterial_IdAndStorageLocation_IdAndOrganization_Id(materialId, storageLocationId, orgId)
+                .orElseGet(() -> {
+                    MaterialLocationThreshold created = new MaterialLocationThreshold();
+                    created.setMaterial(material);
+                    created.setStorageLocation(storageLocation);
+                    created.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+                    return created;
+                });
+
+        threshold.setMinStock(upsertDto.getMinStock());
+        threshold.setMaxStock(upsertDto.getMaxStock());
+        threshold.setSafetyStock(upsertDto.getSafetyStock());
+        threshold.setReorderLevel(upsertDto.getReorderLevel());
+        threshold.setMoq(upsertDto.getMoq());
+
+        threshold = thresholdRepository.save(threshold);
+        return toDto(threshold);
+    }
+
+    /**
+     * Deletes a material's threshold override at a storage location.
+     *
+     * @param materialId The material whose override to delete.
+     * @param storageLocationId The storage location the override applies to.
+     * @throws ResourceNotFoundException if no override exists for the material and location in this organization.
+     */
+    @Transactional
+    public void delete(Long materialId, Long storageLocationId) {
+        MaterialLocationThreshold threshold = thresholdRepository
+                .findByMaterial_IdAndStorageLocation_IdAndOrganization_Id(materialId, storageLocationId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No threshold override was found for material " + materialId
+                                + " at storage location " + storageLocationId + " in this organization"));
+        thresholdRepository.delete(threshold);
+    }
+
+    private MaterialLocationThresholdDto toDto(MaterialLocationThreshold threshold) {
+        MaterialLocationThresholdDto dto = new MaterialLocationThresholdDto();
+        dto.setId(threshold.getId());
+        dto.setMaterialId(threshold.getMaterial().getId());
+        dto.setStorageLocationId(threshold.getStorageLocation().getId());
+        dto.setStorageLocationName(threshold.getStorageLocation().getLocationName());
+        dto.setMinStock(threshold.getMinStock());
+        dto.setMaxStock(threshold.getMaxStock());
+        dto.setSafetyStock(threshold.getSafetyStock());
+        dto.setReorderLevel(threshold.getReorderLevel());
+        dto.setMoq(threshold.getMoq());
+        return dto;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/material/threshold/dto/MaterialLocationThresholdDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/threshold/dto/MaterialLocationThresholdDto.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.material.threshold.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "A material's planning thresholds overridden for a single storage location. "
+        + "Any field left null falls back to the material's global level.")
+@Data
+public class MaterialLocationThresholdDto {
+
+    @Schema(description = "Override id.", example = "7")
+    private Long id;
+
+    @Schema(description = "Id of the material this override applies to.", example = "12")
+    private Long materialId;
+
+    @Schema(description = "Id of the storage location this override applies to.", example = "2")
+    private Long storageLocationId;
+
+    @Schema(description = "Name of the storage location this override applies to.", example = "Main Store")
+    private String storageLocationName;
+
+    @Schema(description = "Minimum stock level at this location before the material is considered low.", example = "150")
+    private Double minStock;
+
+    @Schema(description = "Maximum stock level to hold at this location.", example = "1500")
+    private Double maxStock;
+
+    @Schema(description = "Safety stock buffer kept in reserve at this location.", example = "40")
+    private Double safetyStock;
+
+    @Schema(description = "Stock level at this location at which a reorder should be triggered.", example = "250")
+    private Double reorderLevel;
+
+    @Schema(description = "Minimum order quantity when replenishing this location.", example = "80")
+    private Double moq;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/threshold/dto/MaterialLocationThresholdUpsertDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/threshold/dto/MaterialLocationThresholdUpsertDto.java
@@ -1,0 +1,26 @@
+package org.tornotron.echno_backend.material.threshold.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "Payload to set or replace a material's thresholds at one storage location. "
+        + "Every field is optional; a field left null clears that override so the material's global "
+        + "level applies at the location.")
+@Data
+public class MaterialLocationThresholdUpsertDto {
+
+    @Schema(description = "Minimum stock level at this location before the material is considered low.", example = "150")
+    private Double minStock;
+
+    @Schema(description = "Maximum stock level to hold at this location.", example = "1500")
+    private Double maxStock;
+
+    @Schema(description = "Safety stock buffer kept in reserve at this location.", example = "40")
+    private Double safetyStock;
+
+    @Schema(description = "Stock level at this location at which a reorder should be triggered.", example = "250")
+    private Double reorderLevel;
+
+    @Schema(description = "Minimum order quantity when replenishing this location.", example = "80")
+    private Double moq;
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -268,4 +268,7 @@
     <!-- v4.0 - Attribute attendance approvals to the approving employee -->
     <include file="db/changelog/v4.0/044-add-approved-by-id-to-attendance.xml"/>
 
+    <!-- v4.0 - Material GST rate + per-location threshold overrides (#257) -->
+    <include file="db/changelog/v4.0/045-add-material-gst-rate-and-location-thresholds.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/045-add-material-gst-rate-and-location-thresholds.xml
+++ b/src/main/resources/db/changelog/v4.0/045-add-material-gst-rate-and-location-thresholds.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="045-add-gst-rate-to-material" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="material" columnName="gst_rate"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Applicable GST percentage on a material (for example 18.00), used on invoices.
+            Nullable; a material may have no GST rate recorded.
+        </comment>
+
+        <addColumn tableName="material">
+            <column name="gst_rate" type="NUMERIC"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="045-create-material-location-threshold" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="material_location_threshold"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Per-location override of a material's planning thresholds. Where present, the location's
+            levels replace the material's global ones; a null column falls back to the global level.
+            At most one row per material and storage location.
+        </comment>
+
+        <createTable tableName="material_location_threshold">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="material_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="storage_location_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="min_stock" type="DOUBLE"/>
+            <column name="max_stock" type="DOUBLE"/>
+            <column name="safety_stock" type="DOUBLE"/>
+            <column name="reorder_level" type="DOUBLE"/>
+            <column name="moq" type="DOUBLE"/>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="material_location_threshold"
+                                 baseColumnNames="material_id"
+                                 constraintName="fk_mlt_material"
+                                 referencedTableName="material"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="material_location_threshold"
+                                 baseColumnNames="storage_location_id"
+                                 constraintName="fk_mlt_storage_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="material_location_threshold"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_mlt_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="material_location_threshold"
+                             columnNames="material_id, storage_location_id"
+                             constraintName="uq_material_location_threshold"/>
+
+        <createIndex tableName="material_location_threshold" indexName="idx_mlt_material">
+            <column name="material_id"/>
+        </createIndex>
+        <createIndex tableName="material_location_threshold" indexName="idx_mlt_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/material/threshold/MaterialLocationThresholdRepositoryIT.java
@@ -1,0 +1,145 @@
+package org.tornotron.echno_backend.material.threshold;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link MaterialLocationThresholdRepository} against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Asserts that a persisted per-location override is
+ * retrievable by material and location, that listing an override by material stays scoped to the
+ * material and tenant, and that deleting one removes it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MaterialLocationThresholdRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MaterialLocationThresholdRepository thresholdRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByMaterialAndLocation_returnsThePersistedOverride() {
+        Organization org = persistOrganization("Org A");
+        Material material = persistMaterial(org, "CEM-001", "Cement");
+        StorageLocation location = persistLocation(org, "Main Store");
+        persistThreshold(org, material, location, 150.0, 1500.0);
+        em.flush();
+        em.clear();
+
+        Optional<MaterialLocationThreshold> found = thresholdRepository
+                .findByMaterial_IdAndStorageLocation_IdAndOrganization_Id(
+                        material.getId(), location.getId(), org.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getMinStock()).isEqualTo(150.0);
+        assertThat(found.get().getMaxStock()).isEqualTo(1500.0);
+        assertThat(found.get().getMaterial().getId()).isEqualTo(material.getId());
+        assertThat(found.get().getStorageLocation().getLocationName()).isEqualTo("Main Store");
+        assertThat(found.get().getOrganization().getId()).isEqualTo(org.getId());
+    }
+
+    @Test
+    void findByMaterial_listsOnlyThatMaterialsOverridesInTheTenant() {
+        Organization orgA = persistOrganization("Org A2");
+        Organization orgB = persistOrganization("Org B2");
+
+        Material m1 = persistMaterial(orgA, "M1", "Cement");
+        Material m2 = persistMaterial(orgA, "M2", "Sand");
+        Material otherTenantMaterial = persistMaterial(orgB, "M3", "Steel");
+
+        StorageLocation l1 = persistLocation(orgA, "Store 1");
+        StorageLocation l2 = persistLocation(orgA, "Store 2");
+        StorageLocation lb = persistLocation(orgB, "Store B");
+
+        persistThreshold(orgA, m1, l1, 10.0, 100.0);
+        persistThreshold(orgA, m1, l2, 20.0, 200.0);
+        persistThreshold(orgA, m2, l1, 30.0, 300.0);            // different material, same tenant
+        persistThreshold(orgB, otherTenantMaterial, lb, 40.0, 400.0); // different tenant
+        em.flush();
+        em.clear();
+
+        List<MaterialLocationThreshold> overrides =
+                thresholdRepository.findByMaterial_IdAndOrganization_Id(m1.getId(), orgA.getId());
+
+        assertThat(overrides).hasSize(2);
+        assertThat(overrides).allMatch(o -> o.getMaterial().getId().equals(m1.getId()));
+        assertThat(overrides).allMatch(o -> o.getOrganization().getId().equals(orgA.getId()));
+        assertThat(overrides).extracting(o -> o.getStorageLocation().getLocationName())
+                .containsExactlyInAnyOrder("Store 1", "Store 2");
+    }
+
+    @Test
+    void delete_removesTheOverride() {
+        Organization org = persistOrganization("Org C");
+        Material material = persistMaterial(org, "CEM-C", "Cement");
+        StorageLocation location = persistLocation(org, "Yard");
+        MaterialLocationThreshold threshold = persistThreshold(org, material, location, 5.0, 50.0);
+        em.flush();
+
+        thresholdRepository.delete(threshold);
+        em.flush();
+        em.clear();
+
+        Optional<MaterialLocationThreshold> found = thresholdRepository
+                .findByMaterial_IdAndStorageLocation_IdAndOrganization_Id(
+                        material.getId(), location.getId(), org.getId());
+
+        assertThat(found).isEmpty();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Material persistMaterial(Organization org, String sku, String name) {
+        Material material = new Material();
+        material.setSku(sku);
+        material.setMaterialName(name);
+        material.setUnit("bags");
+        material.setOrganization(org);
+        em.persist(material);
+        return material;
+    }
+
+    private StorageLocation persistLocation(Organization org, String name) {
+        StorageLocation location = new StorageLocation();
+        location.setLocationName(name);
+        location.setLocationType(StorageLocationType.WAREHOUSE);
+        location.setOrganization(org);
+        em.persist(location);
+        return location;
+    }
+
+    private MaterialLocationThreshold persistThreshold(Organization org, Material material,
+                                                       StorageLocation location, Double minStock, Double maxStock) {
+        MaterialLocationThreshold threshold = new MaterialLocationThreshold();
+        threshold.setOrganization(org);
+        threshold.setMaterial(material);
+        threshold.setStorageLocation(location);
+        threshold.setMinStock(minStock);
+        threshold.setMaxStock(maxStock);
+        em.persist(threshold);
+        return threshold;
+    }
+}


### PR DESCRIPTION
Implements the remaining gaps of #257 (Materials module). The rest of #257 was already built; this covers the two outstanding items.

## GST rate on Material
- New nullable `gstRate` (`BigDecimal`, column `gst_rate NUMERIC`) on `Material`, the applicable GST percentage (for example 18.00).
- Wired through `MaterialCreationDto`, `MaterialUpdateDto` and `MaterialDto`, and set on create and partial-update in `MaterialService`, following the existing `hsn` pattern. The response mapping is picked up automatically by MapStruct.

## Per-location threshold overrides
The planning thresholds (minStock, maxStock, safetyStock, reorderLevel, moq) previously lived only on Material (global). #257 wants them settable globally OR specific to the storage location. This adds an override layer:

- `MaterialLocationThreshold` entity (tenant-scoped, one row per material and storage location, unique constraint on `(material_id, storage_location_id)`), its repository, and a `MaterialLocationThresholdService` with tenant-scoped list / upsert (create-or-update) / delete. Both the material and storage location are validated against the current tenant.
- Request DTO `MaterialLocationThresholdUpsertDto` (five nullable threshold fields) and response DTO `MaterialLocationThresholdDto` (id, materialId, storageLocationId, storageLocationName, five thresholds).
- Endpoints added to both the base and `/web` material controllers:
  - `GET    /api/v1/materials[/web]/{materialId}/location-thresholds`
  - `PUT    /api/v1/materials[/web]/{materialId}/location-thresholds/{storageLocationId}`
  - `DELETE /api/v1/materials[/web]/{materialId}/location-thresholds/{storageLocationId}` (204)
  - `/web` guarded by `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')`; base guarded by `material:read` (GET) and `material:update` (PUT/DELETE), each also allowing `material:admin`.

## Migration
Liquibase changeset `045-add-material-gst-rate-and-location-thresholds.xml` (next after 044), included in the master changelog: adds the `gst_rate` column to `material` and creates the `material_location_threshold` table with its foreign keys, unique constraint and indexes. Both changesets are guarded by preconditions.

## Tests
`MaterialLocationThresholdRepositoryIT` (Testcontainers against CockroachDB, mirroring `StockAdjustmentRepositoryIT`): an override is retrievable by material and location, listing by material stays scoped to the material and tenant, and delete removes it.

`./gradlew clean build` on lab `.116`: BUILD SUCCESSFUL, 283 tests passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GST rate support for materials, including creation, updates, and invoice-ready details.
  * Added storage-location-specific overrides for minimum, maximum, safety, reorder, and minimum-order thresholds.
  * Added endpoints to view, create, update, and delete location-specific material thresholds.
  * Added automatic database setup for the new material fields and threshold records.

* **Tests**
  * Added integration coverage for retrieving, listing, and deleting location-specific thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->