### PR TITLE
Give the Keycloak initializer a realm-scoped admin, master only for bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:cockroachdb'
+    testImplementation 'com.github.dasniko:testcontainers-keycloak:3.7.0'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
@@ -4,6 +4,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,15 +14,57 @@ public class KeycloakConfig {
     @Autowired
     KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties;
 
+    // Client id of the realm-scoped initializer service-account client that steady-state reconcile
+    // authenticates as. Defaults to 'echno-initializer'.
+    @Value("${keycloak.initializer.service-client-id:echno-initializer}")
+    private String initializerServiceClientId;
+
+    // Secret of the initializer service-account client. Empty until the environment has been
+    // bootstrapped and the secret provisioned; the master fallback provisions it on first run.
+    @Value("${keycloak.initializer.service-client-secret:}")
+    private String initializerServiceClientSecret;
+
+    /**
+     * Bootstrap-only admin client. Authenticates against the MASTER realm with the admin-cli
+     * password grant (the privileged master credential, H-3). It is used ONLY to bring a fresh or
+     * not-yet-migrated environment up to the point where the realm-scoped initializer client
+     * exists: creating the application realm and provisioning the echno-initializer client. No
+     * steady-state deploy authenticates with this bean.
+     */
     @Bean
-    protected Keycloak keycloak() {
+    protected Keycloak masterKeycloak() {
         return KeycloakBuilder.builder()
-//                .grantType(OAuth2Constants.)
                 .realm(keycloakInitializerConfigurationProperties.getMasterRealm())
                 .clientId(keycloakInitializerConfigurationProperties.getClientId())
                 .username(keycloakInitializerConfigurationProperties.getUsername())
                 .password(keycloakInitializerConfigurationProperties.getPassword())
                 .serverUrl(keycloakInitializerConfigurationProperties.getUrl())
                 .build();
+    }
+
+    /**
+     * Builds a realm-scoped admin client that authenticates as the echno-initializer service
+     * account with the client-credentials grant. It holds the realm-admin composite on the
+     * application realm's realm-management client, i.e. full administrative authority over that one
+     * realm and no access to master (so it cannot create or delete realms). Built on demand rather
+     * than as a singleton bean: it can obtain a token only once the realm and the initializer
+     * client already exist, which is not guaranteed at context-startup time.
+     */
+    public Keycloak buildScopedKeycloak() {
+        return KeycloakBuilder.builder()
+                .serverUrl(keycloakInitializerConfigurationProperties.getUrl())
+                .realm(keycloakInitializerConfigurationProperties.getApplicationRealm())
+                .clientId(initializerServiceClientId)
+                .clientSecret(initializerServiceClientSecret)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build();
+    }
+
+    public String getInitializerServiceClientId() {
+        return initializerServiceClientId;
+    }
+
+    public String getInitializerServiceClientSecret() {
+        return initializerServiceClientSecret;
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -47,7 +47,17 @@ import java.util.Set;
 @DependsOn("keycloakConfigGenerator")
 public class KeycloakInitializer {
 
-    private final Keycloak keycloak;
+    // Bootstrap-only master client (admin-cli password grant on the master realm). Used solely to
+    // create the application realm and provision the echno-initializer client on a fresh or
+    // not-yet-migrated environment. Never used for steady-state reconcile.
+    private final Keycloak masterKeycloak;
+
+    // The admin client every reconcile/content operation runs through. It is set to the realm-scoped
+    // echno-initializer client for the whole reconcile; the master client is only reached, if at all,
+    // to bootstrap that scoped client into existence.
+    private Keycloak admin;
+
+    private final KeycloakConfig keycloakConfig;
 
     private final KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties;
 
@@ -61,12 +71,14 @@ public class KeycloakInitializer {
     @Value("${keycloak.client-id}")
     private String appClientId;
 
-    public KeycloakInitializer(Keycloak keycloak,
+    public KeycloakInitializer(Keycloak masterKeycloak,
                                KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties,
-                               ObjectMapper objectMapper) {
-        this.keycloak = keycloak;
+                               ObjectMapper objectMapper,
+                               KeycloakConfig keycloakConfig) {
+        this.masterKeycloak = masterKeycloak;
         this.keycloakInitializerConfigurationProperties = keycloakInitializerConfigurationProperties;
         this.mapper = objectMapper;
+        this.keycloakConfig = keycloakConfig;
     }
 
 
@@ -81,42 +93,237 @@ public class KeycloakInitializer {
         }
     }
 
+    /**
+     * Reconciles Keycloak on startup, authenticating with the least-privileged credential that can
+     * do the job (H-3). The scoped realm-admin path is tried first: if the echno-initializer service
+     * account can already obtain a token against the application realm, the whole reconcile runs
+     * through it and the privileged master credential is never touched this startup. The master
+     * client is used only to bootstrap a fresh (or not-yet-migrated) environment up to the point
+     * where that scoped client exists: create the realm and provision echno-initializer with the
+     * realm-admin role, then hand off to the scoped client for all remaining work.
+     */
     public void init(boolean overwrite) {
 
         log.info("Initializer start");
 
-        boolean isAlreadyInitialized;
+        Keycloak scoped = keycloakConfig.buildScopedKeycloak();
         try {
-            keycloak.realm(REALM_ID).toRepresentation();
-            isAlreadyInitialized = true;
-        } catch (NotFoundException e) {
-            isAlreadyInitialized = false;
+            if (!overwrite && probeRealm(scoped)) {
+                log.info("Scoped initializer client authenticated against realm '{}'; reconciling with the "
+                        + "realm-scoped admin only (master credential untouched)", REALM_ID);
+                this.admin = scoped;
+                reconcileExistingRealm();
+                log.info("Keycloak reconcile complete (scoped realm-admin)");
+                return;
+            }
+        } finally {
+            if (this.admin != scoped) {
+                closeQuietly(scoped);
+            }
         }
 
-        if(isAlreadyInitialized && overwrite) {
+        // Fresh env, not-yet-migrated realm, or an explicit overwrite: fall back to the master
+        // credential to bring the scoped client into existence, then reconcile through the scoped one.
+        bootstrapWithMaster(overwrite);
+    }
+
+    /**
+     * Bootstrap/overwrite path. Uses the master credential ONLY to create the realm (if absent) and
+     * to provision the echno-initializer client with realm-admin; every subsequent operation runs
+     * through the freshly built scoped client.
+     */
+    private void bootstrapWithMaster(boolean overwrite) {
+        boolean realmExists = probeRealm(masterKeycloak);
+
+        if (realmExists && overwrite) {
             reset();
+            realmExists = false;
         }
 
-        if (!isAlreadyInitialized || overwrite) {
+        if (!realmExists) {
+            initKeycloakRealm();
+        }
 
-            initKeycloak();
+        // Ensure the realm-scoped admin client exists (create it + set its secret + grant realm-admin
+        // if absent). This is the one step that genuinely needs the master credential on a fresh or
+        // pre-migration environment, because the scoped client cannot yet authenticate to create itself.
+        ensureInitializerClient();
 
-            log.info("Keycloak initialized successfully");
-        } else {
+        Keycloak scoped = keycloakConfig.buildScopedKeycloak();
+        this.admin = scoped;
+        try {
+            if (!realmExists) {
+                initKeycloakContents();
+                log.info("Keycloak initialized successfully (fresh bootstrap; scoped realm-admin provisioned)");
+            } else {
+                log.warn("Realm '{}' already existed but the scoped initializer client was not usable; "
+                        + "provisioned it via master and reconciled through it", REALM_ID);
+                reconcileExistingRealm();
+                log.info("Keycloak reconcile complete (scoped realm-admin, provisioned this startup)");
+            }
+        } finally {
+            closeQuietly(scoped);
+        }
+    }
 
-            log.warn("Keycloak initialization cancelled: realm already exists");
-            // Sync client configuration from JSON even if realm exists
-            syncClientConfiguration();
-            // Sync realm-level security settings from JSON even if realm exists
-            syncRealmSecuritySettings();
-            // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
-            ensureAdminMfa();
-            // Ensure service account roles are assigned even if realm exists
-            assignServiceAccountRoles();
-            // Ensure authorization setup (JS policy, resource, permission) exists
-            ensureAuthorizationSetup();
-            // Ensure the H-1 composite job roles exist and carry their granular children
-            ensureCompositeJobRoles();
+    /** The existing-realm reconcile suite, run through {@link #admin}. */
+    private void reconcileExistingRealm() {
+        // Sync client configuration from JSON even if realm exists
+        syncClientConfiguration();
+        // Sync realm-level security settings from JSON even if realm exists
+        syncRealmSecuritySettings();
+        // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
+        ensureAdminMfa();
+        // Ensure service account roles are assigned even if realm exists
+        assignServiceAccountRoles();
+        // Ensure authorization setup (JS policy, resource, permission) exists
+        ensureAuthorizationSetup();
+        // Ensure the H-1 composite job roles exist and carry their granular children
+        ensureCompositeJobRoles();
+    }
+
+    /**
+     * Probes whether the given admin client can read the application realm. A success proves both
+     * that the realm exists and that the client authenticated. Any failure (realm absent, client
+     * absent, or token request rejected) returns false so the caller falls back to bootstrap.
+     */
+    private boolean probeRealm(Keycloak client) {
+        try {
+            client.realm(REALM_ID).toRepresentation();
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        } catch (Exception e) {
+            log.debug("Realm probe against '{}' did not succeed: {}", REALM_ID, e.getMessage());
+            return false;
+        }
+    }
+
+    private void closeQuietly(Keycloak client) {
+        if (client == null) {
+            return;
+        }
+        try {
+            client.close();
+        } catch (Exception e) {
+            log.debug("Failed to close a Keycloak admin client: {}", e.getMessage());
+        }
+    }
+
+    // Composite role on the realm-management client that grants full admin over a single realm.
+    private static final String REALM_ADMIN_ROLE = "realm-admin";
+    private static final String REALM_MANAGEMENT_CLIENT = "realm-management";
+
+    /**
+     * Ensures the realm-scoped initializer client (echno-initializer) exists in the application
+     * realm as a confidential client with a service account holding the realm-admin composite. This
+     * is the migration step that lets every future deploy authenticate as the scoped realm-admin
+     * instead of the master credential. Runs through the master client (the only credential able to
+     * create it on a fresh or pre-migration environment) and is idempotent.
+     */
+    private void ensureInitializerClient() {
+        String clientId = keycloakConfig.getInitializerServiceClientId();
+        String secret = keycloakConfig.getInitializerServiceClientSecret();
+        try {
+            RealmResource realm = masterKeycloak.realm(REALM_ID);
+
+            List<org.keycloak.representations.idm.ClientRepresentation> existing =
+                    realm.clients().findByClientId(clientId);
+
+            String clientUuid;
+            if (existing.isEmpty()) {
+                org.keycloak.representations.idm.ClientRepresentation rep =
+                        new org.keycloak.representations.idm.ClientRepresentation();
+                rep.setClientId(clientId);
+                rep.setEnabled(true);
+                rep.setPublicClient(false);
+                rep.setServiceAccountsEnabled(true);
+                rep.setStandardFlowEnabled(false);
+                rep.setDirectAccessGrantsEnabled(false);
+                rep.setDescription("Realm-scoped admin client used by the startup initializer (H-3). "
+                        + "Holds realm-admin on this realm only; steady-state deploys authenticate as this "
+                        + "service account instead of the master credential.");
+                if (secret != null && !secret.isBlank()) {
+                    rep.setSecret(secret);
+                }
+                try (Response response = realm.clients().create(rep)) {
+                    if (response.getStatus() != 201) {
+                        String body = response.hasEntity() ? response.readEntity(String.class) : "(no body)";
+                        log.error("Failed to create initializer client '{}'. Status: {}, Body: {}",
+                                clientId, response.getStatus(), body);
+                        return;
+                    }
+                    clientUuid = CreatedResponseUtil.getCreatedId(response);
+                }
+                log.info("Created realm-scoped initializer client '{}' (id={})", clientId, clientUuid);
+            } else {
+                org.keycloak.representations.idm.ClientRepresentation rep = existing.get(0);
+                clientUuid = rep.getId();
+                boolean changed = false;
+                if (!Boolean.TRUE.equals(rep.isServiceAccountsEnabled())) {
+                    rep.setServiceAccountsEnabled(true);
+                    changed = true;
+                }
+                if (Boolean.TRUE.equals(rep.isPublicClient())) {
+                    rep.setPublicClient(false);
+                    changed = true;
+                }
+                if (secret != null && !secret.isBlank()) {
+                    // Realign the stored secret with the configured one so the scoped client can log in.
+                    rep.setSecret(secret);
+                    changed = true;
+                }
+                if (changed) {
+                    realm.clients().get(clientUuid).update(rep);
+                    log.info("Reconciled existing initializer client '{}' (id={})", clientId, clientUuid);
+                } else {
+                    log.info("Initializer client '{}' already present (id={})", clientId, clientUuid);
+                }
+            }
+
+            grantRealmAdmin(realm, clientUuid, clientId);
+
+        } catch (Exception e) {
+            log.error("Failed to ensure initializer client '{}': {}", clientId, e.getMessage(), e);
+        }
+    }
+
+    /** Grants the realm-admin composite (from realm-management) to the client's service account, if missing. */
+    private void grantRealmAdmin(RealmResource realm, String clientUuid, String clientId) {
+        try {
+            UserRepresentation serviceAccount = realm.clients().get(clientUuid).getServiceAccountUser();
+            if (serviceAccount == null) {
+                log.error("Initializer client '{}' has no service account user; cannot grant {}",
+                        clientId, REALM_ADMIN_ROLE);
+                return;
+            }
+
+            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmt =
+                    realm.clients().findByClientId(REALM_MANAGEMENT_CLIENT);
+            if (realmMgmt.isEmpty()) {
+                log.error("'{}' client not found; cannot grant {} to '{}'",
+                        REALM_MANAGEMENT_CLIENT, REALM_ADMIN_ROLE, clientId);
+                return;
+            }
+            String realmMgmtUuid = realmMgmt.get(0).getId();
+
+            RoleRepresentation realmAdmin = realm.clients().get(realmMgmtUuid)
+                    .roles().get(REALM_ADMIN_ROLE).toRepresentation();
+
+            RoleMappingResource saRoles = realm.users().get(serviceAccount.getId()).roles();
+            boolean alreadyAssigned = saRoles.clientLevel(realmMgmtUuid).listAll().stream()
+                    .anyMatch(r -> REALM_ADMIN_ROLE.equals(r.getName()));
+
+            if (alreadyAssigned) {
+                log.info("Initializer service account for '{}' already holds {}", clientId, REALM_ADMIN_ROLE);
+                return;
+            }
+
+            saRoles.clientLevel(realmMgmtUuid).add(List.of(realmAdmin));
+            log.info("Granted {} to the initializer service account for '{}'", REALM_ADMIN_ROLE, clientId);
+        } catch (Exception e) {
+            log.error("Failed to grant {} to initializer client '{}': {}",
+                    REALM_ADMIN_ROLE, clientId, e.getMessage(), e);
         }
     }
 
@@ -149,14 +356,14 @@ public class KeycloakInitializer {
     private void syncSingleClient(org.keycloak.representations.idm.ClientRepresentation clientFromConfig) {
         String clientId = clientFromConfig.getClientId();
         try {
-            List<org.keycloak.representations.idm.ClientRepresentation> existingClients = keycloak.realm(REALM_ID).clients().findByClientId(clientId);
+            List<org.keycloak.representations.idm.ClientRepresentation> existingClients = admin.realm(REALM_ID).clients().findByClientId(clientId);
             if (existingClients.isEmpty()) {
                 log.warn("Client '{}' from config not found in Keycloak. Skipping sync.", clientId);
                 return;
             }
 
             org.keycloak.representations.idm.ClientRepresentation existingClient = existingClients.get(0);
-            org.keycloak.admin.client.resource.ClientResource clientResource = keycloak.realm(REALM_ID).clients().get(existingClient.getId());
+            org.keycloak.admin.client.resource.ClientResource clientResource = admin.realm(REALM_ID).clients().get(existingClient.getId());
 
             // Update fields from config on the existing client.
             // We preserve the ID and Secret from the existing client so a rotated secret survives.
@@ -182,7 +389,7 @@ public class KeycloakInitializer {
             }
 
             RealmRepresentation configRealm = mapper.readValue(configFile.toFile(), RealmRepresentation.class);
-            RealmRepresentation liveRealm = keycloak.realm(REALM_ID).toRepresentation();
+            RealmRepresentation liveRealm = admin.realm(REALM_ID).toRepresentation();
 
             // Copy ONLY the explicit security fields that are set in the config onto the live
             // representation. Clients, roles, groups and users are deliberately left untouched so
@@ -211,7 +418,7 @@ public class KeycloakInitializer {
                 return;
             }
 
-            keycloak.realm(REALM_ID).update(liveRealm);
+            admin.realm(REALM_ID).update(liveRealm);
             log.info("Realm-level security settings synced successfully: {}", applied);
 
         } catch (Exception e) {
@@ -257,10 +464,10 @@ public class KeycloakInitializer {
     // (rebind first: a bound flow cannot be deleted). Each step guarded.
     private void useBuiltinBrowserFlow() {
         try {
-            RealmRepresentation realm = keycloak.realm(REALM_ID).toRepresentation();
+            RealmRepresentation realm = admin.realm(REALM_ID).toRepresentation();
             if (!BUILTIN_BROWSER_FLOW.equals(realm.getBrowserFlow())) {
                 realm.setBrowserFlow(BUILTIN_BROWSER_FLOW);
-                keycloak.realm(REALM_ID).update(realm);
+                admin.realm(REALM_ID).update(realm);
                 log.info("Rebound realm browserFlow to the built-in '{}' flow", BUILTIN_BROWSER_FLOW);
             } else {
                 log.info("Realm browserFlow already on the built-in '{}' flow", BUILTIN_BROWSER_FLOW);
@@ -270,7 +477,7 @@ public class KeycloakInitializer {
         }
 
         try {
-            AuthenticationManagementResource flows = keycloak.realm(REALM_ID).flows();
+            AuthenticationManagementResource flows = admin.realm(REALM_ID).flows();
             AuthenticationFlowRepresentation custom = flows.getFlows().stream()
                     .filter(f -> CUSTOM_MFA_FLOW_ALIAS.equals(f.getAlias()))
                     .findFirst()
@@ -289,7 +496,7 @@ public class KeycloakInitializer {
     private void enableConfigureTotpRequiredAction() {
         try {
             RequiredActionProviderRepresentation action =
-                    keycloak.realm(REALM_ID).flows().getRequiredAction(CONFIGURE_TOTP);
+                    admin.realm(REALM_ID).flows().getRequiredAction(CONFIGURE_TOTP);
             if (action == null) {
                 log.warn("{} required action not found; skipping enable", CONFIGURE_TOTP);
                 return;
@@ -304,7 +511,7 @@ public class KeycloakInitializer {
                 changed = true;
             }
             if (changed) {
-                keycloak.realm(REALM_ID).flows().updateRequiredAction(CONFIGURE_TOTP, action);
+                admin.realm(REALM_ID).flows().updateRequiredAction(CONFIGURE_TOTP, action);
                 log.info("Enabled {} required action (defaultAction=false)", CONFIGURE_TOTP);
             } else {
                 log.info("{} required action already enabled", CONFIGURE_TOTP);
@@ -321,7 +528,7 @@ public class KeycloakInitializer {
     private void forceTotpEnrolmentForAdmins() {
         try {
             List<GroupRepresentation> adminGroups = new ArrayList<>();
-            collectSystemAdminGroups(keycloak.realm(REALM_ID).groups().groups(), adminGroups);
+            collectSystemAdminGroups(admin.realm(REALM_ID).groups().groups(), adminGroups);
             if (adminGroups.isEmpty()) {
                 log.info("No '/system-admin' groups found yet; no admins to enrol this reconcile");
                 return;
@@ -329,7 +536,7 @@ public class KeycloakInitializer {
 
             Set<String> processed = new HashSet<>();
             for (GroupRepresentation group : adminGroups) {
-                List<UserRepresentation> members = keycloak.realm(REALM_ID).groups().group(group.getId()).members();
+                List<UserRepresentation> members = admin.realm(REALM_ID).groups().group(group.getId()).members();
                 if (members == null) {
                     continue;
                 }
@@ -347,7 +554,7 @@ public class KeycloakInitializer {
 
     private void forceTotpForAdmin(String userId, String username) {
         try {
-            UserResource userResource = keycloak.realm(REALM_ID).users().get(userId);
+            UserResource userResource = admin.realm(REALM_ID).users().get(userId);
 
             boolean hasOtp = userResource.credentials().stream()
                     .map(CredentialRepresentation::getType)
@@ -383,7 +590,7 @@ public class KeycloakInitializer {
     private void cleanupLegacyRequireMfaRole() {
         RoleRepresentation mfaRole;
         try {
-            mfaRole = keycloak.realm(REALM_ID).roles().get(MFA_ROLE).toRepresentation();
+            mfaRole = admin.realm(REALM_ID).roles().get(MFA_ROLE).toRepresentation();
         } catch (NotFoundException e) {
             return; // already gone
         } catch (Exception e) {
@@ -393,10 +600,10 @@ public class KeycloakInitializer {
 
         try {
             List<GroupRepresentation> adminGroups = new ArrayList<>();
-            collectSystemAdminGroups(keycloak.realm(REALM_ID).groups().groups(), adminGroups);
+            collectSystemAdminGroups(admin.realm(REALM_ID).groups().groups(), adminGroups);
             for (GroupRepresentation group : adminGroups) {
                 try {
-                    RoleMappingResource groupRoles = keycloak.realm(REALM_ID).groups().group(group.getId()).roles();
+                    RoleMappingResource groupRoles = admin.realm(REALM_ID).groups().group(group.getId()).roles();
                     boolean mapped = groupRoles.realmLevel().listAll().stream()
                             .anyMatch(r -> MFA_ROLE.equals(r.getName()));
                     if (mapped) {
@@ -412,7 +619,7 @@ public class KeycloakInitializer {
         }
 
         try {
-            keycloak.realm(REALM_ID).roles().deleteRole(MFA_ROLE);
+            admin.realm(REALM_ID).roles().deleteRole(MFA_ROLE);
             log.info("Deleted unused legacy realm role '{}'", MFA_ROLE);
         } catch (Exception e) {
             log.error("Failed to delete legacy realm role '{}': {}", MFA_ROLE, e.getMessage());
@@ -429,20 +636,22 @@ public class KeycloakInitializer {
                 out.add(group);
             }
             List<GroupRepresentation> subGroups =
-                    keycloak.realm(REALM_ID).groups().group(group.getId()).getSubGroups(0, 1000, false);
+                    admin.realm(REALM_ID).groups().group(group.getId()).getSubGroups(0, 1000, false);
             collectSystemAdminGroups(subGroups, out);
         }
     }
 
-    private void initKeycloak() {
-
-        initKeycloakRealm();
+    /**
+     * The fresh-realm content pipeline, run through {@link #admin} (the scoped realm-admin). Realm
+     * creation itself is handled separately in {@link #bootstrapWithMaster} because it is the one
+     * step that needs the master credential.
+     */
+    private void initKeycloakContents() {
         initKeycloakUsers();
         assignServiceAccountRoles();
         ensureAuthorizationSetup();
         ensureAdminMfa();
         ensureCompositeJobRoles();
-
     }
 
     /**
@@ -528,7 +737,7 @@ public class KeycloakInitializer {
 
     private void ensureCompositeJobRole(CompositeJobRole jobRole) {
         try {
-            RealmResource realm = keycloak.realm(REALM_ID);
+            RealmResource realm = admin.realm(REALM_ID);
 
             // 1. Ensure the composite role itself exists (create if missing, never overwrite).
             boolean exists;
@@ -589,13 +798,13 @@ public class KeycloakInitializer {
             log.info("Assigning service account roles for client '{}'", appClientId);
 
             // 1. Find the client UUID (not clientId) for the application client
-            List<org.keycloak.representations.idm.ClientRepresentation> clients = keycloak.realm(REALM_ID).clients().findByClientId(appClientId);
+            List<org.keycloak.representations.idm.ClientRepresentation> clients = admin.realm(REALM_ID).clients().findByClientId(appClientId);
             if (clients.isEmpty()) {
                 log.error("Client '{}' not found in realm '{}'", appClientId, REALM_ID);
                 return;
             }
             org.keycloak.representations.idm.ClientRepresentation appClientRep = clients.get(0);
-            org.keycloak.admin.client.resource.ClientResource appClientResource = keycloak.realm(REALM_ID).clients().get(appClientRep.getId());
+            org.keycloak.admin.client.resource.ClientResource appClientResource = admin.realm(REALM_ID).clients().get(appClientRep.getId());
 
             // 2. Enable Service Accounts if not enabled
             if (!Boolean.TRUE.equals(appClientRep.isServiceAccountsEnabled())) {
@@ -610,10 +819,10 @@ public class KeycloakInitializer {
                 log.error("Service account user not found for client '{}'", appClientId);
                 return;
             }
-            UserResource serviceAccountUserResource = keycloak.realm(REALM_ID).users().get(serviceAccountUser.getId());
+            UserResource serviceAccountUserResource = admin.realm(REALM_ID).users().get(serviceAccountUser.getId());
 
             // 4. Find the 'realm-management' client UUID
-            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmtClients = keycloak.realm(REALM_ID).clients().findByClientId("realm-management");
+            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmtClients = admin.realm(REALM_ID).clients().findByClientId("realm-management");
             if (realmMgmtClients.isEmpty()) {
                 log.error("'realm-management' client not found!");
                 return;
@@ -626,7 +835,7 @@ public class KeycloakInitializer {
 
             for (String roleName : requiredRoles) {
                 try {
-                    RoleRepresentation role = keycloak.realm(REALM_ID).clients().get(realmMgmtClientRep.getId()).roles().get(roleName).toRepresentation();
+                    RoleRepresentation role = admin.realm(REALM_ID).clients().get(realmMgmtClientRep.getId()).roles().get(roleName).toRepresentation();
                     rolesToAdd.add(role);
                 } catch (Exception e) {
                     log.warn("Role '{}' not found in realm-management", roleName);
@@ -660,7 +869,7 @@ public class KeycloakInitializer {
             realmRepresentationToImport.setRealm(REALM_ID);
             realmRepresentationToImport.setId(REALM_ID);
 
-            keycloak.realms().create(realmRepresentationToImport);
+            masterKeycloak.realms().create(realmRepresentationToImport);
         } catch (IOException e) {
             String errorMessage = String.format("Failed to import keycloak realm representation : %s", e.getMessage());
             log.error(errorMessage);
@@ -706,14 +915,14 @@ public class KeycloakInitializer {
         userCredentialRepresentation.setValue(user.getPassword());
         userRepresentation.setCredentials(List.of(userCredentialRepresentation));
 
-        try (Response response = keycloak.realm(REALM_ID).users().create(userRepresentation)) {
+        try (Response response = admin.realm(REALM_ID).users().create(userRepresentation)) {
             String userId = null;
             if (response.getStatus() == 201) { // CREATED
                 userId = CreatedResponseUtil.getCreatedId(response);
                 log.info("User '{}' created with id {}", user.getUserName(), userId);
             } else if (response.getStatus() == 409) { // CONFLICT
                 log.warn("User '{}' already exists. Fetching to assign roles if needed.", user.getUserName());
-                List<UserRepresentation> users = keycloak.realm(REALM_ID).users().search(user.getUserName());
+                List<UserRepresentation> users = admin.realm(REALM_ID).users().search(user.getUserName());
                 if (!users.isEmpty()) {
                     userId = users.get(0).getId();
                 } else {
@@ -726,10 +935,10 @@ public class KeycloakInitializer {
             }
 
             if (userId != null) {
-                UserResource userResource = keycloak.realm(REALM_ID).users().get(userId);
+                UserResource userResource = admin.realm(REALM_ID).users().get(userId);
                 String roleName = user.isAdmin() ? "admin" : "user";
                 List<RoleRepresentation> rolesToAdd =
-                        Collections.singletonList(keycloak.realm(REALM_ID).roles().get(roleName).toRepresentation());
+                        Collections.singletonList(admin.realm(REALM_ID).roles().get(roleName).toRepresentation());
                 userResource.roles().realmLevel().add(rolesToAdd);
                 log.info("Role '{}' assigned to user '{}'", roleName, user.getUserName());
             }
@@ -741,13 +950,13 @@ public class KeycloakInitializer {
             log.info("Ensuring authorization setup for client '{}'", appClientId);
 
             List<org.keycloak.representations.idm.ClientRepresentation> clients =
-                    keycloak.realm(REALM_ID).clients().findByClientId(appClientId);
+                    admin.realm(REALM_ID).clients().findByClientId(appClientId);
             if (clients.isEmpty()) {
                 log.warn("Client '{}' not found, skipping authorization setup", appClientId);
                 return;
             }
 
-            ClientResource clientResource = keycloak.realm(REALM_ID).clients().get(clients.get(0).getId());
+            ClientResource clientResource = admin.realm(REALM_ID).clients().get(clients.get(0).getId());
 
             String policyId = ensureDefaultRolePolicy(clientResource);
             String resourceId = ensureDefaultResource(clientResource);
@@ -780,13 +989,13 @@ public class KeycloakInitializer {
 
         // required=false = OR logic — user needs at least one of these roles
         try {
-            RoleRepresentation userRole = keycloak.realm(REALM_ID).roles().get("user").toRepresentation();
+            RoleRepresentation userRole = admin.realm(REALM_ID).roles().get("user").toRepresentation();
             policy.addRole(userRole.getId(), false);
         } catch (Exception e) {
             log.warn("Realm role 'user' not found, skipping from Default Policy");
         }
         try {
-            RoleRepresentation adminRole = keycloak.realm(REALM_ID).roles().get("admin").toRepresentation();
+            RoleRepresentation adminRole = admin.realm(REALM_ID).roles().get("admin").toRepresentation();
             policy.addRole(adminRole.getId(), false);
         } catch (Exception e) {
             log.warn("Realm role 'admin' not found, skipping from Default Policy");
@@ -915,16 +1124,16 @@ public class KeycloakInitializer {
     private void ensureUsersHaveBaseRole() {
         try {
             log.info("Ensuring all users have at least the 'user' realm role");
-            RoleRepresentation userRole = keycloak.realm(REALM_ID).roles().get("user").toRepresentation();
+            RoleRepresentation userRole = admin.realm(REALM_ID).roles().get("user").toRepresentation();
 
-            List<UserRepresentation> allUsers = keycloak.realm(REALM_ID).users().list();
+            List<UserRepresentation> allUsers = admin.realm(REALM_ID).users().list();
             for (UserRepresentation u : allUsers) {
-                List<RoleRepresentation> realmRoles = keycloak.realm(REALM_ID).users()
+                List<RoleRepresentation> realmRoles = admin.realm(REALM_ID).users()
                         .get(u.getId()).roles().realmLevel().listAll();
                 boolean hasRole = realmRoles.stream()
                         .anyMatch(r -> "user".equals(r.getName()) || "admin".equals(r.getName()));
                 if (!hasRole) {
-                    keycloak.realm(REALM_ID).users().get(u.getId()).roles()
+                    admin.realm(REALM_ID).users().get(u.getId()).roles()
                             .realmLevel().add(Collections.singletonList(userRole));
                     log.info("Assigned 'user' role to existing user '{}'", u.getUsername());
                 }
@@ -937,7 +1146,7 @@ public class KeycloakInitializer {
 
     public void reset() {
         try {
-         keycloak.realm(REALM_ID).remove();
+         masterKeycloak.realm(REALM_ID).remove();
         } catch (NotFoundException e) {
             log.error("Failed to reset Keycloak", e);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,13 @@ keycloak:
   redirect-uri: ${KEYCLOAK_BACKEND_REDIRECT_URI},${KEYCLOAK_BACKEND_REDIRECT_URI_APIDOG}
   web-origin: ${KEYCLOAK_BACKEND_WEB_ORIGIN}
   secret: ${KEYCLOAK_BACKEND_SECRET}
+  # Realm-scoped initializer client (H-3). Steady-state startup reconcile authenticates as this
+  # confidential service account (realm-admin on the application realm only) instead of the master
+  # credential. The master credential (keycloak-initializer.*) is now used only to bootstrap a fresh
+  # or not-yet-migrated environment: create the realm and provision this client + its secret.
+  initializer:
+    service-client-id: ${KEYCLOAK_INITIALIZER_SERVICE_CLIENT_ID:echno-initializer}
+    service-client-secret: ${KEYCLOAK_INITIALIZER_CLIENT_SECRET:}
   admin:
     userName: ${KEYCLOAK_BACKEND_ADMIN_USERNAME}
     email: ${KEYCLOAK_BACKEND_ADMIN_EMAIL}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.common.configuration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -105,10 +106,19 @@ class KeycloakInitializerScopedAdminIT {
 
     private KeycloakInitializer newInitializer(Keycloak masterClient) {
         KeycloakInitializer initializer =
-                new KeycloakInitializer(masterClient, props, new ObjectMapper(), keycloakConfig);
+                new KeycloakInitializer(masterClient, props, lenientMapper(), keycloakConfig);
         ReflectionTestUtils.setField(initializer, "configOutput", configDir.toString());
         ReflectionTestUtils.setField(initializer, "appClientId", APP_CLIENT_ID);
         return initializer;
+    }
+
+    // Mirrors Spring Boot's injected ObjectMapper, which ignores unknown JSON
+    // properties. A bare new ObjectMapper() fails on any field a newer Keycloak
+    // image adds to a representation, which is what differs between the cached
+    // lab image and the CI runner's pull.
+    private static ObjectMapper lenientMapper() {
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
@@ -1,0 +1,176 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Proves the H-3 scoped-admin redesign against a real Keycloak container: the initializer bootstraps
+ * a fresh realm with the master credential, provisions a realm-scoped echno-initializer client that
+ * holds realm-admin, and then on every subsequent startup reconciles through that scoped client
+ * without ever touching the master credential.
+ *
+ * The test is hermetic: its own realm name and config files, no dependency on the application
+ * database or Spring context.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class KeycloakInitializerScopedAdminIT {
+
+    private static final String TEST_REALM = "echno-it-realm";
+    private static final String INIT_CLIENT_ID = "echno-initializer";
+    private static final String INIT_SECRET = "echno-initializer-it-secret";
+    private static final String APP_CLIENT_ID = "echno-backend";
+    private static final String REALM_MANAGEMENT = "realm-management";
+    private static final String REALM_ADMIN = "realm-admin";
+
+    // Pin the server image to the tag matching the keycloak-admin-client version so the container
+    // API and the client stay in lockstep.
+    private static final KeycloakContainer KEYCLOAK =
+            new KeycloakContainer("quay.io/keycloak/keycloak:26.0.7");
+
+    private static Path configDir;
+    private static Keycloak master;
+    private static KeycloakInitializerConfigurationProperties props;
+    private static KeycloakConfig keycloakConfig;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        KEYCLOAK.start();
+
+        // Stage the realm/user config files the initializer reads from disk.
+        configDir = Files.createTempDirectory("keycloak-it-config");
+        copyResource("keycloak-it/init-keycloak.json", configDir.resolve("init-keycloak.json"));
+        copyResource("keycloak-it/init-keycloak-users.json", configDir.resolve("init-keycloak-users.json"));
+
+        master = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm("master")
+                .clientId("admin-cli")
+                .username(KEYCLOAK.getAdminUsername())
+                .password(KEYCLOAK.getAdminPassword())
+                .grantType(OAuth2Constants.PASSWORD)
+                .build();
+
+        props = new KeycloakInitializerConfigurationProperties();
+        props.setMasterRealm("master");
+        props.setApplicationRealm(TEST_REALM);
+        props.setClientId("admin-cli");
+        props.setUsername(KEYCLOAK.getAdminUsername());
+        props.setPassword(KEYCLOAK.getAdminPassword());
+        props.setUrl(KEYCLOAK.getAuthServerUrl());
+
+        keycloakConfig = new KeycloakConfig();
+        ReflectionTestUtils.setField(keycloakConfig, "keycloakInitializerConfigurationProperties", props);
+        ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientId", INIT_CLIENT_ID);
+        ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientSecret", INIT_SECRET);
+
+        // REALM_ID is a static field normally set from ApplicationReadyEvent; set it directly here.
+        ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", TEST_REALM);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (master != null) {
+            master.close();
+        }
+        KEYCLOAK.stop();
+    }
+
+    private static void copyResource(String classpath, Path target) throws Exception {
+        try (InputStream in = KeycloakInitializerScopedAdminIT.class.getClassLoader().getResourceAsStream(classpath)) {
+            assertThat(in).as("test resource %s", classpath).isNotNull();
+            Files.copy(in, target);
+        }
+    }
+
+    private KeycloakInitializer newInitializer(Keycloak masterClient) {
+        KeycloakInitializer initializer =
+                new KeycloakInitializer(masterClient, props, new ObjectMapper(), keycloakConfig);
+        ReflectionTestUtils.setField(initializer, "configOutput", configDir.toString());
+        ReflectionTestUtils.setField(initializer, "appClientId", APP_CLIENT_ID);
+        return initializer;
+    }
+
+    @Test
+    @Order(1)
+    void freshBootstrapCreatesRealmAndScopedInitializerClient() {
+        KeycloakInitializer initializer = newInitializer(master);
+
+        initializer.init(false);
+
+        // Realm was created.
+        assertThat(master.realm(TEST_REALM).toRepresentation()).isNotNull();
+
+        // The scoped initializer client exists and is confidential with a service account.
+        var initClients = master.realm(TEST_REALM).clients().findByClientId(INIT_CLIENT_ID);
+        assertThat(initClients).hasSize(1);
+        var initClient = initClients.get(0);
+        assertThat(initClient.isPublicClient()).isFalse();
+        assertThat(initClient.isServiceAccountsEnabled()).isTrue();
+
+        // Its service account actually holds realm-admin (from realm-management).
+        UserRepresentation serviceAccount =
+                master.realm(TEST_REALM).clients().get(initClient.getId()).getServiceAccountUser();
+        assertThat(serviceAccount).isNotNull();
+        String realmMgmtUuid =
+                master.realm(TEST_REALM).clients().findByClientId(REALM_MANAGEMENT).get(0).getId();
+        List<RoleRepresentation> saClientRoles = master.realm(TEST_REALM).users()
+                .get(serviceAccount.getId()).roles().clientLevel(realmMgmtUuid).listAll();
+        assertThat(saClientRoles).extracting(RoleRepresentation::getName).contains(REALM_ADMIN);
+
+        // Reconcile completed: a composite job role (H-1) was created through the scoped admin.
+        assertThat(master.realm(TEST_REALM).roles().get("job-leadership").toRepresentation()).isNotNull();
+
+        // And the scoped client can independently authenticate with client_credentials and read the realm.
+        try (Keycloak scoped = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm(TEST_REALM)
+                .clientId(INIT_CLIENT_ID)
+                .clientSecret(INIT_SECRET)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build()) {
+            assertThat(scoped.realm(TEST_REALM).toRepresentation().getRealm()).isEqualTo(TEST_REALM);
+        }
+    }
+
+    @Test
+    @Order(2)
+    void steadyStateReconcilesThroughScopedClientWithoutTouchingMaster() {
+        // A master client that fails the test if any method is invoked on it. Steady-state reconcile
+        // must go entirely through the scoped realm-admin, so this must never be dereferenced.
+        Keycloak forbiddenMaster = mock(Keycloak.class, invocation -> {
+            throw new AssertionError("Steady-state reconcile must not use the master credential; "
+                    + "master method called: " + invocation.getMethod().getName());
+        });
+
+        KeycloakInitializer initializer = newInitializer(forbiddenMaster);
+
+        // If the scoped-first path were not taken, the initializer would call the forbidden master
+        // client (probe/create-realm) and this would throw.
+        assertThatCode(() -> initializer.init(false)).doesNotThrowAnyException();
+
+        // The realm and the scoped client are still intact after the second, master-free run.
+        assertThat(master.realm(TEST_REALM).clients().findByClientId(INIT_CLIENT_ID)).hasSize(1);
+        assertThat(master.realm(TEST_REALM).roles().get("job-leadership").toRepresentation()).isNotNull();
+    }
+}

--- a/src/test/resources/keycloak-it/init-keycloak-users.json
+++ b/src/test/resources/keycloak-it/init-keycloak-users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "userName": "it-admin",
+    "emailId": "it-admin@echno.test",
+    "password": "it-admin-pass",
+    "firstName": "IT",
+    "lastName": "Admin",
+    "isAdmin": true
+  }
+]

--- a/src/test/resources/keycloak-it/init-keycloak.json
+++ b/src/test/resources/keycloak-it/init-keycloak.json
@@ -1,0 +1,44 @@
+{
+  "realm": "echno-it-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "displayName": "Echno IT Realm",
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "bruteForceProtected": true,
+  "failureFactor": 5,
+  "revokeRefreshToken": true,
+  "clients": [
+    {
+      "clientId": "echno-backend",
+      "publicClient": false,
+      "secret": "echno-backend-it-secret",
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {"name": "user", "description": "Regular user role"},
+      {"name": "admin", "description": "Administrator with full access"}
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

The Keycloak startup initializer authenticated as the **master-realm admin** (`admin-cli`
password grant) for *every* operation, including all steady-state reconcile work on each deploy.
That privileged master credential should not sit in the hot path of a normal startup (H-3).

## Change

Introduce a **realm-scoped admin** and use master only to bootstrap:

- A confidential `echno-initializer` client in the application realm, whose service account holds
  the `realm-admin` composite from `realm-management` (full authority over that one realm, no
  access to master, so it cannot create or delete realms).
- On startup the initializer tries this scoped client first. If it can obtain a token, the whole
  reconcile runs through it and the master credential is **never touched** that startup.
- Master is used only to bootstrap a fresh or not-yet-migrated environment: create the realm and
  provision the `echno-initializer` client + its secret, then hand off to the scoped client for
  all remaining work.

`KeycloakConfig` keeps the master client as a clearly bootstrap-only bean (`masterKeycloak`) and
adds a factory (`buildScopedKeycloak`) for the scoped client, built on demand because it can only
authenticate once the realm + client exist.

### Decision flow

1. Build the scoped client, probe `realm(applicationRealm).toRepresentation()`.
2. Probe succeeds and not an overwrite -> reconcile entirely through the scoped client, return
   without touching master.
3. Probe fails (fresh env, or realm exists but the initializer client is not yet provisioned) ->
   use master to create the realm (if absent) and ensure the `echno-initializer` client + secret +
   `realm-admin`, then build the scoped client and run the remaining work through it.

Net: master credentials are exercised only on a fresh or pre-migration startup; every steady-state
deploy authenticates solely as the scoped realm-admin.

## New config

| Key | Env | Default |
|-----|-----|---------|
| `keycloak.initializer.service-client-id` | `KEYCLOAK_INITIALIZER_SERVICE_CLIENT_ID` | `echno-initializer` |
| `keycloak.initializer.service-client-secret` | `KEYCLOAK_INITIALIZER_CLIENT_SECRET` | (empty) |

The master credential config (`keycloak-initializer.*`) is retained unchanged as the bootstrap
fallback.

> Note on the id env var: the spec suggested `KEYCLOAK_INITIALIZER_CLIENT_ID`, but that env is
> already bound to the master `admin-cli` client id (`keycloak-initializer.client-id`). Reusing it
> would make the scoped-client id and the master-client id share one value and break bootstrap, so
> the scoped-client id gets its own `KEYCLOAK_INITIALIZER_SERVICE_CLIENT_ID`. The secret env is
> taken verbatim from the spec.

## Only-master operations (bootstrap-only, by design)

Creating the realm (`realms().create`, a master-realm capability) and provisioning the
`echno-initializer` client itself (chicken-and-egg: the scoped client cannot create itself). Every
steady-state operation (client sync, realm security settings, admin MFA, service-account roles,
authorization setup, composite job roles, user seeding) is covered by `realm-admin` on the echno
realm and runs through the scoped client. `reset()` (realm removal) also needs master but only runs
on the manual overwrite path, never on a normal `init(false)` startup.

## Testcontainers gate

`KeycloakInitializerScopedAdminIT` against a real Keycloak `26.0.7` container (hermetic: own realm +
config files, no app DB):

- **Fresh bootstrap** creates the realm, the confidential `echno-initializer` client, its service
  account with `realm-admin`, and completes reconcile; the scoped client then authenticates
  independently via `client_credentials`.
- **Steady state** runs a second `init()` with the master client replaced by a mock that throws on
  any invocation, proving the reconcile goes entirely through the scoped client with the master
  credential untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added realm-scoped Keycloak service authentication for routine administration.
  * Added configurable initializer client credentials through application settings.
  * Improved realm bootstrap and reconciliation, including automatic setup of required clients, roles, service accounts, and authorization settings.

* **Tests**
  * Added integration coverage for initial realm setup and ongoing reconciliation.
  * Added test fixtures for Keycloak users and realm configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->