### PR TITLE
feat: optional HTTP proxy for the compliance AI client (IITM egress)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
@@ -39,4 +39,15 @@ public class ComplianceAiProperties {
 
     /** Master switch; when false the AI call is skipped and generation no-ops. */
     private boolean enabled = true;
+
+    /**
+     * Optional HTTP forward-proxy host for reaching the inference endpoint. Empty by
+     * default (direct egress, the production behaviour on DigitalOcean). Set it in
+     * environments where the backend has no direct internet and must egress through a
+     * forward proxy (for example the IITM lab, where a haproxy on the host relays out).
+     */
+    private String proxyHost = "";
+
+    /** Proxy port used only when {@code proxyHost} is set. */
+    private int proxyPort = 3128;
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -13,6 +13,8 @@ import org.springframework.web.client.RestClient;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.project.Project;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.time.Duration;
 import java.util.List;
 
@@ -85,6 +87,14 @@ public class OpenAiCompatibleComplianceService {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(10));
         factory.setReadTimeout(Duration.ofSeconds(60));
+        String proxyHost = props.getProxyHost();
+        if (proxyHost != null && !proxyHost.isBlank()) {
+            int proxyPort = props.getProxyPort();
+            factory.setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort)));
+            log.info("Compliance AI egress routed through HTTP proxy {}:{}", proxyHost, proxyPort);
+        } else {
+            log.debug("Compliance AI egress is direct (no proxy configured)");
+        }
         return factory;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,10 @@ compliance:
     max-tokens: 4096
     temperature: 0.2
     enabled: ${COMPLIANCE_AI_ENABLED:true}
+    # Optional forward proxy for egress (unset = direct, the DO production behaviour).
+    # Set both when the backend has no direct internet, e.g. the IITM lab host proxy.
+    proxy-host: ${COMPLIANCE_AI_PROXY_HOST:}
+    proxy-port: ${COMPLIANCE_AI_PROXY_PORT:3128}
 
 
 # Chart-of-accounts auto numbering. level-steps is the gap between sibling codes

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceServiceTest.java
@@ -62,4 +62,26 @@ class OpenAiCompatibleComplianceServiceTest {
 
         assertThat(result).isEmpty();
     }
+
+    @Test
+    void proxyDefaultsToDirectEgress() {
+        ComplianceAiProperties props = new ComplianceAiProperties();
+
+        assertThat(props.getProxyHost()).isEmpty();
+        assertThat(props.getProxyPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void proxyConfigIsOptionalAndDoesNotBreakTheNoOpPath() {
+        ComplianceAiProperties props = new ComplianceAiProperties();
+        props.setEnabled(false);
+        props.setProxyHost("10.24.6.116");
+        props.setProxyPort(3128);
+        OpenAiCompatibleComplianceService service = new OpenAiCompatibleComplianceService(props);
+
+        List<ComplianceSuggestion> result =
+                service.suggestCompliances(sampleProject(), "Tamil Nadu", sampleRules());
+
+        assertThat(result).isEmpty();
+    }
 }


### PR DESCRIPTION
## Why

The compliance AI client (`OpenAiCompatibleComplianceService`) egresses directly to the OpenAI-compatible inference endpoint. That works on DigitalOcean, where the backend has direct internet. At IITM the backend container has no direct route out and must reach the endpoint through the lab host forward proxy (haproxy). Production on DO keeps direct egress, so the proxy has to be optional.

## Change

- `ComplianceAiProperties`: add `proxyHost` (default empty) and `proxyPort` (default 3128).
- `application.yml` `compliance.ai` block: add `proxy-host: ${COMPLIANCE_AI_PROXY_HOST:}` and `proxy-port: ${COMPLIANCE_AI_PROXY_PORT:3128}`.
- `OpenAiCompatibleComplianceService`: when `proxyHost` is non-blank, the request factory routes through an HTTP proxy at `proxyHost:proxyPort` (HTTPS is tunnelled with CONNECT by `SimpleClientHttpRequestFactory`). When blank, behaviour is unchanged (direct egress). Existing 10s connect / 60s read timeouts are kept either way, and the proxy applies only to this client. Startup logs whether a proxy is in effect (host:port, no secrets).

All current behaviour is preserved: disabled / blank-key no-op, fail-soft on errors, same prompt, same `choices[0].message.content` extraction and JSON parsing.

## Config keys

| Property | Env var | Default |
|----------|---------|---------|
| `compliance.ai.proxy-host` | `COMPLIANCE_AI_PROXY_HOST` | (empty = direct) |
| `compliance.ai.proxy-port` | `COMPLIANCE_AI_PROXY_PORT` | `3128` |

## Tests

Added unit tests for the proxy defaults and that setting a proxy does not break the no-op path; existing disabled / blank-key tests unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP proxy support for compliance AI requests.
  * Proxy host and port can be configured through application settings or environment variables.
  * Requests continue to use direct connections when no proxy is configured.

* **Tests**
  * Added coverage for default direct routing and disabled-service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->