### PR TITLE
feat: composite job roles over the granular RBAC permissions (H-1)

### DIFF
--- a/docs/specs/2026-08-25-rbac-composite-job-roles.md
+++ b/docs/specs/2026-08-25-rbac-composite-job-roles.md
@@ -1,0 +1,107 @@
+# RBAC composite job roles (audit finding H-1)
+
+## Problem
+
+The `echno-realm` ships around 52 realm roles. After removing the Keycloak built-ins
+(`default-roles-echno-realm`, `offline_access`, `uma_authorization`) and the two app base roles
+(`user`, `admin`), 47 of them are fine-grained occupation roles: `mason`, `carpenter`,
+`site-engineer`, `architect`, `accountant`, `procurement-officer`, and so on. Each is a flat,
+non-composite realm role with a short job description.
+
+Two problems follow from this:
+
+1. Granting a real person their job means attaching several of these occupation roles one by one.
+   There is no coarser handle, so assignment is slow and error prone, and composites are unused today.
+2. The set is a long, undifferentiated list with no functional grouping, which makes it hard to reason
+   about who can do what.
+
+Audit finding H-1 recommends collapsing the granular roles into a smaller set of composite job roles
+that can be assigned as a unit.
+
+## What the realm actually contains (verified)
+
+The occupation roles were read from the live seed
+(`echno-deployment/ansible/roles/seed/files/keycloak-seed.json`, an Ansible-vault file) rather than
+assumed. Findings that shaped the design:
+
+- The 47 granular roles are occupation titles, not `resource:scope` permission roles. They are all
+  `composite: false`.
+- No seeded user holds an occupation role. The 28 seeded users carry only `user` and
+  `default-roles-echno-realm`; org membership is expressed through the `/org-{id}` groups.
+- The backend has no `@PreAuthorize` check that references an occupation role by name. Occupation
+  roles are a catalogue that is available for assignment, not a live gate on any endpoint.
+- The org-scoped role subgroups (`system-admin`, `org-manager`, `hr-admin`, `project-manager`) are a
+  separate authorization layer. They live as subgroups under `/org-{id}` and are resolved by
+  `JwtAuthConverter` from the JWT `groups` claim into `ORG_{id}_ROLE_{role-name}` authorities, which
+  `@orgSecurity.hasAnyOrgRoleForCurrentTenant(...)` checks. This is path-based and unrelated to realm
+  roles.
+
+Because occupation roles currently gate nothing in application code, adding composites over them is a
+safe, additive taxonomy change. It gives the realm the coarse job handles it lacks without altering
+any existing authority resolution.
+
+## Design: nine composite job roles
+
+Each composite is a new realm role, marked composite, whose children are existing occupation roles.
+Granting a composite grants every child occupation role through Keycloak's composite-role evaluation,
+so behaviour is identical to granting the children individually. Names are prefixed `job-` so they do
+not collide with any existing occupation role (several occupation roles, for example `site-manager`,
+`hr-manager` and `project-manager`, already carry the plain name) and are not confused with the
+`resource:scope` permission authorities produced from the RPT.
+
+| Composite | Children (existing occupation roles) |
+|-----------|--------------------------------------|
+| `job-site-management` | site-manager, site-supervisor, site-engineer, foreman, supervisor, safety-officer, technical-coordinator, document-controller |
+| `job-engineering` | architect, civil-engineer, structural-engineer, planning-engineer, quantity-surveyor |
+| `job-skilled-trades` | mason, carpenter, electrician, plumber, painter, welder, scaffolder, crane-operator, equipment-operator, driver |
+| `job-general-workforce` | laborer, helper, site-cleaner, security-guard |
+| `job-finance-procurement` | accountant, procurement-officer |
+| `job-office-admin` | hr-manager, admin-staff, office-assistant, receptionist, it-support |
+| `job-leadership` | director, owner-representative, project-manager |
+| `job-external-stakeholders` | client, consultant, contractor, sub-contractor, vendor, material-supplier |
+| `job-early-career` | intern, student, trainee |
+
+The nine families cover 46 of the 47 occupation roles. The one deliberately left out is
+`system-admin`: it is the administrative role driven through the org-scoped subgroup layer, not a job
+title, so bundling it into a job family would be misleading.
+
+## Backward compatibility
+
+The change is additive and cannot alter how any current authority resolves:
+
+- The 52 existing roles are untouched. No role is renamed, deleted or repointed.
+- No user or group is auto-assigned a composite. Assignment stays an org-admin action. This change
+  only makes the composites available.
+- Users and groups that still hold granular roles directly keep working exactly as before.
+- `JwtAuthConverter` needs no change. It reads three things: `resource_access` roles into `ROLE_*`,
+  the RPT `authorization.permissions` into `resource:scope` authorities, and the `groups` claim into
+  `ORG_MEMBER_*` / `ORG_{id}_ROLE_*`. A composite realm role surfaces its children as effective realm
+  roles, which flow through the same paths that already handle realm roles; the org-scoped
+  `@orgSecurity` checks are group-path based and are not affected. Verified: no converter change is
+  required.
+
+## Implementation
+
+Reconciled in code, matching the existing idempotent, guarded, check-before-create style already used
+for admin MFA in `common/configuration/KeycloakInitializer`.
+
+- `ensureCompositeJobRoles()` runs on both startup paths: from `initKeycloak()` on a fresh realm, and
+  from the existing-realm branch of `init()` on every subsequent startup, next to
+  `ensureAuthorizationSetup()` and `ensureAdminMfa()`.
+- For each composite, `ensureCompositeJobRole(...)` ensures the composite realm role exists (creates
+  it only when missing, never overwriting), reads the currently attached children with
+  `getRealmRoleComposites()`, and attaches only the missing children with `addComposites(...)`. A
+  child that does not exist in the realm is logged and skipped rather than failing the run.
+- Every step is wrapped so a failure logs and never aborts startup, consistent with the other
+  reconcile methods. Re-running only fills in what is missing; it never removes or reassigns anything.
+
+The composite definitions live in a static list `COMPOSITE_JOB_ROLES` in the same class, so adding a
+family or a child role later is a one-line edit picked up on the next deploy reconcile.
+
+## How a group would use a composite (optional, future)
+
+Assignment is out of scope for this change, but the intended path once an org decides to use a
+composite: attach the composite realm role to the relevant `/org-{id}/{role}` subgroup (group role
+mapping), or to the user directly. Members then inherit the composite's children on their next login.
+This keeps day-to-day role assignment to a single coarse handle while the granular roles remain
+available for finer cases.

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -8,7 +8,9 @@ import org.keycloak.admin.client.CreatedResponseUtil;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -113,6 +115,8 @@ public class KeycloakInitializer {
             assignServiceAccountRoles();
             // Ensure authorization setup (JS policy, resource, permission) exists
             ensureAuthorizationSetup();
+            // Ensure the H-1 composite job roles exist and carry their granular children
+            ensureCompositeJobRoles();
         }
     }
 
@@ -437,7 +441,147 @@ public class KeycloakInitializer {
         assignServiceAccountRoles();
         ensureAuthorizationSetup();
         ensureAdminMfa();
+        ensureCompositeJobRoles();
 
+    }
+
+    /**
+     * Immutable definition of one composite job role: a coarse, function-based realm role that
+     * bundles a set of the fine-grained occupation realm roles as its composite children.
+     */
+    private static final class CompositeJobRole {
+        final String name;
+        final String description;
+        final List<String> children;
+
+        CompositeJobRole(String name, String description, List<String> children) {
+            this.name = name;
+            this.description = description;
+            this.children = children;
+        }
+    }
+
+    /**
+     * H-1 (RBAC role-model improvement): the realm ships ~52 fine-grained occupation realm roles
+     * (mason, site-engineer, accountant, ...) that today have to be assigned one by one. These
+     * composite job roles group them by function so an org admin can grant a single job role and
+     * the member inherits every child occupation role through Keycloak's composite-role evaluation.
+     *
+     * Purely additive: the granular occupation roles are left exactly as they are, no user or group
+     * is auto-assigned a composite here, and the org-scoped role subgroups (system-admin, org-manager,
+     * hr-admin, project-manager, resolved from the JWT "groups" claim by JwtAuthConverter) are a
+     * separate authorization layer that this change does not touch. The occupation role 'system-admin'
+     * is deliberately left out of every family: it is the administrative role driven through the
+     * org-scoped subgroup layer, not a job title to be bundled.
+     */
+    private static final List<CompositeJobRole> COMPOSITE_JOB_ROLES = List.of(
+            new CompositeJobRole("job-site-management",
+                    "Composite job role: site leadership, supervision and safety.",
+                    List.of("site-manager", "site-supervisor", "site-engineer", "foreman",
+                            "supervisor", "safety-officer", "technical-coordinator", "document-controller")),
+            new CompositeJobRole("job-engineering",
+                    "Composite job role: design and engineering professionals.",
+                    List.of("architect", "civil-engineer", "structural-engineer",
+                            "planning-engineer", "quantity-surveyor")),
+            new CompositeJobRole("job-skilled-trades",
+                    "Composite job role: skilled tradespeople and equipment operators.",
+                    List.of("mason", "carpenter", "electrician", "plumber", "painter", "welder",
+                            "scaffolder", "crane-operator", "equipment-operator", "driver")),
+            new CompositeJobRole("job-general-workforce",
+                    "Composite job role: general labour and site facilities.",
+                    List.of("laborer", "helper", "site-cleaner", "security-guard")),
+            new CompositeJobRole("job-finance-procurement",
+                    "Composite job role: finance and procurement.",
+                    List.of("accountant", "procurement-officer")),
+            new CompositeJobRole("job-office-admin",
+                    "Composite job role: office, HR and IT administration and support.",
+                    List.of("hr-manager", "admin-staff", "office-assistant", "receptionist", "it-support")),
+            new CompositeJobRole("job-leadership",
+                    "Composite job role: executive leadership and project management.",
+                    List.of("director", "owner-representative", "project-manager")),
+            new CompositeJobRole("job-external-stakeholders",
+                    "Composite job role: external, non-employee parties.",
+                    List.of("client", "consultant", "contractor", "sub-contractor",
+                            "vendor", "material-supplier")),
+            new CompositeJobRole("job-early-career",
+                    "Composite job role: interns, students and trainees.",
+                    List.of("intern", "student", "trainee"))
+    );
+
+    /**
+     * Codifies the H-1 composite job roles on every startup (both the fresh-realm and existing-realm
+     * paths), fully idempotent and guarded so a failure only logs and never aborts startup. Each
+     * composite is ensured to exist and to carry its granular occupation children; re-running only
+     * fills in whatever is missing and never removes or reassigns anything.
+     */
+    private void ensureCompositeJobRoles() {
+        try {
+            log.info("Ensuring composite job roles over the granular occupation roles (H-1)");
+            for (CompositeJobRole jobRole : COMPOSITE_JOB_ROLES) {
+                ensureCompositeJobRole(jobRole);
+            }
+            log.info("Composite job roles reconcile complete");
+        } catch (Exception e) {
+            log.error("Failed to ensure composite job roles: {}", e.getMessage(), e);
+        }
+    }
+
+    private void ensureCompositeJobRole(CompositeJobRole jobRole) {
+        try {
+            RealmResource realm = keycloak.realm(REALM_ID);
+
+            // 1. Ensure the composite role itself exists (create if missing, never overwrite).
+            boolean exists;
+            try {
+                realm.roles().get(jobRole.name).toRepresentation();
+                exists = true;
+            } catch (NotFoundException e) {
+                exists = false;
+            }
+            if (!exists) {
+                RoleRepresentation rep = new RoleRepresentation();
+                rep.setName(jobRole.name);
+                rep.setDescription(jobRole.description);
+                rep.setComposite(true);
+                realm.roles().create(rep);
+                log.info("Created composite job role '{}'", jobRole.name);
+            }
+
+            RoleResource roleResource = realm.roles().get(jobRole.name);
+
+            // 2. Determine which children are already attached, so we only add what is missing.
+            Set<String> alreadyAttached = new HashSet<>();
+            Set<RoleRepresentation> existingComposites = roleResource.getRealmRoleComposites();
+            if (existingComposites != null) {
+                for (RoleRepresentation r : existingComposites) {
+                    alreadyAttached.add(r.getName());
+                }
+            }
+
+            // 3. Attach any missing child occupation role that actually exists in the realm.
+            List<RoleRepresentation> toAdd = new ArrayList<>();
+            for (String child : jobRole.children) {
+                if (alreadyAttached.contains(child)) {
+                    continue;
+                }
+                try {
+                    toAdd.add(realm.roles().get(child).toRepresentation());
+                } catch (NotFoundException e) {
+                    log.warn("Child occupation role '{}' not found; skipping from composite '{}'",
+                            child, jobRole.name);
+                }
+            }
+
+            if (!toAdd.isEmpty()) {
+                roleResource.addComposites(toAdd);
+                log.info("Added {} child role(s) to composite '{}': {}", toAdd.size(), jobRole.name,
+                        toAdd.stream().map(RoleRepresentation::getName).toList());
+            } else {
+                log.info("Composite job role '{}' already carries all available children", jobRole.name);
+            }
+        } catch (Exception e) {
+            log.error("Failed to ensure composite job role '{}': {}", jobRole.name, e.getMessage());
+        }
     }
 
     private void assignServiceAccountRoles() {


### PR DESCRIPTION
## What

Adds a small set of composite job roles layered over the ~52 fine-grained occupation realm roles in `echno-realm`, addressing audit finding H-1. Instead of attaching several occupation roles one by one, an org admin can grant a single coarse job role and the member inherits every child occupation role through Keycloak's composite-role evaluation.

## The nine composite job roles

| Composite | Children (existing occupation roles) |
|-----------|--------------------------------------|
| `job-site-management` | site-manager, site-supervisor, site-engineer, foreman, supervisor, safety-officer, technical-coordinator, document-controller |
| `job-engineering` | architect, civil-engineer, structural-engineer, planning-engineer, quantity-surveyor |
| `job-skilled-trades` | mason, carpenter, electrician, plumber, painter, welder, scaffolder, crane-operator, equipment-operator, driver |
| `job-general-workforce` | laborer, helper, site-cleaner, security-guard |
| `job-finance-procurement` | accountant, procurement-officer |
| `job-office-admin` | hr-manager, admin-staff, office-assistant, receptionist, it-support |
| `job-leadership` | director, owner-representative, project-manager |
| `job-external-stakeholders` | client, consultant, contractor, sub-contractor, vendor, material-supplier |
| `job-early-career` | intern, student, trainee |

The nine families cover 46 of the 47 occupation roles. `system-admin` is deliberately excluded: it is the administrative role driven through the org-scoped subgroup layer, not a job title. Names are `job-` prefixed so they never collide with an existing occupation role (several occupation roles already carry the plain name, e.g. site-manager, hr-manager, project-manager).

## Implementation

- New `ensureCompositeJobRoles()` / `ensureCompositeJobRole(...)` in `KeycloakInitializer`, reconciled on both startup paths (fresh realm via `initKeycloak()`, existing realm via the else-branch of `init()`), next to `ensureAuthorizationSetup()` and `ensureAdminMfa()`.
- Idempotent, guarded, check-before-create, matching the existing MFA reconcile style: ensures each composite exists (creates only when missing, never overwriting), reads current children with `getRealmRoleComposites()`, and attaches only missing children with `addComposites(...)`. A child not present in the realm is logged and skipped, never failing the run. Failures log and never abort startup.

## Additive and backward compatible

- The 52 existing roles are untouched; nothing renamed, deleted or repointed.
- No user or group is auto-assigned a composite; assignment stays an org-admin action.
- `JwtAuthConverter` needs no change: a composite realm role surfaces its children through the same paths that already handle realm roles, and the org-scoped `@orgSecurity` checks are group-path based and unaffected. Verified: no converter change required.

## Notes

- The occupation role names were read from the live seed (`echno-deployment` keycloak-seed vault), not assumed. They are occupation titles (mason, architect, ...), not `resource:scope` roles; no seeded user holds one and no backend `@PreAuthorize` references one, so this taxonomy addition changes no current behaviour.
- Spec: `docs/specs/2026-08-25-rbac-composite-job-roles.md`.

## Build

`./gradlew clean build` on lab .116: BUILD SUCCESSFUL, full test suite green.