### PR TITLE
feat: per-org posting-account mapping, chart-of-accounts edit + CSV import/export, approval threshold (#341)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/common/csv/CsvUtils.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/common/csv/CsvUtils.java
@@ -1,0 +1,137 @@
+package org.tornotron.echno_backend.finance.common.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A small, dependency-free CSV reader and writer for the finance interchange endpoints.
+ *
+ * <p>Follows the common CSV conventions (the shape RFC 4180 describes): fields are separated by
+ * commas and rows by newlines; a field is quoted with double quotes when it contains a comma, a
+ * quote, or a line break; and a literal quote inside a quoted field is written as two quotes.
+ * Reading accepts both LF and CRLF line endings and unquotes fields symmetrically, so a file this
+ * class writes round-trips back through {@link #parse} unchanged.
+ */
+public final class CsvUtils {
+
+    private CsvUtils() {}
+
+    /**
+     * Renders a single record as a CSV line (without a trailing newline), quoting fields where
+     * needed. A null field is written as an empty field.
+     */
+    public static String toLine(List<String> fields) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < fields.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(escape(fields.get(i)));
+        }
+        return sb.toString();
+    }
+
+    private static String escape(String field) {
+        if (field == null) {
+            return "";
+        }
+        boolean mustQuote = field.indexOf(',') >= 0
+                || field.indexOf('"') >= 0
+                || field.indexOf('\n') >= 0
+                || field.indexOf('\r') >= 0;
+        if (!mustQuote) {
+            return field;
+        }
+        return '"' + field.replace("\"", "\"\"") + '"';
+    }
+
+    /**
+     * Parses CSV text into a list of records, each a list of field values. Quoted fields may span
+     * commas, quotes (doubled), and line breaks. A trailing newline does not yield an extra empty
+     * record. Blank lines outside a quoted field are skipped.
+     */
+    public static List<List<String>> parse(String content) {
+        List<List<String>> rows = new ArrayList<>();
+        if (content == null || content.isEmpty()) {
+            return rows;
+        }
+
+        List<String> currentRow = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean inQuotes = false;
+        boolean fieldStarted = false;
+        int i = 0;
+        int n = content.length();
+
+        while (i < n) {
+            char c = content.charAt(i);
+
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < n && content.charAt(i + 1) == '"') {
+                        field.append('"');
+                        i += 2;
+                    } else {
+                        inQuotes = false;
+                        i++;
+                    }
+                } else {
+                    field.append(c);
+                    i++;
+                }
+                continue;
+            }
+
+            switch (c) {
+                case '"' -> {
+                    inQuotes = true;
+                    fieldStarted = true;
+                    i++;
+                }
+                case ',' -> {
+                    currentRow.add(field.toString());
+                    field.setLength(0);
+                    fieldStarted = true;
+                    i++;
+                }
+                case '\r' -> {
+                    // Treat CR or CRLF as one row terminator.
+                    endRow(rows, currentRow, field, fieldStarted);
+                    currentRow = new ArrayList<>();
+                    field.setLength(0);
+                    fieldStarted = false;
+                    i += (i + 1 < n && content.charAt(i + 1) == '\n') ? 2 : 1;
+                }
+                case '\n' -> {
+                    endRow(rows, currentRow, field, fieldStarted);
+                    currentRow = new ArrayList<>();
+                    field.setLength(0);
+                    fieldStarted = false;
+                    i++;
+                }
+                default -> {
+                    field.append(c);
+                    fieldStarted = true;
+                    i++;
+                }
+            }
+        }
+
+        // Flush the final field/row if the content did not end on a newline.
+        if (fieldStarted || !currentRow.isEmpty() || field.length() > 0) {
+            currentRow.add(field.toString());
+            rows.add(currentRow);
+        }
+        return rows;
+    }
+
+    private static void endRow(List<List<String>> rows, List<String> currentRow,
+                               StringBuilder field, boolean fieldStarted) {
+        if (!fieldStarted && currentRow.isEmpty()) {
+            // A wholly blank line: skip it.
+            return;
+        }
+        currentRow.add(field.toString());
+        rows.add(currentRow);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -1,7 +1,5 @@
 package org.tornotron.echno_backend.finance.construction.service;
 
-import org.tornotron.echno_backend.common.multitenancy.TenantContext;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -9,15 +7,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
-import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
-import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
@@ -27,14 +24,17 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionI
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceSpecifications;
-import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
 import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
 import org.tornotron.echno_backend.finance.ledger.dtos.ReverseJournalRequest;
-import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
 import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
 import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
@@ -67,11 +67,11 @@ public class ConstructionInvoiceService {
     private final EntryNumberGenerator numberGen;
     private final ConstructionInvoiceMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
-    private final AccountRepository accountRepo;
     private final JournalEntryRepository journalRepo;
     private final JournalPostingService postingService;
-    private final ConstructionPostingProperties postingProps;
-    private final InvoicePostingProperties arPostingProps;
+    private final PostingAccountResolver postingAccountResolver;
+    private final FinanceSettingsService financeSettingsService;
+    private final ProjectRepository projectRepository;
     private final UserContextService userContextService;
 
     @Transactional(readOnly = true)
@@ -177,6 +177,12 @@ public class ConstructionInvoiceService {
 
     /**
      * Submit a draft for approval: DRAFT -> PENDING. Records who submitted it and when.
+     *
+     * <p>When an auto-approval threshold applies (per-project override where set, else the
+     * organization-level finance setting) and the invoice total is strictly below it, the invoice
+     * is approved and posted straight away through the same path as {@link #approve}, rather than
+     * left waiting in PENDING. A null effective threshold means every invoice needs manual approval,
+     * which is the original behaviour.
      */
     @Transactional
     public ConstructionInvoiceDto submit(UUID id) {
@@ -186,9 +192,18 @@ public class ConstructionInvoiceService {
                     "Only DRAFT construction invoices can be submitted; invoice "
                             + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
         }
-        inv.setStatus(ConstructionInvoiceStatus.PENDING);
         inv.setSubmittedBy(userContextService.getCurrentUserId());
         inv.setSubmittedAt(Instant.now());
+
+        BigDecimal threshold = effectiveApprovalThreshold(inv);
+        if (threshold != null && inv.getTotalAmount().compareTo(threshold) < 0) {
+            postAndApprove(inv);
+            log.info("Auto-approved construction invoice {} under threshold {} on submit",
+                    inv.getInvoiceNumber(), threshold);
+            return mapper.toDto(inv);
+        }
+
+        inv.setStatus(ConstructionInvoiceStatus.PENDING);
         log.info("Submitted construction invoice {} for approval", inv.getInvoiceNumber());
         return mapper.toDto(inv);
     }
@@ -196,7 +211,8 @@ public class ConstructionInvoiceService {
     /**
      * Approve a pending invoice: PENDING -> APPROVED, and post the journal entry.
      *
-     * <p>Posting is invoice-level to the configured default accounts:
+     * <p>Posting is invoice-level to the accounts resolved for each posting role (a per-org mapping
+     * where set, else the configured default account):
      * <ul>
      *   <li>PURCHASE / EXPENSE: DR default expense (net of discount) + DR GST input
      *       (tax, if any); CR Accounts Payable (gross total).</li>
@@ -213,7 +229,34 @@ public class ConstructionInvoiceService {
                     "Only PENDING construction invoices can be approved; invoice "
                             + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
         }
+        postAndApprove(inv);
+        return mapper.toDto(inv);
+    }
 
+    /**
+     * The effective auto-approval threshold for an invoice: the invoice's project override where
+     * set, otherwise the organization-level finance setting. Null means manual approval is always
+     * required.
+     */
+    private BigDecimal effectiveApprovalThreshold(ConstructionInvoice inv) {
+        if (inv.getProjectId() != null) {
+            BigDecimal projectThreshold = projectRepository
+                    .findByIdAndOrganization_Id(inv.getProjectId(), TenantContext.getCurrentOrgId())
+                    .map(Project::getApprovalThreshold)
+                    .orElse(null);
+            if (projectThreshold != null) {
+                return projectThreshold;
+            }
+        }
+        return financeSettingsService.getApprovalThreshold();
+    }
+
+    /**
+     * Posts the ledger journal entry for the invoice and moves it to APPROVED, recording the
+     * approving user. Shared by {@link #approve} and the auto-approval path in {@link #submit}, so
+     * both raise an identical journal entry.
+     */
+    private void postAndApprove(ConstructionInvoice inv) {
         BigDecimal net = MoneyUtils.normalize(inv.getSubtotal().subtract(inv.getDiscountAmount()));
         BigDecimal tax = MoneyUtils.normalize(inv.getTaxAmount());
         BigDecimal gross = MoneyUtils.normalize(inv.getTotalAmount());
@@ -223,12 +266,12 @@ public class ConstructionInvoiceService {
             case PURCHASE, EXPENSE -> {
                 // TODO: option A AR materialization is only for sales/service; purchase and
                 // expense always post their own payable entry (no AR analog).
-                Account expense = requireAccount(postingProps.getDefaultExpenseCode());
-                Account payable = requireAccount(postingProps.getApAccountCode());
+                Account expense = postingAccountResolver.resolve(PostingRole.DEFAULT_EXPENSE);
+                Account payable = postingAccountResolver.resolve(PostingRole.ACCOUNTS_PAYABLE);
                 jeLines.add(new PostJournalRequest.LineRequest(expense.getId(), net, BigDecimal.ZERO,
                         "Expense - " + inv.getInvoiceNumber()));
                 if (MoneyUtils.isPositive(tax)) {
-                    Account gstInput = requireAccount(postingProps.getGstInputCode());
+                    Account gstInput = postingAccountResolver.resolve(PostingRole.GST_INPUT);
                     jeLines.add(new PostJournalRequest.LineRequest(gstInput.getId(), tax, BigDecimal.ZERO,
                             "GST input - " + inv.getInvoiceNumber()));
                 }
@@ -240,14 +283,14 @@ public class ConstructionInvoiceService {
                 // materializes a real AR Invoice (customer = project client) via
                 // InvoiceService.issue so AR aging and receipts pick it up. Until customer
                 // resolution exists this posts the AR journal entry directly instead.
-                Account receivable = requireAccount(arPostingProps.getArAccountCode());
-                Account revenue = requireAccount(postingProps.getDefaultRevenueCode());
+                Account receivable = postingAccountResolver.resolve(PostingRole.ACCOUNTS_RECEIVABLE);
+                Account revenue = postingAccountResolver.resolve(PostingRole.DEFAULT_REVENUE);
                 jeLines.add(new PostJournalRequest.LineRequest(receivable.getId(), gross, BigDecimal.ZERO,
                         "Receivable - " + inv.getInvoiceNumber()));
                 jeLines.add(new PostJournalRequest.LineRequest(revenue.getId(), BigDecimal.ZERO, net,
                         "Revenue - " + inv.getInvoiceNumber()));
                 if (MoneyUtils.isPositive(tax)) {
-                    Account gstOutput = requireAccount(arPostingProps.getGstOutputCode());
+                    Account gstOutput = postingAccountResolver.resolve(PostingRole.GST_OUTPUT);
                     jeLines.add(new PostJournalRequest.LineRequest(gstOutput.getId(), BigDecimal.ZERO, tax,
                             "GST output - " + inv.getInvoiceNumber()));
                 }
@@ -267,7 +310,6 @@ public class ConstructionInvoiceService {
         inv.setApprovedAt(Instant.now());
 
         log.info("Approved construction invoice {} (JE: {})", inv.getInvoiceNumber(), je.getEntryNumber());
-        return mapper.toDto(inv);
     }
 
     /**
@@ -344,11 +386,6 @@ public class ConstructionInvoiceService {
         return invoiceRepo.findByIdWithLines(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Construction invoice with ID " + id + " was not found"));
-    }
-
-    private Account requireAccount(String code) {
-        return accountRepo.findByCodeAndOrganization_Id(code, TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new AccountNotFoundException(code));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
@@ -1,8 +1,5 @@
 package org.tornotron.echno_backend.finance.invoice.service;
 
-import org.tornotron.echno_backend.common.multitenancy.TenantContext;
-
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,7 +10,6 @@ import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
-import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.invoice.domain.Invoice;
 import org.tornotron.echno_backend.finance.invoice.domain.InvoiceLine;
@@ -31,6 +27,8 @@ import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
 import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
 import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -56,7 +54,7 @@ public class InvoiceService {
     private final JournalPostingService postingService;
     private final EntryNumberGenerator numberGen;
     private final InvoiceMapper mapper;
-    private final InvoicePostingProperties postingProps;
+    private final PostingAccountResolver postingAccountResolver;
     private final TenantEntityHelper tenantEntityHelper;
 
     /**
@@ -181,8 +179,7 @@ public class InvoiceService {
                             + " is currently " + inv.getStatus());
         }
 
-        Account ar = accountRepo.findByCodeAndOrganization_Id(postingProps.getArAccountCode(), TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new AccountNotFoundException(postingProps.getArAccountCode()));
+        Account ar = postingAccountResolver.resolve(PostingRole.ACCOUNTS_RECEIVABLE);
 
         List<PostJournalRequest.LineRequest> jeLines = new ArrayList<>();
 
@@ -204,8 +201,7 @@ public class InvoiceService {
 
         // CR GST Output Payable (if applicable)
         if (MoneyUtils.isPositive(inv.getTaxTotal())) {
-            Account gstOut = accountRepo.findByCodeAndOrganization_Id(postingProps.getGstOutputCode(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new AccountNotFoundException(postingProps.getGstOutputCode()));
+            Account gstOut = postingAccountResolver.resolve(PostingRole.GST_OUTPUT);
             jeLines.add(new PostJournalRequest.LineRequest(gstOut.getId(), BigDecimal.ZERO, inv.getTaxTotal(),
                     "GST output - " + inv.getInvoiceNumber()));
         }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CoaImportSummary.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/CoaImportSummary.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.finance.ledger.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Outcome of a chart-of-accounts CSV import: how many accounts were created and "
+        + "updated, and any per-row errors. Accounts absent from the file are never deleted.")
+public record CoaImportSummary(
+
+        @Schema(description = "Number of accounts created.", example = "4")
+        int created,
+
+        @Schema(description = "Number of existing accounts updated.", example = "12")
+        int updated,
+
+        @Schema(description = "Per-row error messages for rows that were skipped.")
+        List<String> errors
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/UpdateAccountRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/UpdateAccountRequest.java
@@ -1,0 +1,30 @@
+package org.tornotron.echno_backend.finance.ledger.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(description = "Payload to edit an existing account in the chart of accounts.")
+public record UpdateAccountRequest(
+
+        @Schema(description = "Account code, unique within the tenant. Because postings resolve by "
+                + "account id, changing the code is safe.", example = "1100")
+        @NotBlank @Size(max = 20) String code,
+
+        @Schema(description = "Account name.", example = "Cash and Cash Equivalents")
+        @NotBlank @Size(max = 200) String name,
+
+        @Schema(description = "Whether the account is active and available for posting.", example = "true")
+        @NotNull Boolean active,
+
+        @Schema(description = "Optional description of the account.", example = "Petty cash and bank balances")
+        @Size(max = 500) String description,
+
+        @Schema(description = "New parent account id. Omit to leave the parent unchanged. The parent must "
+                + "be in the same tenant, share this account's type, and not create a cycle.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID parentId
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/AccountRepository.java
@@ -31,6 +31,14 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
     boolean existsByCode(String code);
 
     /**
+     * Whether another account in the current tenant already uses the given code, excluding the
+     * account with the given id. Used on edit so an account can keep its own code while a clash
+     * with any other account is still rejected. The Hibernate {@code orgFilter} scopes it to the
+     * current tenant.
+     */
+    boolean existsByCodeAndIdNot(String code, UUID id);
+
+    /**
      * Whether the given organization already owns any account. Used by the
      * chart-of-accounts seeder to stay idempotent: it seeds only an org whose
      * chart is empty. Queries the organization id directly so it does not depend

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/JournalEntryRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/repositories/JournalEntryRepository.java
@@ -31,4 +31,16 @@ public interface JournalEntryRepository extends JpaRepository<JournalEntry, UUID
     Page<JournalEntry> findByEntryDateBetweenAndStatus(LocalDate from, LocalDate to, JournalStatus status, Pageable pageable);
 
     List<JournalEntry> findBySourceTypeAndSourceId(String sourceType, UUID sourceId);
+
+    /**
+     * Tenant-scoped fetch of journal entries with their lines and accounts, for CSV export.
+     * The optional {@code from} and {@code to} bounds are inclusive; a null bound leaves that end
+     * open. Ordered by entry date then entry number so the export is stable.
+     */
+    @EntityGraph(attributePaths = {"lines", "lines.account"})
+    @Query("SELECT je FROM JournalEntry je "
+            + "WHERE (:from IS NULL OR je.entryDate >= :from) "
+            + "AND (:to IS NULL OR je.entryDate <= :to) "
+            + "ORDER BY je.entryDate ASC, je.entryNumber ASC")
+    List<JournalEntry> findForExport(LocalDate from, LocalDate to);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountCsvService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountCsvService.java
@@ -1,0 +1,250 @@
+package org.tornotron.echno_backend.finance.ledger.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.common.csv.CsvUtils;
+import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.dtos.CoaImportSummary;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Exports the tenant's chart of accounts to CSV and imports one back, for interchange with external
+ * bookkeeping systems.
+ *
+ * <p>The interchange columns are {@code code,name,type,parentCode,active}. Import upserts by code:
+ * an account already present is updated, a missing one is created, and an account absent from the
+ * file is left untouched (import never deletes). Rows are applied parent-before-child regardless of
+ * their order in the file, a child's type must match its parent's, and any row that cannot be
+ * applied is reported in the summary rather than aborting the whole import.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountCsvService {
+
+    private static final List<String> HEADER = List.of("code", "name", "type", "parentCode", "active");
+
+    private final AccountRepository repo;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    /**
+     * Exports the whole chart of accounts (active and inactive) as CSV, ordered by code.
+     */
+    @Transactional(readOnly = true)
+    public String exportCsv() {
+        List<Account> all = repo.findAll(Sort.by("code"));
+        StringBuilder sb = new StringBuilder();
+        sb.append(CsvUtils.toLine(HEADER)).append('\n');
+        for (Account a : all) {
+            String parentCode = a.getParent() == null ? "" : a.getParent().getCode();
+            sb.append(CsvUtils.toLine(List.of(
+                    nz(a.getCode()),
+                    nz(a.getName()),
+                    a.getType() == null ? "" : a.getType().name(),
+                    parentCode,
+                    Boolean.toString(a.isActive())))).append('\n');
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Imports a chart-of-accounts CSV, upserting accounts by code within the current tenant.
+     *
+     * @param content The CSV text, with the header row {@code code,name,type,parentCode,active}.
+     * @return A summary of how many accounts were created and updated, and any per-row errors.
+     * @throws InvalidRequestException if the file is empty or its header does not match.
+     */
+    @Transactional
+    public CoaImportSummary importCsv(String content) {
+        List<List<String>> rows = CsvUtils.parse(content);
+        if (rows.isEmpty()) {
+            throw new InvalidRequestException("The CSV file is empty");
+        }
+
+        List<String> header = normalize(rows.get(0));
+        if (!header.equals(HEADER)) {
+            throw new InvalidRequestException(
+                    "Unexpected CSV header; expected " + HEADER + " but found " + header);
+        }
+
+        // Parse the data rows into records keyed by code, preserving file order.
+        Map<String, Record> desired = new LinkedHashMap<>();
+        List<String> errors = new ArrayList<>();
+        for (int r = 1; r < rows.size(); r++) {
+            List<String> row = rows.get(r);
+            int lineNo = r + 1;
+            if (row.size() < HEADER.size()) {
+                errors.add("Line " + lineNo + ": expected " + HEADER.size() + " columns but found " + row.size());
+                continue;
+            }
+            String code = trim(row.get(0));
+            if (code.isEmpty()) {
+                errors.add("Line " + lineNo + ": code is required");
+                continue;
+            }
+            if (desired.containsKey(code)) {
+                errors.add("Line " + lineNo + ": duplicate code '" + code + "' in the file");
+                continue;
+            }
+            desired.put(code, new Record(code, trim(row.get(1)), trim(row.get(2)),
+                    trim(row.get(3)), trim(row.get(4)), lineNo));
+        }
+
+        // Existing accounts by code, so we can update in place and resolve parent references.
+        Map<String, Account> byCode = new HashMap<>();
+        for (Account a : repo.findAll()) {
+            byCode.put(a.getCode(), a);
+        }
+
+        Counters counters = new Counters();
+        Set<String> done = new HashSet<>();
+        Set<String> visiting = new HashSet<>();
+        Map<String, String> failed = new HashMap<>();
+        for (String code : desired.keySet()) {
+            apply(code, desired, byCode, done, visiting, failed, errors, counters);
+        }
+
+        log.info("Imported chart of accounts: {} created, {} updated, {} errors",
+                counters.created, counters.updated, errors.size());
+        return new CoaImportSummary(counters.created, counters.updated, errors);
+    }
+
+    /**
+     * Resolves one code, first ensuring its parent (if any) is applied. Returns the resolved
+     * account, or null when the row could not be applied (an error has been recorded).
+     */
+    private Account apply(String code, Map<String, Record> desired, Map<String, Account> byCode,
+                          Set<String> done, Set<String> visiting, Map<String, String> failed,
+                          List<String> errors, Counters counters) {
+        if (done.contains(code)) {
+            return byCode.get(code);
+        }
+        if (failed.containsKey(code)) {
+            return null;
+        }
+        Record rec = desired.get(code);
+        if (rec == null) {
+            // Not in the file: only valid as a reference to an already-existing account.
+            return byCode.get(code);
+        }
+        if (visiting.contains(code)) {
+            fail(code, "Line " + rec.lineNo + ": parent cycle involving code '" + code + "'", failed, errors);
+            return null;
+        }
+        visiting.add(code);
+
+        Account parent = null;
+        if (!rec.parentCode.isEmpty()) {
+            if (rec.parentCode.equals(code)) {
+                visiting.remove(code);
+                fail(code, "Line " + rec.lineNo + ": account '" + code + "' cannot be its own parent", failed, errors);
+                return null;
+            }
+            parent = apply(rec.parentCode, desired, byCode, done, visiting, failed, errors, counters);
+            if (parent == null && !byCode.containsKey(rec.parentCode)) {
+                visiting.remove(code);
+                fail(code, "Line " + rec.lineNo + ": parent code '" + rec.parentCode
+                        + "' was not found in the file or the existing chart", failed, errors);
+                return null;
+            }
+            if (parent == null) {
+                parent = byCode.get(rec.parentCode);
+            }
+        }
+        visiting.remove(code);
+
+        // Resolve the type: explicit where given, otherwise inherited from the parent.
+        AccountType type;
+        if (!rec.type.isEmpty()) {
+            try {
+                type = AccountType.valueOf(rec.type);
+            } catch (IllegalArgumentException ex) {
+                fail(code, "Line " + rec.lineNo + ": unknown account type '" + rec.type + "'", failed, errors);
+                return null;
+            }
+            if (parent != null && parent.getType() != type) {
+                fail(code, "Line " + rec.lineNo + ": type '" + type + "' does not match parent '"
+                        + parent.getCode() + "' type '" + parent.getType() + "'", failed, errors);
+                return null;
+            }
+        } else if (parent != null) {
+            type = parent.getType();
+        } else {
+            fail(code, "Line " + rec.lineNo + ": type is required for a root account", failed, errors);
+            return null;
+        }
+
+        if (rec.name.isEmpty()) {
+            fail(code, "Line " + rec.lineNo + ": name is required", failed, errors);
+            return null;
+        }
+        boolean active = rec.active.isEmpty() || Boolean.parseBoolean(rec.active);
+
+        Account account = byCode.get(code);
+        boolean isNew = account == null;
+        if (isNew) {
+            account = new Account();
+            account.setCode(code);
+            account.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        }
+        account.setName(rec.name);
+        account.setType(type);
+        account.setActive(active);
+        account.setParent(parent);
+        account = repo.save(account);
+
+        byCode.put(code, account);
+        done.add(code);
+        if (isNew) {
+            counters.created++;
+        } else {
+            counters.updated++;
+        }
+        return account;
+    }
+
+    private void fail(String code, String message, Map<String, String> failed, List<String> errors) {
+        failed.put(code, message);
+        errors.add(message);
+    }
+
+    private List<String> normalize(List<String> header) {
+        List<String> out = new ArrayList<>(header.size());
+        for (String h : header) {
+            out.add(h == null ? "" : h.trim());
+        }
+        return out;
+    }
+
+    private static String trim(String s) {
+        return s == null ? "" : s.trim();
+    }
+
+    private static String nz(String s) {
+        return s == null ? "" : s;
+    }
+
+    /** A parsed CSV data row. */
+    private record Record(String code, String name, String type, String parentCode,
+                          String active, int lineNo) {}
+
+    /** Mutable created/updated tallies threaded through the recursion. */
+    private static final class Counters {
+        int created;
+        int updated;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
@@ -178,6 +178,73 @@ public class AccountService {
     }
 
     /**
+     * Edits an existing account: its code, name, active flag, description, and optionally its parent.
+     *
+     * <p>The code must stay unique within the tenant (a clash with any other account is rejected,
+     * while keeping the account's own code is allowed). When a new parent is supplied it must belong
+     * to the tenant, share this account's type, and not introduce a cycle; omitting the parent id
+     * leaves the current parent unchanged. Because postings resolve accounts by id through the
+     * posting-account mapping, changing an account's code does not disturb any configured posting.
+     *
+     * @param id The id of the account to edit.
+     * @param req The new code, name, active flag, description, and optional parent id.
+     * @return The updated account as a DTO.
+     * @throws AccountNotFoundException if no account with the given id, or no such parent, exists in this organization.
+     * @throws InvalidJournalException if the code is already in use, or the parent has a different type or would form a cycle.
+     */
+    @Transactional
+    public AccountDto update(UUID id, org.tornotron.echno_backend.finance.ledger.dtos.UpdateAccountRequest req) {
+        Account account = repo.findScopedById(id)
+                .orElseThrow(() -> new AccountNotFoundException(id));
+
+        String code = req.code().trim();
+        if (repo.existsByCodeAndIdNot(code, id)) {
+            throw new InvalidJournalException(
+                    "Account code '" + code + "' is already in use in this organization");
+        }
+
+        if (req.parentId() != null && !req.parentId().equals(currentParentId(account))) {
+            Account parent = repo.findScopedById(req.parentId())
+                    .orElseThrow(() -> new AccountNotFoundException(req.parentId()));
+            if (parent.getType() != account.getType()) {
+                throw new InvalidJournalException("Parent account '" + parent.getCode() + "' type '"
+                        + parent.getType() + "' does not match account type '" + account.getType() + "'");
+            }
+            if (wouldFormCycle(account, parent)) {
+                throw new InvalidJournalException("Account '" + account.getCode()
+                        + "' cannot be moved under '" + parent.getCode() + "'; that would create a cycle");
+            }
+            account.setParent(parent);
+        }
+
+        account.setCode(code);
+        account.setName(req.name());
+        account.setActive(req.active());
+        account.setDescription(req.description());
+        return mapper.toDto(account);
+    }
+
+    private UUID currentParentId(Account account) {
+        return account.getParent() == null ? null : account.getParent().getId();
+    }
+
+    /**
+     * Whether making {@code candidateParent} the parent of {@code account} would create a cycle,
+     * i.e. the candidate is the account itself or one of its descendants. Walks up from the
+     * candidate through its ancestors; if the account is reached, the move would loop.
+     */
+    private boolean wouldFormCycle(Account account, Account candidateParent) {
+        Account cursor = candidateParent;
+        while (cursor != null) {
+            if (cursor.getId().equals(account.getId())) {
+                return true;
+            }
+            cursor = cursor.getParent();
+        }
+        return false;
+    }
+
+    /**
      * Marks an account inactive so it can no longer be posted to, keeping its history intact.
      *
      * @param id The id of the account to deactivate.

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalCsvService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalCsvService.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.finance.ledger.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.finance.common.csv.CsvUtils;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntryLine;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Exports the tenant's journal entries to CSV for external systems, one row per journal line.
+ *
+ * <p>The columns are {@code entryDate,entryNumber,accountCode,accountName,debit,credit,narration,
+ * referenceType,referenceId}. The optional date bounds narrow the export by entry date; the rows
+ * are tenant-scoped through the Hibernate organization filter.
+ */
+@Service
+@RequiredArgsConstructor
+public class JournalCsvService {
+
+    private static final List<String> HEADER = List.of(
+            "entryDate", "entryNumber", "accountCode", "accountName",
+            "debit", "credit", "narration", "referenceType", "referenceId");
+
+    private final JournalEntryRepository journalRepo;
+
+    /**
+     * Exports journal entries within the optional inclusive date range as CSV, one row per line.
+     *
+     * @param from Earliest entry date to include, or null for no lower bound.
+     * @param to Latest entry date to include, or null for no upper bound.
+     * @return The CSV text.
+     */
+    @Transactional(readOnly = true)
+    public String exportCsv(LocalDate from, LocalDate to) {
+        List<JournalEntry> entries = journalRepo.findForExport(from, to);
+        StringBuilder sb = new StringBuilder();
+        sb.append(CsvUtils.toLine(HEADER)).append('\n');
+        for (JournalEntry je : entries) {
+            for (JournalEntryLine line : je.getLines()) {
+                sb.append(CsvUtils.toLine(List.of(
+                        je.getEntryDate() == null ? "" : je.getEntryDate().toString(),
+                        nz(je.getEntryNumber()),
+                        line.getAccount() == null ? "" : nz(line.getAccount().getCode()),
+                        line.getAccount() == null ? "" : nz(line.getAccount().getName()),
+                        plain(line.getDebit()),
+                        plain(line.getCredit()),
+                        nz(line.getNarration()),
+                        nz(je.getSourceType()),
+                        je.getSourceId() == null ? "" : je.getSourceId().toString()))).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String plain(BigDecimal value) {
+        return value == null ? "0" : value.toPlainString();
+    }
+
+    private static String nz(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/AccountControllerWeb.java
@@ -6,16 +6,25 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.AccountTreeDto;
+import org.tornotron.echno_backend.finance.ledger.dtos.CoaImportSummary;
 import org.tornotron.echno_backend.finance.ledger.dtos.CreateAccountRequest;
+import org.tornotron.echno_backend.finance.ledger.dtos.UpdateAccountRequest;
+import org.tornotron.echno_backend.finance.ledger.service.AccountCsvService;
 import org.tornotron.echno_backend.finance.ledger.service.AccountService;
 import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +43,7 @@ public class AccountControllerWeb {
 
     private final AccountService service;
     private final ChartOfAccountsSeeder chartOfAccountsSeeder;
+    private final AccountCsvService csvService;
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
@@ -111,6 +121,67 @@ public class AccountControllerWeb {
     })
     public ResponseEntity<AccountDto> create(@Valid @RequestBody CreateAccountRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update an account",
+            description = "Edits an account's code, name, active flag, description and optionally its "
+                    + "parent. The code must stay unique within the tenant; a new parent must share the "
+                    + "account's type and must not form a cycle. Omit the parent id to leave the parent "
+                    + "unchanged. Postings resolve accounts by id, so changing a code is safe."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Account updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, the code clashes, or the parent is invalid"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No account, or no such parent, in the current tenant")
+    })
+    public AccountDto update(@PathVariable UUID id, @Valid @RequestBody UpdateAccountRequest req) {
+        return service.update(id, req);
+    }
+
+    @GetMapping("/export")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Export the chart of accounts as CSV",
+            description = "Streams the whole chart of accounts of the current tenant as a CSV attachment "
+                    + "with the columns code, name, type, parentCode and active."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "CSV generated and returned as an attachment"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<byte[]> export() {
+        byte[] csv = csvService.exportCsv().getBytes(StandardCharsets.UTF_8);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"chart-of-accounts.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(csv);
+    }
+
+    @PostMapping(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Import a chart of accounts from CSV",
+            description = "Upserts accounts by code from an uploaded CSV with the columns code, name, "
+                    + "type, parentCode and active. Existing accounts are updated and missing ones are "
+                    + "created, applied parent-before-child; accounts absent from the file are never "
+                    + "deleted. Returns a summary of the created and updated counts and any per-row errors. "
+                    + "Restricted to system administrators."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Import processed, summary returned"),
+            @ApiResponse(responseCode = "400", description = "The file is missing, empty, or has an unexpected header"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant")
+    })
+    public CoaImportSummary importCsv(@RequestParam("file") MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidRequestException("A non-empty CSV file is required");
+        }
+        String content = new String(file.getBytes(), StandardCharsets.UTF_8);
+        return csvService.importCsv(content);
     }
 
     @PostMapping("/{id}/deactivate")

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalExportControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalExportControllerWeb.java
@@ -1,0 +1,57 @@
+package org.tornotron.echno_backend.finance.ledger.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.tornotron.echno_backend.finance.ledger.service.JournalCsvService;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/finance/journal/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Journal Export",
+        description = "CSV export of the ledger's journal entries for external accounting systems, one "
+                + "row per journal line. Tenant scoped and limited to system administrators and project "
+                + "managers."
+)
+public class JournalExportControllerWeb {
+
+    private final JournalCsvService csvService;
+
+    @GetMapping("/export")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Export journal entries as CSV",
+            description = "Streams the current tenant's journal entries as a CSV attachment with the "
+                    + "columns entryDate, entryNumber, accountCode, accountName, debit, credit, narration, "
+                    + "referenceType and referenceId, one row per line. The optional from and to query "
+                    + "parameters narrow the export by entry date (inclusive)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "CSV generated and returned as an attachment"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<byte[]> export(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        byte[] csv = csvService.exportCsv(from, to).getBytes(StandardCharsets.UTF_8);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"journal-entries.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(csv);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/payment/service/PaymentService.java
@@ -1,7 +1,5 @@
 package org.tornotron.echno_backend.finance.payment.service;
 
-import org.tornotron.echno_backend.common.multitenancy.TenantContext;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -14,7 +12,6 @@ import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
-import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.invoice.domain.Invoice;
 import org.tornotron.echno_backend.finance.invoice.repositories.InvoiceRepository;
@@ -25,9 +22,10 @@ import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
 import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
-import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
 import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
 import org.tornotron.echno_backend.finance.payment.domain.Payment;
 import org.tornotron.echno_backend.finance.payment.domain.PaymentAllocation;
 import org.tornotron.echno_backend.finance.payment.dtos.PaymentDto;
@@ -59,12 +57,11 @@ public class PaymentService {
     private final PaymentRepository paymentRepo;
     private final CustomerRepository customerRepo;
     private final InvoiceRepository invoiceRepo;
-    private final AccountRepository accountRepo;
     private final CompanyBankAccountRepository companyBankRepo;
     private final JournalPostingService postingService;
     private final EntryNumberGenerator numberGen;
     private final PaymentMapper mapper;
-    private final InvoicePostingProperties postingProps;
+    private final PostingAccountResolver postingAccountResolver;
     private final TenantEntityHelper tenantEntityHelper;
 
     /**
@@ -196,8 +193,7 @@ public class PaymentService {
         }
 
         // 6. Post JE: DR Bank, CR Accounts Receivable
-        Account ar = accountRepo.findByCodeAndOrganization_Id(postingProps.getArAccountCode(), TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new AccountNotFoundException(postingProps.getArAccountCode()));
+        Account ar = postingAccountResolver.resolve(PostingRole.ACCOUNTS_RECEIVABLE);
 
         List<PostJournalRequest.LineRequest> jeLines = List.of(
                 new PostJournalRequest.LineRequest(bankLedger.getId(), amount, BigDecimal.ZERO,

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/PostingRole.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/PostingRole.java
@@ -1,0 +1,32 @@
+package org.tornotron.echno_backend.finance.posting;
+
+/**
+ * The fixed set of control-account roles the finance module posts to.
+ *
+ * <p>Each role names a slot in the double-entry postings raised by the invoice, construction
+ * invoice and payment services. A role is resolved to a concrete {@code Account} per tenant: an
+ * organization may map a role to any postable leaf account it likes, and where it has set no
+ * mapping the module falls back to the code configured on the posting properties. Introducing this
+ * indirection lets a tenant point, for example, its default expense postings at a different account
+ * without editing configuration or touching the seeded chart.
+ */
+public enum PostingRole {
+
+    /** Accounts Receivable, debited for the gross total on a sales or service invoice. */
+    ACCOUNTS_RECEIVABLE,
+
+    /** GST Output Payable, credited for the tax on a sales or service invoice. */
+    GST_OUTPUT,
+
+    /** Accounts Payable, credited for the gross total on a purchase or expense invoice. */
+    ACCOUNTS_PAYABLE,
+
+    /** GST Input Credit, debited for the tax on a purchase or expense invoice. */
+    GST_INPUT,
+
+    /** Default revenue account, credited for the net on a sales or service invoice. */
+    DEFAULT_REVENUE,
+
+    /** Default expense account, debited for the net on a purchase or expense invoice. */
+    DEFAULT_EXPENSE
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/domain/PostingAccountMapping.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/domain/PostingAccountMapping.java
@@ -1,0 +1,47 @@
+package org.tornotron.echno_backend.finance.posting.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.UUID;
+
+/**
+ * A per-organization override that points a {@link PostingRole} at a concrete account.
+ *
+ * <p>Where a mapping row exists for a role, the finance postings use its account instead of the
+ * code configured on the posting properties. At most one row exists per organization and role. The
+ * mapping targets the account by id, so renaming or renumbering the account leaves the posting intact.
+ */
+@Entity
+@Table(name = "posting_account_mapping",
+        uniqueConstraints = @UniqueConstraint(name = "uk_posting_account_mapping_role",
+                columnNames = {"organization_id", "role"}))
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostingAccountMapping implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PostingRole role;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/dtos/PostingAccountMappingDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/dtos/PostingAccountMappingDto.java
@@ -1,0 +1,28 @@
+package org.tornotron.echno_backend.finance.posting.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+
+import java.util.UUID;
+
+@Schema(description = "A posting role and the account it currently resolves to for the tenant, "
+        + "whether from an explicit mapping or the configured default.")
+public record PostingAccountMappingDto(
+
+        @Schema(description = "The posting role.", example = "ACCOUNTS_PAYABLE")
+        PostingRole role,
+
+        @Schema(description = "Where the effective account came from: an explicit per-org mapping, "
+                + "or the configured default code.", example = "DEFAULT")
+        PostingAccountResolver.Source source,
+
+        @Schema(description = "Effective account id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        UUID accountId,
+
+        @Schema(description = "Effective account code.", example = "2100")
+        String accountCode,
+
+        @Schema(description = "Effective account name.", example = "Accounts Payable")
+        String accountName
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/dtos/UpsertPostingAccountMappingRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/dtos/UpsertPostingAccountMappingRequest.java
@@ -1,0 +1,15 @@
+package org.tornotron.echno_backend.finance.posting.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+@Schema(description = "Payload to point a posting role at a specific account.")
+public record UpsertPostingAccountMappingRequest(
+
+        @Schema(description = "Id of the account, which must be a postable leaf account in the current "
+                + "tenant.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        @NotNull(message = "accountId is required")
+        UUID accountId
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/repositories/PostingAccountMappingRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/repositories/PostingAccountMappingRepository.java
@@ -1,0 +1,16 @@
+package org.tornotron.echno_backend.finance.posting.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.domain.PostingAccountMapping;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PostingAccountMappingRepository extends JpaRepository<PostingAccountMapping, UUID> {
+
+    List<PostingAccountMapping> findByOrganization_Id(Long organizationId);
+
+    Optional<PostingAccountMapping> findByRoleAndOrganization_Id(PostingRole role, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/service/PostingAccountMappingService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/service/PostingAccountMappingService.java
@@ -1,0 +1,114 @@
+package org.tornotron.echno_backend.finance.posting.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.domain.PostingAccountMapping;
+import org.tornotron.echno_backend.finance.posting.dtos.PostingAccountMappingDto;
+import org.tornotron.echno_backend.finance.posting.repositories.PostingAccountMappingRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Manages the per-organization mapping of posting roles to accounts.
+ *
+ * <p>Reading returns every role with the account it currently resolves to, flagged as coming from
+ * an explicit mapping or the configured default. Writing upserts a role's mapping after checking
+ * the target account is a postable leaf in the tenant; deleting reverts a role to its default.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostingAccountMappingService {
+
+    private final PostingAccountMappingRepository mappingRepo;
+    private final AccountRepository accountRepo;
+    private final PostingAccountResolver resolver;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    /**
+     * Returns every posting role with its effective account (mapped where set, otherwise the
+     * configured default), including the source flag.
+     */
+    @Transactional(readOnly = true)
+    public List<PostingAccountMappingDto> listEffective() {
+        return java.util.Arrays.stream(PostingRole.values())
+                .map(role -> {
+                    PostingAccountResolver.Resolved resolved = resolver.resolveWithSource(role);
+                    Account account = resolved.account();
+                    return new PostingAccountMappingDto(role, resolved.source(),
+                            account.getId(), account.getCode(), account.getName());
+                })
+                .toList();
+    }
+
+    /**
+     * Points a posting role at an account for the current tenant, creating the mapping row or
+     * updating it in place. The account must be a postable (active, leaf) account in the tenant.
+     *
+     * @param role The posting role to map.
+     * @param accountId The target account id.
+     * @return The role's effective mapping after the upsert.
+     * @throws AccountNotFoundException if the account does not exist in the current tenant.
+     * @throws InvalidRequestException if the account is inactive or is a header (non-leaf) account.
+     */
+    @Transactional
+    public PostingAccountMappingDto upsert(PostingRole role, UUID accountId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+
+        Account account = accountRepo.findScopedById(accountId)
+                .orElseThrow(() -> new AccountNotFoundException(accountId));
+        if (!account.isActive()) {
+            throw new InvalidRequestException(
+                    "Account '" + account.getCode() + "' is inactive and cannot be used for posting");
+        }
+        boolean isHeader = !accountRepo.findHeaderIdsAmong(List.of(accountId)).isEmpty();
+        if (isHeader) {
+            throw new InvalidRequestException(
+                    "Account '" + account.getCode() + "' (" + account.getName()
+                            + ") is a header account and cannot be used for posting; choose a leaf account");
+        }
+
+        PostingAccountMapping mapping = mappingRepo.findByRoleAndOrganization_Id(role, orgId)
+                .orElseGet(() -> {
+                    PostingAccountMapping created = new PostingAccountMapping();
+                    created.setRole(role);
+                    created.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+                    return created;
+                });
+        mapping.setAccount(account);
+        mappingRepo.save(mapping);
+        log.info("Mapped posting role {} to account {} for organization {}", role, account.getCode(), orgId);
+
+        PostingAccountResolver.Resolved resolved = resolver.resolveWithSource(role);
+        return new PostingAccountMappingDto(role, resolved.source(),
+                resolved.account().getId(), resolved.account().getCode(), resolved.account().getName());
+    }
+
+    /**
+     * Removes the mapping override for a role, reverting it to the configured default. A no-op when
+     * the role has no mapping, since the default already applies.
+     *
+     * @param role The posting role to revert.
+     * @return The role's effective mapping after the delete (now the default).
+     */
+    @Transactional
+    public PostingAccountMappingDto delete(PostingRole role) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        mappingRepo.findByRoleAndOrganization_Id(role, orgId).ifPresent(mappingRepo::delete);
+        log.info("Removed posting-role mapping {} for organization {}", role, orgId);
+
+        PostingAccountResolver.Resolved resolved = resolver.resolveWithSource(role);
+        return new PostingAccountMappingDto(role, resolved.source(),
+                resolved.account().getId(), resolved.account().getCode(), resolved.account().getName());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/service/PostingAccountResolver.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/service/PostingAccountResolver.java
@@ -1,0 +1,100 @@
+package org.tornotron.echno_backend.finance.posting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.domain.PostingAccountMapping;
+import org.tornotron.echno_backend.finance.posting.repositories.PostingAccountMappingRepository;
+
+import java.util.Optional;
+
+/**
+ * Resolves a {@link PostingRole} to the concrete {@link Account} the finance postings should use
+ * for the current tenant.
+ *
+ * <p>An organization may map a role to any postable leaf account through a
+ * {@link PostingAccountMapping} row; where it has, that account is used. Where it has not, the
+ * resolver falls back to the code configured on {@link InvoicePostingProperties} (receivable side)
+ * and {@link ConstructionPostingProperties} (payable and default sides), resolved against the
+ * current tenant's chart of accounts. The fallback reproduces exactly what the services did before
+ * the mapping existed, so an organization that sets no mapping posts to the same accounts as before.
+ */
+@Service
+@RequiredArgsConstructor
+public class PostingAccountResolver {
+
+    private final PostingAccountMappingRepository mappingRepo;
+    private final AccountRepository accountRepo;
+    private final InvoicePostingProperties invoiceProps;
+    private final ConstructionPostingProperties constructionProps;
+
+    /**
+     * The source of the account a role resolves to: an explicit per-org mapping, or the
+     * configured default code.
+     */
+    public enum Source {
+        MAPPED,
+        DEFAULT
+    }
+
+    /** A resolved role: the effective account and where it came from. */
+    public record Resolved(PostingRole role, Account account, Source source) {}
+
+    /**
+     * Resolves a role to the account the postings should use for the current tenant.
+     *
+     * @param role The posting role to resolve.
+     * @return The effective account.
+     * @throws AccountNotFoundException if no mapping is set and the fallback code does not resolve
+     *         to an account in the current tenant.
+     */
+    @Transactional(readOnly = true)
+    public Account resolve(PostingRole role) {
+        return resolveWithSource(role).account();
+    }
+
+    /**
+     * Resolves a role to its effective account and reports whether it came from a mapping or the
+     * configured default.
+     *
+     * @param role The posting role to resolve.
+     * @return The resolved account and its source.
+     * @throws AccountNotFoundException if no mapping is set and the fallback code does not resolve
+     *         to an account in the current tenant.
+     */
+    @Transactional(readOnly = true)
+    public Resolved resolveWithSource(PostingRole role) {
+        Long orgId = TenantContext.getCurrentOrgId();
+
+        Optional<PostingAccountMapping> mapping = mappingRepo.findByRoleAndOrganization_Id(role, orgId);
+        if (mapping.isPresent()) {
+            return new Resolved(role, mapping.get().getAccount(), Source.MAPPED);
+        }
+
+        String code = defaultCodeFor(role);
+        Account account = accountRepo.findByCodeAndOrganization_Id(code, orgId)
+                .orElseThrow(() -> new AccountNotFoundException(code));
+        return new Resolved(role, account, Source.DEFAULT);
+    }
+
+    /**
+     * The configured fallback account code for a role, used when the tenant has set no mapping.
+     */
+    public String defaultCodeFor(PostingRole role) {
+        return switch (role) {
+            case ACCOUNTS_RECEIVABLE -> invoiceProps.getArAccountCode();
+            case GST_OUTPUT -> invoiceProps.getGstOutputCode();
+            case ACCOUNTS_PAYABLE -> constructionProps.getApAccountCode();
+            case GST_INPUT -> constructionProps.getGstInputCode();
+            case DEFAULT_REVENUE -> constructionProps.getDefaultRevenueCode();
+            case DEFAULT_EXPENSE -> constructionProps.getDefaultExpenseCode();
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/posting/web/PostingAccountMappingControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/posting/web/PostingAccountMappingControllerWeb.java
@@ -1,0 +1,84 @@
+package org.tornotron.echno_backend.finance.posting.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.dtos.PostingAccountMappingDto;
+import org.tornotron.echno_backend.finance.posting.dtos.UpsertPostingAccountMappingRequest;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountMappingService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/finance/posting-accounts/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Posting Account Mapping",
+        description = "Per-organization mapping of finance posting roles (accounts receivable, GST "
+                + "output, accounts payable, GST input, default revenue, default expense) to concrete "
+                + "accounts. Where a role is unmapped, the postings fall back to the configured default "
+                + "account. Reading is open to project managers and system administrators; changing a "
+                + "mapping is restricted to system administrators."
+)
+public class PostingAccountMappingControllerWeb {
+
+    private final PostingAccountMappingService service;
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List effective posting accounts",
+            description = "Returns all six posting roles with the account each currently resolves to for "
+                    + "the tenant, flagged as coming from an explicit mapping (MAPPED) or the configured "
+                    + "default (DEFAULT)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Effective posting accounts returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "A default account is not configured in the tenant's chart")
+    })
+    public List<PostingAccountMappingDto> list() {
+        return service.listEffective();
+    }
+
+    @PutMapping("/{role}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Map a posting role to an account",
+            description = "Points the given posting role at a specific account, creating the mapping or "
+                    + "updating it in place. The account must be a postable leaf account in the current "
+                    + "tenant."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mapping saved, effective mapping returned"),
+            @ApiResponse(responseCode = "400", description = "The account is inactive or is a header account"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No account with the given id in the current tenant")
+    })
+    public PostingAccountMappingDto upsert(@PathVariable PostingRole role,
+                                           @Valid @RequestBody UpsertPostingAccountMappingRequest req) {
+        return service.upsert(role, req.accountId());
+    }
+
+    @DeleteMapping("/{role}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Remove a posting-role mapping",
+            description = "Removes the mapping override for the given role, reverting it to the configured "
+                    + "default account. A no-op when the role has no mapping."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mapping removed, effective (default) mapping returned"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "The default account is not configured in the tenant's chart")
+    })
+    public PostingAccountMappingDto delete(@PathVariable PostingRole role) {
+        return service.delete(role);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettings.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettings.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.finance.settings;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Organization-level finance configuration, one row per tenant.
+ *
+ * <p>Holds the approval threshold that governs whether a construction invoice needs manual
+ * approval. A null {@code approvalThreshold} means every invoice must be approved by hand (the
+ * original behaviour); a value {@code T} means an invoice whose total is below {@code T} is
+ * auto-approved on submit, and one at or above {@code T} still goes through the approval queue.
+ */
+@Entity
+@Table(name = "finance_settings",
+        uniqueConstraints = @UniqueConstraint(name = "uk_finance_settings_org",
+                columnNames = {"organization_id"}))
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FinanceSettings implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    /**
+     * Auto-approval threshold. Null means every invoice needs manual approval; a value T means
+     * invoices below T are auto-approved on submit.
+     */
+    @Column(name = "approval_threshold", precision = 19, scale = 4)
+    private BigDecimal approvalThreshold;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettingsRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettingsRepository.java
@@ -1,0 +1,10 @@
+package org.tornotron.echno_backend.finance.settings;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FinanceSettingsRepository extends JpaRepository<FinanceSettings, Long> {
+
+    Optional<FinanceSettings> findByOrganization_Id(Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettingsService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/FinanceSettingsService.java
@@ -1,0 +1,71 @@
+package org.tornotron.echno_backend.finance.settings;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.settings.dtos.FinanceSettingsDto;
+import org.tornotron.echno_backend.finance.settings.dtos.UpdateFinanceSettingsRequest;
+
+import java.math.BigDecimal;
+
+/**
+ * Manages the single finance-settings row per organization.
+ *
+ * <p>Follows the get-or-create idiom: the first read for a tenant materializes a default row with
+ * no threshold set (every invoice needs approval), and later reads and the update work against that
+ * same row. All access is scoped to the current tenant.
+ */
+@Service
+@RequiredArgsConstructor
+public class FinanceSettingsService {
+
+    private final FinanceSettingsRepository repository;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    /**
+     * Returns the finance settings for the current tenant, creating the row with defaults on first
+     * access.
+     */
+    @Transactional
+    public FinanceSettings getOrCreate() {
+        Long orgId = TenantContext.getCurrentOrgId();
+        return repository.findByOrganization_Id(orgId)
+                .orElseGet(() -> {
+                    FinanceSettings settings = new FinanceSettings();
+                    settings.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+                    settings.setApprovalThreshold(null);
+                    return repository.save(settings);
+                });
+    }
+
+    /** The current tenant's finance settings as a DTO. */
+    @Transactional
+    public FinanceSettingsDto getSettings() {
+        return toDto(getOrCreate());
+    }
+
+    /**
+     * The current tenant's auto-approval threshold, or null when every invoice needs manual
+     * approval. Does not create a row when none exists yet.
+     */
+    @Transactional(readOnly = true)
+    public BigDecimal getApprovalThreshold() {
+        return repository.findByOrganization_Id(TenantContext.getCurrentOrgId())
+                .map(FinanceSettings::getApprovalThreshold)
+                .orElse(null);
+    }
+
+    /** Upserts the finance settings for the current tenant from the request. */
+    @Transactional
+    public FinanceSettingsDto update(UpdateFinanceSettingsRequest request) {
+        FinanceSettings settings = getOrCreate();
+        settings.setApprovalThreshold(request.approvalThreshold());
+        return toDto(repository.save(settings));
+    }
+
+    private FinanceSettingsDto toDto(FinanceSettings settings) {
+        return new FinanceSettingsDto(settings.getApprovalThreshold());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/FinanceSettingsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/FinanceSettingsDto.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.finance.settings.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "Organization-level finance settings.")
+public record FinanceSettingsDto(
+
+        @Schema(description = "Auto-approval threshold. Null means every construction invoice needs "
+                + "manual approval; a value T auto-approves invoices whose total is below T.",
+                example = "50000.0000")
+        BigDecimal approvalThreshold
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/UpdateFinanceSettingsRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/UpdateFinanceSettingsRequest.java
@@ -1,0 +1,16 @@
+package org.tornotron.echno_backend.finance.settings.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.math.BigDecimal;
+
+@Schema(description = "Payload to update the organization-level finance settings.")
+public record UpdateFinanceSettingsRequest(
+
+        @Schema(description = "Auto-approval threshold. Send null to require manual approval on every "
+                + "construction invoice; send a value T to auto-approve invoices whose total is below T.",
+                example = "50000.00")
+        @PositiveOrZero(message = "approvalThreshold must not be negative")
+        BigDecimal approvalThreshold
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/web/FinanceSettingsControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/web/FinanceSettingsControllerWeb.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.finance.settings.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.finance.settings.dtos.FinanceSettingsDto;
+import org.tornotron.echno_backend.finance.settings.dtos.UpdateFinanceSettingsRequest;
+
+@RestController
+@RequestMapping("/api/v1/finance/settings/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Finance Settings",
+        description = "Organization-level finance configuration for the web client. Holds the approval "
+                + "threshold that decides whether a construction invoice is auto-approved on submit or "
+                + "routed for manual approval. Reading is open to project managers and system "
+                + "administrators; changing the settings is restricted to system administrators."
+)
+public class FinanceSettingsControllerWeb {
+
+    private final FinanceSettingsService service;
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get finance settings",
+            description = "Returns the finance settings for the current tenant, creating the default row "
+                    + "on first access. A null approval threshold means every construction invoice needs "
+                    + "manual approval."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Finance settings returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public FinanceSettingsDto get() {
+        return service.getSettings();
+    }
+
+    @PutMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Update finance settings",
+            description = "Sets the auto-approval threshold for the current tenant. Send a null threshold "
+                    + "to require manual approval on every construction invoice, or a value T to "
+                    + "auto-approve invoices whose total is below T."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Finance settings updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant")
+    })
+    public FinanceSettingsDto update(@Valid @RequestBody UpdateFinanceSettingsRequest request) {
+        return service.update(request);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -97,6 +97,14 @@ public class Project implements TenantScopedEntity {
     @Column(name = "progress")
     private Double progress;
 
+    /**
+     * Per-project override of the finance auto-approval threshold. When set, a construction invoice
+     * on this project below this amount is auto-approved on submit; null falls back to the
+     * organization-level finance setting.
+     */
+    @Column(name = "approval_threshold", precision = 19, scale = 4)
+    private java.math.BigDecimal approvalThreshold;
+
     /** The list of attachments associated with this project. */
     @OneToMany(mappedBy = "project")
     private List<Attachment> attachments = new ArrayList<>();

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -271,4 +271,7 @@
     <!-- v4.0 - Material GST rate + per-location threshold overrides (#257) -->
     <include file="db/changelog/v4.0/045-add-material-gst-rate-and-location-thresholds.xml"/>
 
+    <!-- v4.0 - Finance: per-org posting-account mapping, finance settings, project approval threshold (#341) -->
+    <include file="db/changelog/v4.0/046-add-finance-posting-mapping-settings-and-approval-threshold.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/046-add-finance-posting-mapping-settings-and-approval-threshold.xml
+++ b/src/main/resources/db/changelog/v4.0/046-add-finance-posting-mapping-settings-and-approval-threshold.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="046-create-posting-account-mapping" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="posting_account_mapping"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Per-organization override that points a finance posting role (accounts receivable, GST
+            output, accounts payable, GST input, default revenue, default expense) at a concrete
+            account. Where a role has no row, the postings fall back to the configured default code.
+            At most one row per organization and role.
+        </comment>
+
+        <createTable tableName="posting_account_mapping">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="account_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="posting_account_mapping"
+                                 baseColumnNames="account_id"
+                                 constraintName="fk_pam_account"
+                                 referencedTableName="accounts"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="posting_account_mapping"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_pam_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="posting_account_mapping"
+                             columnNames="organization_id, role"
+                             constraintName="uk_posting_account_mapping_role"/>
+
+        <createIndex tableName="posting_account_mapping" indexName="idx_pam_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="046-create-finance-settings" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="finance_settings"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Organization-level finance settings, one row per tenant. Holds the auto-approval
+            threshold: null means every construction invoice needs manual approval, a value T means
+            invoices below T are auto-approved on submit.
+        </comment>
+
+        <createTable tableName="finance_settings">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="approval_threshold" type="NUMERIC(19,4)"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="finance_settings"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_finance_settings_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="finance_settings"
+                             columnNames="organization_id"
+                             constraintName="uk_finance_settings_org"/>
+    </changeSet>
+
+    <changeSet id="046-add-approval-threshold-to-project" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="approval_threshold"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Per-project override of the finance auto-approval threshold. Nullable; a null value falls
+            back to the organization-level finance setting.
+        </comment>
+
+        <addColumn tableName="project">
+            <column name="approval_threshold" type="NUMERIC(19,4)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
@@ -1,0 +1,181 @@
+package org.tornotron.echno_backend.finance.construction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.mapper.JournalEntryMapperImpl;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.finance.settings.dtos.UpdateFinanceSettingsRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the approval-threshold behaviour of construction-invoice submit against a real CockroachDB:
+ * an invoice whose total is below the organization threshold is auto-approved and posted on submit,
+ * while one at or above the threshold, and one with no threshold set, stay PENDING.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// Commit the service writes (no rolled-back ambient transaction) so submit's own transaction reads
+// the finance-settings threshold it needs, and so cleanup deletes committed rows without contending
+// with an open write intent.
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
+        JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
+        InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
+        PostingAccountResolver.class, FinanceSettingsService.class})
+class ConstructionInvoiceAutoApprovalIT extends AbstractIntegrationTest {
+
+    // Total of the built invoice: 10 * 100 = 1000 subtotal, 18% tax = 180, gross 1180.
+    private static final long PROJECT_ID = 7001L;
+
+    @Autowired
+    private ConstructionInvoiceService service;
+
+    @Autowired
+    private ChartOfAccountsSeeder seeder;
+
+    @Autowired
+    private FinanceSettingsService financeSettingsService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Auto Approve Org");
+            entityManager.flush();
+            orgId = org.getId();
+            TenantContext.setCurrentOrgId(orgId);
+            seeder.seedDefaults();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM journal_entry_lines WHERE journal_entry_id IN "
+                    + "(SELECT id FROM journal_entries WHERE organization_id = :org)");
+            exec("DELETE FROM journal_entries WHERE organization_id = :org");
+            exec("DELETE FROM construction_invoice_lines WHERE invoice_id IN "
+                    + "(SELECT id FROM construction_invoices WHERE organization_id = :org)");
+            exec("DELETE FROM construction_invoices WHERE organization_id = :org");
+            exec("DELETE FROM finance_settings WHERE organization_id = :org");
+            exec("DELETE FROM document_sequence WHERE organization_id = :org");
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    @Test
+    void submit_belowOrgThreshold_autoApprovesAndPosts() {
+        financeSettingsService.update(new UpdateFinanceSettingsRequest(new BigDecimal("2000")));
+
+        ConstructionInvoiceDto created = service.create(request());
+        ConstructionInvoiceDto result = service.submit(created.id());
+
+        assertThat(result.status()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(result.journalEntryId()).isNotNull();
+        assertThat(result.submittedAt()).isNotNull();
+        assertThat(result.approvedAt()).isNotNull();
+    }
+
+    @Test
+    void submit_atOrAboveOrgThreshold_staysPending() {
+        financeSettingsService.update(new UpdateFinanceSettingsRequest(new BigDecimal("500")));
+
+        ConstructionInvoiceDto created = service.create(request());
+        ConstructionInvoiceDto result = service.submit(created.id());
+
+        assertThat(result.status()).isEqualTo(ConstructionInvoiceStatus.PENDING);
+        assertThat(result.journalEntryId()).isNull();
+    }
+
+    @Test
+    void submit_withNoThreshold_staysPending() {
+        ConstructionInvoiceDto created = service.create(request());
+        ConstructionInvoiceDto result = service.submit(created.id());
+
+        assertThat(result.status()).isEqualTo(ConstructionInvoiceStatus.PENDING);
+        assertThat(result.journalEntryId()).isNull();
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private CreateConstructionInvoiceRequest request() {
+        return new CreateConstructionInvoiceRequest(
+                ConstructionInvoiceType.PURCHASE,
+                PROJECT_ID,
+                null, null, null,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31),
+                "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
+                "Threshold test", "Standard terms apply",
+                List.of(new ConstructionInvoiceLineRequest("Cement supply", new BigDecimal("10"), "nos",
+                        new BigDecimal("100"), new BigDecimal("18"), null, null, null, null)));
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -56,7 +56,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
-        InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class})
+        InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
+        org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
+        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class})
 class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
 
     private static final long PROJECT_ID = 4001L;

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -53,7 +53,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
-        InvoicePostingProperties.class, UserContextService.class})
+        InvoicePostingProperties.class, UserContextService.class,
+        org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
+        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class})
 class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceServiceIT.java
@@ -51,7 +51,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InvoiceService.class, InvoiceMapperImpl.class, JournalPostingService.class,
         JournalEntryMapperImpl.class, EntryNumberGenerator.class, TenantEntityHelper.class,
-        InvoicePostingProperties.class, JpaAuditingConfig.class})
+        InvoicePostingProperties.class, JpaAuditingConfig.class,
+        org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
+        org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties.class})
 class InvoiceServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/AccountCsvServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/AccountCsvServiceIT.java
@@ -1,0 +1,165 @@
+package org.tornotron.echno_backend.finance.ledger;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.ledger.dtos.CoaImportSummary;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.ledger.service.AccountCsvService;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the chart-of-accounts CSV interchange against a real CockroachDB: importing the file that
+ * export just produced is idempotent (every account already exists, so nothing is created and the
+ * chart is unchanged), and importing a new child listed before its parent still resolves the parent.
+ *
+ * <p>Runs without the rolled-back ambient transaction so the imports commit; every write is cleaned
+ * up in the after-each, which keeps the counts a comparison of this tenant's chart before and after
+ * rather than an absolute number.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({AccountCsvService.class, ChartOfAccountsSeeder.class, TenantEntityHelper.class,
+        JpaAuditingConfig.class})
+class AccountCsvServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private AccountCsvService csvService;
+
+    @Autowired
+    private ChartOfAccountsSeeder seeder;
+
+    @Autowired
+    private AccountRepository accountRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Csv Org");
+            entityManager.flush();
+            orgId = org.getId();
+            TenantContext.setCurrentOrgId(orgId);
+            seeder.seedDefaults();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    @Test
+    void exportThenImport_isIdempotent() {
+        long before = accountRepo.findAll().size();
+        assertThat(before).isGreaterThan(0);
+
+        String exported = csvService.exportCsv();
+
+        CoaImportSummary summary = csvService.importCsv(exported);
+        assertThat(summary.created()).isZero();
+        assertThat(summary.updated()).isEqualTo((int) before);
+        assertThat(summary.errors()).isEmpty();
+
+        // The chart is unchanged and the file exports identically the second time.
+        assertThat(accountRepo.findAll()).hasSize((int) before);
+        assertThat(csvService.exportCsv()).isEqualTo(exported);
+    }
+
+    @Test
+    void import_createsNewChildListedBeforeItsParent() {
+        long before = accountRepo.findAll().size();
+
+        // The child row precedes its parent row in the file; the import must still apply the parent first.
+        String csv = "code,name,type,parentCode,active\n"
+                + "5110,Cement Purchases,EXPENSE,5100,true\n"
+                + "5120,Steel Purchases,EXPENSE,5100,true\n";
+
+        CoaImportSummary summary = csvService.importCsv(csv);
+        assertThat(summary.errors()).isEmpty();
+        assertThat(summary.created()).isEqualTo(2);
+        assertThat(summary.updated()).isZero();
+
+        assertThat(accountRepo.findByCodeAndOrganization_Id("5110", orgId)).isPresent();
+        // Read the lazy parent inside a transaction.
+        String parentCode = inReadTx(() -> accountRepo.findByCodeAndOrganization_Id("5110", orgId)
+                .orElseThrow().getParent().getCode());
+        assertThat(parentCode).isEqualTo("5100");
+        assertThat(accountRepo.findAll()).hasSize((int) before + 2);
+    }
+
+    @Test
+    void import_rejectsRowWhoseTypeMismatchesParent() {
+        String csv = "code,name,type,parentCode,active\n"
+                + "5115,Bad Child,INCOME,5100,true\n";
+
+        CoaImportSummary summary = csvService.importCsv(csv);
+        assertThat(summary.created()).isZero();
+        assertThat(summary.errors()).hasSize(1);
+        assertThat(summary.errors().get(0)).contains("does not match parent");
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private <T> T inReadTx(java.util.function.Supplier<T> work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.setReadOnly(true);
+        return tt.execute(status -> work.get());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/payment/service/PaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/payment/service/PaymentServiceIT.java
@@ -59,7 +59,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({PaymentService.class, PaymentMapperImpl.class, JournalPostingService.class,
         JournalEntryMapperImpl.class, EntryNumberGenerator.class, TenantEntityHelper.class,
-        InvoicePostingProperties.class, JpaAuditingConfig.class})
+        InvoicePostingProperties.class, JpaAuditingConfig.class,
+        org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
+        org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties.class})
 class PaymentServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/posting/PostingAccountResolverIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/posting/PostingAccountResolverIT.java
@@ -1,0 +1,163 @@
+package org.tornotron.echno_backend.finance.posting;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
+import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.finance.posting.domain.PostingAccountMapping;
+import org.tornotron.echno_backend.finance.posting.repositories.PostingAccountMappingRepository;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the posting-account resolution against a real CockroachDB: with no mapping the resolver
+ * falls back to the configured default code, and with a mapping set it returns the mapped account
+ * and flags the source as MAPPED.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// Commit the writes (no rolled-back ambient transaction) so cleanup can delete the mapping and the
+// account it references without contending with an open write intent.
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({PostingAccountResolver.class, TenantEntityHelper.class, JpaAuditingConfig.class,
+        ConstructionPostingProperties.class, InvoicePostingProperties.class, ChartOfAccountsSeeder.class})
+class PostingAccountResolverIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private PostingAccountResolver resolver;
+
+    @Autowired
+    private ChartOfAccountsSeeder seeder;
+
+    @Autowired
+    private AccountRepository accountRepo;
+
+    @Autowired
+    private PostingAccountMappingRepository mappingRepo;
+
+    @Autowired
+    private TenantEntityHelper tenantEntityHelper;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization org = persistOrganization("Resolver Org");
+            entityManager.flush();
+            orgId = org.getId();
+            TenantContext.setCurrentOrgId(orgId);
+            seeder.seedDefaults();
+        });
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+        if (orgId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            exec("DELETE FROM posting_account_mapping WHERE organization_id = :org");
+            exec("DELETE FROM accounts WHERE organization_id = :org");
+            exec("DELETE FROM organization WHERE id = :org");
+        });
+    }
+
+    @Test
+    void resolve_withNoMapping_returnsConfiguredDefaultAccount() {
+        PostingAccountResolver.Resolved payable = resolver.resolveWithSource(PostingRole.ACCOUNTS_PAYABLE);
+        assertThat(payable.source()).isEqualTo(PostingAccountResolver.Source.DEFAULT);
+        assertThat(payable.account().getCode()).isEqualTo("2100");
+
+        assertThat(resolver.resolve(PostingRole.ACCOUNTS_RECEIVABLE).getCode()).isEqualTo("1200");
+        assertThat(resolver.resolve(PostingRole.GST_OUTPUT).getCode()).isEqualTo("2210");
+        assertThat(resolver.resolve(PostingRole.GST_INPUT).getCode()).isEqualTo("1410");
+        assertThat(resolver.resolve(PostingRole.DEFAULT_REVENUE).getCode()).isEqualTo("4100");
+        assertThat(resolver.resolve(PostingRole.DEFAULT_EXPENSE).getCode()).isEqualTo("5100");
+    }
+
+    @Test
+    void resolve_withMapping_returnsMappedAccount() {
+        // Point ACCOUNTS_PAYABLE at a different account than the configured default 2100. Committed so
+        // that resolving reads it back and cleanup can delete it cleanly.
+        inCommittedTx(() -> {
+            Account other = accountRepo.findByCodeAndOrganization_Id("5100", orgId).orElseThrow();
+            PostingAccountMapping mapping = new PostingAccountMapping();
+            mapping.setRole(PostingRole.ACCOUNTS_PAYABLE);
+            mapping.setAccount(other);
+            mapping.setOrganization(other.getOrganization());
+            mappingRepo.save(mapping);
+        });
+
+        // Resolve inside a transaction so the lazily loaded mapped account can be read.
+        inReadTx(() -> {
+            PostingAccountResolver.Resolved payable = resolver.resolveWithSource(PostingRole.ACCOUNTS_PAYABLE);
+            assertThat(payable.source()).isEqualTo(PostingAccountResolver.Source.MAPPED);
+            assertThat(payable.account().getCode()).isEqualTo("5100");
+
+            // An unmapped role still falls back to its default.
+            PostingAccountResolver.Resolved gstInput = resolver.resolveWithSource(PostingRole.GST_INPUT);
+            assertThat(gstInput.source()).isEqualTo(PostingAccountResolver.Source.DEFAULT);
+            assertThat(gstInput.account().getCode()).isEqualTo("1410");
+        });
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void exec(String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private void inReadTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.setReadOnly(true);
+        tt.executeWithoutResult(status -> work.run());
+    }
+}


### PR DESCRIPTION
## Summary

Completes the construction-finance module across four areas. Posting behaviour is unchanged for any organization that sets no mapping: the resolver falls back to the same default account codes the services used before.

### 1. Per-org posting-account mapping
- New `PostingRole` enum: `ACCOUNTS_RECEIVABLE`, `GST_OUTPUT`, `ACCOUNTS_PAYABLE`, `GST_INPUT`, `DEFAULT_REVENUE`, `DEFAULT_EXPENSE`.
- New `PostingAccountMapping` entity (unique per organization + role) and `PostingAccountResolver.resolve(role)`: returns the mapped account where one exists, else the configured default code resolved against the tenant's chart. The config classes remain the source of the fallback codes.
- `ConstructionInvoiceService`, `InvoiceService` and `PaymentService` now resolve their control accounts by role through the resolver. Journal amounts and debit/credit sides are untouched.
- Endpoints under `/api/v1/finance/posting-accounts/web`: `GET` lists all six roles with their effective account and a `source` flag (`MAPPED`/`DEFAULT`); `PUT /{role}` upserts a mapping; `DELETE /{role}` reverts to the default.

### 2. Chart-of-accounts edit
- `PUT /api/v1/finance/accounts/web/{id}` edits code, name, active, description and optionally parent, with per-tenant code uniqueness and cycle/type checks. Because postings resolve by account id, editing a code is safe.

### 3. Approval threshold
- `FinanceSettings` (per org) with a nullable `approvalThreshold`, plus a nullable per-project override on `project`. Effective threshold = project override, else org setting.
- On `submit`, an invoice below the effective threshold is auto-approved and posted through the same path as manual approval; null threshold keeps the current always-manual behaviour.
- Settings endpoints under `/api/v1/finance/settings/web` (`GET`, `PUT`).

### 4. Import / export
- Hand-rolled CSV utility (RFC 4180 style quoting, no new dependency).
- Chart of accounts: `GET .../accounts/web/export` and `POST .../accounts/web/import` (multipart; upsert by code, parent-before-child, type validation, no deletes, returns a created/updated/errors summary).
- Journal: `GET /api/v1/finance/journal/web/export` with optional `from`/`to`.

### Migration
- Liquibase changelog `046-add-finance-posting-mapping-settings-and-approval-threshold.xml` creates `posting_account_mapping` and `finance_settings` and adds `approval_threshold` to `project`.

### Tests
- Added Testcontainers ITs: posting resolver (mapped vs default), auto-approval on submit (below / at-or-above / no threshold), and chart-of-accounts CSV export/import round-trip. Full suite: 291 tests, 0 failures (`./gradlew clean build` BUILD SUCCESSFUL).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import and export charts of accounts using CSV files, with validation and row-level error reporting.
  * Update account details, including codes, status, descriptions, and parent accounts.
  * Export journal entries to CSV with optional date filters.
  * Configure finance posting-account mappings and restore default mappings.
  * Set organization- or project-level invoice approval thresholds.
  * Construction invoices below the threshold are automatically approved and posted.

* **Bug Fixes**
  * Standardized finance account resolution across invoices, payments, and construction invoicing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->