### PR TITLE
Chat phase 2: reactions, mentions, soft-delete, archive, attachments

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -1,19 +1,25 @@
 package org.tornotron.echno_backend.chat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.chat.dto.ArchiveRoomRequestDto;
 import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
 import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
 import org.tornotron.echno_backend.chat.dto.CreateDirectRoomDto;
 import org.tornotron.echno_backend.chat.dto.EditMessageDto;
+import org.tornotron.echno_backend.chat.dto.ReactionRequestDto;
 import org.tornotron.echno_backend.chat.dto.SendMessageDto;
 
 import java.util.List;
@@ -35,9 +41,11 @@ import java.util.List;
 public class ChatControllerWeb {
 
     private final ChatService chatService;
+    private final ObjectMapper objectMapper;
 
-    public ChatControllerWeb(ChatService chatService) {
+    public ChatControllerWeb(ChatService chatService, ObjectMapper objectMapper) {
         this.chatService = chatService;
+        this.objectMapper = objectMapper;
     }
 
     @GetMapping("/rooms/web")
@@ -121,11 +129,13 @@ public class ChatControllerWeb {
         return new ResponseEntity<>(chatService.getMessages(roomId, pageNo, pageSize), HttpStatus.OK);
     }
 
-    @PostMapping("/rooms/web/{roomId}/messages")
+    @PostMapping(value = "/rooms/web/{roomId}/messages", consumes = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Send a message",
-            description = "Posts a message from the current employee to the room and bumps the room's activity."
+            summary = "Send a message (text only)",
+            description = "Posts a text message from the current employee to the room and bumps the room's "
+                    + "activity. Employee and entity mentions are parsed from the body. For a message that "
+                    + "carries file attachments, use the multipart variant of this endpoint."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Message created"),
@@ -137,6 +147,31 @@ public class ChatControllerWeb {
                                                       @Valid @RequestBody SendMessageDto dto) {
         return new ResponseEntity<>(
                 chatService.sendMessage(roomId, dto.getContent(), dto.getReplyToId()), HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/rooms/web/{roomId}/messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Send a message with attachments",
+            description = "Posts a message with one or more file attachments. The message fields travel as a "
+                    + "JSON 'data' part; the files travel as 'attachments' parts. Attachments are stored and "
+                    + "returned with presigned download URLs."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Message created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "content is blank or the data part is malformed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<ChatMessageDto> sendMessageWithAttachments(
+            @PathVariable Long roomId,
+            @RequestPart("data") @Valid String data,
+            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments)
+            throws JsonProcessingException {
+        SendMessageDto dto = objectMapper.readValue(data, SendMessageDto.class);
+        return new ResponseEntity<>(
+                chatService.sendMessage(roomId, dto.getContent(), dto.getReplyToId(), attachments),
+                HttpStatus.CREATED);
     }
 
     @PatchMapping("/messages/web/{id}")
@@ -154,5 +189,57 @@ public class ChatControllerWeb {
     public ResponseEntity<ChatMessageDto> editMessage(@PathVariable Long id,
                                                       @Valid @RequestBody EditMessageDto dto) {
         return new ResponseEntity<>(chatService.editMessage(id, dto.getContent()), HttpStatus.OK);
+    }
+
+    @PostMapping("/messages/web/{id}/reactions")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Toggle a reaction",
+            description = "Adds the caller's emoji reaction to the message, or removes it if they already "
+                    + "reacted with that emoji. Returns the message with its refreshed reaction list."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Reaction toggled"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "emoji is blank"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No message with the given id in this tenant")
+    })
+    public ResponseEntity<ChatMessageDto> toggleReaction(@PathVariable Long id,
+                                                         @Valid @RequestBody ReactionRequestDto dto) {
+        return new ResponseEntity<>(chatService.toggleReaction(id, dto.getEmoji()), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/messages/web/{id}")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Delete a message",
+            description = "Soft-deletes a message, keeping the row so the web can render a tombstone. Only the "
+                    + "sender or a room admin may delete it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Message deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the sender nor a room admin"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No message with the given id in this tenant")
+    })
+    public ResponseEntity<Void> deleteMessage(@PathVariable Long id) {
+        chatService.deleteMessage(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/rooms/web/{roomId}/archive")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @Operation(
+            summary = "Archive or unarchive a room",
+            description = "Sets the room's archived state for the whole conversation. Any participant may toggle it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Room archive state updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "archived is missing"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a participant of the room"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No room with the given id in this tenant")
+    })
+    public ResponseEntity<ChatRoomDto> archiveRoom(@PathVariable Long roomId,
+                                                   @Valid @RequestBody ArchiveRoomRequestDto dto) {
+        return new ResponseEntity<>(chatService.setArchived(roomId, dto.getArchived()), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatEntityMention.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatEntityMention.java
@@ -1,0 +1,52 @@
+package org.tornotron.echno_backend.chat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Objects;
+
+/**
+ * A reference to another domain entity woven into a message body as
+ * {@code #[label](type:id)}. Stored as an element collection on {@link ChatMessage}: the
+ * {@code entityType} is the web vocabulary ({@code task}/{@code issue}/{@code project}),
+ * {@code entityId} the referenced row's id, and {@code label} the display text cached at the
+ * time the mention was written so a later rename does not change what the message reads.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatEntityMention {
+
+    @Column(name = "entity_type", length = 30)
+    private String entityType;
+
+    @Column(name = "entity_id")
+    private Long entityId;
+
+    @Column(name = "label", length = 300)
+    private String label;
+
+    public ChatEntityMention(String entityType, Long entityId, String label) {
+        this.entityType = entityType;
+        this.entityId = entityId;
+        this.label = label;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ChatEntityMention that = (ChatEntityMention) o;
+        return Objects.equals(entityType, that.entityType)
+                && Objects.equals(entityId, that.entityId)
+                && Objects.equals(label, that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entityType, entityId, label);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatMentionParser.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatMentionParser.java
@@ -1,0 +1,71 @@
+package org.tornotron.echno_backend.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Pulls the rich references out of a message body. Two token shapes are recognised, matching
+ * the vocabulary the web composer writes:
+ *
+ * <ul>
+ *   <li>{@code @[Name](employeeId)} - an employee mention, yielding the employee id.</li>
+ *   <li>{@code #[label](type:id)} - an entity mention (task, issue or project), yielding the
+ *       type, id and the label cached as written.</li>
+ * </ul>
+ *
+ * Both lists are de-duplicated in order of first appearance so a body that names the same
+ * target twice stores it once.
+ */
+public final class ChatMentionParser {
+
+    /** {@code @[Name](employeeId)} - the captured group is the employee id. */
+    private static final Pattern MENTION_PATTERN = Pattern.compile("@\\[[^\\]]*]\\((\\d+)\\)");
+
+    /** {@code #[label](type:id)} - groups are label, type and id. */
+    private static final Pattern ENTITY_MENTION_PATTERN =
+            Pattern.compile("#\\[([^\\]]*)]\\((\\w+):(\\d+)\\)");
+
+    private ChatMentionParser() {
+    }
+
+    /** Employee ids from {@code @[Name](id)} tokens, de-duplicated in order of first appearance. */
+    public static List<Long> parseMentions(String content) {
+        List<Long> ids = new ArrayList<>();
+        if (content == null || content.isBlank()) {
+            return ids;
+        }
+        Matcher matcher = MENTION_PATTERN.matcher(content);
+        while (matcher.find()) {
+            Long id = Long.valueOf(matcher.group(1));
+            if (!ids.contains(id)) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Entity references from {@code #[label](type:id)} tokens, de-duplicated on (type, id) in
+     * order of first appearance. The label is kept exactly as written.
+     */
+    public static List<ChatEntityMention> parseEntityMentions(String content) {
+        List<ChatEntityMention> mentions = new ArrayList<>();
+        if (content == null || content.isBlank()) {
+            return mentions;
+        }
+        Matcher matcher = ENTITY_MENTION_PATTERN.matcher(content);
+        while (matcher.find()) {
+            String label = matcher.group(1);
+            String type = matcher.group(2);
+            Long id = Long.valueOf(matcher.group(3));
+            boolean seen = mentions.stream()
+                    .anyMatch(m -> m.getEntityType().equals(type) && m.getEntityId().equals(id));
+            if (!seen) {
+                mentions.add(new ChatEntityMention(type, id, label));
+            }
+        }
+        return mentions;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatMessage.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatMessage.java
@@ -11,12 +11,19 @@ import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.organization.Organization;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A message posted to a {@link ChatRoom}. {@code senderId} is the author's employee id.
- * {@code replyToId} is stored as a plain nullable id (the reply preview is resolved by the
- * client, not here). Editing sets {@code isEdited} and {@code editedAt}; the delete flag is
- * present for forward compatibility but soft-delete is not exposed yet.
+ * {@code replyToId} is stored as a plain nullable id; the reply preview is resolved in the
+ * service from the referenced message. Editing sets {@code isEdited} and {@code editedAt};
+ * soft-delete sets {@code isDeleted} and keeps the row so the client renders a tombstone.
+ *
+ * <p>Rich content is parsed from the body on send: employee mentions ({@code @[Name](id)})
+ * are kept as a list of employee ids, and entity mentions ({@code #[label](type:id)}) as an
+ * element collection. Emoji reactions and file attachments are separate rows referencing
+ * this message.
  */
 @Entity
 @Table(name = "chat_messages")
@@ -51,6 +58,15 @@ public class ChatMessage implements TenantScopedEntity {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "chat_message_mentions", joinColumns = @JoinColumn(name = "message_id"))
+    @Column(name = "employee_id", nullable = false)
+    private List<Long> mentions = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "chat_message_entity_mentions", joinColumns = @JoinColumn(name = "message_id"))
+    private List<ChatEntityMention> entityMentions = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id")

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatReaction.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatReaction.java
@@ -1,0 +1,53 @@
+package org.tornotron.echno_backend.chat;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+
+/**
+ * A single emoji reaction placed by one employee on one {@link ChatMessage}. A reaction is a
+ * row rather than a counter so the DTO can list which employees reacted; the unique
+ * constraint on {@code (message_id, employee_id, emoji)} keeps a toggle idempotent, one row
+ * per employee per emoji per message.
+ */
+@Entity
+@Table(
+        name = "chat_reactions",
+        uniqueConstraints = @UniqueConstraint(name = "uk_chat_reaction_message_employee_emoji",
+                columnNames = {"message_id", "employee_id", "emoji"})
+)
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatReaction implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private ChatMessage message;
+
+    @Column(name = "employee_id", nullable = false)
+    private Long employeeId;
+
+    @Column(name = "emoji", nullable = false, length = 32)
+    private String emoji;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatReactionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatReactionRepository.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatReactionRepository extends JpaRepository<ChatReaction, Long> {
+
+    /** The reaction row for a given message, employee and emoji, if one exists (drives toggle). */
+    Optional<ChatReaction> findByMessage_IdAndEmployeeIdAndEmoji(Long messageId, Long employeeId, String emoji);
+
+    /** All reactions on a message, used to build the grouped reaction list on the DTO. */
+    List<ChatReaction> findByMessage_Id(Long messageId);
+
+    /** All reactions across a set of messages, so a page of messages resolves in one query. */
+    List<ChatReaction> findByMessage_IdIn(List<Long> messageIds);
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
@@ -7,19 +7,27 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
+import org.tornotron.echno_backend.chat.dto.ChatMessageReplyDto;
+import org.tornotron.echno_backend.chat.dto.ChatReactionDto;
 import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
 import org.tornotron.echno_backend.chat.mapper.ChatMapper;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The chat core flow: rooms an employee belongs to, direct-room open-or-create, marking a
@@ -27,38 +35,53 @@ import java.util.List;
  * to the caller's participation; the caller is resolved to their {@link Employee} because
  * chat is employee-centric (senders and participants are employee ids, not user ids).
  *
- * <p>Deferred and intentionally absent here: reactions, mentions, entity mentions,
- * attachments, reply-preview resolution, message delete, archive toggle and any real-time
- * transport. The web client polls.
+ * <p>Rich content is handled here: emoji reaction toggles, employee and entity mentions
+ * parsed from the body on send, file attachments stored through {@link AttachmentService},
+ * reply-preview resolution, message soft-delete and the room archive toggle. Real-time
+ * transport is intentionally absent; the web client polls.
  */
 @Service
 public class ChatService {
 
     private static final String ROOM_DIRECT = "direct";
     private static final String ROLE_MEMBER = "member";
+    private static final String ROLE_ADMIN = "admin";
+
+    /** Polymorphic attachment owner type and S3 folder for chat message files. */
+    private static final String ATTACHMENT_ENTITY_TYPE = "CHAT_MESSAGE";
+    private static final String ATTACHMENT_FOLDER = "chat";
+
+    /** How much of a quoted message the reply preview carries. */
+    private static final int REPLY_SNIPPET_LENGTH = 200;
 
     private final ChatRoomRepository roomRepository;
     private final ChatParticipantRepository participantRepository;
     private final ChatMessageRepository messageRepository;
+    private final ChatReactionRepository reactionRepository;
     private final ChatMapper chatMapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final UserContextService userContextService;
     private final EmployeeRepository employeeRepository;
+    private final AttachmentService attachmentService;
 
     public ChatService(ChatRoomRepository roomRepository,
                        ChatParticipantRepository participantRepository,
                        ChatMessageRepository messageRepository,
+                       ChatReactionRepository reactionRepository,
                        ChatMapper chatMapper,
                        TenantEntityHelper tenantEntityHelper,
                        UserContextService userContextService,
-                       EmployeeRepository employeeRepository) {
+                       EmployeeRepository employeeRepository,
+                       AttachmentService attachmentService) {
         this.roomRepository = roomRepository;
         this.participantRepository = participantRepository;
         this.messageRepository = messageRepository;
+        this.reactionRepository = reactionRepository;
         this.chatMapper = chatMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.userContextService = userContextService;
         this.employeeRepository = employeeRepository;
+        this.attachmentService = attachmentService;
     }
 
     @Transactional(readOnly = true)
@@ -121,11 +144,26 @@ public class ChatService {
         requireParticipant(roomId, employeeId);
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
         return messageRepository.findByRoom_IdAndDeletedFalse(roomId, pageable)
-                .map(chatMapper::toDto);
+                .map(this::toMessageDto);
     }
 
+    /**
+     * Posts a text (optionally reply) message with no attachments. Kept as the JSON path the
+     * web uses today; the multipart overload below adds files.
+     */
     @Transactional
     public ChatMessageDto sendMessage(Long roomId, String content, Long replyToId) {
+        return sendMessage(roomId, content, replyToId, null);
+    }
+
+    /**
+     * Posts a message to the room from the current employee. The body is parsed for employee
+     * mentions ({@code @[Name](id)}) and entity mentions ({@code #[label](type:id)}), which
+     * are persisted on the message. Any {@code files} are stored through the shared
+     * attachment service and linked to the saved message.
+     */
+    @Transactional
+    public ChatMessageDto sendMessage(Long roomId, String content, Long replyToId, List<MultipartFile> files) {
         Long employeeId = resolveCurrentEmployeeId();
         ChatRoom room = requireRoom(roomId);
         requireParticipant(roomId, employeeId);
@@ -136,6 +174,8 @@ public class ChatService {
         message.setSenderId(employeeId);
         message.setContent(content);
         message.setReplyToId(replyToId);
+        message.setMentions(ChatMentionParser.parseMentions(content));
+        message.setEntityMentions(ChatMentionParser.parseEntityMentions(content));
 
         // Bump the room so it sorts to the top of the caller's list and updatedAt reflects
         // the new activity.
@@ -144,7 +184,70 @@ public class ChatService {
 
         // saveAndFlush before mapping so the generated id and @CreationTimestamp land on the DTO.
         ChatMessage saved = messageRepository.saveAndFlush(message);
-        return chatMapper.toDto(saved);
+
+        if (files != null && !files.isEmpty()) {
+            attachmentService.uploadAttachments(files, ATTACHMENT_ENTITY_TYPE, saved.getId(), ATTACHMENT_FOLDER);
+        }
+        return toMessageDto(saved);
+    }
+
+    /**
+     * Toggles the caller's emoji reaction on a message: adds the reaction if absent, removes
+     * it if already present. Returns the message with its refreshed reaction list.
+     */
+    @Transactional
+    public ChatMessageDto toggleReaction(Long messageId, String emoji) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatMessage message = requireMessage(messageId);
+        requireParticipant(message.getRoom().getId(), employeeId);
+
+        reactionRepository.findByMessage_IdAndEmployeeIdAndEmoji(messageId, employeeId, emoji)
+                .ifPresentOrElse(
+                        reactionRepository::delete,
+                        () -> {
+                            ChatReaction reaction = new ChatReaction();
+                            reaction.setMessage(message);
+                            reaction.setEmployeeId(employeeId);
+                            reaction.setEmoji(emoji);
+                            reaction.setOrganization(message.getOrganization());
+                            reactionRepository.save(reaction);
+                        });
+        reactionRepository.flush();
+        return toMessageDto(message);
+    }
+
+    /**
+     * Soft-deletes a message: only its sender or a room admin may delete it, and the row is
+     * kept with {@code isDeleted} set so the web renders a tombstone.
+     */
+    @Transactional
+    public void deleteMessage(Long messageId) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatMessage message = requireMessage(messageId);
+        ChatParticipant participant = requireParticipant(message.getRoom().getId(), employeeId);
+
+        boolean isSender = employeeId.equals(message.getSenderId());
+        boolean isRoomAdmin = ROLE_ADMIN.equalsIgnoreCase(participant.getRole());
+        if (!isSender && !isRoomAdmin) {
+            throw new AccessDeniedException("Only the sender or a room admin can delete this message");
+        }
+
+        message.setDeleted(true);
+        messageRepository.save(message);
+    }
+
+    /**
+     * Archives or unarchives a room for the whole conversation. Any participant may toggle it.
+     */
+    @Transactional
+    public ChatRoomDto setArchived(Long roomId, boolean archived) {
+        Long employeeId = resolveCurrentEmployeeId();
+        ChatRoom room = requireRoom(roomId);
+        requireParticipant(roomId, employeeId);
+
+        room.setArchived(archived);
+        ChatRoom saved = roomRepository.saveAndFlush(room);
+        return toRoomDto(saved, employeeId);
     }
 
     /** Edits the caller's own message. Only the sender may edit; others get a 403. */
@@ -163,9 +266,11 @@ public class ChatService {
         message.setContent(content);
         message.setEdited(true);
         message.setEditedAt(LocalDateTime.now());
+        message.setMentions(ChatMentionParser.parseMentions(content));
+        message.setEntityMentions(ChatMentionParser.parseEntityMentions(content));
 
         ChatMessage saved = messageRepository.saveAndFlush(message);
-        return chatMapper.toDto(saved);
+        return toMessageDto(saved);
     }
 
     // --- helpers -----------------------------------------------------------------
@@ -178,7 +283,7 @@ public class ChatService {
         ChatRoomDto dto = chatMapper.toDto(room);
 
         messageRepository.findFirstByRoom_IdAndDeletedFalseOrderByCreatedAtDesc(room.getId())
-                .ifPresent(last -> dto.setLastMessage(chatMapper.toDto(last)));
+                .ifPresent(last -> dto.setLastMessage(toMessageDto(last)));
 
         LocalDateTime lastReadAt = participantRepository
                 .findByRoom_IdAndEmployeeId(room.getId(), viewerEmployeeId)
@@ -188,6 +293,77 @@ public class ChatService {
         dto.setUnreadCount((int) unread);
 
         return dto;
+    }
+
+    /**
+     * Maps a message to its DTO and fills the fields the mapper cannot: the grouped emoji
+     * reactions, the stored attachments (each freshly presigned), and the reply preview
+     * resolved from {@code replyToId}.
+     */
+    private ChatMessageDto toMessageDto(ChatMessage message) {
+        ChatMessageDto dto = chatMapper.toDto(message);
+        dto.setReactions(groupReactions(message.getId()));
+
+        List<AttachmentDto> attachments =
+                attachmentService.getAttachments(ATTACHMENT_ENTITY_TYPE, message.getId());
+        dto.setAttachments(attachments);
+
+        if (message.getReplyToId() != null) {
+            dto.setReplyTo(buildReplyPreview(message.getReplyToId()));
+        }
+        return dto;
+    }
+
+    /**
+     * Collapses a message's reaction rows into one entry per emoji, each carrying the count
+     * and the employee ids who reacted. Insertion order of first appearance is preserved.
+     */
+    private List<ChatReactionDto> groupReactions(Long messageId) {
+        Map<String, ChatReactionDto> byEmoji = new LinkedHashMap<>();
+        for (ChatReaction reaction : reactionRepository.findByMessage_Id(messageId)) {
+            ChatReactionDto group = byEmoji.computeIfAbsent(reaction.getEmoji(), emoji -> {
+                ChatReactionDto d = new ChatReactionDto();
+                d.setEmoji(emoji);
+                d.setEmployeeIds(new ArrayList<>());
+                return d;
+            });
+            group.getEmployeeIds().add(reaction.getEmployeeId());
+            group.setCount(group.getEmployeeIds().size());
+        }
+        return new ArrayList<>(byEmoji.values());
+    }
+
+    /**
+     * Resolves the compact preview of a replied-to message. A reply to a message that is gone
+     * or belongs to another tenant simply yields no preview.
+     */
+    private ChatMessageReplyDto buildReplyPreview(Long replyToId) {
+        return messageRepository
+                .findByIdAndOrganization_Id(replyToId, TenantContext.getCurrentOrgId())
+                .map(replied -> {
+                    ChatMessageReplyDto preview = new ChatMessageReplyDto();
+                    preview.setId(replied.getId());
+                    preview.setSenderId(replied.getSenderId());
+                    preview.setContent(snippet(replied.getContent()));
+                    return preview;
+                })
+                .orElse(null);
+    }
+
+    private String snippet(String content) {
+        if (content == null) {
+            return null;
+        }
+        return content.length() <= REPLY_SNIPPET_LENGTH
+                ? content
+                : content.substring(0, REPLY_SNIPPET_LENGTH);
+    }
+
+    private ChatMessage requireMessage(Long messageId) {
+        return messageRepository
+                .findByIdAndOrganization_Id(messageId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Message with ID " + messageId + " was not found in this organization"));
     }
 
     private ChatParticipant newParticipant(Long employeeId, Organization organization) {

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ArchiveRoomRequestDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ArchiveRoomRequestDto.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Payload to archive or unarchive a room for the whole conversation.
+ */
+@Schema(description = "Payload to set a room's archived state.")
+@Data
+public class ArchiveRoomRequestDto {
+
+    @Schema(description = "Whether the room should be archived.", example = "true")
+    @NotNull
+    private Boolean archived;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatEntityMentionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatEntityMentionDto.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * An entity reference woven into a message ({@code #[label](type:id)}), on the wire in the
+ * shape the web {@code ChatEntityMention} type parses.
+ */
+@Schema(description = "A reference to a task, issue or project mentioned in a message.")
+@Data
+public class ChatEntityMentionDto {
+
+    @Schema(description = "Kind of entity referenced.", example = "task")
+    private String entityType;
+
+    @Schema(description = "Id of the referenced entity.", example = "42")
+    private Long entityId;
+
+    @Schema(description = "Display label cached when the mention was written.", example = "Pour slab C")
+    private String label;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
@@ -3,16 +3,18 @@ package org.tornotron.echno_backend.chat.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * A chat message on the wire. The rich fields {@code mentions}, {@code entityMentions},
- * {@code reactions} and {@code attachments} are always emitted as empty arrays: they are
- * deferred features, present only so the web parsers have the shape they expect.
+ * A chat message on the wire, with its author, content, edit and delete state, and the rich
+ * fields the web renders: employee {@code mentions}, {@code entityMentions}, grouped emoji
+ * {@code reactions}, file {@code attachments}, and the {@code replyTo} preview resolved from
+ * {@code replyToId}.
  */
-@Schema(description = "A chat message with its author, content and edit state.")
+@Schema(description = "A chat message with its author, content, edit state and rich content.")
 @Data
 public class ChatMessageDto {
 
@@ -31,6 +33,9 @@ public class ChatMessageDto {
     @Schema(description = "Id of the message this one replies to, if any.", example = "1198")
     private Long replyToId;
 
+    @Schema(description = "Preview of the replied-to message; null when this is not a reply.")
+    private ChatMessageReplyDto replyTo;
+
     @Schema(description = "Whether the message has been edited.", example = "false")
     @JsonProperty("isEdited")
     private boolean edited;
@@ -42,17 +47,17 @@ public class ChatMessageDto {
     @JsonProperty("isDeleted")
     private boolean deleted;
 
-    @Schema(description = "Employee ids mentioned in the message. Deferred: always empty.")
+    @Schema(description = "Employee ids mentioned in the message body.")
     private List<Long> mentions = List.of();
 
-    @Schema(description = "Entity mentions in the message. Deferred: always empty.")
-    private List<Object> entityMentions = List.of();
+    @Schema(description = "Task, issue or project references in the message body.")
+    private List<ChatEntityMentionDto> entityMentions = List.of();
 
-    @Schema(description = "Emoji reactions on the message. Deferred: always empty.")
-    private List<Object> reactions = List.of();
+    @Schema(description = "Emoji reactions on the message, grouped by emoji.")
+    private List<ChatReactionDto> reactions = List.of();
 
-    @Schema(description = "File attachments on the message. Deferred: always empty.")
-    private List<Object> attachments = List.of();
+    @Schema(description = "File attachments on the message, each with a presigned download URL.")
+    private List<AttachmentDto> attachments = List.of();
 
     @Schema(description = "When the message was created.", example = "2026-08-20T09:00:00")
     private LocalDateTime createdAt;

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageReplyDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageReplyDto.java
@@ -1,0 +1,23 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * A compact preview of the message a reply points at, resolved from {@code replyToId} so the
+ * web can render the quoted line without a second fetch. The author is carried only as
+ * {@code senderId}; the client resolves the employee. The content is trimmed to a snippet.
+ */
+@Schema(description = "Preview of the message a reply quotes.")
+@Data
+public class ChatMessageReplyDto {
+
+    @Schema(description = "Id of the quoted message.", example = "1198")
+    private Long id;
+
+    @Schema(description = "Employee id of the quoted message's author.", example = "9")
+    private Long senderId;
+
+    @Schema(description = "A trimmed snippet of the quoted message body.", example = "Concrete pour on block C is done.")
+    private String content;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatReactionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatReactionDto.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Emoji reactions on a message, grouped by emoji: one entry per distinct emoji carrying the
+ * total {@code count} and the {@code employeeIds} of everyone who reacted with it. This is
+ * the shape the web {@code ChatReaction} type parses.
+ */
+@Schema(description = "Reactions of one emoji on a message, with who reacted.")
+@Data
+public class ChatReactionDto {
+
+    @Schema(description = "The emoji reacted with.", example = "👍")
+    private String emoji;
+
+    @Schema(description = "How many employees reacted with this emoji.", example = "2")
+    private int count;
+
+    @Schema(description = "Employee ids of everyone who reacted with this emoji.")
+    private List<Long> employeeIds = List.of();
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ReactionRequestDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ReactionRequestDto.java
@@ -1,0 +1,18 @@
+package org.tornotron.echno_backend.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Payload to toggle an emoji reaction on a message: the reaction is added if the caller has
+ * not reacted with this emoji, or removed if they already have.
+ */
+@Schema(description = "Payload to toggle an emoji reaction on a message.")
+@Data
+public class ReactionRequestDto {
+
+    @Schema(description = "The emoji to toggle.", example = "👍")
+    @NotBlank
+    private String emoji;
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/mapper/ChatMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/mapper/ChatMapper.java
@@ -2,9 +2,11 @@ package org.tornotron.echno_backend.chat.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.chat.ChatEntityMention;
 import org.tornotron.echno_backend.chat.ChatMessage;
 import org.tornotron.echno_backend.chat.ChatParticipant;
 import org.tornotron.echno_backend.chat.ChatRoom;
+import org.tornotron.echno_backend.chat.dto.ChatEntityMentionDto;
 import org.tornotron.echno_backend.chat.dto.ChatMessageDto;
 import org.tornotron.echno_backend.chat.dto.ChatParticipantDto;
 import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
@@ -12,8 +14,9 @@ import org.tornotron.echno_backend.chat.dto.ChatRoomDto;
 /**
  * Maps the chat entities to their response DTOs. The room's {@code unreadCount} and
  * {@code lastMessage} are computed in the service and set after mapping, so they are
- * ignored here. The message's deferred rich fields (mentions, reactions, attachments and
- * entity mentions) keep the DTO's empty-array defaults.
+ * ignored here. The message's {@code mentions} and {@code entityMentions} map straight from
+ * the entity; its {@code reactions}, {@code attachments} and {@code replyTo} preview are
+ * resolved and set in the service, so they are ignored here.
  */
 @Mapper(componentModel = "spring")
 public interface ChatMapper {
@@ -25,9 +28,10 @@ public interface ChatMapper {
     ChatParticipantDto toDto(ChatParticipant participant);
 
     @Mapping(source = "room.id", target = "roomId")
-    @Mapping(target = "mentions", ignore = true)
-    @Mapping(target = "entityMentions", ignore = true)
+    @Mapping(target = "replyTo", ignore = true)
     @Mapping(target = "reactions", ignore = true)
     @Mapping(target = "attachments", ignore = true)
     ChatMessageDto toDto(ChatMessage message);
+
+    ChatEntityMentionDto toDto(ChatEntityMention mention);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -289,4 +289,7 @@
     <!-- v4.0 - Chat module (rooms, participants, messages) -->
     <include file="db/changelog/v4.0/051-create-chat.xml"/>
 
+    <!-- v4.0 - Chat phase 2 (reactions, employee mentions, entity mentions) -->
+    <include file="db/changelog/v4.0/052-create-chat-reactions-mentions.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/052-create-chat-reactions-mentions.xml
+++ b/src/main/resources/db/changelog/v4.0/052-create-chat-reactions-mentions.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="052-create-chat-reactions-mentions" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="chat_reactions"/>
+            </not>
+        </preConditions>
+
+        <!-- chat_reactions -->
+        <createTable tableName="chat_reactions">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="message_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="employee_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="emoji" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_reactions"
+                                 baseColumnNames="message_id"
+                                 constraintName="fk_chat_reaction_message"
+                                 referencedTableName="chat_messages"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint baseTableName="chat_reactions"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_chat_reaction_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="chat_reactions"
+                             columnNames="message_id, employee_id, emoji"
+                             constraintName="uk_chat_reaction_message_employee_emoji"/>
+
+        <createIndex tableName="chat_reactions" indexName="idx_chat_reaction_message">
+            <column name="message_id"/>
+        </createIndex>
+        <createIndex tableName="chat_reactions" indexName="idx_chat_reaction_organization">
+            <column name="organization_id"/>
+        </createIndex>
+
+        <!-- chat_message_mentions (element collection: employee ids mentioned in a message) -->
+        <createTable tableName="chat_message_mentions">
+            <column name="message_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="employee_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_message_mentions"
+                                 baseColumnNames="message_id"
+                                 constraintName="fk_chat_message_mention_message"
+                                 referencedTableName="chat_messages"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="chat_message_mentions" indexName="idx_chat_message_mention_message">
+            <column name="message_id"/>
+        </createIndex>
+
+        <!-- chat_message_entity_mentions (element collection: task/issue/project references) -->
+        <createTable tableName="chat_message_entity_mentions">
+            <column name="message_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_type" type="VARCHAR(30)"/>
+            <column name="entity_id" type="BIGINT"/>
+            <column name="label" type="VARCHAR(300)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chat_message_entity_mentions"
+                                 baseColumnNames="message_id"
+                                 constraintName="fk_chat_message_entity_mention_message"
+                                 referencedTableName="chat_messages"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="chat_message_entity_mentions" indexName="idx_chat_message_entity_mention_message">
+            <column name="message_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/chat/ChatMentionParserTest.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/ChatMentionParserTest.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.chat;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ChatMentionParser}: the regex extraction of employee and entity
+ * mentions from a message body, independent of the database.
+ */
+class ChatMentionParserTest {
+
+    @Test
+    void parseMentions_extractsEmployeeIdsInOrderWithoutDuplicates() {
+        String body = "Ping @[Asha](12) and @[Ravi](7), and @[Asha](12) again";
+
+        List<Long> ids = ChatMentionParser.parseMentions(body);
+
+        assertThat(ids).containsExactly(12L, 7L);
+    }
+
+    @Test
+    void parseMentions_returnsEmptyWhenNoTokensOrNull() {
+        assertThat(ChatMentionParser.parseMentions("plain text, no mentions")).isEmpty();
+        assertThat(ChatMentionParser.parseMentions(null)).isEmpty();
+        assertThat(ChatMentionParser.parseMentions("  ")).isEmpty();
+    }
+
+    @Test
+    void parseEntityMentions_extractsTypeIdAndLabel() {
+        String body = "See #[Pour slab C](task:42) blocking #[Crack in beam](issue:9)";
+
+        List<ChatEntityMention> mentions = ChatMentionParser.parseEntityMentions(body);
+
+        assertThat(mentions).hasSize(2);
+        assertThat(mentions.get(0).getEntityType()).isEqualTo("task");
+        assertThat(mentions.get(0).getEntityId()).isEqualTo(42L);
+        assertThat(mentions.get(0).getLabel()).isEqualTo("Pour slab C");
+        assertThat(mentions.get(1).getEntityType()).isEqualTo("issue");
+        assertThat(mentions.get(1).getEntityId()).isEqualTo(9L);
+    }
+
+    @Test
+    void parseEntityMentions_deduplicatesOnTypeAndId() {
+        String body = "#[Project Alpha](project:3) ... #[Alpha again](project:3)";
+
+        List<ChatEntityMention> mentions = ChatMentionParser.parseEntityMentions(body);
+
+        assertThat(mentions).hasSize(1);
+        assertThat(mentions.get(0).getEntityType()).isEqualTo("project");
+        assertThat(mentions.get(0).getEntityId()).isEqualTo(3L);
+    }
+
+    @Test
+    void parsers_keepEmployeeAndEntityMentionsSeparate() {
+        String body = "@[Asha](12) look at #[Pour slab C](task:42)";
+
+        assertThat(ChatMentionParser.parseMentions(body)).containsExactly(12L);
+        assertThat(ChatMentionParser.parseEntityMentions(body))
+                .singleElement()
+                .satisfies(m -> {
+                    assertThat(m.getEntityType()).isEqualTo("task");
+                    assertThat(m.getEntityId()).isEqualTo(42L);
+                });
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/chat/ChatRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/ChatRepositoryIT.java
@@ -34,6 +34,9 @@ class ChatRepositoryIT extends AbstractIntegrationTest {
     private ChatMessageRepository messageRepository;
 
     @Autowired
+    private ChatReactionRepository reactionRepository;
+
+    @Autowired
     private TestEntityManager em;
 
     @Test
@@ -116,6 +119,97 @@ class ChatRepositoryIT extends AbstractIntegrationTest {
 
         assertThat(last).isPresent();
         assertThat(last.get().isDeleted()).isFalse();
+    }
+
+    @Test
+    void reactionToggle_addsThenRemovesTheRow() {
+        Organization org = persistOrganization("Chat Org G");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        ChatMessage message = persistMessage(org, room, BOB, "nice work");
+        em.flush();
+        em.clear();
+
+        // Absent to start: the toggle would add.
+        assertThat(reactionRepository.findByMessage_IdAndEmployeeIdAndEmoji(message.getId(), ALICE, "👍"))
+                .isEmpty();
+
+        ChatReaction reaction = new ChatReaction();
+        reaction.setMessage(em.find(ChatMessage.class, message.getId()));
+        reaction.setEmployeeId(ALICE);
+        reaction.setEmoji("👍");
+        reaction.setOrganization(org);
+        reactionRepository.saveAndFlush(reaction);
+        em.clear();
+
+        // Present now: the toggle would remove, and the message groups one reaction.
+        assertThat(reactionRepository.findByMessage_IdAndEmployeeIdAndEmoji(message.getId(), ALICE, "👍"))
+                .isPresent();
+        assertThat(reactionRepository.findByMessage_Id(message.getId())).hasSize(1);
+
+        reactionRepository.deleteById(
+                reactionRepository.findByMessage_IdAndEmployeeIdAndEmoji(message.getId(), ALICE, "👍")
+                        .orElseThrow().getId());
+        reactionRepository.flush();
+        em.clear();
+
+        assertThat(reactionRepository.findByMessage_Id(message.getId())).isEmpty();
+    }
+
+    @Test
+    void softDelete_keepsRowButHidesFromNonDeletedQueries() {
+        Organization org = persistOrganization("Chat Org H");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        ChatMessage message = persistMessage(org, room, BOB, "to be deleted");
+        em.flush();
+        em.clear();
+
+        ChatMessage loaded = messageRepository.findById(message.getId()).orElseThrow();
+        loaded.setDeleted(true);
+        messageRepository.saveAndFlush(loaded);
+        em.clear();
+
+        // The row survives, but the non-deleted queries no longer see it.
+        assertThat(messageRepository.findById(message.getId())).isPresent();
+        assertThat(messageRepository.findFirstByRoom_IdAndDeletedFalseOrderByCreatedAtDesc(room.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    void archive_flagRoundTripsThroughTheDatabase() {
+        Organization org = persistOrganization("Chat Org I");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        em.flush();
+        em.clear();
+
+        ChatRoom loaded = roomRepository.findByIdAndOrganization_Id(room.getId(), org.getId()).orElseThrow();
+        assertThat(loaded.isArchived()).isFalse();
+        loaded.setArchived(true);
+        roomRepository.saveAndFlush(loaded);
+        em.clear();
+
+        ChatRoom reloaded = roomRepository.findByIdAndOrganization_Id(room.getId(), org.getId()).orElseThrow();
+        assertThat(reloaded.isArchived()).isTrue();
+    }
+
+    @Test
+    void mentions_persistedOnAMessageRoundTripThroughTheDatabase() {
+        Organization org = persistOrganization("Chat Org J");
+        ChatRoom room = persistDirectRoom(org, ALICE, BOB);
+        ChatMessage message = persistMessage(org, room, ALICE,
+                "@[Bob](200) see #[Pour slab C](task:42)");
+        message.setMentions(ChatMentionParser.parseMentions(message.getContent()));
+        message.setEntityMentions(ChatMentionParser.parseEntityMentions(message.getContent()));
+        em.persist(message);
+        em.flush();
+        em.clear();
+
+        ChatMessage reloaded = messageRepository.findById(message.getId()).orElseThrow();
+        assertThat(reloaded.getMentions()).containsExactly(200L);
+        assertThat(reloaded.getEntityMentions()).singleElement().satisfies(m -> {
+            assertThat(m.getEntityType()).isEqualTo("task");
+            assertThat(m.getEntityId()).isEqualTo(42L);
+            assertThat(m.getLabel()).isEqualTo("Pour slab C");
+        });
     }
 
     // --- helpers -----------------------------------------------------------------


### PR DESCRIPTION
## Chat phase 2

Extends the chat module from PR #440 with the phase-2 features that were deferred, so the web chat UI can render its rich content. Real-time / websocket push (the `ChatSocketEvent` type) stays deferred as a separate infrastructure effort; the web keeps polling via TanStack Query.

### Features
- **Reactions.** New `ChatReaction` entity, one row per (message, employee, emoji) with a unique constraint. `POST /chat/messages/web/{id}/reactions` with `{emoji}` toggles the caller's reaction (adds when absent, removes when present) and returns the message with its refreshed reaction list. The message DTO carries reactions grouped by emoji as `{emoji, count, employeeIds}`, matching the web `ChatReaction` type.
- **Message soft-delete.** `DELETE /chat/messages/web/{id}` sets `isDeleted` and keeps the row so the web renders a tombstone. Only the sender or a room admin may delete; returns 204.
- **Room archive.** `POST /chat/rooms/web/{roomId}/archive` with `{archived}` sets the room's archived state for the whole conversation (any participant) and returns the room DTO.
- **Reply preview.** When a message has `replyToId`, the DTO includes `replyTo = {id, senderId, content}` (content trimmed to a snippet), resolved from the referenced message so the web quotes it without a second fetch.
- **Mentions.** On send and edit the body is parsed for employee mentions `@[Name](id)` into `mentions` (employee ids) and entity mentions `#[label](type:id)` into `entityMentions` (`{entityType, entityId, label}`). Both are persisted as element collections and emitted in the DTO. Notification delivery is out of scope; the arrays are stored and returned so the web badges work.
- **Attachments on send.** The send endpoint gains a multipart variant that accepts optional files, stored through the shared `AttachmentService` under entity type `CHAT_MESSAGE` and returned in the DTO as `attachments` with presigned download URLs, reusing the same pattern as issue attachments. The JSON text-only path is unchanged, so a message with no files still works exactly as before.

### Storage notes
- Mentions and entity mentions are JPA element collections (`chat_message_mentions`, `chat_message_entity_mentions`), the simplest shape that round-trips the exact arrays the web expects.
- Attachments reuse the existing polymorphic `Attachment` entity via the `(entityType, entityId)` pair; no new attachment table or schema change.
- Migration changeset 052 (`052-create-chat-reactions-mentions.xml`) adds `chat_reactions` and the two mention collection tables, registered in the master changelog.

### Endpoints added
- `POST /chat/messages/web/{id}/reactions` toggle reaction
- `DELETE /chat/messages/web/{id}` soft-delete
- `POST /chat/rooms/web/{roomId}/archive` archive toggle
- `POST /chat/rooms/web/{roomId}/messages` (multipart variant) send with attachments; the JSON variant is retained

### Tests
Extended `ChatRepositoryIT` (reaction toggle, soft-delete, archive round-trip, mention persistence round-trip) and added `ChatMentionParserTest` for the mention extraction. `./gradlew compileJava test --tests '*Chat*'` is green: 14 tests pass, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send chat messages with optional file attachments.
  * Add emoji reactions, reply previews, and employee or entity mentions.
  * Soft-delete messages and archive or unarchive chat rooms.
  * View grouped reactions, attachment links, and enriched message content.

* **Bug Fixes**
  * Deleted messages are excluded from standard chat results.
  * Mentions and reactions are reliably preserved and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->