### PR TITLE
Self-service organization onboarding: creator becomes system-admin and org is fully seeded on create

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGenerator.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGenerator.java
@@ -63,6 +63,9 @@ public class KeycloakConfigGenerator {
     @Value("${keycloak.service.lastName}")
     private String serviceLastName;
 
+    @Value("${keycloak.registration-allowed}")
+    private boolean registrationAllowed;
+
     @Value("${keycloak.config.output-path}")
     private String outputPath;
 
@@ -87,7 +90,8 @@ public class KeycloakConfigGenerator {
                 .replace("${KEYCLOAK_WEB_ORIGIN}",formatListString(webOrigin))
                 .replace("${KEYCLOAK_FRONTEND_CLIENT_ID}",frontendClientId)
                 .replace("${KEYCLOAK_FRONTEND_REDIRECT_URI}",formatListString(frontendRedirectUri))
-                .replace("${KEYCLOAK_FRONTEND_WEB_ORIGIN}",formatListString(frontendWebOrigin));
+                .replace("${KEYCLOAK_FRONTEND_WEB_ORIGIN}",formatListString(frontendWebOrigin))
+                .replace("${KEYCLOAK_REGISTRATION_ALLOWED}",String.valueOf(registrationAllowed));
 
         writeConfig("init-keycloak.json",config);
 

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -189,6 +189,16 @@ public class KeycloakInitializer {
             // the seeded realm content is never clobbered.
             List<String> applied = new ArrayList<>();
 
+            // Self-service registration is the one realm security setting we deliberately let an
+            // instance flip: default false keeps dedicated/per-client instances closed (the hardened
+            // posture), and the public shared instance sets keycloak.registration-allowed=true so a
+            // signed-up user can create their own org. The template always emits the value, so it is
+            // reconciled onto the realm on every deploy. No other security setting is relaxed here.
+            if (configRealm.isRegistrationAllowed() != null) {
+                liveRealm.setRegistrationAllowed(configRealm.isRegistrationAllowed());
+                applied.add("registrationAllowed=" + configRealm.isRegistrationAllowed());
+            }
+
             if (configRealm.getRevokeRefreshToken() != null) {
                 liveRealm.setRevokeRefreshToken(configRealm.getRevokeRefreshToken());
                 applied.add("revokeRefreshToken=" + configRealm.getRevokeRefreshToken());

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationOnboardingSeeder.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationOnboardingSeeder.java
@@ -1,0 +1,74 @@
+package org.tornotron.echno_backend.organization;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.finance.budget.service.CostCategorySeeder;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+
+/**
+ * Seeds the per-organization finance defaults a freshly created organization needs to be usable:
+ * the chart of accounts, the budget cost categories, and the finance-settings row.
+ *
+ * <p>Every step is idempotent (each underlying seeder skips an org that already has the data) and
+ * independently guarded: a failure in one seed is logged and the remaining seeds still run, so a
+ * seed problem leaves the organization usable and back-fillable rather than half-provisioned. None
+ * of these seeds is critical to the organization existing; the critical work (creating the org, its
+ * Keycloak group, and making the creator its system-admin) is done in the creating transaction, and
+ * this seeding is deliberately run after that transaction commits so a seed failure can never roll
+ * the new organization back.
+ *
+ * <p>Posting-account mappings are intentionally not seeded here: a posting role has no per-org row
+ * until an org overrides it, and until then it resolves to the configured default account by code
+ * against the chart seeded above. Seeding the chart is therefore all that posting needs to work; a
+ * mapping row would only pin a role to an account the org had not chosen to fix.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrganizationOnboardingSeeder {
+
+    private final ChartOfAccountsSeeder chartOfAccountsSeeder;
+    private final CostCategorySeeder costCategorySeeder;
+    private final FinanceSettingsService financeSettingsService;
+
+    /**
+     * Seeds the finance defaults for the given organization. Sets the tenant context to that
+     * organization for the duration of the seed and restores the previous context afterwards, so it
+     * can be called safely outside a request that is already tenant-scoped.
+     *
+     * <p>The chart of accounts is seeded first because the cost categories map to its expense
+     * accounts by code; the finance-settings row is materialized last.
+     *
+     * @param organizationId the id of the newly created organization to seed.
+     */
+    public void seedFinanceDefaults(Long organizationId) {
+        Long previous = TenantContext.getCurrentOrgId();
+        TenantContext.setCurrentOrgId(organizationId);
+        try {
+            runQuietly("chart of accounts", organizationId, () -> chartOfAccountsSeeder.seedDefaults());
+            runQuietly("cost categories", organizationId, () -> costCategorySeeder.seedDefaults());
+            runQuietly("finance settings", organizationId, () -> financeSettingsService.getOrCreate());
+        } finally {
+            if (previous == null) {
+                TenantContext.clear();
+            } else {
+                TenantContext.setCurrentOrgId(previous);
+            }
+        }
+    }
+
+    /**
+     * Runs one seed step, logging and swallowing any failure so the remaining steps still run. Each
+     * seeder is transactional in its own right, so a failed step rolls back only its own work.
+     */
+    private void runQuietly(String what, Long organizationId, Runnable seed) {
+        try {
+            seed.run();
+        } catch (Exception e) {
+            log.error("Failed to seed {} for organization {}: {}", what, organizationId, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -54,7 +54,7 @@ public class OrganizationService {
     private final EmployeeService employeeService;
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
     private final org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity;
-    private final org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder;
+    private final OrganizationOnboardingSeeder onboardingSeeder;
 
     /**
      * Constructs an {@code OrganizationService} with the necessary dependencies.
@@ -63,8 +63,9 @@ public class OrganizationService {
      * @param fileStorageService The service for file storage operations.
      * @param keycloakGroupService The service for managing Keycloak groups.
      * @param subscriptionService The service for handling subscription billing.
+     * @param onboardingSeeder Seeds the per-organization finance defaults for a new organization.
      */
-    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder) {
+    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, OrganizationOnboardingSeeder onboardingSeeder) {
         this.repository = repository;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
@@ -74,7 +75,7 @@ public class OrganizationService {
         this.employeeService = employeeService;
         this.organizationMapper = organizationMapper;
         this.orgSecurity = orgSecurity;
-        this.chartOfAccountsSeeder = chartOfAccountsSeeder;
+        this.onboardingSeeder = onboardingSeeder;
     }
 
     /**
@@ -109,14 +110,45 @@ public class OrganizationService {
         EmployeeJoinOrgDto joinOrgDto = new EmployeeJoinOrgDto();
         EmployeeDto employeeDto = employeeService.joinOrganization(currentUser.getId(), savedOrganization.getId(), joinOrgDto);
         TenantContext.setCurrentOrgId(savedOrganization.getId());
-        chartOfAccountsSeeder.seedDefaults();
+
+        // Make the creator the system-admin of the organization they just created. This is the
+        // linchpin of self-service onboarding: assignOrgRole adds them to the '/org-{id}/system-admin'
+        // Keycloak subgroup (idempotent), so their next token carries ORG_{id}_ROLE_system-admin and
+        // they can administer their own org. It is critical: assignOrgRole rethrows on a Keycloak
+        // failure, which rolls this creation back so the caller sees the error rather than an
+        // org whose creator cannot manage it.
         employeeService.assignOrgRole(employeeDto.getId(), OrgRole.SYSTEM_ADMIN);
 
         if (attachments != null && !attachments.isEmpty()) {
             attachmentService.uploadAttachments(attachments, "ORGANIZATION", savedOrganization.getId(), ORGANIZATION_FOLDER);
         }
 
+        // Seed the org's finance defaults (chart of accounts, cost categories, finance settings)
+        // AFTER this creating transaction commits, so a seed failure is logged and skipped rather
+        // than rolling back the created org. Running them post-commit is also what lets each
+        // idempotent seeder see the committed org and run in its own transaction.
+        scheduleFinanceSeeding(savedOrganization.getId());
+
         return organizationMapper.toSimpleDto(savedOrganization);
+    }
+
+    /**
+     * Runs the per-org finance seeding after the current transaction commits when one is active, so a
+     * seed failure cannot roll back the newly created organization. Falls back to running inline when
+     * there is no active transaction (the seeding is idempotent and independently guarded either way).
+     */
+    private void scheduleFinanceSeeding(Long organizationId) {
+        if (org.springframework.transaction.support.TransactionSynchronizationManager.isSynchronizationActive()) {
+            org.springframework.transaction.support.TransactionSynchronizationManager.registerSynchronization(
+                    new org.springframework.transaction.support.TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            onboardingSeeder.seedFinanceDefaults(organizationId);
+                        }
+                    });
+        } else {
+            onboardingSeeder.seedFinanceDefaults(organizationId);
+        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,11 @@ keycloak:
   redirect-uri: ${KEYCLOAK_BACKEND_REDIRECT_URI},${KEYCLOAK_BACKEND_REDIRECT_URI_APIDOG}
   web-origin: ${KEYCLOAK_BACKEND_WEB_ORIGIN}
   secret: ${KEYCLOAK_BACKEND_SECRET}
+  # Whether the realm's self-service registration page is enabled. Reconciled onto the realm on
+  # every deploy. Default false keeps dedicated/per-client instances closed (an admin creates the
+  # org); the public shared instance sets KEYCLOAK_REGISTRATION_ALLOWED=true so a signed-up user
+  # can create their own org.
+  registration-allowed: ${KEYCLOAK_REGISTRATION_ALLOWED:false}
   admin:
     userName: ${KEYCLOAK_BACKEND_ADMIN_USERNAME}
     email: ${KEYCLOAK_BACKEND_ADMIN_EMAIL}

--- a/src/main/resources/keycloak-templates/init-keycloak.json.template
+++ b/src/main/resources/keycloak-templates/init-keycloak.json.template
@@ -7,6 +7,7 @@
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": true,
   "editUsernameAllowed": false,
+  "registrationAllowed": ${KEYCLOAK_REGISTRATION_ALLOWED},
   "bruteForceProtected": true,
   "failureFactor": 5,
   "revokeRefreshToken": true,

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationOnboardingSeederIT.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationOnboardingSeederIT.java
@@ -1,0 +1,108 @@
+package org.tornotron.echno_backend.organization;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.budget.service.CostCategorySeeder;
+import org.tornotron.echno_backend.finance.ledger.repositories.AccountRepository;
+import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsRepository;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the per-org finance seeding a self-service onboarding runs for a new organization,
+ * against a real CockroachDB: one call seeds the chart of accounts, the default cost categories and
+ * the finance-settings row for the org, and a re-run adds nothing because every underlying seed is
+ * idempotent. This is the seeding half of onboarding; the system-admin grant runs through Keycloak
+ * and is covered separately.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({OrganizationOnboardingSeeder.class, ChartOfAccountsSeeder.class, CostCategorySeeder.class,
+        FinanceSettingsService.class, TenantEntityHelper.class, JpaAuditingConfig.class})
+class OrganizationOnboardingSeederIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private OrganizationOnboardingSeeder onboardingSeeder;
+
+    @Autowired
+    private AccountRepository accountRepo;
+
+    @Autowired
+    private CostCategoryRepository categoryRepo;
+
+    @Autowired
+    private FinanceSettingsRepository financeSettingsRepo;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long orgId;
+
+    @BeforeEach
+    void newOrg() {
+        TenantContext.clear();
+        Organization org = persistOrganization("Onboarding Org");
+        entityManager.flush();
+        orgId = org.getId();
+        // Keep the tenant context set to this org for the whole test: the seeder sets and restores
+        // it internally, and the fail-closed tenant filter needs it set for the read-back assertions.
+        TenantContext.setCurrentOrgId(orgId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void seedsChartCategoriesAndSettings_andIsIdempotent() {
+        onboardingSeeder.seedFinanceDefaults(orgId);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Chart of accounts seeded for the new org.
+        assertThat(accountRepo.existsByOrganizationId(orgId)).isTrue();
+        // Cost categories seeded (the five default construction budget heads).
+        assertThat(categoryRepo.findByActiveTrue()).hasSize(5);
+        // Finance-settings row materialized for the org.
+        assertThat(financeSettingsRepo.findByOrganization_Id(orgId)).isPresent();
+
+        long accountsAfterFirst = accountRepo.count();
+
+        // Re-running seeds nothing new: every underlying seed is idempotent.
+        onboardingSeeder.seedFinanceDefaults(orgId);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(categoryRepo.findByActiveTrue()).hasSize(5);
+        assertThat(accountRepo.count()).isEqualTo(accountsAfterFirst);
+    }
+
+    // --- Helpers ----------------------------------------------------------
+
+    private Organization persistOrganization(String name) {
+        Organization organization = new Organization();
+        organization.setOrganizationName(name);
+        organization.setOrganizationAddress(name + " address");
+        organization.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        entityManager.persist(organization);
+        return organization;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
@@ -43,12 +43,12 @@ class OrganizationServiceBatchAuthzTest {
     @Mock private EmployeeService employeeService;
     @Mock private OrganizationMapper organizationMapper;
     @Mock private OrganizationSecurityService orgSecurity;
-    @Mock private org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder chartOfAccountsSeeder;
+    @Mock private OrganizationOnboardingSeeder onboardingSeeder;
 
     private OrganizationService service() {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
-                organizationMapper, orgSecurity, chartOfAccountsSeeder);
+                organizationMapper, orgSecurity, onboardingSeeder);
     }
 
     private OrganizationPatchDto patch(long id) {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationCreationDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Self-service onboarding wiring for {@code addOrganization}: the creator of an organization must be
+ * made its system-admin, and the organization's finance defaults must be seeded on creation. Both
+ * are the core of the self-service path, since without the system-admin grant the creator cannot
+ * administer the org they just made, and without the seed the org has no chart, cost categories or
+ * finance settings to work with.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationServiceOnboardingTest {
+
+    @Mock private OrganizationRepository repository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private KeycloakGroupService keycloakGroupService;
+    @Mock private SubscriptionService subscriptionService;
+    @Mock private UserContextService userContextService;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationMapper organizationMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+
+    private static final Long CREATOR_USER_ID = 7L;
+    private static final Long NEW_ORG_ID = 42L;
+    private static final Long CREATOR_EMPLOYEE_ID = 5L;
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private OrganizationService service() {
+        return new OrganizationService(repository, attachmentService, fileStorageService,
+                keycloakGroupService, subscriptionService, userContextService, employeeService,
+                organizationMapper, orgSecurity, onboardingSeeder);
+    }
+
+    private OrganizationCreationDto creationDto() {
+        OrganizationCreationDto dto = new OrganizationCreationDto();
+        dto.setOrganizationName("Acme Builders");
+        dto.setOrganizationEmail("acme@example.test");
+        dto.setOrganizationAddress("1 Site Road");
+        dto.setOrganizationPhone("0000000000");
+        return dto;
+    }
+
+    @Test
+    void makesTheCreatorSystemAdminAndSeedsFinanceDefaults() {
+        User creator = mock(User.class);
+        when(creator.getId()).thenReturn(CREATOR_USER_ID);
+        when(userContextService.getCurrentUser()).thenReturn(creator);
+
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+        when(repository.save(any(Organization.class))).thenAnswer(invocation -> {
+            Organization toSave = invocation.getArgument(0);
+            toSave.setId(NEW_ORG_ID);
+            return toSave;
+        });
+
+        EmployeeDto creatorEmployee = new EmployeeDto();
+        creatorEmployee.setId(CREATOR_EMPLOYEE_ID);
+        when(employeeService.joinOrganization(eq(CREATOR_USER_ID), eq(NEW_ORG_ID), any()))
+                .thenReturn(creatorEmployee);
+        when(organizationMapper.toSimpleDto(any())).thenReturn(new OrganizationSimpleDto());
+
+        service().addOrganization(creationDto(), null);
+
+        // The creator is granted the org's system-admin role (which adds them to the
+        // '/org-42/system-admin' Keycloak subgroup under the hood).
+        verify(employeeService).assignOrgRole(CREATOR_EMPLOYEE_ID, OrgRole.SYSTEM_ADMIN);
+        // The org's finance defaults are seeded for the newly created org id. Without an active
+        // transaction in this unit test the seeding runs inline rather than after commit.
+        verify(onboardingSeeder).seedFinanceDefaults(NEW_ORG_ID);
+    }
+}


### PR DESCRIPTION
## Self-service organization onboarding (backend core)

Makes a user who creates an organization its administrator, and fully seeds the org on creation, so both deployment models work: an admin provisioning a dedicated per-client instance, and a signed-up user creating their own org on a shared instance.

### What changed

**1. Creator becomes the org's system-admin (critical, in the creating transaction).**
`addOrganization` continues to grant the creator the `SYSTEM_ADMIN` org-role via `employeeService.assignOrgRole(...)`, which adds them to the `/org-{id}/system-admin` Keycloak subgroup (idempotent `joinGroup`), so their next token carries `ORG_{id}_ROLE_system-admin` and they can administer their own org. This grant stays inside the creating transaction and rethrows on a Keycloak failure, so a failed grant rolls the creation back and surfaces the error rather than leaving an org whose creator cannot manage it. The grant was already present on `development`; this change keeps it critical and documents the intent.

**2. Full per-org seeding on create (best-effort, after commit).**
A new `OrganizationOnboardingSeeder` runs the per-org finance defaults for the new org:
- **Chart of accounts** (`ChartOfAccountsSeeder`) — was already seeded on create.
- **Cost categories** (`CostCategorySeeder`) — now seeded on create (was not before).
- **Finance settings** (`FinanceSettingsService.getOrCreate`) — now materialized on create (was not before).

Each step is idempotent (each seeder skips an org that already has the data) and independently guarded, so a seed failure is logged and skipped rather than corrupting the org. The seeding is registered to run **after the creating transaction commits**, so a seed failure can never roll the new org back, and each idempotent seeder sees the committed org and runs in its own transaction.

**Posting-account mappings are intentionally not seeded.** A posting role has no per-org row until an org overrides it; until then it resolves to the configured default account by code against the seeded chart (see `PostingAccountResolver`). Seeding the chart is therefore all posting needs to work; a mapping row would only pin a role to an account the org had not chosen to fix.

**3. Per-instance public-signup flag.**
Adds `keycloak.registration-allowed` (env `KEYCLOAK_REGISTRATION_ALLOWED`, default **false**), wired through the realm template and `KeycloakConfigGenerator` and reconciled onto the realm's `registrationAllowed` in `KeycloakInitializer.syncRealmSecuritySettings` on every deploy. Default false keeps dedicated/per-client instances closed (the current hardened posture); the public shared instance sets it true to open self-service signup. No other realm security setting is changed.

### Tests
- `OrganizationServiceOnboardingTest` (Mockito) — proves `addOrganization` grants the creator `SYSTEM_ADMIN` and seeds the new org's finance defaults.
- `OrganizationOnboardingSeederIT` (Testcontainers CockroachDB) — proves the chart of accounts, the five default cost categories, and the finance-settings row are all seeded for the new org, and that a re-run adds nothing (idempotent).
- `OrganizationServiceBatchAuthzTest` — constructor updated for the new dependency.

### Out of scope (next layer / product decisions, not built here)
- The web onboarding screen for a no-org user.
- Email verification on signup.
- Anti-abuse / rate-limiting on signup.
- Default-plan / subscription-on-signup decisions. `addOrganization`'s existing subscription handling is left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control over Keycloak self-service registration, disabled by default.
  * New organizations now receive finance defaults, including accounts, budget categories, and finance settings.
  * Finance setup runs after organization creation without preventing creation if a setup step fails.
* **Bug Fixes**
  * Repeated finance setup is handled safely without creating duplicates.
* **Tests**
  * Added coverage for organization onboarding, finance defaults, registration settings, and authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->