### PR TITLE
Classify RPT exchange failures so an expired token, a down Keycloak and a misconfig are distinguishable

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
@@ -130,18 +130,31 @@ public class KeycloakAuthorizationService {
     }
 
     /**
-     * Splits a 4xx from Keycloak into the caller's problem and ours. A 401, or any OAuth error body of
-     * {@code invalid_token} or {@code invalid_grant}, means the caller arrived with a token Keycloak
-     * will not accept. {@code access_denied} means the token was fine but carries no permission.
-     * Everything else (unknown client, unknown audience, bad client credentials, authorization services
-     * switched off) is a misconfiguration on this side.
+     * Splits a 4xx from Keycloak into the caller's problem and ours.
+     *
+     * <p>The OAuth error code in the body is checked first and the HTTP status is only a fallback,
+     * because the two disagree in a way that matters. Keycloak answers 401 with {@code invalid_client}
+     * when <em>our</em> client credentials are wrong, so trusting the status would report a bad client
+     * secret as the caller's expired token: logged below ERROR where nobody looks, and handed back as
+     * {@code invalid_token}, which invites the client to re-authenticate in a loop against a server
+     * whose configuration is broken. An unambiguous error code always beats a guess from the status.
+     *
+     * <p>So: {@code invalid_token} or {@code invalid_grant} means the caller's token was rejected,
+     * {@code access_denied} means the token was fine but carries no permission, and any other explicit
+     * code (unknown client, unknown audience, bad client credentials, authorization services switched
+     * off) is a misconfiguration on this side. Only when the body carries no readable code does the
+     * status decide, and there a 401 is the caller's token.
      */
     private RPTExchangeException classifyClientError(String tokenEndpoint, HttpClientErrorException e) {
         int status = e.getStatusCode().value();
-        String responseBody = truncate(e.getResponseBodyAsString());
-        String oauthError = oauthErrorCode(responseBody);
+        // Classify on the whole body and truncate only what is logged and carried: truncating first
+        // can cut a long payload mid-JSON, so the error code would be unreadable and misclassified.
+        String fullBody = e.getResponseBodyAsString();
+        String oauthError = oauthErrorCode(fullBody);
+        String responseBody = truncate(fullBody);
 
-        if (status == 401 || (oauthError != null && TOKEN_ERRORS.contains(oauthError))) {
+        boolean tokenRejected = oauthError == null ? status == 401 : TOKEN_ERRORS.contains(oauthError);
+        if (tokenRejected) {
             // Routine: a caller turned up with an expired or revoked token. Logged below ERROR on purpose,
             // one stale token can otherwise produce hundreds of lines a minute.
             log.warn("RPT exchange at {} rejected the caller's access token: HTTP {}, error={}. Body: {}",
@@ -163,7 +176,11 @@ public class KeycloakAuthorizationService {
                 "Keycloak rejected the RPT exchange configuration", e);
     }
 
-    /** Reads the OAuth {@code error} code out of an error payload, or returns {@code null} if there is none. */
+    /**
+     * Reads the OAuth {@code error} code out of an error payload, or returns {@code null} if there is
+     * none. Must be given the untruncated body, or a long payload parses as malformed JSON and the
+     * code is lost.
+     */
     @Nullable
     private static String oauthErrorCode(@Nullable String responseBody) {
         if (responseBody == null || responseBody.isBlank()) {

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.common.configuration;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -7,18 +9,35 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 
 
 @Service
 @Slf4j
 public class KeycloakAuthorizationService {
+
+    /** OAuth error codes that mean the caller's own access token was rejected. */
+    private static final Set<String> TOKEN_ERRORS = Set.of("invalid_token", "invalid_grant");
+
+    /** Keycloak's code for "the token is fine, but it grants no permission on this resource". */
+    private static final String ACCESS_DENIED = "access_denied";
+
+    /** Upper bound on how much of Keycloak's response body reaches the log, so one bad token cannot flood it. */
+    private static final int MAX_LOGGED_BODY = 512;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Value("${keycloak.issuer-uri}")
     private String issuerUri;
@@ -37,6 +56,25 @@ public class KeycloakAuthorizationService {
         this.restTemplate = new RestTemplate(factory);
     }
 
+    /** Test seam: builds the service around a supplied client and configuration, bypassing Spring. */
+    KeycloakAuthorizationService(RestTemplate restTemplate, String issuerUri, String clientId) {
+        this.restTemplate = restTemplate;
+        this.issuerUri = issuerUri;
+        this.clientId = clientId;
+    }
+
+    /**
+     * Exchanges the caller's access token for a Requesting Party Token via Keycloak's UMA ticket grant.
+     *
+     * <p>Every failure is classified before it leaves this method, because the same generic error used
+     * to cover a stale caller token, an unreachable Keycloak and a bad client registration alike. See
+     * {@link RPTExchangeException.Reason} for the categories; {@link RPTExchangeFilter} turns them into
+     * the response the caller sees.
+     *
+     * @param accessToken the caller's bearer access token (raw compact JWT, no "Bearer " prefix)
+     * @return the minted RPT
+     * @throws RPTExchangeException with a classified {@link RPTExchangeException.Reason} on any failure
+     */
     public String exchangeForRPT(String accessToken) {
         String tokenEndpoint = issuerUri + "/protocol/openid-connect/token";
 
@@ -46,25 +84,106 @@ public class KeycloakAuthorizationService {
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setBearerAuth(accessToken);
 
-        MultiValueMap<String ,String> params = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket");
         params.add("audience", clientId);
 
-        HttpEntity<MultiValueMap<String,String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
         try {
             ResponseEntity<Map> response = restTemplate.postForEntity(tokenEndpoint, request, Map.class);
-            if (response.getBody() != null && response.getBody().containsKey("access_token")) {
-                String rptToken = (String) response.getBody().get("access_token");
+            Map<?, ?> body = response.getBody();
+            Object rptToken = body == null ? null : body.get("access_token");
+
+            if (rptToken instanceof String rpt && !rpt.isBlank()) {
                 log.debug("Successfully exchanged access token for RPT");
-                return rptToken;
-            } else {
-                log.error("RPT exchange response missing access_token field");
-                throw new RuntimeException("Invalid RPT response from Keycloak");
+                return rpt;
             }
-        } catch (Exception e) {
-            log.error("Failed to exchange access token for RPT: {}", e.getMessage());
-            throw new RuntimeException("Failed to obtain RPT token for authorization", e);
+
+            int status = response.getStatusCode().value();
+            log.error("RPT exchange at {} returned HTTP {} without an access_token field. Keys present: {}",
+                    tokenEndpoint, status, body == null ? "<no body>" : body.keySet());
+            throw new RPTExchangeException(RPTExchangeException.Reason.PROTOCOL_VIOLATION, status, null,
+                    "Keycloak returned a successful response with no access_token");
+
+        } catch (HttpClientErrorException e) {
+            throw classifyClientError(tokenEndpoint, e);
+
+        } catch (HttpServerErrorException e) {
+            String responseBody = truncate(e.getResponseBodyAsString());
+            log.error("RPT exchange at {} failed: Keycloak returned HTTP {}. Body: {}",
+                    tokenEndpoint, e.getStatusCode().value(), responseBody);
+            throw new RPTExchangeException(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE,
+                    e.getStatusCode().value(), responseBody, "Keycloak returned a server error", e);
+
+        } catch (ResourceAccessException e) {
+            log.error("RPT exchange at {} failed: Keycloak is unreachable ({})", tokenEndpoint, e.getMessage());
+            throw new RPTExchangeException(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, null, null,
+                    "Keycloak could not be reached", e);
+
+        } catch (RestClientException e) {
+            // Anything left over from the client: an unreadable payload, a bad redirect, an unknown content type.
+            log.error("RPT exchange at {} failed with an unexpected client error: {}", tokenEndpoint, e.getMessage());
+            throw new RPTExchangeException(RPTExchangeException.Reason.PROTOCOL_VIOLATION, null, null,
+                    "Unexpected failure talking to Keycloak", e);
         }
+    }
+
+    /**
+     * Splits a 4xx from Keycloak into the caller's problem and ours. A 401, or any OAuth error body of
+     * {@code invalid_token} or {@code invalid_grant}, means the caller arrived with a token Keycloak
+     * will not accept. {@code access_denied} means the token was fine but carries no permission.
+     * Everything else (unknown client, unknown audience, bad client credentials, authorization services
+     * switched off) is a misconfiguration on this side.
+     */
+    private RPTExchangeException classifyClientError(String tokenEndpoint, HttpClientErrorException e) {
+        int status = e.getStatusCode().value();
+        String responseBody = truncate(e.getResponseBodyAsString());
+        String oauthError = oauthErrorCode(responseBody);
+
+        if (status == 401 || (oauthError != null && TOKEN_ERRORS.contains(oauthError))) {
+            // Routine: a caller turned up with an expired or revoked token. Logged below ERROR on purpose,
+            // one stale token can otherwise produce hundreds of lines a minute.
+            log.warn("RPT exchange at {} rejected the caller's access token: HTTP {}, error={}. Body: {}",
+                    tokenEndpoint, status, oauthError, responseBody);
+            return new RPTExchangeException(RPTExchangeException.Reason.TOKEN_INVALID, status, responseBody,
+                    "Keycloak rejected the access token", e);
+        }
+
+        if (ACCESS_DENIED.equals(oauthError)) {
+            log.warn("RPT exchange at {} denied permission for the caller: HTTP {}. Body: {}",
+                    tokenEndpoint, status, responseBody);
+            return new RPTExchangeException(RPTExchangeException.Reason.PERMISSION_DENIED, status, responseBody,
+                    "Keycloak granted no permissions for the access token", e);
+        }
+
+        log.error("RPT exchange at {} is misconfigured: Keycloak returned HTTP {}, error={}. Body: {}",
+                tokenEndpoint, status, oauthError, responseBody);
+        return new RPTExchangeException(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, status, responseBody,
+                "Keycloak rejected the RPT exchange configuration", e);
+    }
+
+    /** Reads the OAuth {@code error} code out of an error payload, or returns {@code null} if there is none. */
+    @Nullable
+    private static String oauthErrorCode(@Nullable String responseBody) {
+        if (responseBody == null || responseBody.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode error = OBJECT_MAPPER.readTree(responseBody).get("error");
+            return error == null || !error.isTextual() ? null : error.asText();
+        } catch (Exception ex) {
+            // Not a JSON error payload (an HTML error page from a proxy, say). Nothing to classify on.
+            return null;
+        }
+    }
+
+    /** Bounds a response body for logging. Keycloak error payloads carry no bearer material. */
+    @Nullable
+    private static String truncate(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        return body.length() <= MAX_LOGGED_BODY ? body : body.substring(0, MAX_LOGGED_BODY) + "...(truncated)";
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeException.java
@@ -1,0 +1,104 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Raised by {@link KeycloakAuthorizationService#exchangeForRPT(String)} when the UMA ticket exchange
+ * against Keycloak does not yield a Requesting Party Token.
+ *
+ * <p>The exchange runs on every authenticated request, so it fails for very different reasons that
+ * need very different handling: a caller arriving with a stale access token is routine, an unreachable
+ * Keycloak is an outage, and a bad client registration is our own misconfiguration. Those used to be
+ * indistinguishable in the log and in the response. The {@link Reason} carried here is what lets
+ * {@link RPTExchangeFilter} pick the right HTTP status and the right log level for each.
+ *
+ * <p>The exception carries Keycloak's HTTP status and response body when there was one, so the cause
+ * of a failed exchange can be read straight off a single log line. Neither the incoming access token,
+ * the minted RPT, nor any client credential is ever stored on it.
+ */
+public class RPTExchangeException extends RuntimeException {
+
+    /**
+     * Why the exchange failed, and therefore who owns the problem.
+     */
+    public enum Reason {
+
+        /**
+         * The caller's access token was rejected: expired, revoked or otherwise not valid. Keycloak
+         * answers 401, or an OAuth error body of {@code invalid_token} or {@code invalid_grant}.
+         * The caller has to obtain a fresh token; nothing is wrong on this side.
+         */
+        TOKEN_INVALID,
+
+        /**
+         * The token was accepted but Keycloak refused to grant any permission for it
+         * ({@code access_denied}). A live authorization decision, not a broken token, so re-authenticating
+         * will not help the caller.
+         */
+        PERMISSION_DENIED,
+
+        /**
+         * The exchange itself is misconfigured: unknown or wrong client, an audience Keycloak does not
+         * recognise, bad client credentials, or authorization services not enabled on the client. Ours
+         * to fix, and invisible to the caller.
+         */
+        EXCHANGE_MISCONFIGURED,
+
+        /**
+         * Keycloak could not be reached or did not answer: connection refused, DNS failure, a read or
+         * connect timeout, or a 5xx from Keycloak itself. A dependency outage, so the request is not
+         * the caller's fault and should not be answered as an authentication failure.
+         */
+        KEYCLOAK_UNAVAILABLE,
+
+        /**
+         * Keycloak answered successfully but the payload was not a token response: 2xx with no
+         * {@code access_token} field. Either a proxy sitting in front of the token endpoint or a
+         * protocol change on Keycloak's side.
+         */
+        PROTOCOL_VIOLATION
+    }
+
+    private final Reason reason;
+    private final Integer status;
+    private final String responseBody;
+
+    /**
+     * @param reason       the classified cause of the failure
+     * @param status       Keycloak's HTTP status, or {@code null} when no response was received
+     * @param responseBody Keycloak's response body, or {@code null} when there was none. Callers pass
+     *                     the OAuth error payload only; it never carries bearer material
+     * @param message      a short, log-safe description of what failed
+     * @param cause        the underlying client exception, or {@code null}
+     */
+    public RPTExchangeException(Reason reason,
+                                @Nullable Integer status,
+                                @Nullable String responseBody,
+                                String message,
+                                @Nullable Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+        this.status = status;
+        this.responseBody = responseBody;
+    }
+
+    public RPTExchangeException(Reason reason, @Nullable Integer status, @Nullable String responseBody, String message) {
+        this(reason, status, responseBody, message, null);
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    /** Keycloak's HTTP status, or {@code null} when Keycloak never answered. */
+    @Nullable
+    public Integer getStatus() {
+        return status;
+    }
+
+    /** Keycloak's response body, or {@code null} when there was none. */
+    @Nullable
+    public String getResponseBody() {
+        return responseBody;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
@@ -7,15 +7,21 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class RPTExchangeFilter extends OncePerRequestFilter {
+
+    /** Seconds a client should wait before retrying once Keycloak is the thing that failed. */
+    private static final String RETRY_AFTER_SECONDS = "5";
 
     private final KeycloakAuthorizationService authorizationService;
     private final RPTCache rptCache;
@@ -51,16 +57,68 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
                 };
 
                 filterChain.doFilter(wrappedRequest, response);
+            } catch (RPTExchangeException e) {
+                rejectClassified(response, requestUri, e);
             } catch (Exception e) {
-                log.error("Failed to exchange token for RPT on request to {}: {}", requestUri, e.getMessage());
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("Failed to obtain authorization token");
-                return;
+                log.error("Unexpected failure exchanging token for RPT on request to {}: {}", requestUri, e.getMessage(), e);
+                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "unauthorized",
+                        "Authorization could not be established");
             }
         } else {
             log.debug("No Bearer token found for request to {}, continuing without RPT exchange", requestUri);
             filterChain.doFilter(request, response);
         }
 
+    }
+
+    /**
+     * Turns a classified exchange failure into the response the caller deserves.
+     *
+     * <p>A rejected or expired access token is a 401 the caller can act on by re-authenticating. An
+     * unreachable Keycloak is a 503, because it is not the caller's fault and re-authenticating against
+     * a Keycloak that is down would be exactly the wrong move. A misconfiguration or a protocol break on
+     * our side stays a 401 so nothing about the deployment leaks, but it is logged in full at ERROR.
+     */
+    private void rejectClassified(HttpServletResponse response, String requestUri, RPTExchangeException e) throws IOException {
+        switch (e.getReason()) {
+            case TOKEN_INVALID -> {
+                // Already logged at WARN with the wire detail by the service; keep the per-request line quiet.
+                log.debug("Rejecting request to {}: access token rejected by Keycloak", requestUri);
+                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "invalid_token",
+                        "The access token is expired or invalid");
+            }
+            case PERMISSION_DENIED -> {
+                log.debug("Rejecting request to {}: Keycloak granted no permissions for the caller", requestUri);
+                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "access_denied",
+                        "The access token grants no permissions");
+            }
+            case KEYCLOAK_UNAVAILABLE -> {
+                log.error("Failing request to {} with 503: Keycloak is unavailable (status={})", requestUri, e.getStatus());
+                response.setHeader(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS);
+                writeError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, "service_unavailable",
+                        "Authorization service is temporarily unavailable");
+            }
+            case EXCHANGE_MISCONFIGURED, PROTOCOL_VIOLATION -> {
+                log.error("Rejecting request to {}: RPT exchange failed as {} (status={}, body={})",
+                        requestUri, e.getReason(), e.getStatus(), e.getResponseBody());
+                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "unauthorized",
+                        "Authorization could not be established");
+            }
+        }
+    }
+
+    /**
+     * Writes a terse OAuth-shaped error body so the caller can branch on the code without being told
+     * anything about the deployment. The {@code WWW-Authenticate} header carries the same code on a 401,
+     * per RFC 6750.
+     */
+    private void writeError(HttpServletResponse response, int status, String errorCode, String description) throws IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        if (status == HttpServletResponse.SC_UNAUTHORIZED) {
+            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"" + errorCode + "\"");
+        }
+        response.getWriter().write("{\"error\":\"" + errorCode + "\",\"error_description\":\"" + description + "\"}");
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
@@ -72,45 +72,58 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
     }
 
     /**
+     * The response a classified failure earns: the HTTP status, the OAuth error code the caller can
+     * branch on, and a short description. Deliberately says nothing about the deployment.
+     */
+    private record Rejection(int status, String errorCode, String description) {
+    }
+
+    /**
      * Turns a classified exchange failure into the response the caller deserves.
      *
      * <p>A rejected or expired access token is a 401 the caller can act on by re-authenticating. An
      * unreachable Keycloak is a 503, because it is not the caller's fault and re-authenticating against
      * a Keycloak that is down would be exactly the wrong move. A misconfiguration or a protocol break on
      * our side stays a 401 so nothing about the deployment leaks, but it is logged in full at ERROR.
+     *
+     * <p>This is a switch expression with no default on purpose. The compiler checks it covers every
+     * {@link RPTExchangeException.Reason}, so adding a reason without deciding its response breaks the
+     * build. A switch statement would instead match nothing at runtime and let the request fall out of
+     * the filter as an empty 200, which is the worst answer an auth filter can give.
      */
     private void rejectClassified(HttpServletResponse response, String requestUri, RPTExchangeException e) throws IOException {
-        switch (e.getReason()) {
+        Rejection rejection = switch (e.getReason()) {
             case TOKEN_INVALID -> {
                 // Already logged at WARN with the wire detail by the service; keep the per-request line quiet.
                 log.debug("Rejecting request to {}: access token rejected by Keycloak", requestUri);
-                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "invalid_token",
+                yield new Rejection(HttpServletResponse.SC_UNAUTHORIZED, "invalid_token",
                         "The access token is expired or invalid");
             }
             case PERMISSION_DENIED -> {
                 log.debug("Rejecting request to {}: Keycloak granted no permissions for the caller", requestUri);
-                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "access_denied",
+                yield new Rejection(HttpServletResponse.SC_UNAUTHORIZED, "access_denied",
                         "The access token grants no permissions");
             }
             case KEYCLOAK_UNAVAILABLE -> {
                 log.error("Failing request to {} with 503: Keycloak is unavailable (status={})", requestUri, e.getStatus());
-                response.setHeader(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS);
-                writeError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, "service_unavailable",
+                yield new Rejection(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "service_unavailable",
                         "Authorization service is temporarily unavailable");
             }
             case EXCHANGE_MISCONFIGURED, PROTOCOL_VIOLATION -> {
                 log.error("Rejecting request to {}: RPT exchange failed as {} (status={}, body={})",
                         requestUri, e.getReason(), e.getStatus(), e.getResponseBody());
-                writeError(response, HttpServletResponse.SC_UNAUTHORIZED, "unauthorized",
+                yield new Rejection(HttpServletResponse.SC_UNAUTHORIZED, "unauthorized",
                         "Authorization could not be established");
             }
-        }
+        };
+
+        writeError(response, rejection.status(), rejection.errorCode(), rejection.description());
     }
 
     /**
      * Writes a terse OAuth-shaped error body so the caller can branch on the code without being told
      * anything about the deployment. The {@code WWW-Authenticate} header carries the same code on a 401,
-     * per RFC 6750.
+     * per RFC 6750, and a 503 carries {@code Retry-After}.
      */
     private void writeError(HttpServletResponse response, int status, String errorCode, String description) throws IOException {
         response.setStatus(status);
@@ -118,6 +131,9 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         if (status == HttpServletResponse.SC_UNAUTHORIZED) {
             response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"" + errorCode + "\"");
+        }
+        if (status == HttpServletResponse.SC_SERVICE_UNAVAILABLE) {
+            response.setHeader(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS);
         }
         response.getWriter().write("{\"error\":\"" + errorCode + "\",\"error_description\":\"" + description + "\"}");
     }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilter.java
@@ -81,7 +81,8 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
     /**
      * Turns a classified exchange failure into the response the caller deserves.
      *
-     * <p>A rejected or expired access token is a 401 the caller can act on by re-authenticating. An
+     * <p>A rejected or expired access token is a 401 the caller can act on by re-authenticating. A
+     * refused authorization is a 403, because the token was accepted and a fresh one changes nothing. An
      * unreachable Keycloak is a 503, because it is not the caller's fault and re-authenticating against
      * a Keycloak that is down would be exactly the wrong move. A misconfiguration or a protocol break on
      * our side stays a 401 so nothing about the deployment leaks, but it is logged in full at ERROR.
@@ -100,8 +101,10 @@ public class RPTExchangeFilter extends OncePerRequestFilter {
                         "The access token is expired or invalid");
             }
             case PERMISSION_DENIED -> {
+                // 403, not 401: the token authenticated fine, authorization was refused. No
+                // WWW-Authenticate either, since presenting a different token is not the remedy.
                 log.debug("Rejecting request to {}: Keycloak granted no permissions for the caller", requestUri);
-                yield new Rejection(HttpServletResponse.SC_UNAUTHORIZED, "access_denied",
+                yield new Rejection(HttpServletResponse.SC_FORBIDDEN, "access_denied",
                         "The access token grants no permissions");
             }
             case KEYCLOAK_UNAVAILABLE -> {

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationServiceTest.java
@@ -35,6 +35,9 @@ class KeycloakAuthorizationServiceTest {
 
     private static final String ACCESS_TOKEN = "header.payload.signature";
 
+    /** Mirrors the service's own logging bound, so the truncation test stays honest if it moves. */
+    private static final int MAX_LOGGED_BODY = 512;
+
     private RestTemplate restTemplate;
     private KeycloakAuthorizationService service;
 
@@ -114,6 +117,37 @@ class KeycloakAuthorizationServiceTest {
 
         assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, e.getReason());
         assertEquals(400, e.getStatus().intValue());
+    }
+
+    @Test
+    void invalidClientOn401_classifiesAsMisconfigurationNotAnExpiredToken() {
+        // Keycloak answers 401 with invalid_client when OUR client credentials are wrong. Classifying on
+        // the status alone would report a bad client secret as the caller's expired token: logged below
+        // ERROR where nobody looks, and handed back as invalid_token, which invites the client to
+        // re-authenticate in a loop against a server whose configuration is broken.
+        keycloakThrows(clientError(HttpStatus.UNAUTHORIZED, "{\"error\":\"invalid_client\",\"error_description\":\"Invalid client credentials\"}"));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, e.getReason());
+        assertEquals(401, e.getStatus().intValue());
+    }
+
+    @Test
+    void errorCodeBeyondTheLogTruncationLimit_isStillClassified() {
+        // The body is classified whole and truncated only for logging. Truncating first would cut this
+        // payload mid-JSON, the parse would fail, and it would fall back to the status and be misread
+        // as an expired token.
+        String padding = "x".repeat(MAX_LOGGED_BODY * 2);
+        String body = "{\"error_description\":\"" + padding + "\",\"error\":\"invalid_client\"}";
+        keycloakThrows(clientError(HttpStatus.UNAUTHORIZED, body));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, e.getReason());
+        // Only what is logged and carried is bounded.
+        assertTrue(e.getResponseBody().length() < body.length());
+        assertTrue(e.getResponseBody().endsWith("...(truncated)"));
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakAuthorizationServiceTest.java
@@ -1,0 +1,197 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the failure classification in {@link KeycloakAuthorizationService}. A mocked
+ * {@link RestTemplate} stands in for Keycloak's token endpoint, so each branch can be driven directly:
+ * no Spring context and no network.
+ */
+class KeycloakAuthorizationServiceTest {
+
+    private static final String ACCESS_TOKEN = "header.payload.signature";
+
+    private RestTemplate restTemplate;
+    private KeycloakAuthorizationService service;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        service = new KeycloakAuthorizationService(restTemplate, "https://auth.example.test/realms/echno-realm", "echno-api");
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void keycloakAnswers(Map body) {
+        ResponseEntity<Map> response = new ResponseEntity<>(body, HttpStatus.OK);
+        when(restTemplate.postForEntity(anyString(), any(), eq(Map.class))).thenReturn(response);
+    }
+
+    private void keycloakThrows(RuntimeException e) {
+        when(restTemplate.postForEntity(anyString(), any(), eq(Map.class))).thenThrow(e);
+    }
+
+    private static HttpClientErrorException clientError(HttpStatus status, String body) {
+        return HttpClientErrorException.create(status, status.getReasonPhrase(), HttpHeaders.EMPTY,
+                body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+    }
+
+    private RPTExchangeException exchangeFailure() {
+        return assertThrows(RPTExchangeException.class, () -> service.exchangeForRPT(ACCESS_TOKEN));
+    }
+
+    @Test
+    void successfulExchange_returnsTheRpt() {
+        keycloakAnswers(Map.of("access_token", "rpt-value"));
+
+        assertEquals("rpt-value", service.exchangeForRPT(ACCESS_TOKEN));
+    }
+
+    @Test
+    void unauthorizedFromKeycloak_classifiesAsTokenInvalid() {
+        // The live failure behind issue #458: the BFF forwarded an expired access token.
+        keycloakThrows(clientError(HttpStatus.UNAUTHORIZED, ""));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.TOKEN_INVALID, e.getReason());
+        assertEquals(401, e.getStatus().intValue());
+    }
+
+    @Test
+    void invalidTokenErrorBody_classifiesAsTokenInvalid() {
+        keycloakThrows(clientError(HttpStatus.BAD_REQUEST, "{\"error\":\"invalid_token\"}"));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.TOKEN_INVALID, e.getReason());
+        assertEquals(400, e.getStatus().intValue());
+        assertTrue(e.getResponseBody().contains("invalid_token"));
+    }
+
+    @Test
+    void invalidGrantErrorBody_classifiesAsTokenInvalid() {
+        keycloakThrows(clientError(HttpStatus.BAD_REQUEST, "{\"error\":\"invalid_grant\",\"error_description\":\"Token is not active\"}"));
+
+        assertEquals(RPTExchangeException.Reason.TOKEN_INVALID, exchangeFailure().getReason());
+    }
+
+    @Test
+    void accessDenied_classifiesAsPermissionDenied() {
+        keycloakThrows(clientError(HttpStatus.FORBIDDEN, "{\"error\":\"access_denied\"}"));
+
+        assertEquals(RPTExchangeException.Reason.PERMISSION_DENIED, exchangeFailure().getReason());
+    }
+
+    @Test
+    void invalidClient_classifiesAsMisconfiguration() {
+        keycloakThrows(clientError(HttpStatus.BAD_REQUEST, "{\"error\":\"invalid_client\"}"));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, e.getReason());
+        assertEquals(400, e.getStatus().intValue());
+    }
+
+    @Test
+    void unknownAudience_classifiesAsMisconfiguration() {
+        // What Keycloak answers when the client has no authorization services enabled.
+        keycloakThrows(clientError(HttpStatus.BAD_REQUEST,
+                "{\"error\":\"invalid_resource\",\"error_description\":\"Resource server not found\"}"));
+
+        assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, exchangeFailure().getReason());
+    }
+
+    @Test
+    void nonJsonErrorBody_classifiesAsMisconfiguration() {
+        // An HTML error page from a proxy in front of Keycloak: nothing to classify on, so it is ours.
+        keycloakThrows(clientError(HttpStatus.NOT_FOUND, "<html><body>404 Not Found</body></html>"));
+
+        assertEquals(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, exchangeFailure().getReason());
+    }
+
+    @Test
+    void serverErrorFromKeycloak_classifiesAsUnavailable() {
+        keycloakThrows(HttpServerErrorException.create(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error",
+                HttpHeaders.EMPTY, new byte[0], StandardCharsets.UTF_8));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, e.getReason());
+        assertEquals(500, e.getStatus().intValue());
+    }
+
+    @Test
+    void connectionRefused_classifiesAsUnavailable() {
+        keycloakThrows(new ResourceAccessException("I/O error on POST request", new IOException("Connection refused")));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, e.getReason());
+        assertNull(e.getStatus());
+    }
+
+    @Test
+    void readTimeout_classifiesAsUnavailable() {
+        keycloakThrows(new ResourceAccessException("Read timed out", new SocketTimeoutException("Read timed out")));
+
+        assertEquals(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, exchangeFailure().getReason());
+    }
+
+    @Test
+    void successWithoutAccessToken_classifiesAsProtocolViolation() {
+        keycloakAnswers(Map.of("token_type", "Bearer"));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertEquals(RPTExchangeException.Reason.PROTOCOL_VIOLATION, e.getReason());
+        assertEquals(200, e.getStatus().intValue());
+    }
+
+    @Test
+    void successWithNoBody_classifiesAsProtocolViolation() {
+        keycloakAnswers(null);
+
+        assertEquals(RPTExchangeException.Reason.PROTOCOL_VIOLATION, exchangeFailure().getReason());
+    }
+
+    @Test
+    void successWithBlankAccessToken_classifiesAsProtocolViolation() {
+        keycloakAnswers(Map.of("access_token", "  "));
+
+        assertEquals(RPTExchangeException.Reason.PROTOCOL_VIOLATION, exchangeFailure().getReason());
+    }
+
+    @Test
+    void failure_neverCarriesTheAccessToken() {
+        keycloakThrows(clientError(HttpStatus.UNAUTHORIZED, "{\"error\":\"invalid_token\"}"));
+
+        RPTExchangeException e = exchangeFailure();
+
+        assertFalse(e.getMessage().contains(ACCESS_TOKEN));
+        assertFalse(String.valueOf(e.getResponseBody()).contains(ACCESS_TOKEN));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
@@ -18,17 +18,21 @@ import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link RPTExchangeFilter} + {@link RPTCache}. A real {@link RPTCache} is wired to a
- * mocked {@link KeycloakAuthorizationService}, so these assert the caching contract end to end: the
- * Keycloak exchange runs once per distinct access token, not once per request.
+ * mocked {@link KeycloakAuthorizationService}, so these assert the caching contract end to end (the
+ * Keycloak exchange runs once per distinct access token, not once per request) and the mapping from a
+ * classified {@link RPTExchangeException} to the status and body the caller sees.
  */
 class RPTExchangeFilterTest {
 
@@ -55,14 +59,26 @@ class RPTExchangeFilterTest {
         return signed.serialize();
     }
 
-    private FilterChain invoke(String accessToken) throws Exception {
+    /** One filtered request: the mocked chain it reached (or did not) and the response it produced. */
+    private record Exchange(FilterChain chain, MockHttpServletResponse response) {
+    }
+
+    private Exchange invoke(String accessToken) throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/api/v1/projects");
         request.addHeader("Authorization", "Bearer " + accessToken);
         MockHttpServletResponse response = new MockHttpServletResponse();
         FilterChain chain = mock(FilterChain.class);
         filter.doFilter(request, response, chain);
-        return chain;
+        return new Exchange(chain, response);
+    }
+
+    /** Drives one request whose RPT mint fails with {@code reason}, and returns the resulting response. */
+    private MockHttpServletResponse responseForFailure(RPTExchangeException.Reason reason, Integer status) throws Exception {
+        String token = jwtWithJti(UUID.randomUUID().toString());
+        when(authorizationService.exchangeForRPT(token))
+                .thenThrow(new RPTExchangeException(reason, status, "{\"error\":\"whatever\"}", "exchange failed"));
+        return invoke(token).response();
     }
 
     @Test
@@ -109,10 +125,109 @@ class RPTExchangeFilterTest {
         String token = jwtWithJti(UUID.randomUUID().toString());
         when(authorizationService.exchangeForRPT(token)).thenReturn("rpt-value");
 
-        FilterChain chain = invoke(token);
+        FilterChain chain = invoke(token).chain();
 
         ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
         verify(chain).doFilter(captor.capture(), any());
         assertEquals("Bearer rpt-value", captor.getValue().getHeader("Authorization"));
+    }
+
+    @Test
+    void expiredAccessToken_isRejectedAs401InvalidToken() throws Exception {
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.TOKEN_INVALID, 401);
+
+        assertEquals(401, response.getStatus());
+        // Machine-readable so the caller can tell "get a fresh token" apart from "you are not allowed".
+        assertTrue(response.getContentAsString().contains("\"error\":\"invalid_token\""));
+        assertEquals("Bearer error=\"invalid_token\"", response.getHeader("WWW-Authenticate"));
+    }
+
+    @Test
+    void permissionDenied_isRejectedAs401AccessDenied() throws Exception {
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.PERMISSION_DENIED, 403);
+
+        assertEquals(401, response.getStatus());
+        assertTrue(response.getContentAsString().contains("\"error\":\"access_denied\""));
+    }
+
+    @Test
+    void keycloakUnreachable_isRejectedAs503() throws Exception {
+        // Not the caller's fault: a client that answered a 401 here by re-authenticating would be
+        // hammering a Keycloak that is already down.
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, null);
+
+        assertEquals(503, response.getStatus());
+        assertTrue(response.getContentAsString().contains("\"error\":\"service_unavailable\""));
+        assertEquals("5", response.getHeader("Retry-After"));
+    }
+
+    @Test
+    void keycloakServerError_isRejectedAs503() throws Exception {
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.KEYCLOAK_UNAVAILABLE, 500);
+
+        assertEquals(503, response.getStatus());
+    }
+
+    @Test
+    void misconfiguredExchange_staysA401AndLeaksNothing() throws Exception {
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.EXCHANGE_MISCONFIGURED, 400);
+
+        assertEquals(401, response.getStatus());
+        String body = response.getContentAsString();
+        assertTrue(body.contains("\"error\":\"unauthorized\""));
+        // Keycloak's own error payload must never reach the caller.
+        assertFalse(body.contains("whatever"));
+    }
+
+    @Test
+    void protocolViolation_staysA401() throws Exception {
+        MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.PROTOCOL_VIOLATION, 200);
+
+        assertEquals(401, response.getStatus());
+        assertTrue(response.getContentAsString().contains("\"error\":\"unauthorized\""));
+    }
+
+    @Test
+    void unclassifiedFailure_staysA401() throws Exception {
+        String token = jwtWithJti(UUID.randomUUID().toString());
+        when(authorizationService.exchangeForRPT(token)).thenThrow(new IllegalStateException("boom"));
+
+        Exchange exchange = invoke(token);
+
+        assertEquals(401, exchange.response().getStatus());
+        assertTrue(exchange.response().getContentAsString().contains("\"error\":\"unauthorized\""));
+    }
+
+    @Test
+    void failedExchange_neverReachesTheChain() throws Exception {
+        String token = jwtWithJti(UUID.randomUUID().toString());
+        when(authorizationService.exchangeForRPT(token))
+                .thenThrow(new RPTExchangeException(RPTExchangeException.Reason.TOKEN_INVALID, 401, null, "expired"));
+
+        Exchange exchange = invoke(token);
+
+        verify(exchange.chain(), never()).doFilter(any(), any());
+    }
+
+    @Test
+    void requestWithoutBearerToken_passesStraightThrough() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/public/health");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(authorizationService, never()).exchangeForRPT(anyString());
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void actuatorRequests_areNotFiltered() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/actuator/health");
+
+        assertTrue(filter.shouldNotFilter(request));
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
@@ -188,6 +188,21 @@ class RPTExchangeFilterTest {
     }
 
     @Test
+    void everyClassifiedReason_producesAnErrorStatusAndBody() throws Exception {
+        // Iterates the enum rather than listing the reasons, so a Reason added without a branch in
+        // rejectClassified fails here as well as at the compiler. An unhandled reason would fall out of
+        // the filter as an empty 200: an authorization failure answered as success, with nothing written.
+        for (RPTExchangeException.Reason reason : RPTExchangeException.Reason.values()) {
+            MockHttpServletResponse response = responseForFailure(reason, 400);
+            String body = response.getContentAsString();
+
+            assertTrue(response.getStatus() >= 400, reason + " must not answer with a success status");
+            assertFalse(body.isBlank(), reason + " must write an error body");
+            assertTrue(body.contains("\"error\":\""), reason + " must write a machine-readable error code");
+        }
+    }
+
+    @Test
     void unclassifiedFailure_staysA401() throws Exception {
         String token = jwtWithJti(UUID.randomUUID().toString());
         when(authorizationService.exchangeForRPT(token)).thenThrow(new IllegalStateException("boom"));

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RPTExchangeFilterTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -143,11 +144,14 @@ class RPTExchangeFilterTest {
     }
 
     @Test
-    void permissionDenied_isRejectedAs401AccessDenied() throws Exception {
+    void permissionDenied_isRejectedAs403AccessDenied() throws Exception {
         MockHttpServletResponse response = responseForFailure(RPTExchangeException.Reason.PERMISSION_DENIED, 403);
 
-        assertEquals(401, response.getStatus());
+        // The token authenticated; only the authorization decision went against the caller.
+        assertEquals(403, response.getStatus());
         assertTrue(response.getContentAsString().contains("\"error\":\"access_denied\""));
+        // Re-authenticating is not the remedy, so the caller is not challenged for a new token.
+        assertNull(response.getHeader("WWW-Authenticate"));
     }
 
     @Test


### PR DESCRIPTION
Closes the diagnosability half of #458. The cure for the underlying cause, the BFF forwarding an expired access token instead of refreshing it, ships on the web side; this PR is the second half the issue asks for: make the failure mode diagnosable and classify it correctly.

## Why

`RPTExchangeFilter` logged the same generic sentence for every failure mode. An expired token, an unreachable Keycloak and a bad client secret all produced `Failed to exchange token for RPT on request to ...: Failed to obtain RPT token for authorization`, and all three answered the caller with 401. Keycloak's own status and error body never reached the log, which is why the recent app-wide 401 took longer to pin down than it should have.

## What changed

`KeycloakAuthorizationService.exchangeForRPT` now classifies the failure and throws `RPTExchangeException`, a typed exception in the same package carrying a `Reason`, Keycloak's HTTP status and its response body:

| Reason | Trigger | Log level | Response |
|---|---|---|---|
| `TOKEN_INVALID` | OAuth body of `invalid_token` / `invalid_grant`, or a 401 with no readable error code | WARN | 401, `{"error":"invalid_token"}` + `WWW-Authenticate` |
| `PERMISSION_DENIED` | `access_denied`: the token is fine but grants nothing | WARN | 401, `{"error":"access_denied"}` |
| `EXCHANGE_MISCONFIGURED` | any other explicit error code (`invalid_client`, unknown audience, authorization services off), or any other 4xx | ERROR | 401, `{"error":"unauthorized"}` |
| `KEYCLOAK_UNAVAILABLE` | `ResourceAccessException` (refused, DNS, connect/read timeout) or a 5xx from Keycloak | ERROR | **503**, `{"error":"service_unavailable"}` + `Retry-After` |
| `PROTOCOL_VIOLATION` | 2xx with no `access_token` | ERROR | 401, `{"error":"unauthorized"}` |

Three things worth calling out:

- **Log level follows ownership.** A caller turning up with a stale token is routine, so it logs at WARN, not ERROR. That is the noise the issue flagged: 137 ERROR lines in four minutes for one user's expired token. Config and dependency failures are genuine ERRORs and now log Keycloak's status and (bounded, truncated at 512 chars) response body so a single line explains the failure.
- **503 for a dependency outage.** A client that answers a 401 by re-authenticating against a Keycloak that is down would be doing exactly the wrong thing, so an unreachable or erroring Keycloak is no longer dressed up as an authentication failure.
- **The caller can now distinguish the cases.** The body is terse and OAuth-shaped, so the web side can branch on `invalid_token` (refresh and retry) versus `access_denied` (do not) versus `unauthorized` (opaque). Misconfiguration detail never reaches the caller; it stays a 401 and lives only in the log.

Nothing is logged that carries bearer material: not the access token, not the RPT, not the client secret. Only Keycloak's OAuth error payload, which carries none.

Unchanged: `shouldNotFilter` on `/actuator`, the no-bearer passthrough, the request wrapper that swaps in the RPT, the `RPTCache` contract (a failed mint is still never cached), and the success path on the wire.

## Tests

Plain JUnit + Mockito, no Spring context anywhere, per the test-JVM heap ceiling.

- New `KeycloakAuthorizationServiceTest` (15 tests): a mocked `RestTemplate` drives every classification branch, including a non-JSON error body from a proxy, a blank `access_token`, and an assertion that the access token never lands on the exception.
- `RPTExchangeFilterTest` extended to 14 tests: each reason mapped to its status, body and headers, plus the misconfiguration case asserting Keycloak's payload does not leak to the caller, the chain never being reached on failure, the no-bearer passthrough and `shouldNotFilter`.

```
$ ./gradlew test --tests '*RPTExchangeFilterTest' --tests '*KeycloakAuthorizationServiceTest'
BUILD SUCCESSFUL in 1m
RPTExchangeFilterTest            tests="15" skipped="0" failures="0" errors="0"
KeycloakAuthorizationServiceTest tests="15" skipped="0" failures="0" errors="0"
```


## Division of labour with the web fix

The backend now answers an expired token with a 401 and `{"error":"invalid_token"}`. The web fix on `echno-web` PR #261 keys its automatic session refresh off the BFF's own `SessionTokenExpired` signal, which fires before the request ever reaches the backend. The two therefore do not overlap: the web side recovers the session upstream, and a caller that somehow arrives here with a lapsed token gets a clean, terse 401 rather than an automatic recovery. That is the right split, and the web client should not be wired to this error vocabulary as a refresh trigger.

## Review follow-up

`rejectClassified` was a switch *statement* with arrow labels and no `default`, so the compiler did not enforce exhaustiveness. A sixth `Reason` would have matched nothing, written no status and no body, and let the request fall out of the filter as an empty 200: an authorization failure answered as success, silently. It is now a switch expression yielding a `Rejection` (status, error code, description), which the compiler does check. Verified by temporarily adding a constant:

```
RPTExchangeFilter.java:95: error: the switch expression does not cover all possible input values
        Rejection rejection = switch (e.getReason()) {
                              ^
1 error
```

`Retry-After` moved into `writeError` next to `WWW-Authenticate`, keyed on the status, so each arm is a single `yield`. A new test iterates `Reason.values()` and asserts every constant produces a 4xx or 5xx and a non-empty machine-readable body, so the gap fails the suite as well as the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization-token exchange error handling with clearer, machine-readable OAuth responses.
  * Invalid tokens and denied permissions now return appropriate 401 responses.
  * Service outages now return a 503 response with retry guidance.
  * Added standardized authentication headers and JSON error messages.
  * Prevented sensitive access-token details from appearing in error messages or logs.

* **Tests**
  * Added coverage for successful exchanges, failure scenarios, network errors, malformed responses, and request filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Second review round (CodeRabbit)

**`invalid_client` on a 401 was classified as the caller's problem.** Keycloak answers 401 with `error=invalid_client` when *our* client credentials are wrong. Checking the status before the error code reported a bad client secret as `TOKEN_INVALID`: logged below ERROR where nobody looks, and handed back as `invalid_token`, inviting the client to re-authenticate in a loop against a server whose configuration is broken. That is exactly the confusion the issue describes, so the explicit OAuth error code now decides and the status is only the fallback when the body carries no readable code.

**The body was truncated before it was parsed.** A payload with a long field ahead of `error` parsed as malformed JSON, lost the code, and fell back to the status. Classification now reads `getResponseBodyAsString()` whole and truncates only what is logged and carried on the exception.

**`PERMISSION_DENIED` is now 403.** The token authenticated and only the authorization decision went against the caller, so `WWW-Authenticate` comes off that response as well.

Both classifier fixes have regression tests that were confirmed to fail against the previous ordering:

```
KeycloakAuthorizationServiceTest > invalidClientOn401_classifiesAsMisconfigurationNotAnExpiredToken() FAILED
KeycloakAuthorizationServiceTest > errorCodeBeyondTheLogTruncationLimit_isStillClassified() FAILED
```

### The 401 check before moving to 403

Grepped `echno-web` (`development`, plus PR #261's diff) for anything keying on 401 on this path. Nothing branches on a backend 401 in a way a 403 would bypass:

- Forced sign-out in `components/providers/auth-provider.tsx` fires on the NextAuth session error (`RefreshAccessTokenError`, `SessionRevoked`) and on `sessionExpiresAt`, never on a response status. `proxy.ts` redirects on the same session errors.
- `ApiError.isAuthError` is `status === 401 || status === 403`, so both are treated alike, and `lib/query/retry.ts` suppresses retries for both.
- The 401 cases in `lib/api/api-client.ts` and `lib/utils/api-utils.ts` are message lookup tables; 403 already has the better copy.
- The BFF's own 401s (`Session revoked`, and PR #261's `SessionTokenExpired`) are minted by the BFF before the request reaches the backend. PR #261's `isSessionExpiredResponse` requires both a 401 and that specific body code, and it has a test asserting a 401 without the signal is not recovered from.

### Test output after the fixes

```
$ ./gradlew test --tests '*RPTExchangeFilterTest' --tests '*KeycloakAuthorizationServiceTest' --rerun
32 tests PASSED
RPTExchangeFilterTest            tests="15" skipped="0" failures="0" errors="0"
KeycloakAuthorizationServiceTest tests="17" skipped="0" failures="0" errors="0"
```
