### PR TITLE
Add chat backend module (rooms + messages)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.chat;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
+import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
+import org.tornotron.echno_backend.chat.dto.CreateDirectRoomDto;
+import org.tornotron.echno_backend.chat.dto.EditMessageDto;
+import org.tornotron.echno_backend.chat.dto.SendMessageDto;
+
+import java.util.List;
+
+/**
+ * Employee-facing chat: rooms an employee belongs to and the messages within them. Every
+ * endpoint requires only tenant membership (everyone in the organization can chat), with the
+ * finer participant checks enforced in the service.
+ */
+@RestController
+@Validated
+@RequestMapping("/api/v1/chat")
+@Tag(
+        name = "Chat",
+        description = "One-to-one and group chat between employees of the organization: rooms the caller "
+                + "participates in, their unread counts and last message, and the send/edit message flow. "
+                + "Any member of the tenant may chat; access to a specific room is limited to its participants."
+)
+public class ChatControllerWeb {
+
+    private final ChatService chatService;
+
+    public ChatControllerWeb(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping("/rooms/web")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List the caller's chat rooms",
+            description = "Returns every room the current employee participates in, each with its participants, "
+                    + "latest message and the caller's unread count, newest activity first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Rooms returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
+    public ResponseEntity<List<ChatRoomDto>> readRooms() {
+        return new ResponseEntity<>(chatService.getRoomsForCurrentEmployee(), HttpStatus.OK);
+    }
+
+    @GetMapping("/rooms/web/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Get a chat room",
+            description = "Returns a single room the caller participates in, with its participants, latest "
+                    + "message and unread count."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Room found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<ChatRoomDto> readRoom(@PathVariable Long id) {
+        return new ResponseEntity<>(chatService.getRoom(id), HttpStatus.OK);
+    }
+
+    @PostMapping("/rooms/web/direct")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Open a direct room",
+            description = "Opens the one-to-one direct room with the given employee, reusing the existing one "
+                    + "when present. Idempotent."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Direct room opened or reused"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "employeeId is missing or is the caller"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+    })
+    public ResponseEntity<ChatRoomDto> openDirectRoom(@Valid @RequestBody CreateDirectRoomDto dto) {
+        return new ResponseEntity<>(chatService.openDirectRoom(dto.getEmployeeId()), HttpStatus.OK);
+    }
+
+    @PostMapping("/rooms/web/{roomId}/read")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Mark a room read",
+            description = "Advances the caller's last-read marker in the room to now, clearing the unread count."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Room marked read"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<Void> markRoomRead(@PathVariable Long roomId) {
+        chatService.markRead(roomId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/rooms/web/{roomId}/messages")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "List a room's messages, paginated",
+            description = "Returns a page of the room's non-deleted messages, newest first."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of messages returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<Page<ChatMessageDto>> readMessages(
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "30") int pageSize) {
+        return new ResponseEntity<>(chatService.getMessages(roomId, pageNo, pageSize), HttpStatus.OK);
+    }
+
+    @PostMapping("/rooms/web/{roomId}/messages")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Send a message",
+            description = "Posts a message from the current employee to the room and bumps the room's activity."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Message created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "content is blank"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<ChatMessageDto> sendMessage(@PathVariable Long roomId,
+                                                      @Valid @RequestBody SendMessageDto dto) {
+        return new ResponseEntity<>(
+                chatService.sendMessage(roomId, dto.getContent(), dto.getReplyToId()), HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/messages/web/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Edit a message",
+            description = "Edits the body of the caller's own message, marking it edited. Only the sender may edit."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Message updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "content is blank"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the sender of the message"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No message with the given id in this tenant")
+    })
+    public ResponseEntity<ChatMessageDto> editMessage(@PathVariable Long id,
+                                                      @Valid @RequestBody EditMessageDto dto) {
+        return new ResponseEntity<>(chatService.editMessage(id, dto.getContent()), HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatMessage.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatMessage.java
@@ -1,0 +1,66 @@
+package org.tornotron.echno_backend.chat;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+
+/**
+ * A message posted to a {@link ChatRoom}. {@code senderId} is the author's employee id.
+ * {@code replyToId} is stored as a plain nullable id (the reply preview is resolved by the
+ * client, not here). Editing sets {@code isEdited} and {@code editedAt}; the delete flag is
+ * present for forward compatibility but soft-delete is not exposed yet.
+ */
+@Entity
+@Table(name = "chat_messages")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatMessage implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "reply_to_id")
+    private Long replyToId;
+
+    @Column(name = "is_edited", nullable = false)
+    private boolean edited = false;
+
+    @Column(name = "edited_at")
+    private LocalDateTime editedAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatMessageRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatMessageRepository.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.chat;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Optional<ChatMessage> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /** The latest non-deleted message in a room, used as the room's {@code lastMessage}. */
+    Optional<ChatMessage> findFirstByRoom_IdAndDeletedFalseOrderByCreatedAtDesc(Long roomId);
+
+    /** A page of non-deleted messages in a room, ordered by the {@link Pageable}'s sort. */
+    Page<ChatMessage> findByRoom_IdAndDeletedFalse(Long roomId, Pageable pageable);
+
+    /**
+     * Unread count for a caller who has never read the room: every non-deleted message not
+     * authored by them.
+     */
+    @Query("""
+            SELECT COUNT(m) FROM ChatMessage m
+            WHERE m.room.id = :roomId
+              AND m.deleted = false
+              AND m.senderId <> :employeeId
+            """)
+    long countUnreadAll(@Param("roomId") Long roomId,
+                        @Param("employeeId") Long employeeId);
+
+    /**
+     * Unread count since a known last-read instant: non-deleted messages created after
+     * {@code lastReadAt} and not authored by the caller.
+     */
+    @Query("""
+            SELECT COUNT(m) FROM ChatMessage m
+            WHERE m.room.id = :roomId
+              AND m.deleted = false
+              AND m.senderId <> :employeeId
+              AND m.createdAt > :lastReadAt
+            """)
+    long countUnreadSince(@Param("roomId") Long roomId,
+                          @Param("employeeId") Long employeeId,
+                          @Param("lastReadAt") LocalDateTime lastReadAt);
+
+    /**
+     * Messages in the room the caller has not read, not authored by them and not deleted.
+     * Dispatches on {@code lastReadAt} rather than binding a nullable timestamp inside a
+     * {@code :x IS NULL} clause, which CockroachDB rejects because it cannot type the null
+     * placeholder.
+     */
+    default long countUnread(Long roomId, Long employeeId, LocalDateTime lastReadAt) {
+        return lastReadAt == null
+                ? countUnreadAll(roomId, employeeId)
+                : countUnreadSince(roomId, employeeId, lastReadAt);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatParticipant.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatParticipant.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.chat;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+
+/**
+ * Membership of an employee in a {@link ChatRoom}. {@code employeeId} is the employee's id
+ * (chat is employee-centric, not user-centric); {@code lastReadAt} marks how far the
+ * employee has read the room, and drives the unread count. The role is a plain string
+ * ({@code member}/{@code admin}) matching the web vocabulary.
+ */
+@Entity
+@Table(
+        name = "chat_participants",
+        uniqueConstraints = @UniqueConstraint(name = "uk_chat_participant_room_employee",
+                columnNames = {"room_id", "employee_id"})
+)
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatParticipant implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @Column(name = "employee_id", nullable = false)
+    private Long employeeId;
+
+    @Column(name = "role", nullable = false, length = 20)
+    private String role = "member";
+
+    @Column(name = "last_read_at")
+    private LocalDateTime lastReadAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatParticipantRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatParticipantRepository.java
@@ -1,0 +1,12 @@
+package org.tornotron.echno_backend.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+
+    Optional<ChatParticipant> findByRoom_IdAndEmployeeId(Long roomId, Long employeeId);
+
+    boolean existsByRoom_IdAndEmployeeId(Long roomId, Long employeeId);
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatRoom.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatRoom.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.chat;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A chat room: either a one-to-one {@code direct} conversation or a {@code group} room.
+ * The kind is stored as a plain string ({@code direct}/{@code group}) because the web
+ * client sends and reads its own lowercase vocabulary rather than a Java enum identifier.
+ *
+ * <p>The optional {@code projectId} links a group room to a project; it is kept as a plain
+ * nullable column rather than a JPA relationship, keeping the module self-contained.
+ * Participants are the employees who can see and post to the room.
+ */
+@Entity
+@Table(name = "chat_rooms")
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatRoom implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type", nullable = false, length = 20)
+    private String type;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "project_id")
+    private Long projectId;
+
+    @Column(name = "is_archived", nullable = false)
+    private boolean archived = false;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ChatParticipant> participants = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void addParticipant(ChatParticipant participant) {
+        participant.setRoom(this);
+        this.participants.add(participant);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatRoomRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatRoomRepository.java
@@ -1,0 +1,38 @@
+package org.tornotron.echno_backend.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    Optional<ChatRoom> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * All rooms the given employee participates in, newest activity first. The tenant
+     * orgFilter still applies to the root {@link ChatRoom}, so this never crosses tenants.
+     */
+    @Query("""
+            SELECT r FROM ChatRoom r
+            WHERE r.id IN (SELECT p.room.id FROM ChatParticipant p WHERE p.employeeId = :employeeId)
+            ORDER BY r.updatedAt DESC
+            """)
+    List<ChatRoom> findRoomsForEmployee(@Param("employeeId") Long employeeId);
+
+    /**
+     * The existing one-to-one direct room whose two participants are exactly {@code a} and
+     * {@code b}, if any. Guards on the participant count being two so a group room that
+     * happens to contain both is never returned.
+     */
+    @Query("""
+            SELECT r FROM ChatRoom r
+            WHERE r.type = 'direct'
+              AND (SELECT COUNT(p) FROM ChatParticipant p WHERE p.room = r) = 2
+              AND EXISTS (SELECT 1 FROM ChatParticipant pa WHERE pa.room = r AND pa.employeeId = :a)
+              AND EXISTS (SELECT 1 FROM ChatParticipant pb WHERE pb.room = r AND pb.employeeId = :b)
+            """)
+    List<ChatRoom> findDirectRoomBetween(@Param("a") Long a, @Param("b") Long b);
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
@@ -1,0 +1,230 @@
+package org.tornotron.echno_backend.chat;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
+import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
+import org.tornotron.echno_backend.chat.mapper.ChatMapper;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * The chat core flow: rooms an employee belongs to, direct-room open-or-create, marking a
+ * room read, and the send/edit message path. Everything is scoped to the current tenant and
+ * to the caller's participation; the caller is resolved to their {@link Employee} because
+ * chat is employee-centric (senders and participants are employee ids, not user ids).
+ *
+ * <p>Deferred and intentionally absent here: reactions, mentions, entity mentions,
+ * attachments, reply-preview resolution, message delete, archive toggle and any real-time
+ * transport. The web client polls.
+ */
+@Service
+public class ChatService {
+
+    private static final String ROOM_DIRECT = "direct";
+    private static final String ROLE_MEMBER = "member";
+
+    private final ChatRoomRepository roomRepository;
+    private final ChatParticipantRepository participantRepository;
+    private final ChatMessageRepository messageRepository;
+    private final ChatMapper chatMapper;
+    private final TenantEntityHelper tenantEntityHelper;
+    private final UserContextService userContextService;
+    private final EmployeeRepository employeeRepository;
+
+    public ChatService(ChatRoomRepository roomRepository,
+                       ChatParticipantRepository participantRepository,
+                       ChatMessageRepository messageRepository,
+                       ChatMapper chatMapper,
+                       TenantEntityHelper tenantEntityHelper,
+                       UserContextService userContextService,
+                       EmployeeRepository employeeRepository) {
+        this.roomRepository = roomRepository;
+        this.participantRepository = participantRepository;
+        this.messageRepository = messageRepository;
+        this.chatMapper = chatMapper;
+        this.tenantEntityHelper = tenantEntityHelper;
+        this.userContextService = userContextService;
+        this.employeeRepository = employeeRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomDto> getRoomsForCurrentEmployee() {
+        Long employeeId = resolveCurrentEmployeeId();
+        return roomRepository.findRoomsForEmployee(employeeId).stream()
+                .map(room -> toRoomDto(room, employeeId))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoomDto getRoom(Long roomId) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatRoom room = requireRoom(roomId);
+        requireParticipant(roomId, employeeId);
+        return toRoomDto(room, employeeId);
+    }
+
+    /**
+     * Opens the one-to-one direct room with {@code otherEmployeeId}, reusing the existing one
+     * when present. Idempotent: calling it twice returns the same room.
+     */
+    @Transactional
+    public ChatRoomDto openDirectRoom(Long otherEmployeeId) {
+        Long employeeId = resolveCurrentEmployeeId();
+        if (otherEmployeeId == null || otherEmployeeId.equals(employeeId)) {
+            throw new IllegalArgumentException("A direct room needs a different employee");
+        }
+
+        List<ChatRoom> existing = roomRepository.findDirectRoomBetween(employeeId, otherEmployeeId);
+        if (!existing.isEmpty()) {
+            return toRoomDto(existing.get(0), employeeId);
+        }
+
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
+        ChatRoom room = new ChatRoom();
+        room.setType(ROOM_DIRECT);
+        room.setOrganization(organization);
+        room.addParticipant(newParticipant(employeeId, organization));
+        room.addParticipant(newParticipant(otherEmployeeId, organization));
+
+        ChatRoom saved = roomRepository.saveAndFlush(room);
+        return toRoomDto(saved, employeeId);
+    }
+
+    /** Marks the room read for the caller by advancing their {@code lastReadAt} to now. */
+    @Transactional
+    public void markRead(Long roomId) {
+        Long employeeId = resolveCurrentEmployeeId();
+        requireRoom(roomId);
+        ChatParticipant participant = requireParticipant(roomId, employeeId);
+        participant.setLastReadAt(LocalDateTime.now());
+        participantRepository.save(participant);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChatMessageDto> getMessages(Long roomId, int pageNo, int pageSize) {
+        Long employeeId = resolveCurrentEmployeeId();
+        requireRoom(roomId);
+        requireParticipant(roomId, employeeId);
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return messageRepository.findByRoom_IdAndDeletedFalse(roomId, pageable)
+                .map(chatMapper::toDto);
+    }
+
+    @Transactional
+    public ChatMessageDto sendMessage(Long roomId, String content, Long replyToId) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatRoom room = requireRoom(roomId);
+        requireParticipant(roomId, employeeId);
+
+        ChatMessage message = new ChatMessage();
+        message.setRoom(room);
+        message.setOrganization(room.getOrganization());
+        message.setSenderId(employeeId);
+        message.setContent(content);
+        message.setReplyToId(replyToId);
+
+        // Bump the room so it sorts to the top of the caller's list and updatedAt reflects
+        // the new activity.
+        room.setUpdatedAt(LocalDateTime.now());
+        roomRepository.save(room);
+
+        // saveAndFlush before mapping so the generated id and @CreationTimestamp land on the DTO.
+        ChatMessage saved = messageRepository.saveAndFlush(message);
+        return chatMapper.toDto(saved);
+    }
+
+    /** Edits the caller's own message. Only the sender may edit; others get a 403. */
+    @Transactional
+    public ChatMessageDto editMessage(Long messageId, String content) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatMessage message = messageRepository
+                .findByIdAndOrganization_Id(messageId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Message with ID " + messageId + " was not found in this organization"));
+
+        if (!employeeId.equals(message.getSenderId())) {
+            throw new AccessDeniedException("Only the sender can edit this message");
+        }
+
+        message.setContent(content);
+        message.setEdited(true);
+        message.setEditedAt(LocalDateTime.now());
+
+        ChatMessage saved = messageRepository.saveAndFlush(message);
+        return chatMapper.toDto(saved);
+    }
+
+    // --- helpers -----------------------------------------------------------------
+
+    /**
+     * Builds a room DTO for the given viewer, filling in the fields the mapper cannot: the
+     * latest non-deleted message and the viewer's unread count.
+     */
+    private ChatRoomDto toRoomDto(ChatRoom room, Long viewerEmployeeId) {
+        ChatRoomDto dto = chatMapper.toDto(room);
+
+        messageRepository.findFirstByRoom_IdAndDeletedFalseOrderByCreatedAtDesc(room.getId())
+                .ifPresent(last -> dto.setLastMessage(chatMapper.toDto(last)));
+
+        LocalDateTime lastReadAt = participantRepository
+                .findByRoom_IdAndEmployeeId(room.getId(), viewerEmployeeId)
+                .map(ChatParticipant::getLastReadAt)
+                .orElse(null);
+        long unread = messageRepository.countUnread(room.getId(), viewerEmployeeId, lastReadAt);
+        dto.setUnreadCount((int) unread);
+
+        return dto;
+    }
+
+    private ChatParticipant newParticipant(Long employeeId, Organization organization) {
+        ChatParticipant participant = new ChatParticipant();
+        participant.setEmployeeId(employeeId);
+        participant.setRole(ROLE_MEMBER);
+        participant.setOrganization(organization);
+        return participant;
+    }
+
+    private ChatRoom requireRoom(Long roomId) {
+        return roomRepository
+                .findByIdAndOrganization_Id(roomId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Chat room with ID " + roomId + " was not found in this organization"));
+    }
+
+    private ChatParticipant requireParticipant(Long roomId, Long employeeId) {
+        return participantRepository.findByRoom_IdAndEmployeeId(roomId, employeeId)
+                .orElseThrow(() -> new AccessDeniedException(
+                        "You are not a participant of chat room " + roomId));
+    }
+
+    /**
+     * Resolves the authenticated caller to their {@link Employee} id in the current tenant,
+     * the same user-to-employee lookup the attendance and leave flows use. Chat is
+     * employee-centric, so a caller with no employee record cannot participate.
+     */
+    private Long resolveCurrentEmployeeId() {
+        Long userId = userContextService.getCurrentUserId();
+        if (userId == null) {
+            throw new AccessDeniedException("No authenticated user");
+        }
+        return employeeRepository
+                .findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
+                .map(Employee::getId)
+                .orElseThrow(() -> new AccessDeniedException(
+                        "No employee profile for the current user in this organization"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * A chat message on the wire. The rich fields {@code mentions}, {@code entityMentions},
+ * {@code reactions} and {@code attachments} are always emitted as empty arrays: they are
+ * deferred features, present only so the web parsers have the shape they expect.
+ */
+@Schema(description = "A chat message with its author, content and edit state.")
+@Data
+public class ChatMessageDto {
+
+    @Schema(description = "Message id.", example = "1201")
+    private Long id;
+
+    @Schema(description = "Id of the room the message belongs to.", example = "17")
+    private Long roomId;
+
+    @Schema(description = "Employee id of the message author.", example = "9")
+    private Long senderId;
+
+    @Schema(description = "Message body.", example = "Concrete pour on block C is done.")
+    private String content;
+
+    @Schema(description = "Id of the message this one replies to, if any.", example = "1198")
+    private Long replyToId;
+
+    @Schema(description = "Whether the message has been edited.", example = "false")
+    @JsonProperty("isEdited")
+    private boolean edited;
+
+    @Schema(description = "When the message was edited; null if never.", example = "2026-08-22T14:20:00")
+    private LocalDateTime editedAt;
+
+    @Schema(description = "Whether the message has been deleted.", example = "false")
+    @JsonProperty("isDeleted")
+    private boolean deleted;
+
+    @Schema(description = "Employee ids mentioned in the message. Deferred: always empty.")
+    private List<Long> mentions = List.of();
+
+    @Schema(description = "Entity mentions in the message. Deferred: always empty.")
+    private List<Object> entityMentions = List.of();
+
+    @Schema(description = "Emoji reactions on the message. Deferred: always empty.")
+    private List<Object> reactions = List.of();
+
+    @Schema(description = "File attachments on the message. Deferred: always empty.")
+    private List<Object> attachments = List.of();
+
+    @Schema(description = "When the message was created.", example = "2026-08-20T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "When the message was last updated.", example = "2026-08-22T14:20:00")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatParticipantDto.java
@@ -1,0 +1,23 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "An employee's membership in a chat room.")
+@Data
+public class ChatParticipantDto {
+
+    @Schema(description = "Id of the participating employee.", example = "9")
+    private Long employeeId;
+
+    @Schema(description = "Role of the participant in the room.", example = "member")
+    private String role;
+
+    @Schema(description = "When the employee joined the room.", example = "2026-08-20T09:00:00")
+    private LocalDateTime joinedAt;
+
+    @Schema(description = "How far the employee has read the room; null if never read.", example = "2026-08-22T14:20:00")
+    private LocalDateTime lastReadAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatRoomDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatRoomDto.java
@@ -1,0 +1,51 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * A chat room on the wire, carrying its participants, the latest non-deleted message as
+ * {@code lastMessage}, and the caller's {@code unreadCount}.
+ */
+@Schema(description = "A chat room with its participants, last message and unread count for the caller.")
+@Data
+public class ChatRoomDto {
+
+    @Schema(description = "Room id.", example = "17")
+    private Long id;
+
+    @Schema(description = "Kind of room.", example = "direct")
+    private String type;
+
+    @Schema(description = "Room name; null for a direct room (the client derives it).", example = "Block C site team")
+    private String name;
+
+    @Schema(description = "Room description.", example = "Coordination for the block C interior work")
+    private String description;
+
+    @Schema(description = "Id of the project this room belongs to, for group rooms.", example = "3")
+    private Long projectId;
+
+    @Schema(description = "Participants of the room.")
+    private List<ChatParticipantDto> participants = List.of();
+
+    @Schema(description = "The latest non-deleted message in the room; null when the room is empty.")
+    private ChatMessageDto lastMessage;
+
+    @Schema(description = "Number of messages the caller has not yet read.", example = "3")
+    private int unreadCount;
+
+    @Schema(description = "Whether the room is archived.", example = "false")
+    @JsonProperty("isArchived")
+    private boolean archived;
+
+    @Schema(description = "When the room was created.", example = "2026-08-20T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "When the room was last updated.", example = "2026-08-22T14:20:00")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/CreateDirectRoomDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/CreateDirectRoomDto.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Schema(description = "Payload to open (or reuse) a one-to-one direct room with another employee.")
+@Data
+public class CreateDirectRoomDto {
+
+    @Schema(description = "Employee id of the other party in the direct conversation.", example = "9")
+    @NotNull
+    private Long employeeId;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/EditMessageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/EditMessageDto.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Schema(description = "Payload to edit the body of an existing message.")
+@Data
+public class EditMessageDto {
+
+    @Schema(description = "New message body.", example = "Concrete pour on block C is done, cured overnight.")
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/SendMessageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/SendMessageDto.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Schema(description = "Payload to post a message to a room.")
+@Data
+public class SendMessageDto {
+
+    @Schema(description = "Message body.", example = "Concrete pour on block C is done.")
+    @NotBlank
+    private String content;
+
+    @Schema(description = "Id of the message this one replies to, if any.", example = "1198")
+    private Long replyToId;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/mapper/ChatMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/mapper/ChatMapper.java
@@ -1,0 +1,33 @@
+package org.tornotron.echno_backend.chat.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.chat.ChatMessage;
+import org.tornotron.echno_backend.chat.ChatParticipant;
+import org.tornotron.echno_backend.chat.ChatRoom;
+import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
+import org.tornotron.echno_backend.chat.dto.ChatParticipantDto;
+import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
+
+/**
+ * Maps the chat entities to their response DTOs. The room's {@code unreadCount} and
+ * {@code lastMessage} are computed in the service and set after mapping, so they are
+ * ignored here. The message's deferred rich fields (mentions, reactions, attachments and
+ * entity mentions) keep the DTO's empty-array defaults.
+ */
+@Mapper(componentModel = "spring")
+public interface ChatMapper {
+
+    @Mapping(target = "unreadCount", ignore = true)
+    @Mapping(target = "lastMessage", ignore = true)
+    ChatRoomDto toDto(ChatRoom room);
+
+    ChatParticipantDto toDto(ChatParticipant participant);
+
+    @Mapping(source = "room.id", target = "roomId")
+    @Mapping(target = "mentions", ignore = true)
+    @Mapping(target = "entityMentions", ignore = true)
+    @Mapping(target = "reactions", ignore = true)
+    @Mapping(target = "attachments", ignore = true)
+    ChatMessageDto toDto(ChatMessage message);
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -286,4 +286,7 @@
     <!-- v4.0 - Receipt module -->
     <include file="db/changelog/v4.0/050-create-receipts.xml"/>
 
+    <!-- v4.0 - Chat module (rooms, participants, messages) -->
+    <include file="db/changelog/v4.0/051-create-chat.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/051-create-chat.xml
+++ b/src/main/resources/db/changelog/v4.0/051-create-chat.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="051-create-chat" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="chat_rooms"/>
+            </not>
+        </preConditions>
+
+        <!-- chat_rooms -->
+        <createTable tableName="chat_rooms">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="description" type="TEXT"/>
+            <column name="project_id" type="BIGINT"/>
+            <column name="is_archived" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_rooms"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_chat_room_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="chat_rooms" indexName="idx_chat_room_organization">
+            <column name="organization_id"/>
+        </createIndex>
+
+        <!-- chat_participants -->
+        <createTable tableName="chat_participants">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="room_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="employee_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(20)" defaultValue="member">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_read_at" type="TIMESTAMP"/>
+            <column name="organization_id" type="BIGINT"/>
+            <column name="joined_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_participants"
+                                 baseColumnNames="room_id"
+                                 constraintName="fk_chat_participant_room"
+                                 referencedTableName="chat_rooms"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="chat_participants"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_chat_participant_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="chat_participants"
+                             columnNames="room_id, employee_id"
+                             constraintName="uk_chat_participant_room_employee"/>
+
+        <createIndex tableName="chat_participants" indexName="idx_chat_participant_room">
+            <column name="room_id"/>
+        </createIndex>
+        <createIndex tableName="chat_participants" indexName="idx_chat_participant_employee">
+            <column name="employee_id"/>
+        </createIndex>
+        <createIndex tableName="chat_participants" indexName="idx_chat_participant_organization">
+            <column name="organization_id"/>
+        </createIndex>
+
+        <!-- chat_messages -->
+        <createTable tableName="chat_messages">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="room_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sender_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="content" type="TEXT"/>
+            <column name="reply_to_id" type="BIGINT"/>
+            <column name="is_edited" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="edited_at" type="TIMESTAMP"/>
+            <column name="is_deleted" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_messages"
+                                 baseColumnNames="room_id"
+                                 constraintName="fk_chat_message_room"
+                                 referencedTableName="chat_rooms"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="chat_messages"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_chat_message_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="chat_messages" indexName="idx_chat_message_room">
+            <column name="room_id"/>
+        </createIndex>
+        <createIndex tableName="chat_messages" indexName="idx_chat_message_room_created">
+            <column name="room_id"/>
+            <column name="created_at"/>
+        </createIndex>
+        <createIndex tableName="chat_messages" indexName="idx_chat_message_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/chat/ChatRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/ChatRepositoryIT.java
@@ -1,0 +1,160 @@
+package org.tornotron.echno_backend.chat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the chat repositories against a real CockroachDB
+ * (see {@link AbstractIntegrationTest}). Covers tenant isolation on rooms, the
+ * participant-scoped room query, and the unread-count computation over sent messages.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ChatRepositoryIT extends AbstractIntegrationTest {
+
+    private static final Long ALICE = 100L;
+    private static final Long BOB = 200L;
+    private static final Long CAROL = 300L;
+
+    @Autowired
+    private ChatRoomRepository roomRepository;
+
+    @Autowired
+    private ChatMessageRepository messageRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByIdAndOrganization_doesNotReturnAcrossTenants() {
+        Organization orgA = persistOrganization("Chat Org A");
+        Organization orgB = persistOrganization("Chat Org B");
+        ChatRoom room = persistDirectRoom(orgA, ALICE, BOB);
+        em.flush();
+        em.clear();
+
+        Optional<ChatRoom> sameTenant = roomRepository.findByIdAndOrganization_Id(room.getId(), orgA.getId());
+        Optional<ChatRoom> otherTenant = roomRepository.findByIdAndOrganization_Id(room.getId(), orgB.getId());
+
+        assertThat(sameTenant).isPresent();
+        assertThat(otherTenant).isEmpty();
+    }
+
+    @Test
+    void findRoomsForEmployee_returnsOnlyRoomsTheEmployeeParticipatesIn() {
+        Organization org = persistOrganization("Chat Org C");
+        ChatRoom aliceBob = persistDirectRoom(org, ALICE, BOB);
+        ChatRoom bobCarol = persistDirectRoom(org, BOB, CAROL);
+        em.flush();
+        em.clear();
+
+        List<ChatRoom> aliceRooms = roomRepository.findRoomsForEmployee(ALICE);
+
+        assertThat(aliceRooms).extracting(ChatRoom::getId).contains(aliceBob.getId());
+        assertThat(aliceRooms).extracting(ChatRoom::getId).doesNotContain(bobCarol.getId());
+    }
+
+    @Test
+    void findDirectRoomBetween_findsTheExistingOneToOneRoom() {
+        Organization org = persistOrganization("Chat Org D");
+        ChatRoom aliceBob = persistDirectRoom(org, ALICE, BOB);
+        em.flush();
+        em.clear();
+
+        List<ChatRoom> between = roomRepository.findDirectRoomBetween(ALICE, BOB);
+
+        assertThat(between).extracting(ChatRoom::getId).containsExactly(aliceBob.getId());
+    }
+
+    @Test
+    void countUnread_excludesOwnMessagesAndRespectsLastReadAt() {
+        Organization org = persistOrganization("Chat Org E");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        persistMessage(org, room, BOB, "hi Alice");
+        persistMessage(org, room, BOB, "you there?");
+        persistMessage(org, room, ALICE, "yes, here");
+        em.flush();
+        em.clear();
+
+        // Alice has never read: every message from Bob counts, her own does not.
+        long neverRead = messageRepository.countUnread(room.getId(), ALICE, null);
+        assertThat(neverRead).isEqualTo(2);
+
+        // With a last-read marker in the distant past, the same two still count.
+        long readLongAgo = messageRepository.countUnread(room.getId(), ALICE, LocalDateTime.of(2000, 1, 1, 0, 0));
+        assertThat(readLongAgo).isEqualTo(2);
+
+        // With a last-read marker in the future, nothing is unread.
+        long readInFuture = messageRepository.countUnread(room.getId(), ALICE, LocalDateTime.of(2999, 1, 1, 0, 0));
+        assertThat(readInFuture).isZero();
+    }
+
+    @Test
+    void findFirstByRoom_returnsLatestNonDeletedMessage() {
+        Organization org = persistOrganization("Chat Org F");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        persistMessage(org, room, BOB, "first");
+        ChatMessage deleted = persistMessage(org, room, ALICE, "was deleted");
+        deleted.setDeleted(true);
+        em.persist(deleted);
+        em.flush();
+        em.clear();
+
+        Optional<ChatMessage> last =
+                messageRepository.findFirstByRoom_IdAndDeletedFalseOrderByCreatedAtDesc(room.getId());
+
+        assertThat(last).isPresent();
+        assertThat(last.get().isDeleted()).isFalse();
+    }
+
+    // --- helpers -----------------------------------------------------------------
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private ChatRoom persistDirectRoom(Organization org, Long employeeA, Long employeeB) {
+        ChatRoom room = new ChatRoom();
+        room.setType("direct");
+        room.setOrganization(org);
+        room.addParticipant(newParticipant(org, employeeA));
+        room.addParticipant(newParticipant(org, employeeB));
+        em.persist(room);
+        return room;
+    }
+
+    private ChatParticipant newParticipant(Organization org, Long employeeId) {
+        ChatParticipant participant = new ChatParticipant();
+        participant.setEmployeeId(employeeId);
+        participant.setRole("member");
+        participant.setOrganization(org);
+        return participant;
+    }
+
+    private ChatMessage persistMessage(Organization org, ChatRoom room, Long senderId, String content) {
+        ChatMessage message = new ChatMessage();
+        message.setRoom(room);
+        message.setOrganization(org);
+        message.setSenderId(senderId);
+        message.setContent(content);
+        em.persist(message);
+        return message;
+    }
+}


### PR DESCRIPTION
## Chat backend module (rooms + messages)

Backs the previously mock-only web chat feature with a real tenant-scoped `chat`
domain module, following the `expense` / `receipt` / `subcontract` conventions
(tenant-scoped `@Filter` entity + service + `/web` controller + MapStruct +
Liquibase + Testcontainers IT). This is the working core (MVP); the rich extras
are deferred (see below).

### Endpoints (`/api/v1/chat`, all `@orgSecurity.isMemberOfCurrentTenant()` plus in-service participant checks)

| Method | Path | Behaviour |
|--------|------|-----------|
| GET | `/chat/rooms/web` | Rooms the current employee participates in, each with participants, latest non-deleted message (`lastMessage`) and `unreadCount`, newest activity first. |
| GET | `/chat/rooms/web/{id}` | One room; 404 if not in tenant, 403 if the caller is not a participant. |
| POST | `/chat/rooms/web/direct` | Body `{employeeId}`. Finds the existing 1:1 direct room between the caller and that employee, else creates it (type `direct`, both participants). Idempotent. |
| POST | `/chat/rooms/web/{roomId}/read` | Sets the caller's `lastReadAt = now`. 204. |
| GET | `/chat/rooms/web/{roomId}/messages` | `Page<ChatMessageDto>`, non-deleted messages ordered `createdAt` DESC (page 0 = newest; `pageNo`/`pageSize`, default 0/30). |
| POST | `/chat/rooms/web/{roomId}/messages` | Body `{content, replyToId?}`. Creates a message from the caller, bumps room `updatedAt`, `saveAndFlush` before mapping. 201. |
| PATCH | `/chat/messages/web/{id}` | Body `{content}`. Edits the sender's own message only (403 otherwise); sets `isEdited=true`, `editedAt=now`. |

### Current-employee resolution

Reuses the existing attendance/leave pattern: `UserContextService.getCurrentUserId()`
for the app user id, then `EmployeeRepository.findByUserIdAndOrganizationId(userId, orgId)`
to get the tenant employee. Chat is employee-centric (senders and participants are
employee ids), so a caller with no employee profile in the tenant gets a 403.

### Data model / migration

Changeset **051-create-chat.xml** (next after receipts' 050), registered in the master
changelog. Three tables: `chat_rooms`, `chat_participants`, `chat_messages`, with FKs to
`organization` (and rooms), the unique `(room_id, employee_id)` on participants, and indexes
on `room_id` and `(room_id, created_at)` for messages.

DTOs serialize the camelCase fields the web parsers expect (`roomId`, `senderId`,
`unreadCount`, `isEdited`, `editedAt`, `lastMessage`, `isArchived`, `replyToId`). The message
DTO always emits `mentions`, `entityMentions`, `reactions`, `attachments` as empty arrays so
the web parsers are satisfied.

### Deferred (not built; web features stay no-ops)

- reactions
- mentions and entity mentions
- message attachments
- reply-preview resolution (only `replyToId` is stored)
- message delete (soft-delete flag exists on the row but is not exposed)
- archive toggle (`isArchived` is read-only for now)
- websocket / real-time transport (the web polls via TanStack Query)

### Validation (lab `.116`, CockroachDB v26.2.4 via Testcontainers)

- `./gradlew compileJava` -> BUILD SUCCESSFUL
- `./gradlew test --tests '*ChatRepositoryIT*'` -> BUILD SUCCESSFUL, 5 tests, 0 failed

`ChatRepositoryIT` covers tenant isolation on rooms, the participant-scoped room query,
the direct-room lookup, latest-message selection, and the unread-count computation
(own messages excluded; `lastReadAt` null / past / future).

Note: the unread-count query is split into a null-`lastReadAt` branch and a since branch
(dispatched in the repository) because CockroachDB cannot type a null timestamp placeholder
inside a `:x IS NULL` clause, the same class of issue documented on the receipt search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added employee chat functionality, including direct rooms, room listings, and participant details.
  * Added paginated message viewing, message sending, replies, editing, and read-status tracking.
  * Added unread message counts and latest-message previews.
  * Added tenant-isolated chat data storage and access controls.
* **Tests**
  * Added integration coverage for room access, tenant isolation, unread counts, and message retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->