### PR TITLE
Optional Redis backing for cross-replica cache and rate limiting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     implementation 'javax.cache:cache-api:1.1.1'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.2.2'
     implementation 'com.github.ben-manes.caffeine:jcache:3.2.2'
+    // Optional Redis backing for cross-replica shared state (Spring cache + Bucket4j rate
+    // limiting). Only wired when echno.cache.provider=redis; the default (caffeine) path
+    // never contacts Redis. The Lettuce-based Bucket4j proxy manager version is pinned to
+    // match the bucket4j core the giffing starter pulls (8.14.0).
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.14.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/org/tornotron/echno_backend/EchnoBackendApplication.java
+++ b/src/main/java/org/tornotron/echno_backend/EchnoBackendApplication.java
@@ -2,12 +2,18 @@ package org.tornotron.echno_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.core.Ordered;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@SpringBootApplication
+// Spring Data Redis is on the classpath only to provide the optional cross-replica cache/
+// rate-limit backing (echno.cache.provider=redis). Its auto-configuration is excluded so the
+// default (caffeine) profile never creates a RedisConnectionFactory and never opens a Redis
+// connection; when provider=redis, RedisConfig supplies the connection factory itself.
+@SpringBootApplication(exclude = {RedisAutoConfiguration.class, RedisReactiveAutoConfiguration.class})
 @EnableCaching
 @EnableAsync
 @EnableTransactionManagement(order = Ordered.HIGHEST_PRECEDENCE)

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/EchnoCacheEnvironmentPostProcessor.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/EchnoCacheEnvironmentPostProcessor.java
@@ -1,0 +1,49 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.Map;
+
+/**
+ * Makes {@code echno.cache.provider} the single switch for cross-replica state: when it is set
+ * to {@code redis}, the Bucket4j rate limiter is pointed at Redis by defaulting
+ * {@code bucket4j.cache-to-use} to {@code redis-lettuce}. Together with the {@code RedisClient}
+ * bean from {@code RedisConfig}, that selects the Bucket4j Lettuce (Redis) auto-configuration so
+ * rate limits are enforced cluster-wide instead of per pod.
+ *
+ * <p>The value is added as a low-priority default, so an operator who sets
+ * {@code bucket4j.cache-to-use} explicitly still wins. On the default profile
+ * ({@code echno.cache.provider} unset or {@code caffeine}) this processor does nothing, leaving
+ * the in-process Bucket4j buckets untouched.
+ */
+public class EchnoCacheEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    private static final String PROVIDER_PROPERTY = "echno.cache.provider";
+    private static final String BUCKET4J_CACHE_PROPERTY = "bucket4j.cache-to-use";
+    private static final String REDIS_LETTUCE = "redis-lettuce";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        String provider = environment.getProperty(PROVIDER_PROPERTY, "caffeine");
+        if (!REDIS_LETTUCE.equals(provider) && !"redis".equalsIgnoreCase(provider)) {
+            return;
+        }
+        // Respect an explicit operator choice of Bucket4j backend.
+        if (environment.getProperty(BUCKET4J_CACHE_PROPERTY) != null) {
+            return;
+        }
+        Map<String, Object> defaults = Map.of(BUCKET4J_CACHE_PROPERTY, REDIS_LETTUCE);
+        environment.getPropertySources()
+                .addLast(new MapPropertySource("echnoCacheProviderDefaults", defaults));
+    }
+
+    @Override
+    public int getOrder() {
+        // After the standard config-data processing so echno.cache.provider is already bound.
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RedisConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RedisConfig.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Optional Redis backing for cross-replica shared state, activated only when
+ * {@code echno.cache.provider=redis} (env {@code ECHNO_CACHE_PROVIDER}). It supplies the
+ * Redis connection and turns the Spring cache abstraction into a Redis-backed
+ * {@link RedisCacheManager} so {@code @Cacheable} caches are shared by every replica instead
+ * of each pod holding its own copy.
+ *
+ * <p>When the property is absent or set to {@code caffeine} (the default) none of these beans
+ * exist: Spring Boot's cache auto-configuration keeps the in-process Caffeine cache manager
+ * and no Redis connection is opened, so single-replica deployments behave exactly as before.
+ *
+ * <p>The {@link RedisClient} bean is the Lettuce client the Bucket4j starter picks up for its
+ * Redis-backed rate limiter (see {@code bucket4j.cache-to-use=redis-lettuce}, set from the same
+ * single switch by {@code EchnoCacheEnvironmentPostProcessor}). The distributed rate limiter is
+ * therefore driven by the same {@code echno.cache.provider} property.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "echno.cache.provider", havingValue = "redis")
+@EnableConfigurationProperties(RedisProperties.class)
+@Slf4j
+public class RedisConfig {
+
+    /**
+     * Standalone Lettuce connection factory built from {@code spring.data.redis.*}. Provided
+     * explicitly because Spring Boot's Redis auto-configuration is excluded in
+     * {@code EchnoBackendApplication}, so this bean exists only on the redis profile.
+     */
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory(RedisProperties props) {
+        RedisStandaloneConfiguration standalone =
+                new RedisStandaloneConfiguration(props.getHost(), props.getPort());
+        standalone.setDatabase(props.getDatabase());
+        if (props.getUsername() != null && !props.getUsername().isBlank()) {
+            standalone.setUsername(props.getUsername());
+        }
+        if (props.getPassword() != null && !props.getPassword().isBlank()) {
+            standalone.setPassword(RedisPassword.of(props.getPassword()));
+        }
+        log.info("Redis cache provider active: connecting Spring cache to {}:{} (db {})",
+                props.getHost(), props.getPort(), props.getDatabase());
+        return new LettuceConnectionFactory(standalone);
+    }
+
+    /**
+     * Redis-backed Spring cache manager. Keys are stored as plain strings and values as JSON.
+     * The default entry TTL mirrors the previous Caffeine global spec (expireAfterAccess=3600s);
+     * per-cache TTLs preserve the intent of the domain caches (the subscription cache's 5-minute
+     * window) so a future {@code @Cacheable("subscriptions")} inherits the same freshness bound.
+     * TTLs are expire-after-write under Redis.
+     */
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration base = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> perCache = new HashMap<>();
+        perCache.put("subscriptions", base.entryTtl(Duration.ofMinutes(5)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(base)
+                .withInitialCacheConfigurations(perCache)
+                .build();
+    }
+
+    /**
+     * Lettuce {@link RedisClient} consumed by the Bucket4j Redis (lettuce) auto-configuration so
+     * rate-limit buckets live in Redis and are enforced cluster-wide. Shut down with the context.
+     */
+    @Bean(destroyMethod = "shutdown")
+    public RedisClient bucket4jRedisClient(RedisProperties props) {
+        RedisURI.Builder uri = RedisURI.builder()
+                .withHost(props.getHost())
+                .withPort(props.getPort())
+                .withDatabase(props.getDatabase());
+        if (props.getUsername() != null && !props.getUsername().isBlank()
+                && props.getPassword() != null && !props.getPassword().isBlank()) {
+            uri.withAuthentication(props.getUsername(), props.getPassword().toCharArray());
+        } else if (props.getPassword() != null && !props.getPassword().isBlank()) {
+            uri.withPassword(props.getPassword().toCharArray());
+        }
+        return RedisClient.create(uri.build());
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.tornotron.echno_backend.common.configuration.EchnoCacheEnvironmentPostProcessor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,6 +145,13 @@ keycloak:
 
 
 echno:
+  cache:
+    # Single switch for cross-replica shared state. Default 'caffeine' keeps every cache and the
+    # Bucket4j rate limiter in-process (the single-replica compose staging behaviour: no Redis is
+    # contacted and no Redis bean is created). Set to 'redis' on multi-replica deployments to back
+    # the Spring cache abstraction and the rate limiter with the shared Redis configured under
+    # spring.data.redis below, so limits and cached values are shared across pods.
+    provider: ${ECHNO_CACHE_PROVIDER:caffeine}
   security:
     jwt:
       # Reject any access token whose audience does not include the backend client
@@ -158,6 +165,13 @@ echno:
 
 
 spring:
+  # Connection for the optional Redis cache/rate-limit backing. Only read when
+  # echno.cache.provider=redis; on the default caffeine profile nothing consumes these and no
+  # connection is opened. Host/port follow the Spring Boot standard env vars.
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
   cache:
     cache-names:
       - rate-limit-buckets

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisCacheProviderConditionalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisCacheProviderConditionalTest.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.lettuce.core.RedisClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the guard on the optional Redis backing: with the default cache provider (caffeine)
+ * the {@link RedisConfig} beans are never created, so the application context starts with no
+ * Redis connection factory, no Redis cache manager and no Lettuce client. This is what keeps the
+ * single-replica deployments (which configure no Redis) behaving exactly as before.
+ */
+class RedisCacheProviderConditionalTest {
+
+    private final ApplicationContextRunner runner =
+            new ApplicationContextRunner().withUserConfiguration(RedisConfig.class);
+
+    @Test
+    void noProviderConfigured_createsNoRedisBeans() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(RedisConfig.class);
+            assertThat(context).doesNotHaveBean(RedisConnectionFactory.class);
+            assertThat(context).doesNotHaveBean(RedisCacheManager.class);
+            assertThat(context).doesNotHaveBean(RedisClient.class);
+        });
+    }
+
+    @Test
+    void caffeineProvider_createsNoRedisBeans() {
+        runner.withPropertyValues("echno.cache.provider=caffeine").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(RedisConfig.class);
+            assertThat(context).doesNotHaveBean(RedisConnectionFactory.class);
+            assertThat(context).doesNotHaveBean(RedisCacheManager.class);
+            assertThat(context).doesNotHaveBean(RedisClient.class);
+        });
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
@@ -1,6 +1,5 @@
 package org.tornotron.echno_backend.common.configuration;
 
-import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.distributed.BucketProxy;
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
@@ -115,7 +114,7 @@ class RedisDistributedStateIT {
         LettuceBasedProxyManager<byte[]> proxyManagerB = lettuceProxyManager(newRedisClient());
 
         Supplier<BucketConfiguration> config = () -> BucketConfiguration.builder()
-                .addLimit(Bandwidth.simple(20, Duration.ofMinutes(1)))
+                .addLimit(limit -> limit.capacity(20).refillGreedy(20, Duration.ofMinutes(1)))
                 .build();
 
         byte[] sharedKey = "rate-limit:1.2.3.4".getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
@@ -1,0 +1,164 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.BucketProxy;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
+import io.lettuce.core.RedisClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for the optional Redis backing against a real Redis container. It proves the
+ * two properties that make the state cross-replica:
+ *
+ * <ol>
+ *   <li>a value written through one Redis-backed Spring cache manager is served to a second,
+ *       independent cache manager (as two pods would each have) from the shared Redis;</li>
+ *   <li>two independent Bucket4j proxy managers pointed at the same Redis key consume from one
+ *       shared token allowance, so a rate limit is enforced cluster-wide.</li>
+ * </ol>
+ *
+ * It also confirms {@link RedisConfig} actually creates its beans when the provider is redis.
+ */
+@Testcontainers
+class RedisDistributedStateIT {
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private final RedisConfig redisConfig = new RedisConfig();
+    private final List<AutoCloseable> closeables = new ArrayList<>();
+
+    private String host;
+    private int port;
+
+    @BeforeEach
+    void resolveEndpoint() {
+        host = REDIS.getHost();
+        port = REDIS.getMappedPort(6379);
+    }
+
+    @AfterEach
+    void closeResources() {
+        for (AutoCloseable c : closeables) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+        closeables.clear();
+    }
+
+    /** A separate connection factory per manager stands in for a separate pod. */
+    private RedisConnectionFactory newConnectionFactory() {
+        LettuceConnectionFactory factory =
+                new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+        factory.afterPropertiesSet();
+        closeables.add(factory::destroy);
+        return factory;
+    }
+
+    private RedisClient newRedisClient() {
+        RedisClient client = RedisClient.create(
+                io.lettuce.core.RedisURI.builder().withHost(host).withPort(port).build());
+        closeables.add(client::shutdown);
+        return client;
+    }
+
+    @Test
+    void cacheableValueIsSharedAcrossTwoCacheManagersViaRedis() {
+        // Two independent Redis-backed cache managers, as two replicas would build.
+        RedisCacheManager writerManager = redisConfig.cacheManager(newConnectionFactory());
+        writerManager.afterPropertiesSet();
+        RedisCacheManager readerManager = redisConfig.cacheManager(newConnectionFactory());
+        readerManager.afterPropertiesSet();
+
+        Cache writerCache = writerManager.getCache("subscriptions");
+        Cache readerCache = readerManager.getCache("subscriptions");
+        assertThat(writerCache).isNotNull();
+        assertThat(readerCache).isNotNull();
+
+        writerCache.put("user-42", "premium-plan");
+
+        // The second manager, with its own connection, reads the value from the shared Redis.
+        Cache.ValueWrapper fromReader = readerCache.get("user-42");
+        assertThat(fromReader).isNotNull();
+        assertThat(fromReader.get()).isEqualTo("premium-plan");
+    }
+
+    @Test
+    void rateLimiterSharesOneBucketAcrossTwoProxyManagers() {
+        LettuceBasedProxyManager<byte[]> proxyManagerA = lettuceProxyManager(newRedisClient());
+        LettuceBasedProxyManager<byte[]> proxyManagerB = lettuceProxyManager(newRedisClient());
+
+        Supplier<BucketConfiguration> config = () -> BucketConfiguration.builder()
+                .addLimit(Bandwidth.simple(20, Duration.ofMinutes(1)))
+                .build();
+
+        byte[] sharedKey = "rate-limit:1.2.3.4".getBytes(StandardCharsets.UTF_8);
+        BucketProxy bucketA = proxyManagerA.builder().build(sharedKey, config);
+        BucketProxy bucketB = proxyManagerB.builder().build(sharedKey, config);
+
+        // Consume 15 of the 20 tokens through the first manager.
+        for (int i = 0; i < 15; i++) {
+            assertThat(bucketA.tryConsume(1)).as("token %d via A", i).isTrue();
+        }
+
+        // The second manager, a separate instance, sees only the remaining 5 tokens.
+        assertThat(bucketB.getAvailableTokens()).isEqualTo(5);
+        for (int i = 0; i < 5; i++) {
+            assertThat(bucketB.tryConsume(1)).as("token %d via B", i).isTrue();
+        }
+
+        // The shared allowance is now exhausted for both managers.
+        assertThat(bucketB.tryConsume(1)).isFalse();
+        assertThat(bucketA.tryConsume(1)).isFalse();
+    }
+
+    @Test
+    void redisProviderCreatesRedisBeans() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(RedisConfig.class)
+                .withPropertyValues(
+                        "echno.cache.provider=redis",
+                        "spring.data.redis.host=" + host,
+                        "spring.data.redis.port=" + port)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(RedisConfig.class);
+                    assertThat(context).hasSingleBean(RedisConnectionFactory.class);
+                    assertThat(context).hasSingleBean(RedisCacheManager.class);
+                    assertThat(context).hasBean("bucket4jRedisClient");
+                });
+    }
+
+    private LettuceBasedProxyManager<byte[]> lettuceProxyManager(RedisClient client) {
+        return LettuceBasedProxyManager.builderFor(client)
+                .withExpirationStrategy(ExpirationAfterWriteStrategy
+                        .basedOnTimeForRefillingBucketUpToMax(Duration.ofMinutes(2)))
+                .build();
+    }
+}


### PR DESCRIPTION
## What

Adds an opt-in Redis backing so multi-replica deployments share cache and rate-limit state instead of each pod holding its own. A single switch controls it:

- \`echno.cache.provider\` (env \`ECHNO_CACHE_PROVIDER\`, default \`caffeine\`; set to \`redis\` to enable)
- Redis endpoint via the Spring Boot standard \`spring.data.redis.host\` / \`spring.data.redis.port\` (env \`SPRING_DATA_REDIS_HOST\` / \`SPRING_DATA_REDIS_PORT\`, port default 6379)

When \`provider=redis\`:

- The Spring cache abstraction is backed by a \`RedisCacheManager\`, so \`@Cacheable\` caches are shared across pods. Per-cache TTLs are preserved (default 1h mirroring the old Caffeine global spec; \`subscriptions\` at 5m).
- The Bucket4j rate limiter uses the Lettuce Redis proxy manager (\`bucket4j.cache-to-use=redis-lettuce\`, defaulted from the same switch by an \`EnvironmentPostProcessor\`), so limits are enforced cluster-wide. Limit values are unchanged.

The RPT jti cache and the manual subscription Caffeine cache stay per-pod by design (short-lived / not \`@Cacheable\`), matching the existing RPT-cache guidance.

## Default path is unchanged

With no Redis configured (\`provider=caffeine\`, the single-replica compose staging), Redis auto-configuration is excluded, no Redis bean is created, and no connection is attempted. No new required env. This is safe on the single-replica staging.

## Tests (Testcontainers Redis)

- \`RedisDistributedStateIT\`: a \`@Cacheable\` value written through one cache manager is served from Redis to a second independent manager; two Bucket4j proxy managers pointed at the same Redis key consume one shared allowance; and \`provider=redis\` creates the expected beans.
- \`RedisCacheProviderConditionalTest\`: with the default/\`caffeine\` provider, no Redis bean is created and the context starts cleanly.

Validated on lab .116: \`./gradlew compileJava\` BUILD SUCCESSFUL; the two new test classes (5 tests) BUILD SUCCESSFUL with a real Redis container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis support for shared caching and distributed rate limiting.
  * Added configurable cache provider selection, defaulting to local in-process caching.
  * Redis-backed caching supports configurable connection settings and cache expiration policies.

* **Bug Fixes**
  * Prevented unwanted Redis connections when Redis caching is not selected.

* **Tests**
  * Added coverage for provider selection, Redis cache sharing, and distributed rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->