### PR TITLE
Fix logback root so console logging is never silently detached

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -42,13 +42,28 @@
         </appender>
     </springProfile>
 
-    <!-- Root Logger Configuration -->
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <springProfile name="loki">
+    <!--
+      Root logger. Console is always attached, so a stdout log shipper and
+      `kubectl logs` always see everything; Loki is added on top only under the
+      loki profile.
+
+      A <springProfile> must NOT be nested inside <root> (or <appender>/<logger>):
+      Spring Boot's sanity checker rejects it and the enclosing element's appender
+      refs stop being applied, which silently detaches CONSOLE and loses every
+      application log. So the two variants are declared as sibling roots, each
+      wrapped in a top-level <springProfile>.
+    -->
+    <springProfile name="loki">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="LOKI"/>
-        </springProfile>
-    </root>
+        </root>
+    </springProfile>
+    <springProfile name="!loki">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
 
     <!-- Specific Logger Configurations -->
     <logger name="org.tornotron.echno_backend" level="INFO"/>


### PR DESCRIPTION
`logback-spring.xml` nested `<springProfile name="loki">` inside `<root>`. Spring Boot's sanity checker rejects that nesting and stops applying the root's appender refs, so the **CONSOLE appender was detached and every application log was lost on stdout**.

In the k8s deployment the backend runs the default (non-loki) profile and logs only to console, so this made backend logs completely invisible — a startup exception went nowhere. It is why the recent redis-provider boot crash had to be reproduced on a lab node to diagnose.

Declares the two variants as sibling roots each wrapped in a top-level `<springProfile>`: console is always attached; Loki is added on top only under the loki profile.

Verified on a lab node running the full-context boot IT: the invalid-nesting warning is gone and the previously-absent JSON console logs now appear (0 → present).