### PR TITLE
Give the Keycloak initializer a realm-scoped admin, master only for bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:cockroachdb'
+    testImplementation 'com.github.dasniko:testcontainers-keycloak:3.7.0'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
@@ -4,6 +4,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,15 +14,57 @@ public class KeycloakConfig {
     @Autowired
     KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties;
 
+    // Client id of the realm-scoped initializer service-account client that steady-state reconcile
+    // authenticates as. Defaults to 'echno-initializer'.
+    @Value("${keycloak.initializer.service-client-id:echno-initializer}")
+    private String initializerServiceClientId;
+
+    // Secret of the initializer service-account client. Empty until the environment has been
+    // bootstrapped and the secret provisioned; the master fallback provisions it on first run.
+    @Value("${keycloak.initializer.service-client-secret:}")
+    private String initializerServiceClientSecret;
+
+    /**
+     * Bootstrap-only admin client. Authenticates against the MASTER realm with the admin-cli
+     * password grant (the privileged master credential, H-3). It is used ONLY to bring a fresh or
+     * not-yet-migrated environment up to the point where the realm-scoped initializer client
+     * exists: creating the application realm and provisioning the echno-initializer client. No
+     * steady-state deploy authenticates with this bean.
+     */
     @Bean
-    protected Keycloak keycloak() {
+    protected Keycloak masterKeycloak() {
         return KeycloakBuilder.builder()
-//                .grantType(OAuth2Constants.)
                 .realm(keycloakInitializerConfigurationProperties.getMasterRealm())
                 .clientId(keycloakInitializerConfigurationProperties.getClientId())
                 .username(keycloakInitializerConfigurationProperties.getUsername())
                 .password(keycloakInitializerConfigurationProperties.getPassword())
                 .serverUrl(keycloakInitializerConfigurationProperties.getUrl())
                 .build();
+    }
+
+    /**
+     * Builds a realm-scoped admin client that authenticates as the echno-initializer service
+     * account with the client-credentials grant. It holds the realm-admin composite on the
+     * application realm's realm-management client, i.e. full administrative authority over that one
+     * realm and no access to master (so it cannot create or delete realms). Built on demand rather
+     * than as a singleton bean: it can obtain a token only once the realm and the initializer
+     * client already exist, which is not guaranteed at context-startup time.
+     */
+    public Keycloak buildScopedKeycloak() {
+        return KeycloakBuilder.builder()
+                .serverUrl(keycloakInitializerConfigurationProperties.getUrl())
+                .realm(keycloakInitializerConfigurationProperties.getApplicationRealm())
+                .clientId(initializerServiceClientId)
+                .clientSecret(initializerServiceClientSecret)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build();
+    }
+
+    public String getInitializerServiceClientId() {
+        return initializerServiceClientId;
+    }
+
+    public String getInitializerServiceClientSecret() {
+        return initializerServiceClientSecret;
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -47,7 +47,19 @@ import java.util.Set;
 @DependsOn("keycloakConfigGenerator")
 public class KeycloakInitializer {
 
-    private final Keycloak keycloak;
+    // Bootstrap-only master client (admin-cli password grant on the master realm). Used solely to
+    // create the application realm and to provision/repair the echno-initializer client on a fresh
+    // or not-yet-migrated environment. Never used for steady-state reconcile once the scoped client
+    // is usable.
+    private final Keycloak masterKeycloak;
+
+    // The admin client every reconcile/content operation runs through. It is set to the realm-scoped
+    // echno-initializer client for the whole reconcile; the master client is only reached, if at all,
+    // to bootstrap that scoped client into existence, or as a last-resort fallback when the scoped
+    // client cannot authenticate even after repair.
+    private Keycloak admin;
+
+    private final KeycloakConfig keycloakConfig;
 
     private final KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties;
 
@@ -55,18 +67,24 @@ public class KeycloakInitializer {
 
     private static String REALM_ID;
 
+    // Composite role on the realm-management client that grants full admin over a single realm.
+    private static final String REALM_ADMIN_ROLE = "realm-admin";
+    private static final String REALM_MANAGEMENT_CLIENT = "realm-management";
+
     @Value("${keycloak.config.output-path}")
     private String configOutput;
 
     @Value("${keycloak.client-id}")
     private String appClientId;
 
-    public KeycloakInitializer(Keycloak keycloak,
+    public KeycloakInitializer(Keycloak masterKeycloak,
                                KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties,
-                               ObjectMapper objectMapper) {
-        this.keycloak = keycloak;
+                               ObjectMapper objectMapper,
+                               KeycloakConfig keycloakConfig) {
+        this.masterKeycloak = masterKeycloak;
         this.keycloakInitializerConfigurationProperties = keycloakInitializerConfigurationProperties;
         this.mapper = objectMapper;
+        this.keycloakConfig = keycloakConfig;
     }
 
 
@@ -81,42 +99,295 @@ public class KeycloakInitializer {
         }
     }
 
+    /**
+     * Reconciles Keycloak on startup, authenticating with the least-privileged credential that can
+     * do the job (H-3). The scoped realm-admin path is tried first: if the echno-initializer service
+     * account can already obtain a token against the application realm, the whole reconcile runs
+     * through it and the privileged master credential is never touched this startup. The master
+     * client is used only to bootstrap a fresh (or not-yet-migrated) environment up to the point
+     * where that scoped client exists: create the realm and provision echno-initializer with the
+     * realm-admin role, then hand off to the scoped client for all remaining work.
+     */
     public void init(boolean overwrite) {
 
         log.info("Initializer start");
 
-        boolean isAlreadyInitialized;
+        Keycloak scoped = keycloakConfig.buildScopedKeycloak();
         try {
-            keycloak.realm(REALM_ID).toRepresentation();
-            isAlreadyInitialized = true;
-        } catch (NotFoundException e) {
-            isAlreadyInitialized = false;
+            if (!overwrite && probeRealm(scoped)) {
+                log.info("Scoped initializer client authenticated against realm '{}'; reconciling with the "
+                        + "realm-scoped admin only (master credential untouched)", REALM_ID);
+                this.admin = scoped;
+                reconcileExistingRealm();
+                log.info("Keycloak reconcile complete (scoped realm-admin)");
+                return;
+            }
+        } finally {
+            if (this.admin != scoped) {
+                closeQuietly(scoped);
+            }
         }
 
-        if(isAlreadyInitialized && overwrite) {
+        // Fresh env, not-yet-migrated realm, an unusable scoped client, or an explicit overwrite:
+        // fall back to the master credential to bring the scoped client into existence, then hand
+        // reconcile off to the scoped client (or to master if the scoped client still cannot log in).
+        bootstrapWithMaster(overwrite);
+    }
+
+    /**
+     * Bootstrap/repair path. Uses the master credential ONLY to create the realm (if absent) and to
+     * provision or repair the echno-initializer client with realm-admin. Every subsequent operation
+     * runs through the freshly built scoped client once it is proven to authenticate; if it still
+     * cannot (misconfigured secret, etc.) the whole reconcile falls back to master for this startup
+     * rather than being left half-done through a non-authenticating client.
+     */
+    private void bootstrapWithMaster(boolean overwrite) {
+        boolean realmExists = probeRealm(masterKeycloak);
+
+        if (realmExists && overwrite) {
             reset();
+            realmExists = false;
         }
 
-        if (!isAlreadyInitialized || overwrite) {
+        if (!realmExists) {
+            initKeycloakRealm();
+        }
 
-            initKeycloak();
+        // Ensure the realm-scoped admin client exists with a secret Keycloak actually validates (the
+        // create path honours ClientRepresentation.setSecret; the realign path deletes and recreates
+        // it, never an in-place secret update) and holds realm-admin. This is the one step that
+        // genuinely needs the master credential on a fresh or pre-migration environment, because the
+        // scoped client cannot yet authenticate to create itself.
+        ensureInitializerClient();
 
-            log.info("Keycloak initialized successfully");
-        } else {
+        Keycloak scoped = keycloakConfig.buildScopedKeycloak();
+        boolean scopedUsable = verifyScoped(scoped);
 
-            log.warn("Keycloak initialization cancelled: realm already exists");
-            // Sync client configuration from JSON even if realm exists
-            syncClientConfiguration();
-            // Sync realm-level security settings from JSON even if realm exists
-            syncRealmSecuritySettings();
-            // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
-            ensureAdminMfa();
-            // Ensure service account roles are assigned even if realm exists
-            assignServiceAccountRoles();
-            // Ensure authorization setup (JS policy, resource, permission) exists
-            ensureAuthorizationSetup();
-            // Ensure the H-1 composite job roles exist and carry their granular children
-            ensureCompositeJobRoles();
+        try {
+            if (scopedUsable) {
+                this.admin = scoped;
+                if (!realmExists) {
+                    initKeycloakContents();
+                    log.info("Keycloak initialized successfully (fresh bootstrap; scoped realm-admin provisioned)");
+                } else {
+                    log.warn("Realm '{}' already existed but the scoped initializer client was not usable; "
+                            + "repaired it via master and reconciled through the scoped realm-admin", REALM_ID);
+                    reconcileExistingRealm();
+                    log.info("Keycloak reconcile complete (scoped realm-admin, provisioned this startup)");
+                }
+            } else {
+                // The scoped client still cannot obtain a token even after repair. Do NOT run a
+                // half-broken reconcile through it (that is exactly the 401 spam we are avoiding);
+                // complete this startup through the master credential and warn loudly.
+                closeQuietly(scoped);
+                this.admin = masterKeycloak;
+                log.warn("Scoped initializer client '{}' could not authenticate against realm '{}' even after "
+                                + "provisioning; falling back to the master credential for this startup's reconcile. "
+                                + "Check keycloak.initializer.service-client-secret.",
+                        keycloakConfig.getInitializerServiceClientId(), REALM_ID);
+                if (!realmExists) {
+                    initKeycloakContents();
+                    log.info("Keycloak initialized successfully (fresh bootstrap; master fallback)");
+                } else {
+                    reconcileExistingRealm();
+                    log.info("Keycloak reconcile complete (master fallback)");
+                }
+            }
+        } finally {
+            if (this.admin != scoped) {
+                closeQuietly(scoped);
+            }
+        }
+    }
+
+    /** The existing-realm reconcile suite, run through {@link #admin}. */
+    private void reconcileExistingRealm() {
+        // Sync client configuration from JSON even if realm exists
+        syncClientConfiguration();
+        // Sync realm-level security settings from JSON even if realm exists
+        syncRealmSecuritySettings();
+        // Ensure admin-only MFA (conditional TOTP) is codified even if realm exists
+        ensureAdminMfa();
+        // Ensure service account roles are assigned even if realm exists
+        assignServiceAccountRoles();
+        // Ensure authorization setup (JS policy, resource, permission) exists
+        ensureAuthorizationSetup();
+        // Ensure the H-1 composite job roles exist and carry their granular children
+        ensureCompositeJobRoles();
+    }
+
+    /**
+     * Probes whether the given admin client can read the application realm. A success proves both
+     * that the realm exists and that the client authenticated. Any failure (realm absent, client
+     * absent, or token request rejected) returns false so the caller falls back to bootstrap.
+     */
+    private boolean probeRealm(Keycloak client) {
+        try {
+            client.realm(REALM_ID).toRepresentation();
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        } catch (Exception e) {
+            log.debug("Realm probe against '{}' did not succeed: {}", REALM_ID, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * The real client-credentials check that the reverted attempt never exercised: obtain an access
+     * token as the scoped service account and confirm it can read the realm. This is exactly the
+     * grant that returned unauthorized_client live, so we run it before trusting the scoped client.
+     */
+    private boolean verifyScoped(Keycloak scoped) {
+        try {
+            String token = scoped.tokenManager().getAccessTokenString();
+            if (token == null || token.isBlank()) {
+                return false;
+            }
+            // A token alone proves the client_credentials grant; the read proves realm-admin authority.
+            scoped.realm(REALM_ID).toRepresentation();
+            return true;
+        } catch (Exception e) {
+            log.warn("Scoped initializer client failed client_credentials verification against realm '{}': {}",
+                    REALM_ID, e.getMessage());
+            return false;
+        }
+    }
+
+    private void closeQuietly(Keycloak client) {
+        if (client == null) {
+            return;
+        }
+        try {
+            client.close();
+        } catch (Exception e) {
+            log.debug("Failed to close a Keycloak admin client: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Ensures the realm-scoped initializer client (echno-initializer) exists in the application
+     * realm as a confidential client whose stored secret equals the configured one and whose service
+     * account holds the realm-admin composite.
+     *
+     * <p>The critical detail (the reason the reverted attempt failed live): Keycloak only honours a
+     * caller-supplied secret in {@link org.keycloak.representations.idm.ClientRepresentation#setSecret}
+     * on CREATE. Setting it on an existing client and calling update does NOT replace the credential
+     * Keycloak validates, so a subsequent client_credentials grant is rejected as unauthorized_client.
+     * Therefore:
+     * <ul>
+     *   <li>MISSING client: create it with the secret in the representation.</li>
+     *   <li>EXISTING but unusable client (we only reach here when the scoped probe already failed):
+     *       DELETE it and recreate with the configured secret, never an in-place secret update. This
+     *       guarantees the stored credential equals the config value.</li>
+     * </ul>
+     * Runs through the master client (the only credential able to create it on a fresh or
+     * pre-migration environment) and is idempotent.
+     */
+    private void ensureInitializerClient() {
+        String clientId = keycloakConfig.getInitializerServiceClientId();
+        String secret = keycloakConfig.getInitializerServiceClientSecret();
+        if (secret == null || secret.isBlank()) {
+            log.warn("No keycloak.initializer.service-client-secret configured; the scoped initializer client "
+                    + "cannot be given a usable secret and reconcile will fall back to the master credential.");
+        }
+        try {
+            RealmResource realm = masterKeycloak.realm(REALM_ID);
+
+            List<org.keycloak.representations.idm.ClientRepresentation> existing =
+                    realm.clients().findByClientId(clientId);
+
+            // Realign case: the client already exists but could not authenticate (we only ever run
+            // ensureInitializerClient after the scoped probe failed). An in-place secret update does
+            // not establish the validated credential, so delete and recreate from scratch.
+            if (!existing.isEmpty()) {
+                String staleUuid = existing.get(0).getId();
+                realm.clients().get(staleUuid).remove();
+                log.warn("Deleted existing initializer client '{}' (id={}) to recreate it with a validated "
+                        + "secret (in-place secret updates are not honoured by Keycloak)", clientId, staleUuid);
+            }
+
+            String clientUuid = createInitializerClient(realm, clientId, secret);
+            if (clientUuid == null) {
+                return;
+            }
+            grantRealmAdmin(realm, clientUuid, clientId);
+
+        } catch (Exception e) {
+            log.error("Failed to ensure initializer client '{}': {}", clientId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Creates the confidential echno-initializer service-account client with the configured secret
+     * in the representation (the only reliable way to set a specific, Keycloak-validated secret).
+     * Returns the created client UUID, or null on failure.
+     */
+    private String createInitializerClient(RealmResource realm, String clientId, String secret) {
+        org.keycloak.representations.idm.ClientRepresentation rep =
+                new org.keycloak.representations.idm.ClientRepresentation();
+        rep.setClientId(clientId);
+        rep.setEnabled(true);
+        rep.setPublicClient(false);
+        rep.setServiceAccountsEnabled(true);
+        rep.setStandardFlowEnabled(false);
+        rep.setDirectAccessGrantsEnabled(false);
+        rep.setDescription("Realm-scoped admin client used by the startup initializer (H-3). "
+                + "Holds realm-admin on this realm only; steady-state deploys authenticate as this "
+                + "service account instead of the master credential.");
+        if (secret != null && !secret.isBlank()) {
+            rep.setSecret(secret);
+        }
+        try (Response response = realm.clients().create(rep)) {
+            if (response.getStatus() != 201) {
+                String body = response.hasEntity() ? response.readEntity(String.class) : "(no body)";
+                log.error("Failed to create initializer client '{}'. Status: {}, Body: {}",
+                        clientId, response.getStatus(), body);
+                return null;
+            }
+            String clientUuid = CreatedResponseUtil.getCreatedId(response);
+            log.info("Created realm-scoped initializer client '{}' (id={}) with a validated secret",
+                    clientId, clientUuid);
+            return clientUuid;
+        }
+    }
+
+    /** Grants the realm-admin composite (from realm-management) to the client's service account, if missing. */
+    private void grantRealmAdmin(RealmResource realm, String clientUuid, String clientId) {
+        try {
+            UserRepresentation serviceAccount = realm.clients().get(clientUuid).getServiceAccountUser();
+            if (serviceAccount == null) {
+                log.error("Initializer client '{}' has no service account user; cannot grant {}",
+                        clientId, REALM_ADMIN_ROLE);
+                return;
+            }
+
+            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmt =
+                    realm.clients().findByClientId(REALM_MANAGEMENT_CLIENT);
+            if (realmMgmt.isEmpty()) {
+                log.error("'{}' client not found; cannot grant {} to '{}'",
+                        REALM_MANAGEMENT_CLIENT, REALM_ADMIN_ROLE, clientId);
+                return;
+            }
+            String realmMgmtUuid = realmMgmt.get(0).getId();
+
+            RoleRepresentation realmAdmin = realm.clients().get(realmMgmtUuid)
+                    .roles().get(REALM_ADMIN_ROLE).toRepresentation();
+
+            RoleMappingResource saRoles = realm.users().get(serviceAccount.getId()).roles();
+            boolean alreadyAssigned = saRoles.clientLevel(realmMgmtUuid).listAll().stream()
+                    .anyMatch(r -> REALM_ADMIN_ROLE.equals(r.getName()));
+
+            if (alreadyAssigned) {
+                log.info("Initializer service account for '{}' already holds {}", clientId, REALM_ADMIN_ROLE);
+                return;
+            }
+
+            saRoles.clientLevel(realmMgmtUuid).add(List.of(realmAdmin));
+            log.info("Granted {} to the initializer service account for '{}'", REALM_ADMIN_ROLE, clientId);
+        } catch (Exception e) {
+            log.error("Failed to grant {} to initializer client '{}': {}",
+                    REALM_ADMIN_ROLE, clientId, e.getMessage(), e);
         }
     }
 
@@ -149,14 +420,14 @@ public class KeycloakInitializer {
     private void syncSingleClient(org.keycloak.representations.idm.ClientRepresentation clientFromConfig) {
         String clientId = clientFromConfig.getClientId();
         try {
-            List<org.keycloak.representations.idm.ClientRepresentation> existingClients = keycloak.realm(REALM_ID).clients().findByClientId(clientId);
+            List<org.keycloak.representations.idm.ClientRepresentation> existingClients = admin.realm(REALM_ID).clients().findByClientId(clientId);
             if (existingClients.isEmpty()) {
                 log.warn("Client '{}' from config not found in Keycloak. Skipping sync.", clientId);
                 return;
             }
 
             org.keycloak.representations.idm.ClientRepresentation existingClient = existingClients.get(0);
-            org.keycloak.admin.client.resource.ClientResource clientResource = keycloak.realm(REALM_ID).clients().get(existingClient.getId());
+            org.keycloak.admin.client.resource.ClientResource clientResource = admin.realm(REALM_ID).clients().get(existingClient.getId());
 
             // Update fields from config on the existing client.
             // We preserve the ID and Secret from the existing client so a rotated secret survives.
@@ -182,7 +453,7 @@ public class KeycloakInitializer {
             }
 
             RealmRepresentation configRealm = mapper.readValue(configFile.toFile(), RealmRepresentation.class);
-            RealmRepresentation liveRealm = keycloak.realm(REALM_ID).toRepresentation();
+            RealmRepresentation liveRealm = admin.realm(REALM_ID).toRepresentation();
 
             // Copy ONLY the explicit security fields that are set in the config onto the live
             // representation. Clients, roles, groups and users are deliberately left untouched so
@@ -221,7 +492,7 @@ public class KeycloakInitializer {
                 return;
             }
 
-            keycloak.realm(REALM_ID).update(liveRealm);
+            admin.realm(REALM_ID).update(liveRealm);
             log.info("Realm-level security settings synced successfully: {}", applied);
 
         } catch (Exception e) {
@@ -267,10 +538,10 @@ public class KeycloakInitializer {
     // (rebind first: a bound flow cannot be deleted). Each step guarded.
     private void useBuiltinBrowserFlow() {
         try {
-            RealmRepresentation realm = keycloak.realm(REALM_ID).toRepresentation();
+            RealmRepresentation realm = admin.realm(REALM_ID).toRepresentation();
             if (!BUILTIN_BROWSER_FLOW.equals(realm.getBrowserFlow())) {
                 realm.setBrowserFlow(BUILTIN_BROWSER_FLOW);
-                keycloak.realm(REALM_ID).update(realm);
+                admin.realm(REALM_ID).update(realm);
                 log.info("Rebound realm browserFlow to the built-in '{}' flow", BUILTIN_BROWSER_FLOW);
             } else {
                 log.info("Realm browserFlow already on the built-in '{}' flow", BUILTIN_BROWSER_FLOW);
@@ -280,7 +551,7 @@ public class KeycloakInitializer {
         }
 
         try {
-            AuthenticationManagementResource flows = keycloak.realm(REALM_ID).flows();
+            AuthenticationManagementResource flows = admin.realm(REALM_ID).flows();
             AuthenticationFlowRepresentation custom = flows.getFlows().stream()
                     .filter(f -> CUSTOM_MFA_FLOW_ALIAS.equals(f.getAlias()))
                     .findFirst()
@@ -299,7 +570,7 @@ public class KeycloakInitializer {
     private void enableConfigureTotpRequiredAction() {
         try {
             RequiredActionProviderRepresentation action =
-                    keycloak.realm(REALM_ID).flows().getRequiredAction(CONFIGURE_TOTP);
+                    admin.realm(REALM_ID).flows().getRequiredAction(CONFIGURE_TOTP);
             if (action == null) {
                 log.warn("{} required action not found; skipping enable", CONFIGURE_TOTP);
                 return;
@@ -314,7 +585,7 @@ public class KeycloakInitializer {
                 changed = true;
             }
             if (changed) {
-                keycloak.realm(REALM_ID).flows().updateRequiredAction(CONFIGURE_TOTP, action);
+                admin.realm(REALM_ID).flows().updateRequiredAction(CONFIGURE_TOTP, action);
                 log.info("Enabled {} required action (defaultAction=false)", CONFIGURE_TOTP);
             } else {
                 log.info("{} required action already enabled", CONFIGURE_TOTP);
@@ -331,7 +602,7 @@ public class KeycloakInitializer {
     private void forceTotpEnrolmentForAdmins() {
         try {
             List<GroupRepresentation> adminGroups = new ArrayList<>();
-            collectSystemAdminGroups(keycloak.realm(REALM_ID).groups().groups(), adminGroups);
+            collectSystemAdminGroups(admin.realm(REALM_ID).groups().groups(), adminGroups);
             if (adminGroups.isEmpty()) {
                 log.info("No '/system-admin' groups found yet; no admins to enrol this reconcile");
                 return;
@@ -339,7 +610,7 @@ public class KeycloakInitializer {
 
             Set<String> processed = new HashSet<>();
             for (GroupRepresentation group : adminGroups) {
-                List<UserRepresentation> members = keycloak.realm(REALM_ID).groups().group(group.getId()).members();
+                List<UserRepresentation> members = admin.realm(REALM_ID).groups().group(group.getId()).members();
                 if (members == null) {
                     continue;
                 }
@@ -357,7 +628,7 @@ public class KeycloakInitializer {
 
     private void forceTotpForAdmin(String userId, String username) {
         try {
-            UserResource userResource = keycloak.realm(REALM_ID).users().get(userId);
+            UserResource userResource = admin.realm(REALM_ID).users().get(userId);
 
             boolean hasOtp = userResource.credentials().stream()
                     .map(CredentialRepresentation::getType)
@@ -393,7 +664,7 @@ public class KeycloakInitializer {
     private void cleanupLegacyRequireMfaRole() {
         RoleRepresentation mfaRole;
         try {
-            mfaRole = keycloak.realm(REALM_ID).roles().get(MFA_ROLE).toRepresentation();
+            mfaRole = admin.realm(REALM_ID).roles().get(MFA_ROLE).toRepresentation();
         } catch (NotFoundException e) {
             return; // already gone
         } catch (Exception e) {
@@ -403,10 +674,10 @@ public class KeycloakInitializer {
 
         try {
             List<GroupRepresentation> adminGroups = new ArrayList<>();
-            collectSystemAdminGroups(keycloak.realm(REALM_ID).groups().groups(), adminGroups);
+            collectSystemAdminGroups(admin.realm(REALM_ID).groups().groups(), adminGroups);
             for (GroupRepresentation group : adminGroups) {
                 try {
-                    RoleMappingResource groupRoles = keycloak.realm(REALM_ID).groups().group(group.getId()).roles();
+                    RoleMappingResource groupRoles = admin.realm(REALM_ID).groups().group(group.getId()).roles();
                     boolean mapped = groupRoles.realmLevel().listAll().stream()
                             .anyMatch(r -> MFA_ROLE.equals(r.getName()));
                     if (mapped) {
@@ -422,7 +693,7 @@ public class KeycloakInitializer {
         }
 
         try {
-            keycloak.realm(REALM_ID).roles().deleteRole(MFA_ROLE);
+            admin.realm(REALM_ID).roles().deleteRole(MFA_ROLE);
             log.info("Deleted unused legacy realm role '{}'", MFA_ROLE);
         } catch (Exception e) {
             log.error("Failed to delete legacy realm role '{}': {}", MFA_ROLE, e.getMessage());
@@ -439,20 +710,22 @@ public class KeycloakInitializer {
                 out.add(group);
             }
             List<GroupRepresentation> subGroups =
-                    keycloak.realm(REALM_ID).groups().group(group.getId()).getSubGroups(0, 1000, false);
+                    admin.realm(REALM_ID).groups().group(group.getId()).getSubGroups(0, 1000, false);
             collectSystemAdminGroups(subGroups, out);
         }
     }
 
-    private void initKeycloak() {
-
-        initKeycloakRealm();
+    /**
+     * The fresh-realm content pipeline, run through {@link #admin}. Realm creation itself is handled
+     * separately in {@link #bootstrapWithMaster} because it is the one step that needs the master
+     * credential.
+     */
+    private void initKeycloakContents() {
         initKeycloakUsers();
         assignServiceAccountRoles();
         ensureAuthorizationSetup();
         ensureAdminMfa();
         ensureCompositeJobRoles();
-
     }
 
     /**
@@ -538,7 +811,7 @@ public class KeycloakInitializer {
 
     private void ensureCompositeJobRole(CompositeJobRole jobRole) {
         try {
-            RealmResource realm = keycloak.realm(REALM_ID);
+            RealmResource realm = admin.realm(REALM_ID);
 
             // 1. Ensure the composite role itself exists (create if missing, never overwrite).
             boolean exists;
@@ -599,13 +872,13 @@ public class KeycloakInitializer {
             log.info("Assigning service account roles for client '{}'", appClientId);
 
             // 1. Find the client UUID (not clientId) for the application client
-            List<org.keycloak.representations.idm.ClientRepresentation> clients = keycloak.realm(REALM_ID).clients().findByClientId(appClientId);
+            List<org.keycloak.representations.idm.ClientRepresentation> clients = admin.realm(REALM_ID).clients().findByClientId(appClientId);
             if (clients.isEmpty()) {
                 log.error("Client '{}' not found in realm '{}'", appClientId, REALM_ID);
                 return;
             }
             org.keycloak.representations.idm.ClientRepresentation appClientRep = clients.get(0);
-            org.keycloak.admin.client.resource.ClientResource appClientResource = keycloak.realm(REALM_ID).clients().get(appClientRep.getId());
+            org.keycloak.admin.client.resource.ClientResource appClientResource = admin.realm(REALM_ID).clients().get(appClientRep.getId());
 
             // 2. Enable Service Accounts if not enabled
             if (!Boolean.TRUE.equals(appClientRep.isServiceAccountsEnabled())) {
@@ -620,10 +893,10 @@ public class KeycloakInitializer {
                 log.error("Service account user not found for client '{}'", appClientId);
                 return;
             }
-            UserResource serviceAccountUserResource = keycloak.realm(REALM_ID).users().get(serviceAccountUser.getId());
+            UserResource serviceAccountUserResource = admin.realm(REALM_ID).users().get(serviceAccountUser.getId());
 
             // 4. Find the 'realm-management' client UUID
-            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmtClients = keycloak.realm(REALM_ID).clients().findByClientId("realm-management");
+            List<org.keycloak.representations.idm.ClientRepresentation> realmMgmtClients = admin.realm(REALM_ID).clients().findByClientId("realm-management");
             if (realmMgmtClients.isEmpty()) {
                 log.error("'realm-management' client not found!");
                 return;
@@ -636,7 +909,7 @@ public class KeycloakInitializer {
 
             for (String roleName : requiredRoles) {
                 try {
-                    RoleRepresentation role = keycloak.realm(REALM_ID).clients().get(realmMgmtClientRep.getId()).roles().get(roleName).toRepresentation();
+                    RoleRepresentation role = admin.realm(REALM_ID).clients().get(realmMgmtClientRep.getId()).roles().get(roleName).toRepresentation();
                     rolesToAdd.add(role);
                 } catch (Exception e) {
                     log.warn("Role '{}' not found in realm-management", roleName);
@@ -670,7 +943,7 @@ public class KeycloakInitializer {
             realmRepresentationToImport.setRealm(REALM_ID);
             realmRepresentationToImport.setId(REALM_ID);
 
-            keycloak.realms().create(realmRepresentationToImport);
+            masterKeycloak.realms().create(realmRepresentationToImport);
         } catch (IOException e) {
             String errorMessage = String.format("Failed to import keycloak realm representation : %s", e.getMessage());
             log.error(errorMessage);
@@ -716,14 +989,14 @@ public class KeycloakInitializer {
         userCredentialRepresentation.setValue(user.getPassword());
         userRepresentation.setCredentials(List.of(userCredentialRepresentation));
 
-        try (Response response = keycloak.realm(REALM_ID).users().create(userRepresentation)) {
+        try (Response response = admin.realm(REALM_ID).users().create(userRepresentation)) {
             String userId = null;
             if (response.getStatus() == 201) { // CREATED
                 userId = CreatedResponseUtil.getCreatedId(response);
                 log.info("User '{}' created with id {}", user.getUserName(), userId);
             } else if (response.getStatus() == 409) { // CONFLICT
                 log.warn("User '{}' already exists. Fetching to assign roles if needed.", user.getUserName());
-                List<UserRepresentation> users = keycloak.realm(REALM_ID).users().search(user.getUserName());
+                List<UserRepresentation> users = admin.realm(REALM_ID).users().search(user.getUserName());
                 if (!users.isEmpty()) {
                     userId = users.get(0).getId();
                 } else {
@@ -736,10 +1009,10 @@ public class KeycloakInitializer {
             }
 
             if (userId != null) {
-                UserResource userResource = keycloak.realm(REALM_ID).users().get(userId);
+                UserResource userResource = admin.realm(REALM_ID).users().get(userId);
                 String roleName = user.isAdmin() ? "admin" : "user";
                 List<RoleRepresentation> rolesToAdd =
-                        Collections.singletonList(keycloak.realm(REALM_ID).roles().get(roleName).toRepresentation());
+                        Collections.singletonList(admin.realm(REALM_ID).roles().get(roleName).toRepresentation());
                 userResource.roles().realmLevel().add(rolesToAdd);
                 log.info("Role '{}' assigned to user '{}'", roleName, user.getUserName());
             }
@@ -751,13 +1024,13 @@ public class KeycloakInitializer {
             log.info("Ensuring authorization setup for client '{}'", appClientId);
 
             List<org.keycloak.representations.idm.ClientRepresentation> clients =
-                    keycloak.realm(REALM_ID).clients().findByClientId(appClientId);
+                    admin.realm(REALM_ID).clients().findByClientId(appClientId);
             if (clients.isEmpty()) {
                 log.warn("Client '{}' not found, skipping authorization setup", appClientId);
                 return;
             }
 
-            ClientResource clientResource = keycloak.realm(REALM_ID).clients().get(clients.get(0).getId());
+            ClientResource clientResource = admin.realm(REALM_ID).clients().get(clients.get(0).getId());
 
             String policyId = ensureDefaultRolePolicy(clientResource);
             String resourceId = ensureDefaultResource(clientResource);
@@ -790,13 +1063,13 @@ public class KeycloakInitializer {
 
         // required=false = OR logic — user needs at least one of these roles
         try {
-            RoleRepresentation userRole = keycloak.realm(REALM_ID).roles().get("user").toRepresentation();
+            RoleRepresentation userRole = admin.realm(REALM_ID).roles().get("user").toRepresentation();
             policy.addRole(userRole.getId(), false);
         } catch (Exception e) {
             log.warn("Realm role 'user' not found, skipping from Default Policy");
         }
         try {
-            RoleRepresentation adminRole = keycloak.realm(REALM_ID).roles().get("admin").toRepresentation();
+            RoleRepresentation adminRole = admin.realm(REALM_ID).roles().get("admin").toRepresentation();
             policy.addRole(adminRole.getId(), false);
         } catch (Exception e) {
             log.warn("Realm role 'admin' not found, skipping from Default Policy");
@@ -925,16 +1198,16 @@ public class KeycloakInitializer {
     private void ensureUsersHaveBaseRole() {
         try {
             log.info("Ensuring all users have at least the 'user' realm role");
-            RoleRepresentation userRole = keycloak.realm(REALM_ID).roles().get("user").toRepresentation();
+            RoleRepresentation userRole = admin.realm(REALM_ID).roles().get("user").toRepresentation();
 
-            List<UserRepresentation> allUsers = keycloak.realm(REALM_ID).users().list();
+            List<UserRepresentation> allUsers = admin.realm(REALM_ID).users().list();
             for (UserRepresentation u : allUsers) {
-                List<RoleRepresentation> realmRoles = keycloak.realm(REALM_ID).users()
+                List<RoleRepresentation> realmRoles = admin.realm(REALM_ID).users()
                         .get(u.getId()).roles().realmLevel().listAll();
                 boolean hasRole = realmRoles.stream()
                         .anyMatch(r -> "user".equals(r.getName()) || "admin".equals(r.getName()));
                 if (!hasRole) {
-                    keycloak.realm(REALM_ID).users().get(u.getId()).roles()
+                    admin.realm(REALM_ID).users().get(u.getId()).roles()
                             .realmLevel().add(Collections.singletonList(userRole));
                     log.info("Assigned 'user' role to existing user '{}'", u.getUsername());
                 }
@@ -947,7 +1220,7 @@ public class KeycloakInitializer {
 
     public void reset() {
         try {
-         keycloak.realm(REALM_ID).remove();
+         masterKeycloak.realm(REALM_ID).remove();
         } catch (NotFoundException e) {
             log.error("Failed to reset Keycloak", e);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,6 +121,13 @@ keycloak:
   # org); the public shared instance sets KEYCLOAK_REGISTRATION_ALLOWED=true so a signed-up user
   # can create their own org.
   registration-allowed: ${KEYCLOAK_REGISTRATION_ALLOWED:false}
+  # Realm-scoped initializer client (H-3). Steady-state startup reconcile authenticates as this
+  # confidential service account (realm-admin on the application realm only) instead of the master
+  # credential. The master credential (keycloak-initializer.*) is now used only to bootstrap a fresh
+  # or not-yet-migrated environment: create the realm and provision this client + its secret.
+  initializer:
+    service-client-id: ${KEYCLOAK_INITIALIZER_SERVICE_CLIENT_ID:echno-initializer}
+    service-client-secret: ${KEYCLOAK_INITIALIZER_CLIENT_SECRET:}
   admin:
     userName: ${KEYCLOAK_BACKEND_ADMIN_USERNAME}
     email: ${KEYCLOAK_BACKEND_ADMIN_EMAIL}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
@@ -1,0 +1,256 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Proves the H-3 scoped-admin redesign against a real Keycloak container.
+ *
+ * <p>Two scenarios are covered:
+ * <ol>
+ *   <li>Fresh bootstrap: the initializer creates the realm with the master credential, provisions a
+ *       realm-scoped echno-initializer client that holds realm-admin, and the scoped client can then
+ *       authenticate with client_credentials.</li>
+ *   <li>The exact failure that reverted the first attempt: an echno-initializer client that already
+ *       exists with the WRONG secret (so client_credentials is rejected as unauthorized_client). The
+ *       initializer must repair it (delete + recreate with the configured secret, which Keycloak
+ *       validates) so a freshly built scoped client can obtain a token.</li>
+ * </ol>
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class KeycloakInitializerScopedAdminIT {
+
+    private static final String TEST_REALM = "echno-it-realm";
+    private static final String INIT_CLIENT_ID = "echno-initializer";
+    private static final String INIT_SECRET = "echno-initializer-it-secret";
+    private static final String WRONG_SECRET = "deliberately-wrong-secret";
+    private static final String APP_CLIENT_ID = "echno-backend";
+    private static final String REALM_MANAGEMENT = "realm-management";
+    private static final String REALM_ADMIN = "realm-admin";
+    private static final String COMPOSITE_JOB_ROLE = "job-leadership";
+
+    // Pin the server image to the tag matching the keycloak-admin-client version so the container
+    // API and the client stay in lockstep.
+    private static final KeycloakContainer KEYCLOAK =
+            new KeycloakContainer("quay.io/keycloak/keycloak:26.0.7");
+
+    private static Path configDir;
+    private static Keycloak master;
+    private static KeycloakInitializerConfigurationProperties props;
+    private static KeycloakConfig keycloakConfig;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        KEYCLOAK.start();
+
+        // Stage the realm/user config files the initializer reads from disk.
+        configDir = Files.createTempDirectory("keycloak-it-config");
+        copyResource("keycloak-it/init-keycloak.json", configDir.resolve("init-keycloak.json"));
+        copyResource("keycloak-it/init-keycloak-users.json", configDir.resolve("init-keycloak-users.json"));
+
+        master = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm("master")
+                .clientId("admin-cli")
+                .username(KEYCLOAK.getAdminUsername())
+                .password(KEYCLOAK.getAdminPassword())
+                .grantType(OAuth2Constants.PASSWORD)
+                .build();
+
+        props = new KeycloakInitializerConfigurationProperties();
+        props.setMasterRealm("master");
+        props.setApplicationRealm(TEST_REALM);
+        props.setClientId("admin-cli");
+        props.setUsername(KEYCLOAK.getAdminUsername());
+        props.setPassword(KEYCLOAK.getAdminPassword());
+        props.setUrl(KEYCLOAK.getAuthServerUrl());
+
+        keycloakConfig = new KeycloakConfig();
+        ReflectionTestUtils.setField(keycloakConfig, "keycloakInitializerConfigurationProperties", props);
+        ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientId", INIT_CLIENT_ID);
+        ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientSecret", INIT_SECRET);
+
+        // REALM_ID is a static field normally set from ApplicationReadyEvent; set it directly here.
+        ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", TEST_REALM);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (master != null) {
+            master.close();
+        }
+        KEYCLOAK.stop();
+    }
+
+    private static void copyResource(String classpath, Path target) throws Exception {
+        try (InputStream in = KeycloakInitializerScopedAdminIT.class.getClassLoader().getResourceAsStream(classpath)) {
+            assertThat(in).as("test resource %s", classpath).isNotNull();
+            Files.copy(in, target);
+        }
+    }
+
+    private KeycloakInitializer newInitializer() {
+        // Mirror Spring Boot's auto-configured mapper, which ignores unknown properties, so the
+        // Keycloak RealmRepresentation config parses the same way it does at runtime.
+        ObjectMapper lenientMapper = new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        KeycloakInitializer initializer =
+                new KeycloakInitializer(master, props, lenientMapper, keycloakConfig);
+        ReflectionTestUtils.setField(initializer, "configOutput", configDir.toString());
+        ReflectionTestUtils.setField(initializer, "appClientId", APP_CLIENT_ID);
+        return initializer;
+    }
+
+    private boolean realmExists() {
+        try {
+            master.realm(TEST_REALM).toRepresentation();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** Builds a scoped client_credentials client with the given secret and returns the access token string. */
+    private String fetchScopedToken(String secret) {
+        try (Keycloak scoped = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm(TEST_REALM)
+                .clientId(INIT_CLIENT_ID)
+                .clientSecret(secret)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build()) {
+            return scoped.tokenManager().getAccessTokenString();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void freshBootstrapCreatesRealmAndScopedInitializerClient() {
+        KeycloakInitializer initializer = newInitializer();
+
+        initializer.init(false);
+
+        // Realm was created.
+        assertThat(master.realm(TEST_REALM).toRepresentation()).isNotNull();
+
+        // The scoped initializer client exists and is confidential with a service account.
+        List<ClientRepresentation> initClients = master.realm(TEST_REALM).clients().findByClientId(INIT_CLIENT_ID);
+        assertThat(initClients).hasSize(1);
+        ClientRepresentation initClient = initClients.get(0);
+        assertThat(initClient.isPublicClient()).isFalse();
+        assertThat(initClient.isServiceAccountsEnabled()).isTrue();
+
+        // Its service account actually holds realm-admin (from realm-management).
+        UserRepresentation serviceAccount =
+                master.realm(TEST_REALM).clients().get(initClient.getId()).getServiceAccountUser();
+        assertThat(serviceAccount).isNotNull();
+        String realmMgmtUuid =
+                master.realm(TEST_REALM).clients().findByClientId(REALM_MANAGEMENT).get(0).getId();
+        List<RoleRepresentation> saClientRoles = master.realm(TEST_REALM).users()
+                .get(serviceAccount.getId()).roles().clientLevel(realmMgmtUuid).listAll();
+        assertThat(saClientRoles).extracting(RoleRepresentation::getName).contains(REALM_ADMIN);
+
+        // Reconcile completed: a composite job role (H-1) was created through the scoped admin.
+        assertThat(master.realm(TEST_REALM).roles().get(COMPOSITE_JOB_ROLE).toRepresentation()).isNotNull();
+
+        // The scoped client can independently obtain a client_credentials token with the config secret.
+        assertThatCode(() -> {
+            String token = fetchScopedToken(INIT_SECRET);
+            assertThat(token).isNotBlank();
+        }).doesNotThrowAnyException();
+    }
+
+    /**
+     * The exact live failure the reverted attempt did not cover: an echno-initializer client that
+     * already exists with a secret that does NOT match the configured one. The client_credentials
+     * grant is rejected until the initializer repairs the client by recreating it with a validated
+     * secret. This test drives that repair against a real Keycloak.
+     */
+    @Test
+    @Order(2)
+    void existingClientWithWrongSecret_isRepairedAndScopedAuthWorks() {
+        // The realm exists from the fresh bootstrap; guard defensively in case of isolated execution.
+        if (!realmExists()) {
+            newInitializer().init(false);
+        }
+
+        // Replace the good client with one carrying a DELIBERATELY WRONG secret, reproducing the
+        // broken live state: the stored credential differs from the configured one.
+        List<ClientRepresentation> current = master.realm(TEST_REALM).clients().findByClientId(INIT_CLIENT_ID);
+        for (ClientRepresentation c : current) {
+            master.realm(TEST_REALM).clients().get(c.getId()).remove();
+        }
+        ClientRepresentation broken = new ClientRepresentation();
+        broken.setClientId(INIT_CLIENT_ID);
+        broken.setEnabled(true);
+        broken.setPublicClient(false);
+        broken.setServiceAccountsEnabled(true);
+        broken.setStandardFlowEnabled(false);
+        broken.setDirectAccessGrantsEnabled(false);
+        broken.setSecret(WRONG_SECRET);
+        String brokenUuid;
+        try (Response response = master.realm(TEST_REALM).clients().create(broken)) {
+            assertThat(response.getStatus()).isEqualTo(201);
+            brokenUuid = CreatedResponseUtil.getCreatedId(response);
+        }
+        assertThat(brokenUuid).isNotBlank();
+
+        // Precondition: with the wrong stored secret, the configured secret cannot authenticate.
+        assertThatCode(() -> fetchScopedToken(INIT_SECRET))
+                .as("client_credentials must fail while the stored secret is wrong")
+                .isInstanceOf(Exception.class);
+
+        // Run the initializer with the correct configured secret. It must detect the unusable scoped
+        // client, delete + recreate it with a validated secret, and finish the reconcile.
+        assertThatCode(() -> newInitializer().init(false)).doesNotThrowAnyException();
+
+        // (a) The client was recreated (fresh UUID, not an in-place secret update).
+        List<ClientRepresentation> repaired = master.realm(TEST_REALM).clients().findByClientId(INIT_CLIENT_ID);
+        assertThat(repaired).hasSize(1);
+        assertThat(repaired.get(0).getId()).isNotEqualTo(brokenUuid);
+
+        // (b) THE assertion that failed live: a freshly built scoped client can now obtain a
+        // client_credentials access token with the configured secret, with no exception.
+        assertThatCode(() -> {
+            String token = fetchScopedToken(INIT_SECRET);
+            assertThat(token).isNotBlank();
+        }).doesNotThrowAnyException();
+
+        // (c) Reconcile artifacts still exist (composite job role from H-1).
+        assertThat(master.realm(TEST_REALM).roles().get(COMPOSITE_JOB_ROLE).toRepresentation()).isNotNull();
+
+        // And the repaired service account holds realm-admin again.
+        UserRepresentation serviceAccount =
+                master.realm(TEST_REALM).clients().get(repaired.get(0).getId()).getServiceAccountUser();
+        assertThat(serviceAccount).isNotNull();
+        String realmMgmtUuid =
+                master.realm(TEST_REALM).clients().findByClientId(REALM_MANAGEMENT).get(0).getId();
+        List<RoleRepresentation> saClientRoles = master.realm(TEST_REALM).users()
+                .get(serviceAccount.getId()).roles().clientLevel(realmMgmtUuid).listAll();
+        assertThat(saClientRoles).extracting(RoleRepresentation::getName).contains(REALM_ADMIN);
+    }
+}

--- a/src/test/resources/keycloak-it/init-keycloak-users.json
+++ b/src/test/resources/keycloak-it/init-keycloak-users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "userName": "it-admin",
+    "emailId": "it-admin@echno.test",
+    "password": "it-admin-pass",
+    "firstName": "IT",
+    "lastName": "Admin",
+    "isAdmin": true
+  }
+]

--- a/src/test/resources/keycloak-it/init-keycloak.json
+++ b/src/test/resources/keycloak-it/init-keycloak.json
@@ -1,0 +1,44 @@
+{
+  "realm": "echno-it-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "displayName": "Echno IT Realm",
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "bruteForceProtected": true,
+  "failureFactor": 5,
+  "revokeRefreshToken": true,
+  "clients": [
+    {
+      "clientId": "echno-backend",
+      "publicClient": false,
+      "secret": "echno-backend-it-secret",
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {"name": "user", "description": "Regular user role"},
+      {"name": "admin", "description": "Administrator with full access"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Re-implements the H-3 refactor so the startup Keycloak initializer stops using the master-realm admin credential for steady-state reconcile. Master is now used only to bootstrap a fresh or not-yet-migrated environment; every reconcile runs through a realm-scoped `echno-initializer` service client that holds `realm-admin` on the application realm only.

This replaces the earlier attempt that was reverted because it failed live: the scoped client's `client_credentials` grant returned `unauthorized_client`.

## Root cause of the earlier failure, and the fix

Keycloak only honours a caller-supplied `ClientRepresentation.setSecret(...)` on **CREATE**, not on update. The reverted code set the secret on an existing client and called `update()`, which did not replace the credential Keycloak validates, so the subsequent `client_credentials` grant was rejected. Its Testcontainers test only exercised the create path, so the failure never surfaced.

`ensureInitializerClient` now:

- **Missing client**: creates it with the secret in the representation (create honours it).
- **Existing but unusable client** (the realign case that broke live): **deletes and recreates** it with the configured secret, never an in-place secret update. This guarantees the stored, validated credential equals the config value.

Before trusting the scoped client the initializer performs a **real `client_credentials` token fetch** (`verifyScoped`). If it still fails, the whole reconcile falls back to the master credential for that startup with a clear WARN, so reconcile is never left half-done through a non-authenticating client (which was the source of the 401 spam).

## Design

- `KeycloakConfig`: bootstrap-only `masterKeycloak` bean plus a `buildScopedKeycloak()` factory (`grantType=client_credentials`, realm = application realm, clientId/secret from config).
- Flow: probe the scoped client first; if it authenticates, reconcile entirely through it and never touch master. Otherwise bootstrap via master (create realm if absent, ensure/repair the initializer client), verify the scoped client, then reconcile through it (or fall back to master).
- New config: `keycloak.initializer.service-client-id` (`KEYCLOAK_INITIALIZER_SERVICE_CLIENT_ID`, default `echno-initializer`) and `keycloak.initializer.service-client-secret` (`KEYCLOAK_INITIALIZER_CLIENT_SECRET`). Master creds retained as bootstrap fallback.

## Tests

New Testcontainers Keycloak IT (`KeycloakInitializerScopedAdminIT`, real `quay.io/keycloak/keycloak:26.0.7`):

- `freshBootstrapCreatesRealmAndScopedInitializerClient`: fresh bootstrap creates the realm and a confidential `echno-initializer` client holding `realm-admin`, reconcile artifacts exist, and the scoped client authenticates via `client_credentials`.
- `existingClientWithWrongSecret_isRepairedAndScopedAuthWorks`: pre-creates an `echno-initializer` client with a **deliberately wrong secret** (so `client_credentials` 401s), runs the initializer with the correct config secret, and asserts the client is repaired (fresh UUID), a freshly built scoped client obtains a real access token with the configured secret, `realm-admin` is held again, and a composite job role exists. This reproduces exactly the grant that failed live.

Built and tested on lab node `.116`:

- `./gradlew compileJava` -> BUILD SUCCESSFUL
- `./gradlew test --tests ...KeycloakInitializerScopedAdminIT` -> BUILD SUCCESSFUL, 2 tests passed.