### PR TITLE
Surface compliance-generation preconditions as clear 4xx errors

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
 
@@ -42,6 +44,11 @@ public class ComplianceGenerationListener {
         try {
             TenantContext.setCurrentOrgId(orgId);
             complianceGenerationService.generateForProject(projectId, orgId);
+        } catch (InvalidRequestException | ResourceNotFoundException e) {
+            // Expected on auto-approval: a project approved without a state in its address, or
+            // before any rules exist for its jurisdiction, is normal. Log quietly and move on;
+            // a project manager can regenerate once the precondition is met.
+            log.info("Compliance auto-generation skipped for project {}: {}", projectId, e.getMessage());
         } catch (Exception e) {
             log.error("Compliance generation failed for project {} in organization {}: {}",
                     projectId, orgId, e.getMessage(), e);

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
@@ -58,9 +60,15 @@ public class ComplianceGenerationService {
 
     /**
      * Generates the missing compliance inspections for a project. Returns the DTOs of
-     * the rows created by this call (empty when the AI is disabled/unconfigured, the
-     * project has no resolvable state or type, no rules match, or everything already
-     * exists).
+     * the rows created by this call; the list is empty in the genuine "generation ran
+     * but nothing applied" cases (the AI found no applicable rule, or every applicable
+     * compliance already exists).
+     *
+     * <p>Precondition failures are surfaced instead of silently returning empty so the
+     * caller can tell the user what to fix: a missing project raises
+     * {@link ResourceNotFoundException} (404); a project with no type, an address with
+     * no recognisable state, no rules registered for that jurisdiction, or an
+     * unconfigured AI service each raise {@link InvalidRequestException} (400).
      *
      * @param projectId the project to generate for
      * @param orgId     the owning organization; must match the current tenant context
@@ -69,34 +77,42 @@ public class ComplianceGenerationService {
     public List<InspectionDto> generateForProject(Long projectId, Long orgId) {
         Project project = projectRepository.findByIdAndOrganization_Id(projectId, orgId).orElse(null);
         if (project == null) {
-            log.warn("Compliance generation skipped: project {} not found in organization {}", projectId, orgId);
-            return List.of();
+            throw new ResourceNotFoundException(
+                    "No project with id " + projectId + " was found in this organization.");
         }
 
         ProjectType projectType = project.getProjectType();
         if (projectType == null) {
-            log.warn("Compliance generation skipped for project {}: projectType is not set", projectId);
-            return List.of();
+            throw new InvalidRequestException(
+                    "This project has no type set. Add a project type (for example Residential or "
+                            + "Commercial) before generating compliance.");
         }
 
         String state = IndianStateResolver.resolve(project.getProjectAddress());
         if (state == null) {
-            log.warn("Compliance generation skipped for project {}: could not resolve a state from address '{}'",
-                    projectId, project.getProjectAddress());
-            return List.of();
+            throw new InvalidRequestException(
+                    "The project address does not include a recognised state, so the applicable "
+                            + "regulations cannot be determined. Add the state to the project address "
+                            + "(for example 'Chennai, Tamil Nadu') and try again.");
         }
 
         List<ComplianceRule> candidateRules =
                 ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(state, projectType);
         if (candidateRules.isEmpty()) {
-            log.info("No compliance rules registered for state '{}' and type {} (project {})",
-                    state, projectType, projectId);
-            return List.of();
+            throw new InvalidRequestException(
+                    "No compliance rules are registered for this project's state (" + state
+                            + ") and type (" + projectType + ") yet. Once rules for that jurisdiction "
+                            + "are added, generation will produce results.");
         }
 
         List<ComplianceSuggestion> suggestions =
                 complianceAiService.suggestCompliances(project, state, candidateRules);
         if (suggestions.isEmpty()) {
+            if (!complianceAiService.isConfigured()) {
+                throw new InvalidRequestException(
+                        "The compliance AI service is not configured, so suggestions cannot be "
+                                + "generated. Set the compliance AI key and try again.");
+            }
             log.info("Compliance AI returned no suggestions for project {}", projectId);
             return List.of();
         }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -39,6 +39,15 @@ public class OpenAiCompatibleComplianceService {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
+     * Whether the AI service is switched on and has an API key, decided purely from
+     * config with no network call. When this is false the service always no-ops, so
+     * callers can tell "AI not configured" apart from "AI ran and found nothing".
+     */
+    public boolean isConfigured() {
+        return props.isEnabled() && props.getApiKey() != null && !props.getApiKey().isBlank();
+    }
+
+    /**
      * Asks the model which of the candidate rules apply to the project. Returns one
      * suggestion per rule the model reasoned about; an empty list means "generate
      * nothing" (either the AI is off/unconfigured or the call failed).
@@ -46,7 +55,7 @@ public class OpenAiCompatibleComplianceService {
     public List<ComplianceSuggestion> suggestCompliances(Project project,
                                                          String state,
                                                          List<ComplianceRule> candidateRules) {
-        if (!props.isEnabled() || props.getApiKey() == null || props.getApiKey().isBlank()) {
+        if (!isConfigured()) {
             log.info("Compliance AI disabled or API key not configured; skipping AI suggestion for project {}",
                     project.getId());
             return List.of();

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -47,8 +47,8 @@ public class ComplianceControllerWeb {
                     + "matched rule are not duplicated."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Generation ran; the created inspections are returned (possibly empty)"),
-            @ApiResponse(responseCode = "400", description = "No organization context set: the X-Organization-Id header is required"),
+            @ApiResponse(responseCode = "200", description = "Generation ran; the created inspections are returned (possibly empty when nothing new applied)"),
+            @ApiResponse(responseCode = "400", description = "No organization context set (the X-Organization-Id header is required), or a precondition is unmet: the project has no type, its address carries no recognisable state, no rules are registered for its jurisdiction, or the AI service is not configured. The detail message states what to fix."),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
     })

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
@@ -1,0 +1,137 @@
+package org.tornotron.echno_backend.compliance;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the precondition handling in {@link ComplianceGenerationService}. Each
+ * unmet precondition must surface a clear 4xx exception (rather than silently returning
+ * an empty list), so the frontend's error toast can tell the user exactly what to fix.
+ * Pure Mockito, no database.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceGenerationServiceTest {
+
+    private static final Long PROJECT_ID = 42L;
+    private static final Long ORG_ID = 7L;
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private ComplianceRuleRepository ruleRepository;
+    @Mock
+    private OpenAiCompatibleComplianceService complianceAiService;
+    @Mock
+    private InspectionRepository inspectionRepository;
+    @Mock
+    private EntryNumberGenerator numberGen;
+    @Mock
+    private TenantEntityHelper tenantEntityHelper;
+    @Mock
+    private InspectionMapper inspectionMapper;
+
+    @InjectMocks
+    private ComplianceGenerationService service;
+
+    private Project project(ProjectType type, String address) {
+        Project project = new Project();
+        project.setProjectName("Test Project");
+        project.setProjectType(type);
+        project.setProjectAddress(address);
+        return project;
+    }
+
+    @Test
+    void projectNotFound_throwsResourceNotFound() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("No project with id " + PROJECT_ID);
+    }
+
+    @Test
+    void noProjectType_throwsInvalidRequest() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project(null, "12 Mount Road, Chennai, Tamil Nadu")));
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("no type set");
+    }
+
+    @Test
+    void unresolvableAddress_throwsInvalidRequest() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "No state named here")));
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("recognised state");
+    }
+
+    @Test
+    void noRulesForJurisdiction_throwsInvalidRequest() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai, Tamil Nadu")));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue("Tamil Nadu", ProjectType.RESIDENTIAL))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("No compliance rules are registered")
+                .hasMessageContaining("Tamil Nadu");
+    }
+
+    @Test
+    void aiNotConfigured_throwsInvalidRequest() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai, Tamil Nadu")));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
+                .thenReturn(List.of(new org.tornotron.echno_backend.compliance.domain.ComplianceRule()));
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+                .thenReturn(List.of());
+        when(complianceAiService.isConfigured()).thenReturn(false);
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("AI service is not configured");
+    }
+
+    @Test
+    void aiConfiguredButNoSuggestions_returnsEmpty() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai, Tamil Nadu")));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
+                .thenReturn(List.of(new org.tornotron.echno_backend.compliance.domain.ComplianceRule()));
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+                .thenReturn(List.of());
+        when(complianceAiService.isConfigured()).thenReturn(true);
+
+        assertThat(service.generateForProject(PROJECT_ID, ORG_ID)).isEmpty();
+    }
+}


### PR DESCRIPTION
The compliance "Generate compliance" feature silently produced nothing whenever a precondition was unmet, and the web app then showed a misleading "No new compliances were required" toast. The backend returned an empty list for five distinct situations, so the frontend could not tell a genuine empty result apart from a fixable setup problem.

## What changed

`ComplianceGenerationService.generateForProject` now throws for the precondition cases so the frontend error toast can tell the user exactly what to fix. The mappings go through the existing `GlobalExceptionHandler`:

- Project not found -> `ResourceNotFoundException` (404).
- Project has no type -> `InvalidRequestException` (400): "This project has no type set. Add a project type (for example Residential or Commercial) before generating compliance."
- Address has no recognisable state -> `InvalidRequestException` (400): "The project address does not include a recognised state, so the applicable regulations cannot be determined. Add the state to the project address (for example 'Chennai, Tamil Nadu') and try again."
- No rules registered for the jurisdiction -> `InvalidRequestException` (400): "No compliance rules are registered for this project's state (X) and type (Y) yet. Once rules for that jurisdiction are added, generation will produce results."
- AI returned nothing and the AI service is not configured -> `InvalidRequestException` (400): "The compliance AI service is not configured, so suggestions cannot be generated. Set the compliance AI key and try again."

The genuine empty result is preserved as an empty `200`: when the AI is configured but returns no applicable rule, or when every applicable compliance already exists, the call still returns an empty list and the existing "No new compliances were required" toast is accurate.

A clean, no-network `isConfigured()` signal was added to `OpenAiCompatibleComplianceService` (config-only: `enabled` plus a non-blank key) to distinguish "AI not configured" from "AI ran and found nothing".

## Auto-approval path

`ComplianceGenerationListener` wraps generation in try/catch. Because these preconditions are expected on auto-approval (a project approved without a state in its address, or before any rules exist, is normal), it now logs `InvalidRequestException` and `ResourceNotFoundException` at INFO (message only) and keeps ERROR with a stack trace for any other exception. The approval path never fails.

## Tests

Added `ComplianceGenerationServiceTest` (Mockito, no DB) covering the four precondition throws plus the configured/unconfigured empty-result split. Six tests, all passing.

Validated on the lab build box: `./gradlew compileJava` BUILD SUCCESSFUL; `./gradlew test --tests '*ComplianceGeneration*'` BUILD SUCCESSFUL, 6 tests passed.