### PR TITLE
Keep an unreachable Redis from failing the backend's startup

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,5 +13,8 @@ regexTarget = "match"
 regexes = ['''keycloak-db:5432/keycloak''']
 
 [[allowlists]]
-description = "Full-context redis boot IT. Its @SpringBootTest properties are dummy stand-ins for the deployment environment (object store, keycloak, encryption key) so the context can start; none are real credentials."
-paths = ['''src/test/java/org/tornotron/echno_backend/common/configuration/RedisFullContextBootIT\.java''']
+description = "Full-context redis boot ITs, one against a reachable redis and one against an unreachable one. Their @SpringBootTest properties are dummy stand-ins for the deployment environment (object store, keycloak, encryption key) so the context can start; none are real credentials."
+paths = [
+  '''src/test/java/org/tornotron/echno_backend/common/configuration/RedisFullContextBootIT\.java''',
+  '''src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT\.java''',
+]

--- a/src/main/java/org/tornotron/echno_backend/chat/realtime/ChatRealtimeRedisConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/realtime/ChatRealtimeRedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * Redis wiring for cross-replica chat delivery, active only when
@@ -30,6 +31,9 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 @ConditionalOnProperty(name = "echno.cache.provider", havingValue = "redis")
 public class ChatRealtimeRedisConfig {
 
+    /** How long the container waits before re-establishing a subscription it has lost. */
+    private static final long RECOVERY_INTERVAL_MS = 10_000L;
+
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
@@ -42,10 +46,25 @@ public class ChatRealtimeRedisConfig {
     @Bean
     public RedisMessageListenerContainer chatEventListenerContainer(
             RedisConnectionFactory connectionFactory, ChatEventSubscriber subscriber) {
-        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        // isAutoStartup is overridden rather than set: RedisMessageListenerContainer exposes no
+        // setter for it, and this is the only hook that keeps the lifecycle processor from
+        // starting the subscription during context refresh.
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer() {
+            @Override
+            public boolean isAutoStartup() {
+                return false;
+            }
+        };
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(subscriber, new ChannelTopic(RedisChatEventPublisher.CHANNEL));
-        log.info("Chat real-time delivery subscribed to Redis channel {}", RedisChatEventPublisher.CHANNEL);
+        // Do NOT start with the context. The container opens its subscription during startup, and
+        // an unreachable Redis makes that throw out of the lifecycle processor and take the whole
+        // context with it. That is a real deployment state rather than a hypothetical: the app
+        // deploy renders SPRING_DATA_REDIS_HOST while only an infra run creates the container, so
+        // the two can legitimately be out of step. The cache and rate limiter never noticed
+        // because Lettuce connects lazily. Chat must not be the reason the API fails to boot, so
+        // ChatStreamSubscription starts this after the context is up and keeps retrying.
+        container.setRecoveryBackoff(new FixedBackOff(RECOVERY_INTERVAL_MS, Long.MAX_VALUE));
         return container;
     }
 

--- a/src/main/java/org/tornotron/echno_backend/chat/realtime/ChatStreamSubscription.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/realtime/ChatStreamSubscription.java
@@ -1,0 +1,53 @@
+package org.tornotron.echno_backend.chat.realtime;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Starts and keeps alive the Redis subscription that feeds cross-replica chat delivery.
+ *
+ * <p>The container is configured not to start with the application context, because opening a
+ * subscription against an unreachable Redis throws out of the lifecycle processor and fails the
+ * whole context. A chat feature must not be able to stop the API from booting, so the subscription
+ * is established after startup instead, and a failure to establish it is a degraded feature rather
+ * than a dead service: writes still succeed, and the web client still has the polling it kept.
+ *
+ * <p>Retrying on a schedule also means a backend that started before its Redis picks the
+ * subscription up on its own, rather than needing a restart to notice.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "echno.cache.provider", havingValue = "redis")
+public class ChatStreamSubscription {
+
+    private final RedisMessageListenerContainer container;
+
+    /** Keeps the failure log to one line per outage instead of one per attempt. */
+    private final AtomicBoolean reportedFailure = new AtomicBoolean();
+
+    @Scheduled(initialDelay = 0, fixedDelay = 30_000L)
+    public void ensureSubscribed() {
+        if (container.isRunning()) {
+            return;
+        }
+        try {
+            container.start();
+            log.info("Chat real-time delivery subscribed to Redis channel {}",
+                    RedisChatEventPublisher.CHANNEL);
+            reportedFailure.set(false);
+        } catch (Exception e) {
+            if (reportedFailure.compareAndSet(false, true)) {
+                log.error("Chat real-time delivery could not subscribe to Redis ({}). Messages will "
+                        + "still send and the web client falls back to polling; cross-replica live "
+                        + "delivery is off until Redis is reachable.", e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/chat/realtime/RedisChatEventPublisher.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/realtime/RedisChatEventPublisher.java
@@ -37,6 +37,7 @@ public class RedisChatEventPublisher implements ChatEventPublisher {
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
+    private final ChatStreamRegistry registry;
 
     @Override
     public void publish(ChatEvent event) {
@@ -48,8 +49,13 @@ public class RedisChatEventPublisher implements ChatEventPublisher {
             // the reader's poll will still show it.
             log.error("Could not serialize chat event for room {}: {}", event.roomId(), e.getMessage());
         } catch (Exception e) {
-            log.warn("Could not publish chat event for room {} to Redis, falling back to the client poll: {}",
+            // Redis is unreachable. Deliver to this replica's own streams instead. That is never
+            // wrong, only incomplete: a recipient connected here sees the change immediately, and
+            // one connected elsewhere falls back to their poll. On a single-replica deployment,
+            // which is what the compose staging is, it is complete.
+            log.warn("Could not publish chat event for room {} to Redis, delivering locally only: {}",
                     event.roomId(), e.getMessage());
+            registry.deliver(event);
         }
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/chat/realtime/ChatEventFanOutIT.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/realtime/ChatEventFanOutIT.java
@@ -142,8 +142,9 @@ class ChatEventFanOutIT {
         closeables.add(container::destroy);
     }
 
-    private RedisChatEventPublisher publisherFor(ChatStreamRegistry ignored) {
-        return new RedisChatEventPublisher(new StringRedisTemplate(connectionFactory()), objectMapper);
+    private RedisChatEventPublisher publisherFor(ChatStreamRegistry registry) {
+        return new RedisChatEventPublisher(
+                new StringRedisTemplate(connectionFactory()), objectMapper, registry);
     }
 
     private RedisConnectionFactory connectionFactory() {

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisFullContextBootIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisFullContextBootIT.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.common.configuration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
@@ -28,7 +29,14 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
  * encryption) so the context reaches the redis wiring instead of failing earlier on an unresolved
  * placeholder. The keycloak initializer is an async {@code ApplicationReadyEvent} listener, so it runs
  * after refresh on another thread and does not affect this context-load assertion.
+ *
+ * <p>The context is closed after the class, which matters more than it looks. The redis container
+ * stops when the class finishes, but a cached Spring context would outlive it and keep its Lettuce
+ * connection factory alive, reconnecting to a mapped port that no longer exists. Those reconnect
+ * threads are not daemons, so the test JVM never exits and the whole task hangs until CI's timeout
+ * kills it. Closing the context here retires the connections with the container that served them.
  */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
         "echno.cache.provider=redis",
         "BACKEND_API_VERSION=v1",

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.common.configuration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
 /**
@@ -21,7 +22,13 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
  * <p>So the rule this pins down: an unreachable broker degrades real-time delivery and nothing else.
  * The context must still load, the API must still serve, and chat falls back to the polling the web
  * client deliberately kept.
+ *
+ * <p>The context is closed after the class. Spring otherwise caches every distinct test context
+ * for the life of the test JVM, and the JVM here is deliberately capped at 1 GB so the suite fits
+ * the CI runner alongside the CockroachDB container. A whole-application context that exists to
+ * make one assertion and is shared with nothing has no business being retained.
  */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
         "echno.cache.provider=redis",
         "BACKEND_API_VERSION=v1",

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+/**
+ * Boots the whole application context with {@code echno.cache.provider=redis} pointed at a Redis
+ * that is not there.
+ *
+ * <p>This is the deployment reality, not a hypothetical. The compose staging sets
+ * {@code ECHNO_CACHE_PROVIDER=redis} and {@code SPRING_DATA_REDIS_HOST=echno-redis} while the redis
+ * container itself may not be running: the app deploy renders the backend environment, but only an
+ * infra run creates that container, and the two are deployed by different playbook runs.
+ *
+ * <p>The cache and rate limiter tolerated that, because Lettuce connects lazily and neither touches
+ * Redis until something asks it to. Chat real-time delivery does not: its listener container opens a
+ * subscription while the context is refreshing. Without care that turns a missing broker into a
+ * backend that never becomes healthy, which is a chat feature taking the whole API down with it.
+ *
+ * <p>So the rule this pins down: an unreachable broker degrades real-time delivery and nothing else.
+ * The context must still load, the API must still serve, and chat falls back to the polling the web
+ * client deliberately kept.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "echno.cache.provider=redis",
+        "BACKEND_API_VERSION=v1",
+        "DIGITAL_OCEAN_SPACES_URI=http://localhost:9000",
+        "DIGITAL_OCEAN_SPACES_KEY_ID=test",
+        "DIGITAL_OCEAN_SPACES_KEY_SECRET=test",
+        "DIGITAL_OCEAN_SPACES_BUCKET_NAME=test-bucket",
+        "DIGITAL_OCEAN_SPACES_CDN_ENDPOINT=http://localhost:9000",
+        "ENCRYPTION_SECRET_KEY=0123456789abcdef0123456789abcdef",
+        "KEYCLOAK_BACKEND_ADMIN_EMAIL=admin@test.local",
+        "KEYCLOAK_BACKEND_ADMIN_FIRST_NAME=Test",
+        "KEYCLOAK_BACKEND_ADMIN_LAST_NAME=Admin",
+        "KEYCLOAK_BACKEND_ADMIN_PASSWORD=pw",
+        "KEYCLOAK_BACKEND_ADMIN_USERNAME=admin",
+        "KEYCLOAK_BACKEND_CLIENT=backend",
+        "KEYCLOAK_BACKEND_REDIRECT_URI=http://localhost/*",
+        "KEYCLOAK_BACKEND_REDIRECT_URI_APIDOG=http://localhost/webjars/*",
+        "KEYCLOAK_BACKEND_SECRET=secret",
+        "KEYCLOAK_BACKEND_SERVICE_EMAIL=svc@test.local",
+        "KEYCLOAK_BACKEND_SERVICE_FIRST_NAME=Test",
+        "KEYCLOAK_BACKEND_SERVICE_LAST_NAME=Service",
+        "KEYCLOAK_BACKEND_SERVICE_PASSWORD=pw",
+        "KEYCLOAK_BACKEND_SERVICE_USERNAME=svc",
+        "KEYCLOAK_BACKEND_WEB_ORIGIN=http://localhost",
+        "KEYCLOAK_FRONTEND_CLIENT=frontend",
+        "KEYCLOAK_FRONTEND_REDIRECT_URI=http://localhost/*",
+        "KEYCLOAK_FRONTEND_WEB_ORIGIN=http://localhost",
+        "KEYCLOAK_INITIALIZER_APPLICATION_REALM=echno-realm",
+        "KEYCLOAK_INITIALIZER_CLIENT_ID=admin-cli",
+        "KEYCLOAK_INITIALIZER_MASTER_REALM=master",
+        "KEYCLOAK_INITIALIZER_PASSWORD=pw",
+        "KEYCLOAK_INITIALIZER_URL=http://localhost:0",
+        "KEYCLOAK_INITIALIZER_USERNAME=admin",
+        "SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI=http://localhost:0/realms/echno-realm"
+})
+class RedisUnreachableBootIT extends AbstractIntegrationTest {
+
+    // Port 1 is reserved and nothing listens on it, so every connection attempt is refused
+    // immediately rather than hanging until a timeout.
+    static {
+        System.setProperty("spring.data.redis.host", "127.0.0.1");
+        System.setProperty("spring.data.redis.port", "1");
+    }
+
+    @Test
+    void contextLoadsWithoutAReachableRedis() {
+    }
+}


### PR DESCRIPTION
Follow-up to #452. The chat stream deploy to the IITM compose staging failed its health check and Ansible rolled it back, so the site kept serving the previous release. This is the cause and the fix.

## What happened

The backend on `.116` is configured with `ECHNO_CACHE_PROVIDER=redis` and `SPRING_DATA_REDIS_HOST=echno-redis`, but **no `echno-redis` container is running there**. The redis service exists in the infra role's compose template on `echno-deployment` `main`, and the rendered `compose.infra.yml` on the box is dated 2026-07-21, before it was added. The app deploy workflow runs only the `apps` role, so it renders an environment referencing a container that only an infra run would create. The two have simply been out of step since July.

Nothing noticed, because the two existing consumers of Redis connect lazily. The Spring cache and the Bucket4j rate limiter open a connection when something asks them to, so a missing broker degraded quietly and never announced itself.

Chat real-time delivery broke that. `RedisMessageListenerContainer` opens its subscription while the context is refreshing, so an unreachable Redis threw out of `DefaultLifecycleProcessor` and took the whole context down:

```
ApplicationContextException at DefaultLifecycleProcessor.java:408
  RedisListenerExecutionFailedException at RedisMessageListenerContainer.java:383
    RedisConnectionFailureException -> RedisConnectionException -> java.net.ConnectException
```

A chat feature must not be able to stop the API from booting. That is the defect here, independent of the missing container: had Redis simply gone down in production, this change would have turned a degraded cache into a dead service.

## The fix

- The listener container no longer starts with the context. `RedisMessageListenerContainer` exposes no `setAutoStartup`, so `isAutoStartup()` is overridden; this is the only hook that keeps the lifecycle processor out of it.
- A new `ChatStreamSubscription` establishes the subscription after startup on a 30 second schedule, retrying until it succeeds and logging the failure once per outage rather than once per attempt. A backend that starts before its Redis therefore picks the subscription up on its own instead of needing a restart.
- `RedisChatEventPublisher` falls back to delivering into this replica's own registry when the publish fails. That is never wrong, only incomplete: a recipient connected to this replica sees the change immediately and one connected elsewhere falls back to their poll. On a single-replica deployment, which is what the compose staging is, it is complete.
- `setRecoveryBackoff` with a fixed 10 second interval so a subscription lost mid-life is re-established.

Net effect: an unreachable broker degrades cross-replica live delivery and nothing else. Writes still succeed, the API still serves, and the web client still has the polling it deliberately kept.

## Test

`RedisUnreachableBootIT` boots the whole application context with `echno.cache.provider=redis` pointed at a closed port. It fails without this change with the trace above, and passes with it. It sits alongside `RedisFullContextBootIT`, which covers the reachable path and still passes, so the pair pins both directions.

The chat suite is unchanged and green: registry 7, fan-out 3, listener 3, endpoint 5, repository 10, parser 5.

## Still outstanding, not in this PR

The `echno-redis` container genuinely should exist on `.116`; the configuration expects it. That needs an infra run against the reserved compose staging, which restarts the infra stack (CockroachDB, Keycloak) and so wants a deliberate window rather than riding along with an app deploy. Tracked in #453.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The application now starts successfully even when Redis is temporarily unavailable.
  * Real-time chat updates continue through a local fallback when Redis publishing fails.
  * Redis listener connections retry automatically and recover after connectivity is restored.
* **Tests**
  * Added coverage confirming successful application startup and chat degradation when Redis cannot be reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->