### PR TITLE
feat: unify employee shift timing onto the structured ShiftTiming entity

### DIFF
--- a/docs/specs/2026-08-24-shift-unification.md
+++ b/docs/specs/2026-08-24-shift-unification.md
@@ -1,0 +1,99 @@
+# Shift unification: employee and invite reference the structured ShiftTiming
+
+## Problem
+
+The backend carried two disconnected notions of a work shift.
+
+1. A structured `ShiftTiming` entity (package `attendance`) with a real schedule:
+   `shiftName`, `startTime`, `endTime`, `lunchBreakStart`/`lunchBreakEnd`,
+   `gracePeriodMinutes`, `minimumWorkHours`, `halfDayWorkHours`,
+   `overtimeThreshold`, and its owning `organization`. It is tenant scoped and has
+   a full controller/service/repository/DTO stack. `Attendance.shiftTiming` is a
+   `@ManyToOne` to it, and the attendance calculation runs against its windows and
+   thresholds.
+
+2. A free-text `String shiftTiming` on `Employee` (column `shift_timing`), also
+   present on `EmployeeDto`, `EmployeeCreationDto`, `EmployeeJoinOrgDto` and on
+   `InviteCodeGenerationDto`. This was a plain label such as `09:00-18:00`, never
+   linked to the structured entity, so an employee's shift and the shift the
+   attendance engine used were unrelated values.
+
+The two never met: an employee's stored shift string could not drive attendance,
+and attendance always required the shift id to be passed on every check-in.
+
+## Target
+
+Employee (and the invite that seeds a new employee) reference the structured
+`ShiftTiming` by foreign key. Attendance derives an employee's shift from their
+assigned `ShiftTiming` when they have one, and only falls back to a shift id
+supplied on the request when they do not.
+
+## Changes
+
+### Employee entity
+
+- New `shiftTiming` association: `@ManyToOne(fetch = LAZY)` to
+  `attendance.ShiftTiming`, column `shift_timing_id`, nullable. This is the
+  structured shift the employee works.
+- The old `String shiftTiming` field is renamed to `legacyShiftTiming`
+  (column `legacy_shift_timing`). It is kept, not dropped, so the original label
+  survives for reference and for the name-match backfill below. It is removed from
+  the response DTO.
+
+### ProjectInviteCode entity
+
+- New `shiftTiming` association: `@ManyToOne` to `ShiftTiming`, column
+  `shift_timing_id`, nullable. An invite records the structured shift a joining
+  employee should be given. The id also continues to travel inside the invite's
+  `employeeDetails` JSON payload, which is what actually seeds the join.
+
+### DTOs
+
+- `EmployeeCreationDto`: `String shiftTiming` becomes `Long shiftTimingId`
+  (optional, nullable).
+- `EmployeeJoinOrgDto`: `String shiftTiming` becomes `Long shiftTimingId`
+  (optional, nullable).
+- `EmployeeDto` (response): `String shiftTiming` becomes `Long shiftTimingId` plus
+  a nested read-only `ShiftTimingDto shiftTiming` holding the resolved shift, null
+  when the employee has none.
+- `InviteCodeGenerationDto`: `String shiftTiming` becomes `Long shiftTimingId`
+  (nullable).
+
+### Services and mappers
+
+- `EmployeeService` gains a `resolveShiftTiming(shiftTimingId, organization)`
+  helper: null id yields no shift, a non-null id is looked up scoped to that
+  organization, and an id that does not belong to the organization is rejected with
+  `ResourceNotFoundException`. Create and join both set the `shiftTiming` foreign
+  key through it. The batch patch path accepts a `shiftTimingId` key.
+- `EmployeeMapper` maps the association to `shiftTimingId` and to the nested
+  `ShiftTimingDto` via the existing `ShiftTimingMapper`.
+- `ProjectInviteCodeService` stores `shiftTimingId` in the invite payload and on
+  the invite's own foreign key at generation, and reads it back into
+  `EmployeeJoinOrgDto.shiftTimingId` when the code is used, so a user joining
+  through an invite is given the invite's shift.
+
+### Attendance integration
+
+`AttendanceService.checkIn` now prefers the employee's assigned `shiftTiming` when
+present, and only looks up `AttendanceCheckInDto.shiftTimingId` when the employee
+has no assigned shift. The request field is now optional; a check-in is rejected
+only when neither source yields a shift. The existing calculation and its null
+guards are unchanged: a non-null `ShiftTiming` still reaches the builder.
+
+## Backfill decision
+
+Existing employees hold only the free-text label in `legacy_shift_timing`. The
+migration backfills `shift_timing_id` by matching that label to a `ShiftTiming` in
+the same organization on a case-insensitive, trimmed comparison of the shift name:
+
+```
+lower(trim(shift_timing.shift_name)) = lower(trim(employee.legacy_shift_timing))
+```
+
+Only a name match sets the foreign key. Labels that were free-form times such as
+`09:00-18:00`, or that match no shift, leave `shift_timing_id` null; those
+employees simply have no structured shift until one is assigned. The times inside a
+label are deliberately not parsed into a shift, because a label carries no lunch
+window, grace period or thresholds, so a parsed guess would be a worse record than
+an honest null. The legacy column is retained so the match can be revisited later.

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -118,9 +118,19 @@ public class AttendanceService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Project with ID " + dto.getProjectId() + " was not found in this organization"));
 
-        ShiftTiming shift = shiftTimingRepository.findByIdAndOrganization_Id(dto.getShiftTimingId(), orgId)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "Shift timing with ID " + dto.getShiftTimingId() + " was not found in this organization"));
+        // Prefer the employee's assigned structured shift. Only when they have none
+        // do we fall back to a shift id supplied on the request (the pre-unification
+        // behavior). A check-in is rejected when neither source yields a shift.
+        ShiftTiming shift = employee.getShiftTiming();
+        if (shift == null) {
+            if (dto.getShiftTimingId() == null) {
+                throw new ValidationException(
+                        "No shift timing is assigned to this employee and none was supplied on the request");
+            }
+            shift = shiftTimingRepository.findByIdAndOrganization_Id(dto.getShiftTimingId(), orgId)
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Shift timing with ID " + dto.getShiftTimingId() + " was not found in this organization"));
+        }
 
         AttendanceSettings settings = settingsService.resolveEffectiveSettings(orgId, dto.getProjectId());
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
@@ -22,8 +22,9 @@ public class AttendanceCheckInDto {
     @NotNull
     private Long projectId;
 
-    @Schema(description = "Id of the shift the employee is working.", example = "5")
-    @NotNull
+    @Schema(description = "Id of the shift the employee is working. Optional: when omitted, the "
+            + "employee's assigned shift is used. Required only if the employee has no assigned shift.",
+            example = "5")
     private Long shiftTimingId;
 
     @Schema(description = "Timestamp of the check-in event.", example = "2026-01-15T09:02:00")

--- a/src/main/java/org/tornotron/echno_backend/employee/Employee.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/Employee.java
@@ -70,9 +70,21 @@ public class Employee implements TenantScopedEntity {
     @JoinColumn(name = "manager_id")
     private Employee manager;
 
-    /** The employee's work shift schedule. */
-    @Column(name = "shift_timing", nullable = true)
-    private String shiftTiming;
+    /**
+     * The employee's structured work shift. Drives the shift the attendance engine
+     * uses for this employee when set.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shift_timing_id")
+    private org.tornotron.echno_backend.attendance.ShiftTiming shiftTiming;
+
+    /**
+     * The employee's former free-text shift label (for example {@code 09:00-18:00}).
+     * Retained for reference and for the name-match backfill onto {@link #shiftTiming};
+     * not exposed on the response DTO.
+     */
+    @Column(name = "legacy_shift_timing", nullable = true)
+    private String legacyShiftTiming;
 
     /** The current employment status of the employee. */
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import lombok.extern.slf4j.Slf4j;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -50,6 +52,7 @@ public class EmployeeService {
     private final KeycloakGroupService keycloakGroupService;
     private final EmployeeMapper employeeMapper;
     private final EmployeeHierarchyService employeeHierarchyService;
+    private final ShiftTimingRepository shiftTimingRepository;
 
     /**
      * Constructs an EmployeeService with the necessary repositories.
@@ -60,13 +63,34 @@ public class EmployeeService {
      * @param keycloakGroupService   The service for managing Keycloak groups.
      * @param employeeHierarchyService The service owning the reporting hierarchy.
      */
-    public EmployeeService(EmployeeRepository employeeRepository, OrganizationRepository organizationRepository, UserRepository userRepository, KeycloakGroupService keycloakGroupService, EmployeeMapper employeeMapper, EmployeeHierarchyService employeeHierarchyService) {
+    public EmployeeService(EmployeeRepository employeeRepository, OrganizationRepository organizationRepository, UserRepository userRepository, KeycloakGroupService keycloakGroupService, EmployeeMapper employeeMapper, EmployeeHierarchyService employeeHierarchyService, ShiftTimingRepository shiftTimingRepository) {
         this.employeeRepository = employeeRepository;
         this.organizationRepository = organizationRepository;
         this.userRepository = userRepository;
         this.keycloakGroupService = keycloakGroupService;
         this.employeeMapper = employeeMapper;
         this.employeeHierarchyService = employeeHierarchyService;
+        this.shiftTimingRepository = shiftTimingRepository;
+    }
+
+    /**
+     * Resolves a structured shift for an employee. A null id yields no shift. A
+     * non-null id is looked up scoped to the given organization, and an id that does
+     * not belong to that organization is rejected so a shift cannot be borrowed
+     * across tenants.
+     *
+     * @param shiftTimingId The id of the shift to assign, or null for none.
+     * @param organization  The organization the employee belongs to.
+     * @return The resolved shift, or null when no id was supplied.
+     * @throws ResourceNotFoundException if the id does not resolve within the organization.
+     */
+    private ShiftTiming resolveShiftTiming(Long shiftTimingId, Organization organization) {
+        if (shiftTimingId == null) {
+            return null;
+        }
+        return shiftTimingRepository.findByIdAndOrganization_Id(shiftTimingId, organization.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Shift timing with ID " + shiftTimingId + " was not found in this organization"));
     }
 
     /**
@@ -95,6 +119,8 @@ public class EmployeeService {
             }
             employee.setManager(manager);
         }
+
+        employee.setShiftTiming(resolveShiftTiming(employeeCreationDto.getShiftTimingId(), organization));
 
         return employeeMapper.toDto(employeeRepository.save(employee));
     }
@@ -145,7 +171,7 @@ public class EmployeeService {
             employee.setManager(manager);
         }
 
-        employee.setShiftTiming(employeeJoinOrgDto.getShiftTiming());
+        employee.setShiftTiming(resolveShiftTiming(employeeJoinOrgDto.getShiftTimingId(), org));
         employee.setStatus(EmployeeStatus.valueOf(employeeJoinOrgDto.getStatus()));
 
         employee.setEmployeeName(user.getName());
@@ -308,8 +334,13 @@ public class EmployeeService {
                 case "salary":
                     employee.setSalary((Double) value);
                     break;
-                case "shiftTiming":
-                    employee.setShiftTiming((String) value);
+                case "shiftTimingId":
+                    if (value == null) {
+                        employee.setShiftTiming(null);
+                    } else {
+                        Long shiftTimingId = ((Number) value).longValue();
+                        employee.setShiftTiming(resolveShiftTiming(shiftTimingId, employee.getOrganization()));
+                    }
                     break;
                 case "department":
                     employee.setDepartment((String) value);

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -34,8 +34,8 @@ public class EmployeeCreationDto {
     @Schema(description = "Id of this employee's reporting manager.", example = "5")
     private Long managerId;
 
-    @Schema(description = "Working shift.", example = "09:00-18:00")
-    private String shiftTiming;
+    @Schema(description = "Id of the structured shift timing to assign to the employee.", example = "5")
+    private Long shiftTimingId;
 
     @Schema(description = "Employment status.", example = "active")
     @NotBlank(message = "status is required")

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.employee.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.tornotron.echno_backend.attendance.dto.ShiftTimingDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
@@ -66,8 +67,11 @@ public class EmployeeDto {
     @Schema(description = "Name of this employee's reporting manager.", example = "Priya Nair")
     private String managerName;
 
-    @Schema(description = "Working shift.", example = "09:00-18:00")
-    private String shiftTiming;
+    @Schema(description = "Id of the structured shift timing assigned to the employee.", example = "5")
+    private Long shiftTimingId;
+
+    @Schema(description = "The resolved structured shift assigned to the employee. Null when unassigned.")
+    private ShiftTimingDto shiftTiming;
 
     @Schema(description = "Employment status.", example = "ACTIVE")
     private EmployeeStatus status;

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
@@ -34,8 +34,8 @@ public class EmployeeJoinOrgDto {
     @Schema(description = "Id of this employee's reporting manager.", example = "5")
     private Long managerId;
 
-    @Schema(description = "Working shift.", example = "09:00-18:00")
-    private String shiftTiming;
+    @Schema(description = "Id of the structured shift timing to assign to the employee.", example = "5")
+    private Long shiftTimingId;
 
     @Schema(description = "Employment status. Defaults to active.", example = "active")
     @NotBlank(message = "status is required")

--- a/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.employee.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
 import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -14,9 +15,11 @@ import org.tornotron.echno_backend.employee.dto.EmployeeDto;
  * {@code isManager} is deliberately left unset to match the previous converter, which
  * never populated it (the DTO field stays null rather than the entity's boolean false).
  */
-@Mapper(componentModel = "spring", uses = AttachmentMapper.class)
+@Mapper(componentModel = "spring", uses = {AttachmentMapper.class, ShiftTimingMapper.class})
 public interface EmployeeMapper {
 
+    @Mapping(source = "shiftTiming.id", target = "shiftTimingId")
+    @Mapping(source = "shiftTiming", target = "shiftTiming")
     @Mapping(source = "organization.id", target = "organizationId")
     @Mapping(source = "organization.organizationName", target = "organizationName")
     @Mapping(source = "manager.id", target = "managerId")

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCode.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCode.java
@@ -35,6 +35,15 @@ public class ProjectInviteCode implements TenantScopedEntity {
     @ManyToOne
     private Organization organization;
 
+    /**
+     * The structured shift a joining employee should be assigned. Nullable: an invite
+     * need not carry a shift. The same id also travels inside {@link #employeeDetails},
+     * which is what seeds the employee at join time.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shift_timing_id")
+    private org.tornotron.echno_backend.attendance.ShiftTiming shiftTiming;
+
     /** The date and time when this invite code expires. */
     @Column(nullable = false)
     private LocalDateTime expiryDate;

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeService.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.projectInviteCode;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
 import org.tornotron.echno_backend.projectInviteCode.mapper.ProjectInviteCodeMapper;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
@@ -40,6 +42,7 @@ public class ProjectInviteCodeService {
     private final EmployeeRepository employeeRepository;
     private final ProjectInviteCodeMapper projectInviteCodeMapper;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
+    private final ShiftTimingRepository shiftTimingRepository;
 
     /**
      * Constructs a ProjectInviteCodeService with the necessary repositories and services.
@@ -48,7 +51,7 @@ public class ProjectInviteCodeService {
      * @param employeeService        The service for employee-related operations.
      * @param organizationRepository The repository for organization data access.
      */
-    public ProjectInviteCodeService(ProjectInviteCodeRepository inviteCodeRepository, EmployeeService employeeService, OrganizationRepository organizationRepository, FileStorageService fileStorageService, EmployeeRepository employeeRepository, ProjectInviteCodeMapper projectInviteCodeMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper) {
+    public ProjectInviteCodeService(ProjectInviteCodeRepository inviteCodeRepository, EmployeeService employeeService, OrganizationRepository organizationRepository, FileStorageService fileStorageService, EmployeeRepository employeeRepository, ProjectInviteCodeMapper projectInviteCodeMapper, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, ShiftTimingRepository shiftTimingRepository) {
         this.inviteCodeRepository = inviteCodeRepository;
         this.employeeService = employeeService;
         this.organizationRepository = organizationRepository;
@@ -56,6 +59,7 @@ public class ProjectInviteCodeService {
         this.employeeRepository = employeeRepository;
         this.projectInviteCodeMapper = projectInviteCodeMapper;
         this.organizationMapper = organizationMapper;
+        this.shiftTimingRepository = shiftTimingRepository;
     }
 
     /**
@@ -85,10 +89,19 @@ public class ProjectInviteCodeService {
                 throw new ResourceNotFoundException("Manager with ID " + inviteCodeGenerationDto.getManagerId() + " was not found with a manager role in this organization");
             }
         }
+        ShiftTiming shiftTiming = null;
+        if (inviteCodeGenerationDto.getShiftTimingId() != null) {
+            shiftTiming = shiftTimingRepository.findByIdAndOrganization_Id(
+                            inviteCodeGenerationDto.getShiftTimingId(), organizationId)
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Shift timing with ID " + inviteCodeGenerationDto.getShiftTimingId()
+                                    + " was not found in this organization"));
+        }
         int inviteCode = generateSecureFiveDigitNumber();
         ProjectInviteCode projectInviteCode = new ProjectInviteCode();
         projectInviteCode.setCode(inviteCode);
         projectInviteCode.setOrganization(organization);
+        projectInviteCode.setShiftTiming(shiftTiming);
         projectInviteCode.setExpiryDate(LocalDateTime.now().plusDays(inviteCodeGenerationDto.getValidityDays()));
         projectInviteCode.setActive(true);
         projectInviteCode.setMaxUses(inviteCodeGenerationDto.getMaxUses());
@@ -99,7 +112,7 @@ public class ProjectInviteCodeService {
         employeeDetails.put("joiningDate", LocalDateTime.now().toString());
         employeeDetails.put("salary", inviteCodeGenerationDto.getSalary());
         employeeDetails.put("managerId", inviteCodeGenerationDto.getManagerId());
-        employeeDetails.put("shiftTiming", inviteCodeGenerationDto.getShiftTiming());
+        employeeDetails.put("shiftTimingId", inviteCodeGenerationDto.getShiftTimingId());
         employeeDetails.put("status", inviteCodeGenerationDto.getStatus());
         employeeDetails.put("employeeId", inviteCodeGenerationDto.getEmployeeId());
         employeeDetails.put("employeeName", inviteCodeGenerationDto.getEmployeeName());
@@ -147,7 +160,9 @@ public class ProjectInviteCodeService {
         if (employeeDetails.get("managerId") != null) {
             employeeJoinOrgDto.setManagerId(((Number) employeeDetails.get("managerId")).longValue());
         }
-        employeeJoinOrgDto.setShiftTiming((String) employeeDetails.get("shiftTiming"));
+        if (employeeDetails.get("shiftTimingId") != null) {
+            employeeJoinOrgDto.setShiftTimingId(((Number) employeeDetails.get("shiftTimingId")).longValue());
+        }
         employeeJoinOrgDto.setStatus((String) employeeDetails.get("status"));
         employeeJoinOrgDto.setEmployeeId((String) employeeDetails.get("employeeId"));
         employeeJoinOrgDto.setEmployeeName((String) employeeDetails.get("employeeName"));

--- a/src/main/java/org/tornotron/echno_backend/projectInviteCode/dto/InviteCodeGenerationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/projectInviteCode/dto/InviteCodeGenerationDto.java
@@ -35,7 +35,7 @@ public class InviteCodeGenerationDto {
 
     private Long managerId;
 
-    private String shiftTiming;
+    private Long shiftTimingId;
 
     @NotBlank(message = "status is required")
     @Size(min = 3, max = 50, message = "status must be between 3 and 50 characters")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -277,4 +277,7 @@
     <!-- v4.0 - Finance: project budgeting and cost control (cost categories, budget allocations, tagged lines) -->
     <include file="db/changelog/v4.0/047-create-budget-cost-control.xml"/>
 
+    <!-- v4.0 - Unify employee and invite shift onto the structured ShiftTiming entity -->
+    <include file="db/changelog/v4.0/048-unify-employee-shift-timing.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/048-unify-employee-shift-timing.xml
+++ b/src/main/resources/db/changelog/v4.0/048-unify-employee-shift-timing.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="048-rename-employee-shift-timing-to-legacy" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="employee" columnName="shift_timing"/>
+            <not>
+                <columnExists tableName="employee" columnName="legacy_shift_timing"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The free-text shift label is superseded by a structured shift foreign key. Keep the label
+            under a legacy name so it survives for reference and for the name-match backfill below.
+        </comment>
+
+        <renameColumn tableName="employee"
+                      oldColumnName="shift_timing"
+                      newColumnName="legacy_shift_timing"
+                      columnDataType="VARCHAR(100)"/>
+    </changeSet>
+
+    <changeSet id="048-add-employee-shift-timing-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="employee" columnName="shift_timing_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The employee's structured shift. Nullable: an employee need not have an assigned shift.
+        </comment>
+
+        <addColumn tableName="employee">
+            <column name="shift_timing_id" type="BIGINT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="employee"
+                                 baseColumnNames="shift_timing_id"
+                                 constraintName="fk_employee_shift_timing"
+                                 referencedTableName="shift_timing"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="employee" indexName="idx_employee_shift_timing">
+            <column name="shift_timing_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="048-add-invite-shift-timing-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project_invite_code" columnName="shift_timing_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The structured shift an invite grants a joining employee. Nullable: an invite need not
+            carry a shift. The same id also rides inside the invite's employee_details payload.
+        </comment>
+
+        <addColumn tableName="project_invite_code">
+            <column name="shift_timing_id" type="BIGINT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="project_invite_code"
+                                 baseColumnNames="shift_timing_id"
+                                 constraintName="fk_invite_shift_timing"
+                                 referencedTableName="shift_timing"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="project_invite_code" indexName="idx_invite_shift_timing">
+            <column name="shift_timing_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="048-backfill-employee-shift-timing-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="employee" columnName="legacy_shift_timing"/>
+            <columnExists tableName="employee" columnName="shift_timing_id"/>
+        </preConditions>
+
+        <comment>
+            Backfill the structured shift by matching the retained legacy label to a shift in the same
+            organization, case-insensitively and trimmed, on the shift name only. Labels that were
+            free-form times or that match no shift stay null; the times in a label are not parsed,
+            since a label carries no lunch window, grace period or thresholds.
+        </comment>
+
+        <sql>
+            UPDATE employee
+            SET shift_timing_id = (
+                SELECT st.id
+                FROM shift_timing st
+                WHERE st.organization_id = employee.organization_id
+                  AND lower(trim(st.shift_name)) = lower(trim(employee.legacy_shift_timing))
+                LIMIT 1
+            )
+            WHERE legacy_shift_timing IS NOT NULL
+              AND shift_timing_id IS NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
@@ -1,0 +1,185 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * End-to-end exercise of the shift unification against a real CockroachDB: joining
+ * an organization resolves the structured {@link ShiftTiming} from the supplied id,
+ * sets the employee's foreign key, and nests the resolved shift in the response;
+ * a shift id from another organization is rejected; and the join path used by an
+ * invite (an {@link EmployeeJoinOrgDto} carrying a shiftTimingId) assigns the shift.
+ *
+ * <p>Keycloak group membership and file storage are external, so they are mocked;
+ * everything else runs against the real schema built by Liquibase.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({EmployeeService.class, EmployeeHierarchyService.class, EmployeeMapperImpl.class,
+        AttachmentMapperImpl.class, ShiftTimingMapper.class})
+class EmployeeShiftUnificationIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private EmployeeService employeeService;
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @MockBean
+    private KeycloakGroupService keycloakGroupService;
+
+    @MockBean
+    private FileStorageService fileStorageService;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long shiftAId;
+    private Long shiftBId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        Organization orgA = persistOrganization("Org A");
+        Organization orgB = persistOrganization("Org B");
+        orgAId = orgA.getId();
+        orgBId = orgB.getId();
+        shiftAId = persistShift(orgA, "General Shift").getId();
+        shiftBId = persistShift(orgB, "Night Shift").getId();
+        em.flush();
+    }
+
+    @Test
+    void join_withValidShiftTimingId_setsForeignKeyAndNestsResolvedShift() {
+        User user = persistUser("alice");
+        em.flush();
+
+        EmployeeJoinOrgDto dto = joinDto();
+        dto.setShiftTimingId(shiftAId);
+
+        EmployeeDto result = employeeService.joinOrganization(user.getId(), orgAId, dto);
+
+        assertThat(result.getShiftTimingId()).isEqualTo(shiftAId);
+        assertThat(result.getShiftTiming()).isNotNull();
+        assertThat(result.getShiftTiming().getShiftName()).isEqualTo("General Shift");
+
+        Employee persisted = employeeRepository.findById(result.getId()).orElseThrow();
+        assertThat(persisted.getShiftTiming()).isNotNull();
+        assertThat(persisted.getShiftTiming().getId()).isEqualTo(shiftAId);
+    }
+
+    @Test
+    void join_withForeignTenantShiftTimingId_isRejected() {
+        User user = persistUser("bob");
+        em.flush();
+
+        EmployeeJoinOrgDto dto = joinDto();
+        // A shift that belongs to Org B cannot be assigned while joining Org A.
+        dto.setShiftTimingId(shiftBId);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> employeeService.joinOrganization(user.getId(), orgAId, dto));
+    }
+
+    @Test
+    void join_viaInviteCarryingShiftTimingId_assignsThatShift() {
+        User user = persistUser("carol");
+        em.flush();
+
+        // This is exactly the DTO ProjectInviteCodeService builds from an invite's
+        // stored employee details when a user redeems the code.
+        EmployeeJoinOrgDto inviteDto = joinDto();
+        inviteDto.setShiftTimingId(shiftAId);
+
+        EmployeeDto result = employeeService.joinOrganization(user.getId(), orgAId, inviteDto);
+
+        Employee persisted = employeeRepository.findById(result.getId()).orElseThrow();
+        assertThat(persisted.getShiftTiming()).isNotNull();
+        assertThat(persisted.getShiftTiming().getId()).isEqualTo(shiftAId);
+    }
+
+    @Test
+    void join_withoutShiftTimingId_leavesShiftUnassigned() {
+        User user = persistUser("dave");
+        em.flush();
+
+        EmployeeDto result = employeeService.joinOrganization(user.getId(), orgAId, joinDto());
+
+        assertThat(result.getShiftTimingId()).isNull();
+        assertThat(result.getShiftTiming()).isNull();
+    }
+
+    private EmployeeJoinOrgDto joinDto() {
+        EmployeeJoinOrgDto dto = new EmployeeJoinOrgDto();
+        dto.setDesignation("Site Engineer");
+        dto.setDepartment("Civil");
+        dto.setStatus("active");
+        return dto;
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private ShiftTiming persistShift(Organization org, String name) {
+        ShiftTiming shift = ShiftTiming.builder()
+                .shiftName(name)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .lunchBreakStart(LocalTime.of(13, 0))
+                .lunchBreakEnd(LocalTime.of(13, 30))
+                .gracePeriodMinutes(15)
+                .minimumWorkHours(java.math.BigDecimal.valueOf(8.0))
+                .halfDayWorkHours(java.math.BigDecimal.valueOf(4.0))
+                .overtimeThreshold(java.math.BigDecimal.valueOf(9.0))
+                .organization(org)
+                .build();
+        em.persist(shift);
+        return shift;
+    }
+
+    private User persistUser(String name) {
+        User user = new User();
+        user.setKeycloakId("kc-" + name);
+        user.setName(name);
+        user.setGender("U");
+        user.setEmail(name + "@emp.test");
+        user.setPhone("00000" + name.hashCode());
+        user.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(user);
+        return user;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
@@ -36,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({PayableService.class, PayableMapperImpl.class, EmployeeMapperImpl.class,
-        AttachmentMapperImpl.class, TenantEntityHelper.class})
+        AttachmentMapperImpl.class, TenantEntityHelper.class,
+        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper.class})
 class PayableServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/projectInviteCode/ProjectInviteCodeServiceTest.java
@@ -64,6 +64,7 @@ class ProjectInviteCodeServiceTest {
     @Mock private EmployeeRepository employeeRepository;
     @Mock private ProjectInviteCodeMapper projectInviteCodeMapper;
     @Mock private OrganizationMapper organizationMapper;
+    @Mock private org.tornotron.echno_backend.attendance.ShiftTimingRepository shiftTimingRepository;
 
     private ProjectInviteCodeService service;
 
@@ -71,7 +72,8 @@ class ProjectInviteCodeServiceTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new ProjectInviteCodeService(inviteCodeRepository, employeeService, organizationRepository,
-                fileStorageService, employeeRepository, projectInviteCodeMapper, organizationMapper);
+                fileStorageService, employeeRepository, projectInviteCodeMapper, organizationMapper,
+                shiftTimingRepository);
     }
 
     @AfterEach
@@ -151,6 +153,47 @@ class ProjectInviteCodeServiceTest {
     }
 
     @Test
+    void generateInviteCode_withShiftTimingId_resolvesShiftAndStoresIdInDetails() {
+        Long shiftId = 9L;
+        org.tornotron.echno_backend.attendance.ShiftTiming shift =
+                new org.tornotron.echno_backend.attendance.ShiftTiming();
+        shift.setId(shiftId);
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(shiftTimingRepository.findByIdAndOrganization_Id(shiftId, ORG)).thenReturn(Optional.of(shift));
+        when(inviteCodeRepository.save(any(ProjectInviteCode.class))).thenAnswer(inv -> {
+            ProjectInviteCode saved = inv.getArgument(0);
+            saved.setId(INVITE_ID);
+            return saved;
+        });
+        when(projectInviteCodeMapper.toDto(any())).thenReturn(new ProjectInviteCodeDto());
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setShiftTimingId(shiftId);
+
+        service.generateInviteCode(dto, ORG);
+
+        ArgumentCaptor<ProjectInviteCode> captor = ArgumentCaptor.forClass(ProjectInviteCode.class);
+        verify(inviteCodeRepository).save(captor.capture());
+        ProjectInviteCode saved = captor.getValue();
+        assertThat(saved.getShiftTiming()).isSameAs(shift);
+        assertThat(saved.getEmployeeDetails()).containsEntry("shiftTimingId", shiftId);
+    }
+
+    @Test
+    void generateInviteCode_unknownShiftTimingId_throwsNotFound() {
+        Long shiftId = 9L;
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(shiftTimingRepository.findByIdAndOrganization_Id(shiftId, ORG)).thenReturn(Optional.empty());
+
+        InviteCodeGenerationDto dto = generationDto();
+        dto.setShiftTimingId(shiftId);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.generateInviteCode(dto, ORG));
+        verify(inviteCodeRepository, never()).save(any());
+    }
+
+    @Test
     void generateInviteCode_notPersisted_throwsDatabaseError() {
         when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
         // save returns an entity whose id is still null -> persistence failure
@@ -225,6 +268,7 @@ class ProjectInviteCodeServiceTest {
         ProjectInviteCode code = storedCode(true, LocalDateTime.now().plusDays(5), 5, 1);
         code.getEmployeeDetails().put("managerId", 8);
         code.getEmployeeDetails().put("salary", 55000.0);
+        code.getEmployeeDetails().put("shiftTimingId", 9);
         when(inviteCodeRepository.findByCode(12345)).thenReturn(Optional.of(code));
         OrganizationDto orgDto = new OrganizationDto();
         when(organizationMapper.toDto(any())).thenReturn(orgDto);
@@ -239,6 +283,9 @@ class ProjectInviteCodeServiceTest {
         assertThat(joinDto.getEmail()).isEqualTo("jane@example.com");
         assertThat(joinDto.getManagerId()).isEqualTo(8L);
         assertThat(joinDto.getSalary()).isEqualTo(55000.0);
+        // The invite's stored shift id is carried into the join so the new employee is
+        // given that structured shift.
+        assertThat(joinDto.getShiftTimingId()).isEqualTo(9L);
     }
 
     @Test


### PR DESCRIPTION
## What

Unifies the two disconnected shift concepts. Employee and the project invite now reference the structured `attendance.ShiftTiming` entity by foreign key instead of carrying a free-text `String shiftTiming` label, and attendance derives an employee's shift from their assigned `ShiftTiming`.

Spec: `docs/specs/2026-08-24-shift-unification.md`.

## Changes

- **Employee entity**: new `shiftTiming` `@ManyToOne(LAZY)` to `ShiftTiming` (column `shift_timing_id`, nullable). The old `String shiftTiming` is renamed to `legacyShiftTiming` (column `legacy_shift_timing`), kept for reference and the backfill, and removed from the response DTO.
- **ProjectInviteCode entity**: new `shiftTiming` `@ManyToOne` (column `shift_timing_id`). The invite carries `shiftTimingId` both on the FK and inside its stored `employeeDetails` payload, which is what seeds the join.
- **DTOs**:
  - `EmployeeCreationDto`: `String shiftTiming` -> `Long shiftTimingId` (nullable).
  - `EmployeeJoinOrgDto`: `String shiftTiming` -> `Long shiftTimingId` (nullable).
  - `EmployeeDto` (response): `String shiftTiming` -> `Long shiftTimingId` + nested read-only `ShiftTimingDto shiftTiming` (null when unassigned).
  - `InviteCodeGenerationDto`: `String shiftTiming` -> `Long shiftTimingId` (nullable).
- **Services/mappers**: create, join and the batch patch (`shiftTimingId` key) resolve the FK from the id, validating it belongs to the current tenant (rejected with `ResourceNotFoundException` otherwise, null when omitted). Joining via an invite assigns the invite's shift. `EmployeeMapper` nests the `ShiftTimingDto` via the existing `ShiftTimingMapper`.
- **Attendance**: `checkIn` prefers the employee's assigned `shiftTiming`; it falls back to `AttendanceCheckInDto.shiftTimingId` (now optional) only when the employee has none, and rejects a check-in when neither yields a shift. Existing calculation and null-guards unchanged.
- **Migration** `src/main/resources/db/changelog/v4.0/048-unify-employee-shift-timing.xml` (precondition-guarded): rename `employee.shift_timing` -> `legacy_shift_timing`; add `employee.shift_timing_id` + FK; add `project_invite_code.shift_timing_id` + FK; backfill `shift_timing_id` by case-insensitive, trimmed match of the legacy label to a shift name within the same organization (name match only, unmatched stay null, times not parsed).

## Tests

`./gradlew clean build` on the lab build box: **BUILD SUCCESSFUL, 300 tests, 0 failures**.

- New `EmployeeShiftUnificationIT` (Testcontainers): valid `shiftTimingId` sets the FK and nests the resolved `ShiftTimingDto`; a foreign-tenant id is rejected; the invite-driven join assigns the shift; an omitted id leaves it unassigned.
- `ProjectInviteCodeServiceTest`: added coverage that the invite carries `shiftTimingId` into the join and rejects an unknown shift at generation.
- `PayableServiceIT` import updated for the new `EmployeeMapper` dependency on `ShiftTimingMapper`.

## Notes for core + web

The request/response contract changed: `shiftTiming` (string) is gone from employee create/join/response and the invite payload, replaced by `shiftTimingId` (Long); the response additionally nests a read-only `shiftTiming` object. Attendance check-in `shiftTimingId` is now optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employees and invitations can now use structured shift selections instead of free-text shift labels.
  * Employee records display both the selected shift ID and its shift details.
  * Invite-based employee setup carries the selected shift automatically.
  * Shift selections are validated within the employee’s organization.

* **Improvements**
  * Attendance check-in uses an employee’s assigned shift when available, otherwise the shift provided in the request.
  * Existing shift labels are matched to available shifts during data migration where possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->