### PR TITLE
feat: project budgeting and cost-control (allocated/committed/spent/remaining per budget head)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/budget/domain/BudgetAllocation.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/domain/BudgetAllocation.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.finance.budget.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * The amount allocated to one budget head (cost category) on one project.
+ *
+ * <p>A project's budget is the set of these rows: one allocation per cost category, each carrying the
+ * money set aside for that head. The pair (project, cost category) is unique, so upserting an
+ * allocation replaces the amount rather than adding a second row. Cost-control compares this allocated
+ * amount against the committed and spent amounts rolled up from tagged construction invoice lines.
+ */
+@Entity
+@Table(name = "budget_allocation",
+        uniqueConstraints = @UniqueConstraint(name = "uk_budget_allocation_project_category",
+                columnNames = {"project_id", "cost_category_id"}),
+        indexes = {
+                @Index(name = "idx_budget_allocation_project", columnList = "project_id"),
+                @Index(name = "idx_budget_allocation_category", columnList = "cost_category_id")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class BudgetAllocation extends BaseEntity implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cost_category_id", nullable = false)
+    private CostCategory costCategory;
+
+    @Column(name = "allocated_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal allocatedAmount = BigDecimal.ZERO;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/domain/CostCategory.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/domain/CostCategory.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.finance.budget.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.domain.BaseEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.UUID;
+
+/**
+ * A budget head (cost category) in a project budget: materials, labour, plant, overheads and so on.
+ *
+ * <p>Cost categories are an org-level master list. A project budget is expressed as a set of
+ * {@link BudgetAllocation} rows, one per category, and a construction invoice line is tagged to a
+ * category so its cost rolls up under that head in the project cost-control view. An optional
+ * {@code expenseAccount} aligns a head with a ledger expense account so budget reporting and the
+ * chart of accounts line up. A category is deactivated rather than deleted so tagged history survives.
+ */
+@Entity
+@Table(name = "cost_category",
+        uniqueConstraints = @UniqueConstraint(name = "uk_cost_category_name",
+                columnNames = {"organization_id", "name"}))
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CostCategory extends BaseEntity implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 20)
+    private String code;
+
+    /** Optional ledger expense account this head maps to, for reporting alignment. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expense_account_id")
+    private Account expenseAccount;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/BudgetAllocationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/BudgetAllocationDto.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Schema(description = "One budget-head allocation on a project: the amount set aside for a cost category.")
+public record BudgetAllocationDto(
+        @Schema(description = "Unique allocation id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        UUID id,
+
+        @Schema(description = "Project the allocation belongs to.", example = "42")
+        Long projectId,
+
+        @Schema(description = "Cost category (budget head) the amount is allocated to.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID costCategoryId,
+
+        @Schema(description = "Cost category name.", example = "Materials")
+        String costCategoryName,
+
+        @Schema(description = "Amount allocated to this head.", example = "500000.00")
+        BigDecimal allocatedAmount
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
@@ -1,0 +1,28 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "A budget head (cost category) in the org-level master list, optionally aligned to "
+        + "a ledger expense account.")
+public record CostCategoryDto(
+        @Schema(description = "Unique cost category id.", example = "3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+        UUID id,
+
+        @Schema(description = "Cost category name, unique within the tenant.", example = "Materials")
+        String name,
+
+        @Schema(description = "Optional short code for the head.", example = "MAT")
+        String code,
+
+        @Schema(description = "Ledger expense account this head maps to, or null.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID expenseAccountId,
+
+        @Schema(description = "Code of the mapped expense account, or null.", example = "5100")
+        String expenseAccountCode,
+
+        @Schema(description = "Whether the head is active and available for tagging.", example = "true")
+        boolean active
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CreateCostCategoryRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CreateCostCategoryRequest.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(description = "Payload to create a budget head (cost category).")
+public record CreateCostCategoryRequest(
+        @Schema(description = "Cost category name, unique within the tenant.", example = "Materials")
+        @NotBlank @Size(max = 200) String name,
+
+        @Schema(description = "Optional short code for the head.", example = "MAT")
+        @Size(max = 20) String code,
+
+        @Schema(description = "Optional ledger expense account to map this head to.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID expenseAccountId
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlDto.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Project cost-control view: the per-head allocated, committed, spent and remaining "
+        + "amounts, plus a project total row.")
+public record ProjectCostControlDto(
+        @Schema(description = "Project the cost-control view is for.", example = "42")
+        Long projectId,
+
+        @Schema(description = "Per budget head roll-up. Includes any head with an allocation or tagged spend.")
+        List<ProjectCostControlLineDto> categories,
+
+        @Schema(description = "Project total row summing each column across the heads.")
+        ProjectCostControlLineDto totals
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlLineDto.java
@@ -1,0 +1,33 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Schema(description = "Cost-control roll-up for one budget head on a project: what was allocated against "
+        + "what has been committed and spent, and what remains.")
+public record ProjectCostControlLineDto(
+        @Schema(description = "Cost category (budget head) id, or null for the project total row.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID costCategoryId,
+
+        @Schema(description = "Cost category name, or 'Total' for the project total row.", example = "Materials")
+        String costCategoryName,
+
+        @Schema(description = "Amount allocated to this head.", example = "500000.00")
+        BigDecimal allocated,
+
+        @Schema(description = "Approved obligations not yet fully paid, tagged to this head.", example = "120000.00")
+        BigDecimal committed,
+
+        @Schema(description = "Amount already spent (on fully paid invoices), tagged to this head.",
+                example = "300000.00")
+        BigDecimal spent,
+
+        @Schema(description = "Remaining budget: allocated minus committed minus spent.", example = "80000.00")
+        BigDecimal remaining,
+
+        @Schema(description = "Whether committed plus spent has exceeded the allocation.", example = "false")
+        boolean overBudget
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/UpdateCostCategoryRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/UpdateCostCategoryRequest.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(description = "Payload to edit an existing budget head (cost category).")
+public record UpdateCostCategoryRequest(
+        @Schema(description = "Cost category name, unique within the tenant.", example = "Materials")
+        @NotBlank @Size(max = 200) String name,
+
+        @Schema(description = "Optional short code for the head.", example = "MAT")
+        @Size(max = 20) String code,
+
+        @Schema(description = "Optional ledger expense account to map this head to. Omit to clear the mapping.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID expenseAccountId,
+
+        @Schema(description = "Whether the head is active and available for tagging.", example = "true")
+        @NotNull Boolean active
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/UpsertBudgetAllocationRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/UpsertBudgetAllocationRequest.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.finance.budget.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+@Schema(description = "Payload to set the amount allocated to a budget head on a project. The project and "
+        + "cost category come from the path; upserting replaces any existing allocation for the pair.")
+public record UpsertBudgetAllocationRequest(
+        @Schema(description = "Amount to allocate to this head.", example = "500000.00")
+        @NotNull @DecimalMin(value = "0.0") BigDecimal allocatedAmount
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/mapper/BudgetAllocationMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/mapper/BudgetAllocationMapper.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.finance.budget.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.finance.budget.domain.BudgetAllocation;
+import org.tornotron.echno_backend.finance.budget.dtos.BudgetAllocationDto;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BudgetAllocationMapper {
+
+    @Mapping(source = "project.id", target = "projectId")
+    @Mapping(source = "costCategory.id", target = "costCategoryId")
+    @Mapping(source = "costCategory.name", target = "costCategoryName")
+    BudgetAllocationDto toDto(BudgetAllocation allocation);
+
+    List<BudgetAllocationDto> toDtos(List<BudgetAllocation> allocations);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/mapper/CostCategoryMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/mapper/CostCategoryMapper.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.finance.budget.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.CostCategoryDto;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CostCategoryMapper {
+
+    @Mapping(source = "expenseAccount.id", target = "expenseAccountId")
+    @Mapping(source = "expenseAccount.code", target = "expenseAccountCode")
+    CostCategoryDto toDto(CostCategory category);
+
+    List<CostCategoryDto> toDtos(List<CostCategory> categories);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/BudgetAllocationRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/BudgetAllocationRepository.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.finance.budget.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.finance.budget.domain.BudgetAllocation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BudgetAllocationRepository extends JpaRepository<BudgetAllocation, UUID> {
+
+    List<BudgetAllocation> findByProject_IdAndOrganization_Id(Long projectId, Long organizationId);
+
+    /**
+     * Org-scoped lookup of the single allocation for a project and cost-category pair, which the
+     * unique constraint guarantees. Used by the upsert and delete paths.
+     */
+    @Query("SELECT a FROM BudgetAllocation a WHERE a.project.id = :projectId "
+            + "AND a.costCategory.id = :costCategoryId")
+    Optional<BudgetAllocation> findByProjectAndCategory(@Param("projectId") Long projectId,
+                                                        @Param("costCategoryId") UUID costCategoryId);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/CategoryCostAggregate.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/CategoryCostAggregate.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.finance.budget.repositories;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Per cost-category roll-up of construction invoice line amounts for one project, produced by a
+ * single grouped query so the cost-control view does not fan out into per-invoice reads.
+ *
+ * <p>{@code committed} sums lines on approved-but-not-fully-paid invoices; {@code spent} sums lines
+ * on fully paid invoices. Both are restricted to lines tagged to the category.
+ */
+public interface CategoryCostAggregate {
+    UUID getCostCategoryId();
+    BigDecimal getCommitted();
+    BigDecimal getSpent();
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/CostCategoryRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/repositories/CostCategoryRepository.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.finance.budget.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CostCategoryRepository extends JpaRepository<CostCategory, UUID> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT c FROM CostCategory c WHERE c.id = :id")
+    Optional<CostCategory> findScopedById(@Param("id") UUID id);
+
+    List<CostCategory> findByActiveTrue();
+
+    /** All active categories whose id is in the given set, scoped to the current tenant. */
+    List<CostCategory> findByIdIn(Collection<UUID> ids);
+
+    /**
+     * Whether another category in the current tenant already uses the given name, excluding the
+     * category with the given id. Used on edit so a category can keep its own name while a clash
+     * with any other is rejected.
+     */
+    boolean existsByNameAndIdNot(String name, UUID id);
+
+    boolean existsByName(String name);
+
+    /**
+     * Whether the given organization already owns any cost category. Used by the seeder to stay
+     * idempotent. Queries the organization id directly so it does not depend on the Hibernate
+     * {@code orgFilter} being enabled.
+     */
+    boolean existsByOrganizationId(Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/service/BudgetAllocationService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/service/BudgetAllocationService.java
@@ -1,0 +1,96 @@
+package org.tornotron.echno_backend.finance.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.domain.BudgetAllocation;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.BudgetAllocationDto;
+import org.tornotron.echno_backend.finance.budget.dtos.UpsertBudgetAllocationRequest;
+import org.tornotron.echno_backend.finance.budget.mapper.BudgetAllocationMapper;
+import org.tornotron.echno_backend.finance.budget.repositories.BudgetAllocationRepository;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Manages a project's budget: the set of {@link BudgetAllocation} rows, one per budget head.
+ *
+ * <p>The upsert is keyed on (project, cost category), which the unique constraint enforces, so setting
+ * the amount for a head that already has an allocation replaces it rather than adding a second row.
+ * The project and cost category are both validated against the current tenant.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BudgetAllocationService {
+
+    private final BudgetAllocationRepository repo;
+    private final CostCategoryRepository categoryRepo;
+    private final ProjectRepository projectRepository;
+    private final BudgetAllocationMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public List<BudgetAllocationDto> findByProject(Long projectId) {
+        requireProject(projectId);
+        return mapper.toDtos(
+                repo.findByProject_IdAndOrganization_Id(projectId, TenantContext.getCurrentOrgId()));
+    }
+
+    /**
+     * Sets the amount allocated to a budget head on a project, creating the allocation on first use
+     * and replacing the amount thereafter.
+     */
+    @Transactional
+    public BudgetAllocationDto upsert(Long projectId, UUID costCategoryId, UpsertBudgetAllocationRequest req) {
+        Project project = requireProject(projectId);
+        CostCategory category = requireCategory(costCategoryId);
+
+        BudgetAllocation allocation = repo.findByProjectAndCategory(projectId, costCategoryId)
+                .orElseGet(() -> {
+                    BudgetAllocation created = new BudgetAllocation();
+                    created.setProject(project);
+                    created.setCostCategory(category);
+                    created.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+                    return created;
+                });
+        allocation.setAllocatedAmount(MoneyUtils.normalize(req.allocatedAmount()));
+
+        BudgetAllocation saved = repo.save(allocation);
+        log.info("Upserted budget allocation for project {} category {} at {}",
+                projectId, costCategoryId, saved.getAllocatedAmount());
+        return mapper.toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long projectId, UUID costCategoryId) {
+        requireProject(projectId);
+        BudgetAllocation allocation = repo.findByProjectAndCategory(projectId, costCategoryId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No budget allocation for project " + projectId + " and cost category "
+                                + costCategoryId));
+        repo.delete(allocation);
+        log.info("Deleted budget allocation for project {} category {}", projectId, costCategoryId);
+    }
+
+    private Project requireProject(Long projectId) {
+        return projectRepository.findByIdAndOrganization_Id(projectId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Project with ID " + projectId + " was not found"));
+    }
+
+    private CostCategory requireCategory(UUID costCategoryId) {
+        return categoryRepo.findScopedById(costCategoryId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Cost category with ID " + costCategoryId + " was not found"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategorySeeder.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategorySeeder.java
@@ -1,0 +1,86 @@
+package org.tornotron.echno_backend.finance.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+
+/**
+ * Seeds a default set of budget heads (cost categories) for the current tenant, each mapped to the
+ * matching seeded expense account by code.
+ *
+ * <p>The heads mirror the construction expense accounts: Materials (5100), Subcontractor (5200),
+ * Labour (5300), Plant and Equipment (5400), and Other (5900). The expense account is resolved by
+ * code in the tenant; when an org has retuned its chart and a code is absent the head is still seeded,
+ * only without the account mapping.
+ *
+ * <p>Idempotent: if the tenant already owns any cost category the seed is skipped, so it is safe to
+ * run on organization creation and to re-run to back-fill an existing org.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CostCategorySeeder {
+
+    private final CostCategoryRepository categoryRepo;
+    private final AccountRepository accountRepo;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    /** One default head: its name, optional code, and the expense account code it maps to. */
+    private record SeedCategory(String name, String code, String expenseAccountCode) {}
+
+    private static final List<SeedCategory> DEFAULT_CATEGORIES = List.of(
+            new SeedCategory("Materials", "MAT", "5100"),
+            new SeedCategory("Subcontractor", "SUB", "5200"),
+            new SeedCategory("Labour", "LAB", "5300"),
+            new SeedCategory("Plant and Equipment", "PLT", "5400"),
+            new SeedCategory("Other", "OTH", "5900")
+    );
+
+    /**
+     * Seeds the default budget heads for the current tenant if it has none yet.
+     *
+     * @return the number of categories created (0 when the org already had any).
+     */
+    @Transactional
+    public int seedDefaults() {
+        Organization org = tenantEntityHelper.resolveCurrentOrganization();
+
+        if (categoryRepo.existsByOrganizationId(org.getId())) {
+            log.debug("Cost categories already present for organization {}, skipping seed", org.getId());
+            return 0;
+        }
+
+        Long orgId = TenantContext.getCurrentOrgId();
+        int created = 0;
+        for (SeedCategory seed : DEFAULT_CATEGORIES) {
+            Account account = accountRepo.findByCodeAndOrganization_Id(seed.expenseAccountCode(), orgId)
+                    .orElse(null);
+            if (account == null) {
+                log.debug("Expense account {} not found for organization {}, seeding head '{}' unmapped",
+                        seed.expenseAccountCode(), org.getId(), seed.name());
+            }
+
+            CostCategory category = new CostCategory();
+            category.setName(seed.name());
+            category.setCode(seed.code());
+            category.setExpenseAccount(account);
+            category.setActive(true);
+            category.setOrganization(org);
+            categoryRepo.save(category);
+            created++;
+        }
+
+        log.info("Seeded {} default cost categories for organization {}", created, org.getId());
+        return created;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategoryService.java
@@ -1,0 +1,113 @@
+package org.tornotron.echno_backend.finance.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.CostCategoryDto;
+import org.tornotron.echno_backend.finance.budget.dtos.CreateCostCategoryRequest;
+import org.tornotron.echno_backend.finance.budget.dtos.UpdateCostCategoryRequest;
+import org.tornotron.echno_backend.finance.budget.mapper.CostCategoryMapper;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Manages the org-level list of budget heads (cost categories): lookups, creation, editing, and
+ * deactivation. A head may be mapped to a ledger expense account so budget reporting and the chart of
+ * accounts line up. Names are unique per organization, and a head is deactivated rather than deleted
+ * so invoice lines tagged to it keep their reference.
+ */
+@Service
+@RequiredArgsConstructor
+public class CostCategoryService {
+
+    private final CostCategoryRepository repo;
+    private final CostCategoryMapper mapper;
+    private final AccountRepository accountRepo;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public List<CostCategoryDto> findAll(boolean activeOnly) {
+        return mapper.toDtos(activeOnly
+                ? repo.findByActiveTrue()
+                : repo.findAll(Sort.by("name")));
+    }
+
+    @Transactional(readOnly = true)
+    public CostCategoryDto findById(UUID id) {
+        return mapper.toDto(requireCategory(id));
+    }
+
+    @Transactional
+    public CostCategoryDto create(CreateCostCategoryRequest req) {
+        String name = req.name().trim();
+        if (repo.existsByName(name)) {
+            throw new InvalidRequestException(
+                    "Cost category '" + name + "' already exists in this organization");
+        }
+        CostCategory category = new CostCategory();
+        category.setName(name);
+        category.setCode(trimToNull(req.code()));
+        category.setExpenseAccount(resolveAccount(req.expenseAccountId()));
+        category.setActive(true);
+        category.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        return mapper.toDto(repo.save(category));
+    }
+
+    @Transactional
+    public CostCategoryDto update(UUID id, UpdateCostCategoryRequest req) {
+        CostCategory category = requireCategory(id);
+        String name = req.name().trim();
+        if (repo.existsByNameAndIdNot(name, id)) {
+            throw new InvalidRequestException(
+                    "Cost category '" + name + "' already exists in this organization");
+        }
+        category.setName(name);
+        category.setCode(trimToNull(req.code()));
+        category.setExpenseAccount(resolveAccount(req.expenseAccountId()));
+        category.setActive(req.active());
+        return mapper.toDto(category);
+    }
+
+    @Transactional
+    public CostCategoryDto deactivate(UUID id) {
+        CostCategory category = requireCategory(id);
+        category.setActive(false);
+        return mapper.toDto(category);
+    }
+
+    private CostCategory requireCategory(UUID id) {
+        return repo.findScopedById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Cost category with ID " + id + " was not found"));
+    }
+
+    /**
+     * Resolves an expense account by id within the current tenant, or null when no id is given.
+     * Guards that a mapped account belongs to the tenant.
+     */
+    private Account resolveAccount(UUID accountId) {
+        if (accountId == null) {
+            return null;
+        }
+        return accountRepo.findScopedById(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Account with ID " + accountId + " was not found"));
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/service/ProjectCostControlService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/service/ProjectCostControlService.java
@@ -1,0 +1,132 @@
+package org.tornotron.echno_backend.finance.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.configuration.MoneyUtils;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.finance.budget.domain.BudgetAllocation;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlDto;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlLineDto;
+import org.tornotron.echno_backend.finance.budget.repositories.BudgetAllocationRepository;
+import org.tornotron.echno_backend.finance.budget.repositories.CategoryCostAggregate;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceLineRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Builds the project cost-control view: for each budget head on a project, the amount allocated
+ * against what has been committed (approved but not fully paid) and spent (fully paid), and what
+ * remains.
+ *
+ * <p>The heads shown are the union of those with a budget allocation and those with any tagged spend,
+ * so a category that has cost against it but no allocation still surfaces (as over budget). The
+ * committed and spent amounts come from one grouped query over the tagged invoice lines, never a
+ * per-invoice fan-out. A project total row sums each column.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProjectCostControlService {
+
+    private static final String TOTAL_LABEL = "Total";
+
+    // Approved and beyond, but not a terminal fully-paid or cancelled state: these are the
+    // statuses whose unpaid balance counts as a committed obligation.
+    private static final List<ConstructionInvoiceStatus> COMMITTED_STATUSES = List.of(
+            ConstructionInvoiceStatus.APPROVED,
+            ConstructionInvoiceStatus.SENT,
+            ConstructionInvoiceStatus.PARTIALLY_PAID,
+            ConstructionInvoiceStatus.OVERDUE);
+
+    private final BudgetAllocationRepository allocationRepo;
+    private final CostCategoryRepository categoryRepo;
+    private final ConstructionInvoiceLineRepository lineRepo;
+    private final ProjectRepository projectRepository;
+
+    @Transactional(readOnly = true)
+    public ProjectCostControlDto getForProject(Long projectId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (!projectRepository.existsByIdAndOrganization_Id(projectId, orgId)) {
+            throw new ResourceNotFoundException("Project with ID " + projectId + " was not found");
+        }
+
+        Map<UUID, BigDecimal> allocatedByCategory = new HashMap<>();
+        for (BudgetAllocation allocation : allocationRepo.findByProject_IdAndOrganization_Id(projectId, orgId)) {
+            allocatedByCategory.put(allocation.getCostCategory().getId(),
+                    MoneyUtils.normalize(allocation.getAllocatedAmount()));
+        }
+
+        Map<UUID, BigDecimal> committedByCategory = new HashMap<>();
+        Map<UUID, BigDecimal> spentByCategory = new HashMap<>();
+        List<CategoryCostAggregate> aggregates = lineRepo.aggregateByCategoryForProject(
+                projectId, orgId, ConstructionPaymentStatus.PAID, COMMITTED_STATUSES);
+        for (CategoryCostAggregate row : aggregates) {
+            committedByCategory.put(row.getCostCategoryId(), MoneyUtils.normalize(row.getCommitted()));
+            spentByCategory.put(row.getCostCategoryId(), MoneyUtils.normalize(row.getSpent()));
+        }
+
+        // Union of heads that carry an allocation or any tagged spend, in a stable order.
+        Set<UUID> categoryIds = new LinkedHashSet<>();
+        categoryIds.addAll(allocatedByCategory.keySet());
+        categoryIds.addAll(committedByCategory.keySet());
+
+        Map<UUID, String> nameById = new HashMap<>();
+        if (!categoryIds.isEmpty()) {
+            for (CostCategory category : categoryRepo.findByIdIn(categoryIds)) {
+                nameById.put(category.getId(), category.getName());
+            }
+        }
+
+        List<ProjectCostControlLineDto> lines = new ArrayList<>();
+        BigDecimal totalAllocated = BigDecimal.ZERO;
+        BigDecimal totalCommitted = BigDecimal.ZERO;
+        BigDecimal totalSpent = BigDecimal.ZERO;
+
+        for (UUID categoryId : categoryIds) {
+            BigDecimal allocated = allocatedByCategory.getOrDefault(categoryId, MoneyUtils.normalize(null));
+            BigDecimal committed = committedByCategory.getOrDefault(categoryId, MoneyUtils.normalize(null));
+            BigDecimal spent = spentByCategory.getOrDefault(categoryId, MoneyUtils.normalize(null));
+            lines.add(buildLine(categoryId, nameById.getOrDefault(categoryId, "(unknown)"),
+                    allocated, committed, spent));
+
+            totalAllocated = totalAllocated.add(allocated);
+            totalCommitted = totalCommitted.add(committed);
+            totalSpent = totalSpent.add(spent);
+        }
+
+        // Present heads alphabetically by name for a stable, readable view.
+        lines.sort(Comparator.comparing(ProjectCostControlLineDto::costCategoryName,
+                String.CASE_INSENSITIVE_ORDER));
+
+        ProjectCostControlLineDto totals = buildLine(null, TOTAL_LABEL,
+                MoneyUtils.normalize(totalAllocated),
+                MoneyUtils.normalize(totalCommitted),
+                MoneyUtils.normalize(totalSpent));
+
+        return new ProjectCostControlDto(projectId, lines, totals);
+    }
+
+    private ProjectCostControlLineDto buildLine(UUID categoryId, String name,
+                                                BigDecimal allocated, BigDecimal committed, BigDecimal spent) {
+        BigDecimal consumed = committed.add(spent);
+        BigDecimal remaining = MoneyUtils.normalize(allocated.subtract(consumed));
+        boolean overBudget = consumed.compareTo(allocated) > 0;
+        return new ProjectCostControlLineDto(categoryId, name,
+                MoneyUtils.normalize(allocated), MoneyUtils.normalize(committed),
+                MoneyUtils.normalize(spent), remaining, overBudget);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/web/BudgetAllocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/web/BudgetAllocationControllerWeb.java
@@ -1,0 +1,82 @@
+package org.tornotron.echno_backend.finance.budget.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.budget.dtos.BudgetAllocationDto;
+import org.tornotron.echno_backend.finance.budget.dtos.UpsertBudgetAllocationRequest;
+import org.tornotron.echno_backend.finance.budget.service.BudgetAllocationService;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/finance/projects/{projectId}/budget/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Project Budget",
+        description = "A project's budget, expressed as one allocation per budget head (cost category). "
+                + "All endpoints are tenant scoped and limited to system administrators and project managers."
+)
+public class BudgetAllocationControllerWeb {
+
+    private final BudgetAllocationService service;
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List a project's budget allocations",
+            description = "Returns the set of budget-head allocations that make up the project's budget."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of budget allocations"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+    })
+    public List<BudgetAllocationDto> list(@PathVariable Long projectId) {
+        return service.findByProject(projectId);
+    }
+
+    @PutMapping("/{costCategoryId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Set the allocation for a budget head",
+            description = "Sets the amount allocated to a cost category on the project. Creates the "
+                    + "allocation on first use and replaces the amount thereafter, so the call is idempotent "
+                    + "for a given project and category."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Allocation created or updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No such project or cost category in the current tenant")
+    })
+    public BudgetAllocationDto upsert(@PathVariable Long projectId,
+                                      @PathVariable UUID costCategoryId,
+                                      @Valid @RequestBody UpsertBudgetAllocationRequest req) {
+        return service.upsert(projectId, costCategoryId, req);
+    }
+
+    @DeleteMapping("/{costCategoryId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Remove a budget-head allocation",
+            description = "Deletes the allocation for a cost category on the project, taking that head out "
+                    + "of the project's budget."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Allocation deleted"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No such project, or no allocation for the category, in the current tenant")
+    })
+    public ResponseEntity<Void> delete(@PathVariable Long projectId, @PathVariable UUID costCategoryId) {
+        service.delete(projectId, costCategoryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/web/CostCategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/web/CostCategoryControllerWeb.java
@@ -1,0 +1,134 @@
+package org.tornotron.echno_backend.finance.budget.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.budget.dtos.CostCategoryDto;
+import org.tornotron.echno_backend.finance.budget.dtos.CreateCostCategoryRequest;
+import org.tornotron.echno_backend.finance.budget.dtos.UpdateCostCategoryRequest;
+import org.tornotron.echno_backend.finance.budget.service.CostCategoryService;
+import org.tornotron.echno_backend.finance.budget.service.CostCategorySeeder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/finance/cost-categories/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Cost Categories",
+        description = "Budget heads (cost categories) that a project budget is broken down by and that "
+                + "construction invoice lines are tagged to. An org-level master list, optionally aligned "
+                + "to a ledger expense account. All endpoints are tenant scoped and limited to system "
+                + "administrators and project managers, apart from the default seed, which is admin only."
+)
+public class CostCategoryControllerWeb {
+
+    private final CostCategoryService service;
+    private final CostCategorySeeder seeder;
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List cost categories",
+            description = "Returns the budget heads in the current tenant. By default only active heads are "
+                    + "returned; set activeOnly to false to include deactivated ones."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of cost categories"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public List<CostCategoryDto> list(@RequestParam(defaultValue = "true") boolean activeOnly) {
+        return service.findAll(activeOnly);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a cost category by id",
+            description = "Returns a single budget head by its unique id."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cost category found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No cost category with the given id in the current tenant")
+    })
+    public CostCategoryDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Create a cost category",
+            description = "Creates a budget head. The name must be unique within the tenant; an optional "
+                    + "expense account maps the head to the chart of accounts for reporting."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Cost category created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed or the name is already in use"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "The referenced expense account does not exist")
+    })
+    public ResponseEntity<CostCategoryDto> create(@Valid @RequestBody CreateCostCategoryRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Update a cost category",
+            description = "Edits a budget head's name, code, expense-account mapping and active flag. The "
+                    + "name must stay unique within the tenant; omit the expense account id to clear the mapping."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cost category updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed or the name clashes"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No cost category, or no such expense account, in the current tenant")
+    })
+    public CostCategoryDto update(@PathVariable UUID id, @Valid @RequestBody UpdateCostCategoryRequest req) {
+        return service.update(id, req);
+    }
+
+    @PostMapping("/{id}/deactivate")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Deactivate a cost category",
+            description = "Marks a budget head inactive so it can no longer be tagged on new invoice lines "
+                    + "or allocated to. Existing tagged lines and allocations are left unchanged."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cost category deactivated"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No cost category with the given id in the current tenant")
+    })
+    public CostCategoryDto deactivate(@PathVariable UUID id) {
+        return service.deactivate(id);
+    }
+
+    @PostMapping("/seed-defaults")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Seed the default cost categories",
+            description = "Creates a default set of budget heads (Materials, Subcontractor, Labour, Plant "
+                    + "and Equipment, Other) mapped to the seeded expense accounts. The operation is "
+                    + "idempotent: a tenant that already has any cost category is left untouched. Returns "
+                    + "the number of categories created. Restricted to system administrators."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Seed complete, returns the count of categories created"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a system administrator in the current tenant")
+    })
+    public Map<String, Integer> seedDefaults() {
+        return Map.of("created", seeder.seedDefaults());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/web/ProjectCostControlControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/web/ProjectCostControlControllerWeb.java
@@ -1,0 +1,46 @@
+package org.tornotron.echno_backend.finance.budget.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlDto;
+import org.tornotron.echno_backend.finance.budget.service.ProjectCostControlService;
+
+@RestController
+@RequestMapping("/api/v1/finance/projects/{projectId}/cost-control/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Project Cost Control",
+        description = "The project cost-control view: per budget head, the amount allocated against what has "
+                + "been committed (approved but not fully paid) and spent (fully paid), and what remains, with "
+                + "over-budget heads flagged. Tenant scoped and limited to system administrators and project managers."
+)
+public class ProjectCostControlControllerWeb {
+
+    private final ProjectCostControlService service;
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get the cost-control view for a project",
+            description = "Returns the per-budget-head roll-up of allocated, committed, spent and remaining "
+                    + "amounts for the project, plus a project total row. Heads with an allocation or any "
+                    + "tagged spend are included; a head whose committed plus spent exceeds its allocation is "
+                    + "flagged as over budget."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cost-control view for the project"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+    })
+    public ProjectCostControlDto get(@PathVariable Long projectId) {
+        return service.getForProject(projectId);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoiceLine.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoiceLine.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -53,6 +54,12 @@ public class ConstructionInvoiceLine {
 
     @Column(nullable = false, precision = 19, scale = 4)
     private BigDecimal total;                              // subtotal + tax - discount
+
+    // Budget head this line consumes, for project cost-control roll-up. Nullable: a line
+    // without a head is untagged and does not contribute to any category's spend.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cost_category_id")
+    private CostCategory costCategory;
 
     // Nullable scalar references to core-domain records (no cross-module FK).
     @Column(name = "inventory_item_id")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineDto.java
@@ -47,5 +47,13 @@ public record ConstructionInvoiceLineDto(
         Long assetId,
 
         @Schema(description = "Task the line is charged against, if any.", example = "1204")
-        Long taskId
+        Long taskId,
+
+        @Schema(description = "Budget head (cost category) this line is charged against, if any.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        UUID costCategoryId,
+
+        @Schema(description = "Name of the budget head this line is charged against, if any.",
+                example = "Materials")
+        String costCategoryName
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceLineRequest.java
@@ -38,5 +38,10 @@ public record ConstructionInvoiceLineRequest(
         Long assetId,
 
         @Schema(description = "Task this line is attributed to, if applicable.", example = "512")
-        Long taskId
+        Long taskId,
+
+        @Schema(description = "Budget head (cost category) this line is charged against, if applicable. "
+                + "Must belong to the current tenant. Omit to leave the line untagged.",
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+        java.util.UUID costCategoryId
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.finance.construction.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
@@ -11,5 +12,7 @@ public interface ConstructionInvoiceMapper {
 
     ConstructionInvoiceDto toDto(ConstructionInvoice invoice);
 
+    @Mapping(source = "costCategory.id", target = "costCategoryId")
+    @Mapping(source = "costCategory.name", target = "costCategoryName")
     ConstructionInvoiceLineDto toLineDto(ConstructionInvoiceLine line);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceLineRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceLineRepository.java
@@ -1,0 +1,48 @@
+package org.tornotron.echno_backend.finance.construction.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.finance.budget.repositories.CategoryCostAggregate;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ConstructionInvoiceLineRepository extends JpaRepository<ConstructionInvoiceLine, UUID> {
+
+    /**
+     * Rolls up tagged invoice line totals by cost category for one project, in a single grouped query.
+     *
+     * <p>Only lines carrying a cost category count. For each head:
+     * <ul>
+     *   <li><b>spent</b> sums line totals on invoices whose payment status is fully paid.</li>
+     *   <li><b>committed</b> sums line totals on invoices that are approved or beyond (a status in
+     *       {@code committedStatuses}) and not yet fully paid.</li>
+     * </ul>
+     * The organization id is passed explicitly rather than relying on the Hibernate {@code orgFilter}
+     * so the roll-up is correct regardless of whether the filter is enabled on the session.
+     */
+    @Query("""
+            SELECT l.costCategory.id AS costCategoryId,
+                   COALESCE(SUM(CASE WHEN l.invoice.paymentStatus = :paid THEN l.total ELSE 0 END), 0) AS spent,
+                   COALESCE(SUM(CASE WHEN l.invoice.paymentStatus <> :paid
+                                      AND l.invoice.status IN :committedStatuses
+                                     THEN l.total ELSE 0 END), 0) AS committed
+            FROM ConstructionInvoiceLine l
+            WHERE l.invoice.projectId = :projectId
+              AND l.invoice.organization.id = :organizationId
+              AND l.costCategory IS NOT NULL
+            GROUP BY l.costCategory.id
+            """)
+    List<CategoryCostAggregate> aggregateByCategoryForProject(
+            @Param("projectId") Long projectId,
+            @Param("organizationId") Long organizationId,
+            @Param("paid") ConstructionPaymentStatus paid,
+            @Param("committedStatuses") Collection<ConstructionInvoiceStatus> committedStatuses);
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -12,6 +12,8 @@ import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
@@ -73,6 +75,7 @@ public class ConstructionInvoiceService {
     private final FinanceSettingsService financeSettingsService;
     private final ProjectRepository projectRepository;
     private final UserContextService userContextService;
+    private final CostCategoryRepository costCategoryRepository;
 
     @Transactional(readOnly = true)
     public ConstructionInvoiceDto findById(UUID id) {
@@ -428,6 +431,7 @@ public class ConstructionInvoiceService {
             line.setInventoryItemId(lr.inventoryItemId());
             line.setAssetId(lr.assetId());
             line.setTaskId(lr.taskId());
+            line.setCostCategory(resolveCostCategory(lr.costCategoryId()));
             inv.addLine(line);
 
             subtotal = subtotal.add(lineSub);
@@ -444,5 +448,19 @@ public class ConstructionInvoiceService {
         inv.setTotalAmount(total);
         inv.setPaidAmount(paid);
         inv.setBalanceAmount(MoneyUtils.normalize(total.subtract(paid)));
+    }
+
+    /**
+     * Resolves a line's budget head by id within the current tenant, or null when the line carries no
+     * head. A non-null id that does not resolve in the tenant is rejected, so a line can only be tagged
+     * to a cost category the org actually owns.
+     */
+    private CostCategory resolveCostCategory(UUID costCategoryId) {
+        if (costCategoryId == null) {
+            return null;
+        }
+        return costCategoryRepository.findScopedById(costCategoryId)
+                .orElseThrow(() -> new InvalidRequestException(
+                        "Cost category with ID " + costCategoryId + " was not found"));
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -274,4 +274,7 @@
     <!-- v4.0 - Finance: per-org posting-account mapping, finance settings, project approval threshold (#341) -->
     <include file="db/changelog/v4.0/046-add-finance-posting-mapping-settings-and-approval-threshold.xml"/>
 
+    <!-- v4.0 - Finance: project budgeting and cost control (cost categories, budget allocations, tagged lines) -->
+    <include file="db/changelog/v4.0/047-create-budget-cost-control.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/047-create-budget-cost-control.xml
+++ b/src/main/resources/db/changelog/v4.0/047-create-budget-cost-control.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="047-create-cost-category" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="cost_category"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Org-level master list of budget heads (cost categories) that project budgets are broken
+            down by and that construction invoice lines are tagged to. An optional expense account
+            aligns a head with the chart of accounts for reporting. Names are unique per organization.
+        </comment>
+
+        <createTable tableName="cost_category">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="code" type="VARCHAR(20)"/>
+            <column name="expense_account_id" type="UUID"/>
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(100)"/>
+            <column name="updated_by" type="VARCHAR(100)"/>
+            <column name="version" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="cost_category"
+                                 baseColumnNames="expense_account_id"
+                                 constraintName="fk_cost_category_account"
+                                 referencedTableName="accounts"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="cost_category"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_cost_category_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="cost_category"
+                             columnNames="organization_id, name"
+                             constraintName="uk_cost_category_name"/>
+
+        <createIndex tableName="cost_category" indexName="idx_cost_category_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="047-create-budget-allocation" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="budget_allocation"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            A project's budget: one allocation row per budget head, holding the amount set aside for
+            that cost category. The (project, cost category) pair is unique, so an upsert replaces the
+            amount rather than adding a second row.
+        </comment>
+
+        <createTable tableName="budget_allocation">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cost_category_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="allocated_amount" type="NUMERIC(19, 4)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(100)"/>
+            <column name="updated_by" type="VARCHAR(100)"/>
+            <column name="version" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="budget_allocation"
+                                 baseColumnNames="project_id"
+                                 constraintName="fk_budget_allocation_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="budget_allocation"
+                                 baseColumnNames="cost_category_id"
+                                 constraintName="fk_budget_allocation_category"
+                                 referencedTableName="cost_category"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="budget_allocation"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_budget_allocation_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="budget_allocation"
+                             columnNames="project_id, cost_category_id"
+                             constraintName="uk_budget_allocation_project_category"/>
+
+        <createIndex tableName="budget_allocation" indexName="idx_budget_allocation_project">
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="budget_allocation" indexName="idx_budget_allocation_category">
+            <column name="cost_category_id"/>
+        </createIndex>
+        <createIndex tableName="budget_allocation" indexName="idx_budget_allocation_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="047-add-cost-category-to-construction-invoice-line" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="construction_invoice_lines" columnName="cost_category_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Tag a construction invoice line to a budget head so its cost rolls up under that cost
+            category in the project cost-control view. Nullable: a line without a head is untagged.
+        </comment>
+
+        <addColumn tableName="construction_invoice_lines">
+            <column name="cost_category_id" type="UUID"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="construction_invoice_lines"
+                                 baseColumnNames="cost_category_id"
+                                 constraintName="fk_cinvl_cost_category"
+                                 referencedTableName="cost_category"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="construction_invoice_lines" indexName="idx_cinvl_cost_category">
+            <column name="cost_category_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/budget/BudgetAllocationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/budget/BudgetAllocationServiceIT.java
@@ -1,0 +1,123 @@
+package org.tornotron.echno_backend.finance.budget;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.BudgetAllocationDto;
+import org.tornotron.echno_backend.finance.budget.dtos.UpsertBudgetAllocationRequest;
+import org.tornotron.echno_backend.finance.budget.mapper.BudgetAllocationMapperImpl;
+import org.tornotron.echno_backend.finance.budget.repositories.BudgetAllocationRepository;
+import org.tornotron.echno_backend.finance.budget.service.BudgetAllocationService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the project budget upsert against a real CockroachDB: setting the amount for a budget
+ * head that already has an allocation replaces it rather than adding a second row, so the (project,
+ * cost category) pair stays unique, and a second head produces a second row.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({BudgetAllocationService.class, BudgetAllocationMapperImpl.class, TenantEntityHelper.class,
+        JpaAuditingConfig.class})
+class BudgetAllocationServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private BudgetAllocationService service;
+
+    @Autowired
+    private BudgetAllocationRepository repo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long projectId;
+    private UUID materialsId;
+    private UUID labourId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        Organization org = persistOrganization("Budget Org");
+        entityManager.flush();
+        TenantContext.setCurrentOrgId(org.getId());
+
+        Project project = new Project();
+        project.setProjectName("Tower A");
+        project.setOrganization(org);
+        entityManager.persist(project);
+        projectId = project.getId();
+
+        materialsId = persistCategory(org, "Materials");
+        labourId = persistCategory(org, "Labour");
+        entityManager.flush();
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void upsert_isIdempotentPerProjectAndCategory() {
+        // First allocation for Materials.
+        service.upsert(projectId, materialsId, new UpsertBudgetAllocationRequest(new BigDecimal("100000")));
+        // Second upsert for the same head replaces the amount, does not add a row.
+        BudgetAllocationDto updated = service.upsert(projectId, materialsId,
+                new UpsertBudgetAllocationRequest(new BigDecimal("250000")));
+        assertThat(updated.allocatedAmount()).isEqualByComparingTo("250000");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Exactly one Materials allocation survives; the amount is the latest.
+        assertThat(repo.findByProjectAndCategory(projectId, materialsId)).isPresent();
+        List<BudgetAllocationDto> afterMaterials = service.findByProject(projectId);
+        assertThat(afterMaterials).hasSize(1);
+        assertThat(afterMaterials.getFirst().allocatedAmount()).isEqualByComparingTo("250000");
+
+        // A different head produces a distinct second row.
+        service.upsert(projectId, labourId, new UpsertBudgetAllocationRequest(new BigDecimal("80000")));
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(service.findByProject(projectId)).hasSize(2);
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private UUID persistCategory(Organization org, String name) {
+        CostCategory category = new CostCategory();
+        category.setName(name);
+        category.setActive(true);
+        category.setOrganization(org);
+        entityManager.persist(category);
+        return category.getId();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization organization = new Organization();
+        organization.setOrganizationName(name);
+        organization.setOrganizationAddress(name + " address");
+        organization.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        entityManager.persist(organization);
+        return organization;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/budget/CostCategorySeederIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/budget/CostCategorySeederIT.java
@@ -1,0 +1,100 @@
+package org.tornotron.echno_backend.finance.budget;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.budget.service.CostCategorySeeder;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the default cost-category seed against a real CockroachDB: the first run creates the
+ * default heads mapped to the seeded expense accounts by code, and a re-run is a no-op because the
+ * tenant already owns categories, so the seed is idempotent and safe to back-fill with.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({CostCategorySeeder.class, ChartOfAccountsSeeder.class, TenantEntityHelper.class,
+        JpaAuditingConfig.class})
+class CostCategorySeederIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private CostCategorySeeder costSeeder;
+
+    @Autowired
+    private ChartOfAccountsSeeder chartSeeder;
+
+    @Autowired
+    private CostCategoryRepository categoryRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        Organization org = persistOrganization("Seed Org");
+        entityManager.flush();
+        TenantContext.setCurrentOrgId(org.getId());
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void seedDefaults_createsHeadsMappedToAccounts_andIsIdempotent() {
+        chartSeeder.seedDefaults();
+
+        int firstRun = costSeeder.seedDefaults();
+        assertThat(firstRun).isEqualTo(5);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(categoryRepo.findByActiveTrue()).hasSize(5);
+
+        CostCategory materials = categoryRepo.findByActiveTrue().stream()
+                .filter(c -> c.getName().equals("Materials"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Materials head was not seeded"));
+        // The head is aligned to the Cost of Materials and Purchases expense account (5100).
+        assertThat(materials.getExpenseAccount()).isNotNull();
+        assertThat(materials.getExpenseAccount().getCode()).isEqualTo("5100");
+
+        // Re-running is a no-op: the tenant already owns categories.
+        int secondRun = costSeeder.seedDefaults();
+        assertThat(secondRun).isZero();
+
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(categoryRepo.findByActiveTrue()).hasSize(5);
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private Organization persistOrganization(String name) {
+        Organization organization = new Organization();
+        organization.setOrganizationName(name);
+        organization.setOrganizationAddress(name + " address");
+        organization.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        entityManager.persist(organization);
+        return organization;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/budget/ProjectCostControlServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/budget/ProjectCostControlServiceIT.java
@@ -1,0 +1,201 @@
+package org.tornotron.echno_backend.finance.budget;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.finance.budget.domain.BudgetAllocation;
+import org.tornotron.echno_backend.finance.budget.domain.CostCategory;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlDto;
+import org.tornotron.echno_backend.finance.budget.dtos.ProjectCostControlLineDto;
+import org.tornotron.echno_backend.finance.budget.service.ProjectCostControlService;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the project cost-control roll-up against a real CockroachDB: allocated, committed and
+ * spent are summed per budget head from the tagged invoice lines, remaining is derived, and the
+ * over-budget flag is raised where committed plus spent passes the allocation. Committed counts an
+ * approved-but-unpaid invoice; spent counts a fully paid one; a draft invoice is excluded; and a head
+ * with tagged spend but no allocation still surfaces through the union.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ProjectCostControlService.class, JpaAuditingConfig.class})
+class ProjectCostControlServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ProjectCostControlService service;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Organization org;
+    private Long projectId;
+    private CostCategory materials;
+    private CostCategory labour;
+    private CostCategory plant;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        org = persistOrganization("Cost Control Org");
+        entityManager.flush();
+        TenantContext.setCurrentOrgId(org.getId());
+
+        Project project = new Project();
+        project.setProjectName("Tower A");
+        project.setOrganization(org);
+        entityManager.persist(project);
+        projectId = project.getId();
+
+        materials = persistCategory("Materials");
+        labour = persistCategory("Labour");
+        plant = persistCategory("Plant");
+
+        // Budget: Materials and Labour are allocated; Plant deliberately has none, to test the union.
+        persistAllocation(project, materials, "400000");
+        persistAllocation(project, labour, "200000");
+
+        // Materials: an approved-unpaid invoice (committed) and a fully-paid one (spent).
+        persistInvoice("CINV-A", ConstructionInvoiceStatus.APPROVED, ConstructionPaymentStatus.UNPAID,
+                materials, "120000");
+        persistInvoice("CINV-B", ConstructionInvoiceStatus.APPROVED, ConstructionPaymentStatus.PAID,
+                materials, "300000");
+        // Labour: only a draft invoice, which must not count as either committed or spent.
+        persistInvoice("CINV-C", ConstructionInvoiceStatus.DRAFT, ConstructionPaymentStatus.UNPAID,
+                labour, "50000");
+        // Plant: a paid invoice with no allocation, so it surfaces only through spend.
+        persistInvoice("CINV-D", ConstructionInvoiceStatus.APPROVED, ConstructionPaymentStatus.PAID,
+                plant, "50000");
+
+        entityManager.flush();
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void costControl_rollsUpAllocatedCommittedSpentAndRemaining() {
+        ProjectCostControlDto view = service.getForProject(projectId);
+
+        assertThat(view.projectId()).isEqualTo(projectId);
+        // Materials + Labour + Plant: Labour has no spend but has an allocation; Plant no allocation.
+        assertThat(view.categories()).hasSize(3);
+
+        ProjectCostControlLineDto mat = lineFor(view, "Materials");
+        assertThat(mat.allocated()).isEqualByComparingTo("400000");
+        assertThat(mat.committed()).isEqualByComparingTo("120000");
+        assertThat(mat.spent()).isEqualByComparingTo("300000");
+        assertThat(mat.remaining()).isEqualByComparingTo("-20000");   // 400000 - 120000 - 300000
+        assertThat(mat.overBudget()).isTrue();                        // 420000 > 400000
+
+        ProjectCostControlLineDto lab = lineFor(view, "Labour");
+        assertThat(lab.allocated()).isEqualByComparingTo("200000");
+        assertThat(lab.committed()).isEqualByComparingTo("0");        // draft invoice excluded
+        assertThat(lab.spent()).isEqualByComparingTo("0");
+        assertThat(lab.remaining()).isEqualByComparingTo("200000");
+        assertThat(lab.overBudget()).isFalse();
+
+        ProjectCostControlLineDto plt = lineFor(view, "Plant");
+        assertThat(plt.allocated()).isEqualByComparingTo("0");        // no allocation, union via spend
+        assertThat(plt.committed()).isEqualByComparingTo("0");
+        assertThat(plt.spent()).isEqualByComparingTo("50000");
+        assertThat(plt.remaining()).isEqualByComparingTo("-50000");
+        assertThat(plt.overBudget()).isTrue();
+
+        ProjectCostControlLineDto totals = view.totals();
+        assertThat(totals.costCategoryId()).isNull();
+        assertThat(totals.allocated()).isEqualByComparingTo("600000");
+        assertThat(totals.committed()).isEqualByComparingTo("120000");
+        assertThat(totals.spent()).isEqualByComparingTo("350000");
+        assertThat(totals.remaining()).isEqualByComparingTo("130000");  // 600000 - 120000 - 350000
+        assertThat(totals.overBudget()).isFalse();                      // 470000 < 600000
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private ProjectCostControlLineDto lineFor(ProjectCostControlDto view, String name) {
+        return view.categories().stream()
+                .filter(l -> l.costCategoryName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No cost-control line for " + name));
+    }
+
+    private CostCategory persistCategory(String name) {
+        CostCategory category = new CostCategory();
+        category.setName(name);
+        category.setActive(true);
+        category.setOrganization(org);
+        entityManager.persist(category);
+        return category;
+    }
+
+    private void persistAllocation(Project project, CostCategory category, String amount) {
+        BudgetAllocation allocation = new BudgetAllocation();
+        allocation.setProject(project);
+        allocation.setCostCategory(category);
+        allocation.setAllocatedAmount(new BigDecimal(amount));
+        allocation.setOrganization(org);
+        entityManager.persist(allocation);
+    }
+
+    private void persistInvoice(String number, ConstructionInvoiceStatus status,
+                                ConstructionPaymentStatus paymentStatus, CostCategory category, String lineTotal) {
+        BigDecimal total = new BigDecimal(lineTotal);
+
+        ConstructionInvoice invoice = new ConstructionInvoice();
+        invoice.setInvoiceNumber(number);
+        invoice.setType(ConstructionInvoiceType.PURCHASE);
+        invoice.setStatus(status);
+        invoice.setPaymentStatus(paymentStatus);
+        invoice.setProjectId(projectId);
+        invoice.setIssueDate(LocalDate.of(2026, 8, 1));
+        invoice.setDueDate(LocalDate.of(2026, 8, 31));
+        invoice.setSubtotal(total);
+        invoice.setTotalAmount(total);
+        invoice.setOrganization(org);
+
+        ConstructionInvoiceLine line = new ConstructionInvoiceLine();
+        line.setDescription("Work for " + category.getName());
+        line.setQuantity(BigDecimal.ONE);
+        line.setUnit("lot");
+        line.setUnitPrice(total);
+        line.setSubtotal(total);
+        line.setTotal(total);
+        line.setCostCategory(category);
+        invoice.addLine(line);
+
+        entityManager.persist(invoice);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization organization = new Organization();
+        organization.setOrganizationName(name);
+        organization.setOrganizationAddress(name + " address");
+        organization.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        entityManager.persist(organization);
+        return organization;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
@@ -156,7 +156,7 @@ class ConstructionInvoiceAutoApprovalIT extends AbstractIntegrationTest {
                 "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
                 "Threshold test", "Standard terms apply",
                 List.of(new ConstructionInvoiceLineRequest("Cement supply", new BigDecimal("10"), "nos",
-                        new BigDecimal("100"), new BigDecimal("18"), null, null, null, null)));
+                        new BigDecimal("100"), new BigDecimal("18"), null, null, null, null, null)));
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -210,7 +210,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
                 "Posting test", "Standard terms apply",
                 // 10 * 100 = 1000 subtotal, 18% tax = 180, no discount -> gross 1180
                 List.of(new ConstructionInvoiceLineRequest("Cement supply", bd("10"), "nos",
-                        bd("100"), bd("18"), null, null, null, null)));
+                        bd("100"), bd("18"), null, null, null, null, null)));
     }
 
     private BigDecimal debit(JournalEntry je, String code) {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -143,9 +143,9 @@ class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
                 "First running bill", "Standard terms apply",
                 List.of(
                         new ConstructionInvoiceLineRequest("Cement supply", bd("2"), "nos",
-                                bd("100"), bd("18"), null, null, null, null),
+                                bd("100"), bd("18"), null, null, null, null, null),
                         new ConstructionInvoiceLineRequest("Steel supply", bd("1"), "lot",
-                                bd("50"), bd("18"), bd("10"), null, null, null)
+                                bd("50"), bd("18"), bd("10"), null, null, null, null)
                 )
         );
 
@@ -203,7 +203,7 @@ class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
                 "Revised running bill", "Standard terms apply",
                 List.of(
                         new ConstructionInvoiceLineRequest("Cement supply", bd("3"), "nos",
-                                bd("100"), bd("18"), null, null, null, null)
+                                bd("100"), bd("18"), null, null, null, null, null)
                 )
         );
 

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
@@ -74,7 +74,7 @@ class ConstructionInvoicePdfServiceTest {
                 UUID.randomUUID(), "OPC 53 grade cement", new BigDecimal("200"), "bag",
                 new BigDecimal("350.00"), new BigDecimal("18.0"), new BigDecimal("12600.00"),
                 new BigDecimal("5.0"), new BigDecimal("3500.00"), new BigDecimal("70000.00"),
-                new BigDecimal("79100.00"), 512L, 88L, 1204L);
+                new BigDecimal("79100.00"), 512L, 88L, 1204L, UUID.randomUUID(), "Materials");
 
         return new ConstructionInvoiceDto(
                 UUID.randomUUID(), "CINV-2026-0042", ConstructionInvoiceType.PURCHASE,


### PR DESCRIPTION
Builds the project budgeting / cost-control phase (design: docs/specs/2026-08-19 section 3). Turns the construction finance data into a project cost-control tool showing, per budget head, Budget allocated -> committed -> spent -> remaining.

## What is added

### Cost categories (budget heads), org-level master
- `CostCategory` (finance/budget): name (unique per tenant), optional code, optional expense-account mapping to the ledger, active flag.
- CRUD + seed under `/api/v1/finance/cost-categories/web`. The seed creates a default set mapped to the seeded expense accounts (Materials 5100, Subcontractor 5200, Labour 5300, Plant and Equipment 5400, Other 5900), idempotent per tenant.

### Project budget allocation
- `BudgetAllocation` (finance/budget): amount allocated to a (project, cost category), unique per pair. The set of rows is a project's budget.
- Endpoints under `/api/v1/finance/projects/{projectId}/budget/web`: list, upsert `PUT /{costCategoryId}`, delete `DELETE /{costCategoryId}`.

### Tagged invoice lines
- Construction invoice lines carry a nullable cost category, threaded through the line request/response DTOs, the mapper and the service, validated against the tenant. Lines without a head stay untagged.

### Cost-control report
- `GET /api/v1/finance/projects/{projectId}/cost-control/web` returns, per head: allocated, committed (approved and not fully paid), spent (fully paid), remaining, and an over-budget flag, plus a project total row. Heads with an allocation or any tagged spend are included. The committed/spent roll-up is one grouped query, not an N+1.

### Migration
- Liquibase `047-create-budget-cost-control.xml`: creates `cost_category` and `budget_allocation`, adds `cost_category_id` to `construction_invoice_lines`. Precondition-guarded and registered in the master changelog.

## Auth
All web endpoints are tenant scoped and gated on `system-admin` or `project-manager`; the default seed is `system-admin` only, mirroring the ledger controllers.

## Tests
Testcontainers ITs against real CockroachDB: cost-control roll-up correctness (approved-unpaid vs fully-paid, draft excluded, union of allocated and spent, over-budget), budget upsert idempotency, and cost-category seed idempotency. Full suite: 294 tests, 0 failures on `./gradlew clean build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added management of organization cost categories, including creation, editing, deactivation, listing, and default seeding.
  * Added project budget allocation management with create, update, list, and delete support.
  * Added project cost-control reporting with allocated, committed, spent, remaining, total, and over-budget figures.
  * Invoice lines can now be associated with budget cost categories.
* **Tests**
  * Added integration coverage for allocations, category seeding, and cost-control calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->