### PR TITLE
Bill sales and service construction invoices through a real AR invoice

### DIFF
--- a/docs/specs/2026-08-19-construction-finance-approvals-budgeting.md
+++ b/docs/specs/2026-08-19-construction-finance-approvals-budgeting.md
@@ -115,13 +115,19 @@ cancel, record-payment), the audit-trail fields, and the ledger posting on appro
   cash/bank, inventory, equity, revenue, and construction expense accounts. All the posting control accounts are
   postable leaves. The construction posting codes are config-driven (`finance.construction.*`), so any of them can
   be retuned without a code change.
-- **Sales/service posts a direct AR journal entry, not option A.** For sales and service construction
-  invoices the approve step posts DR Accounts Receivable / CR revenue + CR GST output directly (base spec
-  section 4 option B mechanics), rather than materializing a real AR `Invoice` via `InvoiceService.issue`
-  (the preferred option A). Option A needs customer resolution from the project's client, which is not built
-  yet, so those invoices do not appear in AR aging or customer statements. The service carries a
-  `// TODO: option A AR materialization` marker at the posting site. Materializing the AR invoice is the
-  follow-up that closes this gap.
+- **Sales/service materializes a real AR invoice (option A), with option B as the fallback.** A project
+  now carries its client as `project.customer_id`, a nullable finance customer id set on create or through
+  the project patch. Where an invoice's project has a client, approving a sales or service construction
+  invoice raises and issues a real AR `Invoice` against that customer through `InvoiceService`, and the
+  construction invoice adopts that invoice's journal entry, recording the AR invoice on
+  `construction_invoices.ar_invoice_id`. The amount is then a normal receivable: it appears in AR aging and
+  customer statements and is settled by an ordinary receipt. Cancelling the construction invoice cancels the
+  AR invoice, which reverses the same entry and refuses if a receipt has already landed. Where the project
+  has no client, or names one that no longer resolves or has been deactivated, approval falls back to
+  posting DR Accounts Receivable / CR revenue + CR GST output directly (option B mechanics), which is also
+  what every invoice approved before this change did. The AR document has no discount column, so a
+  discounted construction line is billed as a single unit priced at its net-of-discount amount; that keeps
+  the two documents' tax and totals identical.
 - **Payment recording is invoice-level only.** `record-payment` advances the invoice's paid/balance amounts
   and payment status and stamps `payment_recorded_by`; it does not post a cash-movement journal entry. Cash
   posting stays with the construction payment voucher phase.

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionInvoice.java
@@ -139,6 +139,12 @@ public class ConstructionInvoice extends BaseEntity implements TenantScopedEntit
     @Column(name = "reversal_journal_entry_id")
     private UUID reversalJournalEntryId;
 
+    // The AR invoice raised for this invoice when it was approved. Set only on a sales or
+    // service invoice whose project carries a client; the receivable then lives on that AR
+    // invoice (aging, receipts) and this invoice carries no receivable entry of its own.
+    @Column(name = "ar_invoice_id")
+    private UUID arInvoiceId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id")
     private Organization organization;

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -107,6 +107,11 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Reversal journal entry, present when the invoice was cancelled after posting.")
         UUID reversalJournalEntryId,
 
+        @Schema(description = "AR invoice raised for this invoice on approval. Present on a sales or "
+                + "service invoice whose project has a client; null otherwise.",
+                example = "1c9d4b7a-0f2e-4a63-8b11-5d7c2e9f4a88")
+        UUID arInvoiceId,
+
         @Schema(description = "Invoice line items.")
         List<ConstructionInvoiceLineDto> lines
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionInvoiceRepository.java
@@ -23,4 +23,12 @@ public interface ConstructionInvoiceRepository
     @EntityGraph(attributePaths = {"lines"})
     @Query("SELECT ci FROM ConstructionInvoice ci WHERE ci.id = :id")
     Optional<ConstructionInvoice> findByIdWithLines(@Param("id") UUID id);
+
+    /**
+     * Org-scoped lookup of the construction invoice that adopted a given AR invoice, if any.
+     * At most one invoice can adopt an AR invoice: each approval raises its own. Used by the
+     * AR module to refuse cancelling an invoice whose lifecycle another document owns.
+     */
+    @Query("SELECT ci FROM ConstructionInvoice ci WHERE ci.arInvoiceId = :arInvoiceId")
+    Optional<ConstructionInvoice> findByArInvoiceId(@Param("arInvoiceId") UUID arInvoiceId);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -26,10 +26,15 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionI
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceSpecifications;
+import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
+import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.domain.Customer;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
 import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
 import org.tornotron.echno_backend.finance.ledger.dtos.ReverseJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
 import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
 import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
 import org.tornotron.echno_backend.finance.posting.PostingRole;
@@ -55,6 +60,12 @@ import java.util.UUID;
  * reverses that entry. Posting is invoice-level to the default accounts configured on
  * {@link ConstructionPostingProperties}; per-line cost-category posting is the later
  * budgeting phase.
+ *
+ * <p>Sales and service invoices bill through accounts receivable. Where the invoice's project
+ * names a client, approval materializes a real AR {@link org.tornotron.echno_backend.finance.invoice.domain.Invoice}
+ * against that customer and takes its journal entry as its own, so the amount appears in AR
+ * aging and can be settled by an ordinary receipt. Where the project has no client, the
+ * receivable entry is posted directly and no AR document exists.
  */
 @Slf4j
 @Service
@@ -76,6 +87,8 @@ public class ConstructionInvoiceService {
     private final ProjectRepository projectRepository;
     private final UserContextService userContextService;
     private final CostCategoryRepository costCategoryRepository;
+    private final CustomerRepository customerRepository;
+    private final InvoiceService invoiceService;
 
     @Transactional(readOnly = true)
     public ConstructionInvoiceDto findById(UUID id) {
@@ -219,8 +232,9 @@ public class ConstructionInvoiceService {
      * <ul>
      *   <li>PURCHASE / EXPENSE: DR default expense (net of discount) + DR GST input
      *       (tax, if any); CR Accounts Payable (gross total).</li>
-     *   <li>SALES / SERVICE: DR Accounts Receivable (gross total); CR default revenue
-     *       (net of discount) + CR GST output (tax, if any).</li>
+     *   <li>SALES / SERVICE: an AR invoice is raised to the project's client and its own entry
+     *       (DR Accounts Receivable; CR revenue + CR GST output) becomes this invoice's entry.
+     *       With no client on the project, the same entry is posted directly instead.</li>
      * </ul>
      * The posted journal-entry id is stored on the invoice for drill-back and reversal.
      */
@@ -258,8 +272,23 @@ public class ConstructionInvoiceService {
      * Posts the ledger journal entry for the invoice and moves it to APPROVED, recording the
      * approving user. Shared by {@link #approve} and the auto-approval path in {@link #submit}, so
      * both raise an identical journal entry.
+     *
+     * <p>A sales or service invoice whose project has a client takes the AR route: the entry comes
+     * from the AR invoice raised for it. Everything else posts its own entry from the invoice
+     * totals.
      */
     private void postAndApprove(ConstructionInvoice inv) {
+        if (isReceivableType(inv.getType())) {
+            Customer client = resolveProjectClient(inv);
+            if (client != null && !inv.getLines().isEmpty()) {
+                materializeArInvoice(inv, client);
+                markApproved(inv);
+                log.info("Approved construction invoice {} through AR invoice {} for customer {}",
+                        inv.getInvoiceNumber(), inv.getArInvoiceId(), client.getCode());
+                return;
+            }
+        }
+
         BigDecimal net = MoneyUtils.normalize(inv.getSubtotal().subtract(inv.getDiscountAmount()));
         BigDecimal tax = MoneyUtils.normalize(inv.getTaxAmount());
         BigDecimal gross = MoneyUtils.normalize(inv.getTotalAmount());
@@ -267,8 +296,8 @@ public class ConstructionInvoiceService {
         List<PostJournalRequest.LineRequest> jeLines = new ArrayList<>();
         switch (inv.getType()) {
             case PURCHASE, EXPENSE -> {
-                // TODO: option A AR materialization is only for sales/service; purchase and
-                // expense always post their own payable entry (no AR analog).
+                // The payable side has no document to materialize: purchase and expense
+                // invoices always post their own entry.
                 Account expense = postingAccountResolver.resolve(PostingRole.DEFAULT_EXPENSE);
                 Account payable = postingAccountResolver.resolve(PostingRole.ACCOUNTS_PAYABLE);
                 jeLines.add(new PostJournalRequest.LineRequest(expense.getId(), net, BigDecimal.ZERO,
@@ -282,10 +311,9 @@ public class ConstructionInvoiceService {
                         "Payable - " + inv.getInvoiceNumber()));
             }
             case SALES, SERVICE -> {
-                // TODO: option A AR materialization - the preferred sales/service path
-                // materializes a real AR Invoice (customer = project client) via
-                // InvoiceService.issue so AR aging and receipts pick it up. Until customer
-                // resolution exists this posts the AR journal entry directly instead.
+                // Reached only when the project names no client, so there is no customer to
+                // raise an AR invoice against. The receivable is posted straight to the ledger
+                // and stays out of AR aging until a client is set.
                 Account receivable = postingAccountResolver.resolve(PostingRole.ACCOUNTS_RECEIVABLE);
                 Account revenue = postingAccountResolver.resolve(PostingRole.DEFAULT_REVENUE);
                 jeLines.add(new PostJournalRequest.LineRequest(receivable.getId(), gross, BigDecimal.ZERO,
@@ -308,17 +336,99 @@ public class ConstructionInvoiceService {
 
         JournalEntry je = postingService.postInternal(jeReq, SOURCE_TYPE, inv.getId());
         inv.setJournalEntryId(je.getId());
-        inv.setStatus(ConstructionInvoiceStatus.APPROVED);
-        inv.setApprovedBy(userContextService.getCurrentUserId());
-        inv.setApprovedAt(Instant.now());
+        markApproved(inv);
 
         log.info("Approved construction invoice {} (JE: {})", inv.getInvoiceNumber(), je.getEntryNumber());
     }
 
+    /** Moves the invoice to APPROVED and records who approved it and when. */
+    private void markApproved(ConstructionInvoice inv) {
+        inv.setStatus(ConstructionInvoiceStatus.APPROVED);
+        inv.setApprovedBy(userContextService.getCurrentUserId());
+        inv.setApprovedAt(Instant.now());
+    }
+
+    /** Whether the invoice type bills a customer rather than recording a supplier's bill. */
+    private boolean isReceivableType(ConstructionInvoiceType type) {
+        return type == ConstructionInvoiceType.SALES || type == ConstructionInvoiceType.SERVICE;
+    }
+
+    /**
+     * The active customer the invoice's project is billed to, or null when the project has no
+     * client set. A client that no longer resolves in the tenant, or has been deactivated, is
+     * also treated as absent: approval falls back to the direct receivable posting rather than
+     * failing, and says so in the log.
+     */
+    private Customer resolveProjectClient(ConstructionInvoice inv) {
+        if (inv.getProjectId() == null) {
+            return null;
+        }
+        UUID customerId = projectRepository
+                .findByIdAndOrganization_Id(inv.getProjectId(), TenantContext.getCurrentOrgId())
+                .map(Project::getCustomerId)
+                .orElse(null);
+        if (customerId == null) {
+            return null;
+        }
+        Customer customer = customerRepository.findScopedById(customerId).orElse(null);
+        if (customer == null || !customer.isActive()) {
+            log.warn("Project {} names customer {} as its client but it is missing or inactive; "
+                            + "posting the receivable for construction invoice {} directly",
+                    inv.getProjectId(), customerId, inv.getInvoiceNumber());
+            return null;
+        }
+        return customer;
+    }
+
+    /**
+     * Raises and issues the AR invoice that carries this invoice's receivable, and adopts its
+     * journal entry. The AR document repeats the construction lines against the resolved default
+     * revenue account, so the two totals agree to the paisa, and the receivable is then tracked
+     * in one place: AR aging, customer statements, and ordinary receipts all see it.
+     */
+    private void materializeArInvoice(ConstructionInvoice inv, Customer client) {
+        Account revenue = postingAccountResolver.resolve(PostingRole.DEFAULT_REVENUE);
+
+        List<CreateInvoiceRequest.LineRequest> arLines = new ArrayList<>();
+        for (ConstructionInvoiceLine line : inv.getLines()) {
+            arLines.add(toArLine(line, revenue.getId()));
+        }
+
+        CreateInvoiceRequest req = new CreateInvoiceRequest(
+                client.getId(),
+                inv.getIssueDate(),
+                inv.getDueDate(),
+                "Raised from construction invoice " + inv.getInvoiceNumber(),
+                arLines);
+
+        InvoiceDto issued = invoiceService.issue(invoiceService.createDraft(req).id());
+        inv.setArInvoiceId(issued.id());
+        inv.setJournalEntryId(issued.journalEntryId());
+    }
+
+    /**
+     * Maps one construction line onto an AR invoice line. An AR line has no discount of its own,
+     * so a discounted line is billed as a single unit priced at its net-of-discount amount; that
+     * keeps the AR line's tax and total identical to the construction line's rather than letting
+     * the discount round differently. A line with no discount keeps its quantity and unit price.
+     */
+    private CreateInvoiceRequest.LineRequest toArLine(ConstructionInvoiceLine line, UUID revenueAccountId) {
+        BigDecimal taxRate = MoneyUtils.normalize(line.getTaxRate());
+        if (MoneyUtils.isPositive(line.getDiscountAmount())) {
+            BigDecimal net = MoneyUtils.normalize(line.getSubtotal().subtract(line.getDiscountAmount()));
+            return new CreateInvoiceRequest.LineRequest(
+                    line.getDescription(), BigDecimal.ONE, net, taxRate, revenueAccountId);
+        }
+        return new CreateInvoiceRequest.LineRequest(
+                line.getDescription(), line.getQuantity(), line.getUnitPrice(), taxRate, revenueAccountId);
+    }
+
     /**
      * Cancel an invoice. An approved invoice with a posted entry and no payments has that
-     * entry reversed via the ledger; anything with a payment applied is refused. The
-     * status moves to CANCELLED.
+     * entry reversed via the ledger; anything with a payment applied is refused. Where the
+     * approval materialized an AR invoice, that invoice is cancelled instead, which reverses
+     * the same entry and takes the receivable back out of AR aging. The status moves to
+     * CANCELLED.
      */
     @Transactional
     public ConstructionInvoiceDto cancel(UUID id, String reason) {
@@ -334,7 +444,12 @@ public class ConstructionInvoiceService {
                             + "; it has payments applied");
         }
 
-        if (inv.getStatus() == ConstructionInvoiceStatus.APPROVED && inv.getJournalEntryId() != null) {
+        if (inv.getArInvoiceId() != null) {
+            // The entry belongs to the AR invoice, so unwind it from that side: cancelling the
+            // AR invoice reverses the entry and refuses if a receipt has already been applied.
+            InvoiceDto cancelledAr = invoiceService.cancel(inv.getArInvoiceId(), reason);
+            inv.setReversalJournalEntryId(cancelledAr.reversalJournalEntryId());
+        } else if (inv.getStatus() == ConstructionInvoiceStatus.APPROVED && inv.getJournalEntryId() != null) {
             JournalEntry reversal = journalRepo.findByIdWithLines(inv.getJournalEntryId())
                     .map(je -> postingService.reverse(je.getId(), new ReverseJournalRequest(reason)).id())
                     .map(reversalId -> journalRepo.findScopedById(reversalId).orElseThrow())

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -447,7 +447,9 @@ public class ConstructionInvoiceService {
         if (inv.getArInvoiceId() != null) {
             // The entry belongs to the AR invoice, so unwind it from that side: cancelling the
             // AR invoice reverses the entry and refuses if a receipt has already been applied.
-            InvoiceDto cancelledAr = invoiceService.cancel(inv.getArInvoiceId(), reason);
+            // The internal call is the one that skips the AR module's own refusal to cancel an
+            // invoice a construction invoice raised, which is this cancellation.
+            InvoiceDto cancelledAr = invoiceService.cancelInternal(inv.getArInvoiceId(), reason);
             inv.setReversalJournalEntryId(cancelledAr.reversalJournalEntryId());
         } else if (inv.getStatus() == ConstructionInvoiceStatus.APPROVED && inv.getJournalEntryId() != null) {
             JournalEntry reversal = journalRepo.findByIdWithLines(inv.getJournalEntryId())

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
 import org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapper;
 import org.tornotron.echno_backend.finance.invoice.repositories.InvoiceRepository;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.Customer;
@@ -41,6 +42,10 @@ import java.util.*;
  * the revenue accounts and any GST output payable) and moves it to ISSUED. Cancellation reverses that
  * journal entry when the invoice is unpaid; once any payment has been applied the invoice can no
  * longer be cancelled and a credit note is required instead.
+ *
+ * <p>An invoice raised by another document (a sales or service construction invoice materializes
+ * one on approval) belongs to that document's lifecycle: {@link #cancel} refuses it and the source
+ * document is cancelled instead, which unwinds both sides through {@link #cancelInternal}.
  */
 @Slf4j
 @Service
@@ -56,6 +61,7 @@ public class InvoiceService {
     private final InvoiceMapper mapper;
     private final PostingAccountResolver postingAccountResolver;
     private final TenantEntityHelper tenantEntityHelper;
+    private final ConstructionInvoiceRepository constructionInvoiceRepo;
 
     /**
      * Retrieves a single invoice with its line items.
@@ -228,6 +234,35 @@ public class InvoiceService {
      * entry reversed and the reversal id is recorded before it moves to CANCELLED. An invoice that
      * has any payment applied cannot be cancelled; a credit note is required instead.
      *
+     * <p>An invoice another document raised for itself is refused here: its source document owns
+     * the journal entry they share, so cancelling this invoice on its own would leave that document
+     * approved against a reversed entry. Cancelling the source unwinds both sides.
+     *
+     * @param invoiceId The id of the invoice to cancel.
+     * @param reason Free-text reason recorded on the reversal entry.
+     * @return The cancelled invoice as a DTO.
+     * @throws ResourceNotFoundException if the invoice does not exist.
+     * @throws InvalidJournalException if the invoice has payments applied, is already cancelled, was raised by another document, or its original journal entry cannot be found.
+     */
+    @Transactional
+    public InvoiceDto cancel(UUID invoiceId, String reason) {
+        constructionInvoiceRepo.findByArInvoiceId(invoiceId).ifPresent(source -> {
+            throw new InvalidJournalException(
+                    "Invoice was raised for construction invoice " + source.getInvoiceNumber()
+                            + " and cannot be cancelled on its own; cancel construction invoice "
+                            + source.getInvoiceNumber() + " instead");
+        });
+        return cancelInternal(invoiceId, reason);
+    }
+
+    /**
+     * Cancels an invoice without the check on who raised it.
+     *
+     * <p>The document that materialized an invoice uses this to unwind it as part of cancelling
+     * itself; every other caller goes through {@link #cancel}. The payment guard stays in force
+     * here, so a receipt already applied on this side still blocks the cancellation, whichever
+     * document it was asked for.
+     *
      * @param invoiceId The id of the invoice to cancel.
      * @param reason Free-text reason recorded on the reversal entry.
      * @return The cancelled invoice as a DTO.
@@ -235,7 +270,7 @@ public class InvoiceService {
      * @throws InvalidJournalException if the invoice has payments applied, is already cancelled, or its original journal entry cannot be found.
      */
     @Transactional
-    public InvoiceDto cancel(UUID invoiceId, String reason) {
+    public InvoiceDto cancelInternal(UUID invoiceId, String reason) {
         Invoice inv = invoiceRepo.findByIdWithLines(invoiceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Invoice with ID " + invoiceId + " was not found"));
 

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -105,6 +105,15 @@ public class Project implements TenantScopedEntity {
     @Column(name = "approval_threshold", precision = 19, scale = 4)
     private java.math.BigDecimal approvalThreshold;
 
+    /**
+     * The finance customer this project is billed to, its client. Kept as a plain id rather than
+     * an association so the core project stays decoupled from the finance module. When set, a
+     * sales or service construction invoice on the project is billed by materializing a real AR
+     * invoice against this customer; when null, that invoice posts its receivable entry directly.
+     */
+    @Column(name = "customer_id")
+    private java.util.UUID customerId;
+
     /** The list of attachments associated with this project. */
     @OneToMany(mappedBy = "project")
     private List<Attachment> attachments = new ArrayList<>();

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
@@ -28,6 +29,7 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +48,7 @@ public class ProjectService {
     private final ProjectMapper projectMapper;
     private final EmployeeMapper employeeMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final CustomerRepository customerRepository;
 
     /**
      * Constructs a ProjectService with the necessary repositories.
@@ -54,13 +57,15 @@ public class ProjectService {
      * @param organizationRepository The repository for organization data access.
      * @param employeeRepository     The repository for employee data access.
      * @param attachmentService      The service for attachment operations.
+     * @param customerRepository     The repository used to validate the project's client.
      */
     public ProjectService(ProjectRepository repository,
                           OrganizationRepository organizationRepository,
                           EmployeeRepository employeeRepository,
                           AttachmentService attachmentService, ProjectMapper projectMapper,
                           EmployeeMapper employeeMapper,
-                          ApplicationEventPublisher eventPublisher) {
+                          ApplicationEventPublisher eventPublisher,
+                          CustomerRepository customerRepository) {
         this.repository = repository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
@@ -68,6 +73,7 @@ public class ProjectService {
         this.projectMapper = projectMapper;
         this.employeeMapper = employeeMapper;
         this.eventPublisher = eventPublisher;
+        this.customerRepository = customerRepository;
     }
 
     /**
@@ -95,6 +101,7 @@ public class ProjectService {
             if (projectDto.getProjectType() != null && !projectDto.getProjectType().isBlank()) {
                 project.setProjectType(ProjectType.valueOf(projectDto.getProjectType()));
             }
+            project.setCustomerId(requireCustomerInTenant(projectDto.getCustomerId()));
             project.setOrganization(organization);
             project.setStartDate(projectDto.getStartDate());
             project.setEndDate(projectDto.getEndDate());
@@ -195,6 +202,13 @@ public class ProjectService {
                 case "projectType":
                     project.setProjectType(value != null ? ProjectType.valueOf((String) value) : null);
                     break;
+                case "customerId":
+                    // Sent as a string over JSON; a null or blank value clears the client.
+                    String customerId = value != null ? value.toString().trim() : null;
+                    project.setCustomerId(customerId == null || customerId.isEmpty()
+                            ? null
+                            : requireCustomerInTenant(UUID.fromString(customerId)));
+                    break;
                 case "projectLongitude":
                     float longitude = ((Number) value).floatValue();
                     if(longitude >= -180 && longitude <= 180) {
@@ -213,6 +227,25 @@ public class ProjectService {
                     break;
             }
         });
+    }
+
+    /**
+     * Checks that a project's client exists in the current tenant before it is stored on the
+     * project. A null id means the project has no client and is returned unchanged.
+     *
+     * @param customerId The finance customer id to validate, or null.
+     * @return The same id, once it is known to resolve in this tenant.
+     * @throws ResourceNotFoundException if the id does not resolve to a customer in this tenant.
+     */
+    private UUID requireCustomerInTenant(UUID customerId) {
+        if (customerId == null) {
+            return null;
+        }
+        if (customerRepository.findScopedById(customerId).isEmpty()) {
+            throw new ResourceNotFoundException(
+                    "Customer with ID " + customerId + " was not found in this organization");
+        }
+        return customerId;
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Schema(description = "Payload to create a construction project. Sent as the JSON data part of the "
         + "multipart create request.")
@@ -39,6 +40,11 @@ public class ProjectCreationDto {
     @Schema(description = "Optional construction category. Drives compliance matching.", example = "RESIDENTIAL")
     @Size(max = 50, message = "projectType must be at most 50 characters")
     private String projectType;
+
+    /** Optional finance customer the project is billed to. Must already exist in the tenant. */
+    @Schema(description = "Optional finance customer the project is billed to (its client).",
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+    private UUID customerId;
 
     @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
     @NotNull

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -10,6 +10,7 @@ import org.tornotron.echno_backend.task.dto.TaskDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Schema(description = "Full view of a construction project, including its team, tasks, attachments "
         + "and overall progress.")
@@ -32,6 +33,10 @@ public class ProjectDto {
 
     @Schema(description = "Construction category of the project.", example = "RESIDENTIAL")
     private ProjectType projectType;
+
+    @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+    private UUID customerId;
 
     @Schema(description = "Employees assigned to the project team.")
     private List<EmployeeDto> employees;

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -7,6 +7,7 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Schema(description = "Condensed view of a construction project without its team, tasks or attachments. "
         + "Returned when a project is created.")
@@ -29,6 +30,10 @@ public class ProjectSimpleDto {
 
     @Schema(description = "Construction category of the project.", example = "RESIDENTIAL")
     private ProjectType projectType;
+
+    @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+    private UUID customerId;
 
     @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
     private Float projectLatitude;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -292,4 +292,7 @@
     <!-- v4.0 - Chat phase 2 (reactions, employee mentions, entity mentions) -->
     <include file="db/changelog/v4.0/052-create-chat-reactions-mentions.xml"/>
 
+    <!-- v4.0 - Finance: project client and the AR invoice materialized for sales/service billing -->
+    <include file="db/changelog/v4.0/053-add-project-customer-and-ar-invoice-link.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/053-add-project-customer-and-ar-invoice-link.xml
+++ b/src/main/resources/db/changelog/v4.0/053-add-project-customer-and-ar-invoice-link.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="053-add-customer-to-project" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="customer_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The finance customer a project is billed to (its client). Nullable: a project with no
+            client keeps the direct receivable posting. Held as a plain id rather than a foreign key,
+            matching the way the construction finance tables reference core-domain records.
+        </comment>
+
+        <addColumn tableName="project">
+            <column name="customer_id" type="UUID"/>
+        </addColumn>
+
+        <createIndex tableName="project" indexName="idx_project_customer">
+            <column name="customer_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="053-add-ar-invoice-to-construction-invoices" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="construction_invoices" columnName="ar_invoice_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The AR invoice materialized when a sales or service construction invoice is approved
+            against a project that has a client. Null on purchase and expense invoices, and on
+            sales/service invoices approved before a client was set, which post the receivable
+            entry directly instead.
+        </comment>
+
+        <addColumn tableName="construction_invoices">
+            <column name="ar_invoice_id" type="UUID"/>
+        </addColumn>
+
+        <createIndex tableName="construction_invoices" indexName="idx_cinv_ar_invoice">
+            <column name="ar_invoice_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
@@ -52,6 +52,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 // with an open write intent.
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        org.tornotron.echno_backend.finance.invoice.service.InvoiceService.class,
+        org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -11,10 +11,13 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
+import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -25,14 +28,19 @@ import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionI
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
 import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
 import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
+import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntryLine;
+import org.tornotron.echno_backend.finance.ledger.domain.Customer;
 import org.tornotron.echno_backend.finance.ledger.mapper.JournalEntryMapperImpl;
 import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
 import org.tornotron.echno_backend.finance.ledger.service.ChartOfAccountsSeeder;
 import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import org.tornotron.echno_backend.user.UserContextService;
 
@@ -50,6 +58,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * accounts payable; approving a sales invoice posts DR accounts receivable / CR revenue
  * + CR GST output; both store the journal-entry id. Cancel reverses the posted entry,
  * approving from the wrong status is refused, and a missing control account aborts.
+ *
+ * <p>The AR route is exercised here too, because it is the only place both documents are
+ * real: a sales invoice on a project with a client materializes an AR invoice whose total
+ * must equal the construction invoice's to the paisa, since the entry the construction
+ * invoice adopts is the AR invoice's. The two cancellation doors are pinned alongside it.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -69,6 +82,9 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
     private ConstructionInvoiceService service;
 
     @Autowired
+    private InvoiceService invoiceService;
+
+    @Autowired
     private ChartOfAccountsSeeder seeder;
 
     @Autowired
@@ -81,6 +97,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
     private PlatformTransactionManager txManager;
 
     private Long orgId;
+    private UUID customerId;
 
     // The org and the chart of accounts must be committed, not held in the rolled-back
     // test transaction: EntryNumberGenerator.next() runs in REQUIRES_NEW (document_sequence
@@ -113,6 +130,11 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
             exec("DELETE FROM construction_invoice_lines WHERE invoice_id IN "
                     + "(SELECT id FROM construction_invoices WHERE organization_id = :org)");
             exec("DELETE FROM construction_invoices WHERE organization_id = :org");
+            exec("DELETE FROM invoice_lines WHERE invoice_id IN "
+                    + "(SELECT id FROM invoices WHERE organization_id = :org)");
+            exec("DELETE FROM invoices WHERE organization_id = :org");
+            exec("DELETE FROM customers WHERE organization_id = :org");
+            exec("DELETE FROM project WHERE organization_id = :org");
             exec("DELETE FROM document_sequence WHERE organization_id = :org");
             exec("DELETE FROM accounts WHERE organization_id = :org");
             exec("DELETE FROM organization WHERE id = :org");
@@ -199,7 +221,122 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
                 .isThrownBy(() -> service.approve(created.id()));
     }
 
+    // The two AR tests below commit their writes instead of running inside the rolled-back
+    // ambient transaction. The AR path writes an invoice whose lines reference the committed
+    // chart of accounts, and holding those writes open leaves the cleanup's DELETE FROM
+    // accounts waiting on the test's own transaction until the statement timeout. Committing
+    // them is what ConstructionInvoiceAutoApprovalIT does for the same reason; the cleanup
+    // already deletes every table they touch.
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void approve_salesInvoiceForAProjectClient_materializesAnArInvoiceThatTotalsTheSame() {
+        ConstructionInvoiceDto created = service.create(clientRequest(seedClientProject()));
+        service.submit(created.id());
+
+        ConstructionInvoiceDto approved = service.approve(created.id());
+        assertThat(approved.arInvoiceId()).isNotNull();
+
+        InvoiceDto ar = invoiceService.findById(approved.arInvoiceId());
+        assertThat(ar.customerId()).isEqualTo(customerId);
+        // Pinned so the equality below cannot pass on two trivially equal numbers: 12.36%
+        // tax on a 7.5%-discounted line lands well inside the store scale.
+        assertThat(approved.totalAmount()).isEqualByComparingTo("6638.5453");
+        // The whole design rests on this: the construction invoice adopts the AR invoice's
+        // entry, so a receivable posted for a different amount than the invoice claims would
+        // be a silent divergence on the money path.
+        assertThat(ar.total()).isEqualByComparingTo(approved.totalAmount());
+        assertThat(approved.journalEntryId()).isEqualTo(ar.journalEntryId());
+
+        withJournalEntry(approved.journalEntryId(), je -> {
+            assertThat(je.getSourceType()).isEqualTo("INVOICE");
+            assertThat(debit(je, "1200")).isEqualByComparingTo(approved.totalAmount());
+            assertBalanced(je);
+        });
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void cancel_theArInvoiceOnItsOwn_isRefused_whileCancellingTheConstructionInvoiceUnwindsBoth() {
+        ConstructionInvoiceDto created = service.create(clientRequest(seedClientProject()));
+        service.submit(created.id());
+        ConstructionInvoiceDto approved = service.approve(created.id());
+        UUID arInvoiceId = approved.arInvoiceId();
+
+        // The AR door is shut: the construction invoice owns the entry they share.
+        assertThatExceptionOfType(InvalidJournalException.class)
+                .isThrownBy(() -> invoiceService.cancel(arInvoiceId, "Cancelled from the AR module"))
+                .withMessageContaining(created.invoiceNumber());
+
+        ConstructionInvoiceDto cancelled = service.cancel(created.id(), "Client withdrew the claim");
+        assertThat(cancelled.status()).isEqualTo(ConstructionInvoiceStatus.CANCELLED);
+        assertThat(cancelled.reversalJournalEntryId()).isNotNull();
+        assertThat(invoiceService.findById(arInvoiceId).status()).isEqualTo(InvoiceStatus.CANCELLED);
+
+        withJournalEntry(approved.journalEntryId(),
+                je -> assertThat(je.getStatus()).isEqualTo(JournalStatus.REVERSED));
+        withJournalEntry(cancelled.reversalJournalEntryId(), this::assertBalanced);
+    }
+
     // --- Helpers ----------------------------------------------------------
+
+    /**
+     * Commits a customer and a project that names it as its client, for the AR tests to bill
+     * against. Committed rather than left in a test transaction because those tests run
+     * outside one, for the reason given on {@link #approve_salesInvoiceForAProjectClient_materializesAnArInvoiceThatTotalsTheSame}.
+     *
+     * @return The id of the project, for the invoice request to bill against.
+     */
+    private Long seedClientProject() {
+        Long[] projectId = new Long[1];
+        inCommittedTx(() -> {
+            Organization org = entityManager.getReference(Organization.class, orgId);
+
+            Customer client = new Customer();
+            client.setCode("CUST-POST-1");
+            client.setName("Asset Homes Pvt Ltd");
+            client.setOrganization(org);
+            entityManager.persist(client);
+
+            Project project = new Project();
+            project.setProjectName("Tower B, Riverside Residences");
+            project.setProjectAddress("12 Marina Road, Chennai");
+            project.setOrganization(org);
+            project.setCustomerId(client.getId());
+            entityManager.persist(project);
+            entityManager.flush();
+
+            customerId = client.getId();
+            projectId[0] = project.getId();
+        });
+        return projectId[0];
+    }
+
+    /** Reads a posted entry with its lines and accounts inside a transaction, for assertions. */
+    private void withJournalEntry(UUID journalEntryId, java.util.function.Consumer<JournalEntry> assertions) {
+        inCommittedTx(() -> assertions.accept(
+                journalRepo.findByIdWithLines(journalEntryId).orElseThrow()));
+    }
+
+    /**
+     * A sales invoice on the project that names a client, with one discounted line and one
+     * undiscounted line at a tax rate that does not divide evenly, so the two documents have
+     * to round the same way rather than merely happening to agree on round numbers.
+     */
+    private CreateConstructionInvoiceRequest clientRequest(Long projectId) {
+        return new CreateConstructionInvoiceRequest(
+                ConstructionInvoiceType.SALES,
+                projectId,
+                null, null, null,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31),
+                "Net 30", "Bank Transfer", "29ABCDE1234F1Z5", "GST",
+                "AR materialization test", "Standard terms apply",
+                List.of(
+                        new ConstructionInvoiceLineRequest("Piling works", bd("7"), "lot",
+                                bd("333.33"), bd("12.36"), bd("7.5"), null, null, null, null),
+                        new ConstructionInvoiceLineRequest("Site supervision", bd("3"), "month",
+                                bd("1249.99"), bd("12.36"), null, null, null, null, null)));
+    }
 
     private CreateConstructionInvoiceRequest request(ConstructionInvoiceType type) {
         return new CreateConstructionInvoiceRequest(

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -54,6 +54,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        org.tornotron.echno_backend.finance.invoice.service.InvoiceService.class,
+        org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -51,6 +51,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ConstructionInvoiceService.class, ConstructionInvoiceMapperImpl.class,
+        org.tornotron.echno_backend.finance.invoice.service.InvoiceService.class,
+        org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class,

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
@@ -61,6 +61,7 @@ class ConstructionInvoicePdfServiceTest {
                 null, null, null, null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
+                null,
                 null);
 
         byte[] pdf = service.render(invoice);
@@ -86,6 +87,7 @@ class ConstructionInvoicePdfServiceTest {
                 "Net 30", "BANK_TRANSFER", "29ABCDE1234F1Z5", "CGST_SGST",
                 "Second progress claim for tower B", "Payable within 30 days of receipt.",
                 5L, null, 2L, null, 5L, UUID.randomUUID(), null,
+                null,
                 List.of(line));
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
@@ -55,8 +55,10 @@ import static org.mockito.Mockito.when;
  * Everything the service talks to is mocked, so what is pinned here is the routing and the
  * line mapping: an invoice on a project with a client raises a real AR invoice and adopts
  * its journal entry, a discounted line is billed at its net so the two documents agree,
- * cancelling unwinds through the AR invoice, and an absent, unknown or inactive client
- * falls back to posting the receivable directly.
+ * cancelling unwinds through the AR invoice on the internal call that the AR module's own
+ * refusal does not block, and an absent, unknown or inactive client falls back to posting
+ * the receivable directly. The totals the two documents must agree on are reconciled in
+ * ConstructionInvoicePostingIT, where both are real.
  */
 @ExtendWith(MockitoExtension.class)
 class ConstructionInvoiceArMaterializationTest {
@@ -179,7 +181,7 @@ class ConstructionInvoiceArMaterializationTest {
         inv.setArInvoiceId(arInvoiceId);
         inv.setJournalEntryId(arJournalEntryId);
         UUID reversalId = UUID.randomUUID();
-        when(invoiceService.cancel(arInvoiceId, "Client withdrew the claim"))
+        when(invoiceService.cancelInternal(arInvoiceId, "Client withdrew the claim"))
                 .thenReturn(arInvoiceDto(arJournalEntryId, reversalId));
 
         service.cancel(inv.getId(), "Client withdrew the claim");

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
@@ -1,0 +1,300 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
+import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
+import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
+import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.domain.Customer;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the AR route a sales or service construction invoice takes on approval.
+ * Everything the service talks to is mocked, so what is pinned here is the routing and the
+ * line mapping: an invoice on a project with a client raises a real AR invoice and adopts
+ * its journal entry, a discounted line is billed at its net so the two documents agree,
+ * cancelling unwinds through the AR invoice, and an absent, unknown or inactive client
+ * falls back to posting the receivable directly.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionInvoiceArMaterializationTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long PROJECT_ID = 41L;
+
+    @Mock private ConstructionInvoiceRepository invoiceRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private ConstructionInvoiceMapper mapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private JournalEntryRepository journalRepo;
+    @Mock private JournalPostingService postingService;
+    @Mock private PostingAccountResolver postingAccountResolver;
+    @Mock private FinanceSettingsService financeSettingsService;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private CostCategoryRepository costCategoryRepository;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private InvoiceService invoiceService;
+
+    private ConstructionInvoiceService service;
+
+    private final UUID arInvoiceId = UUID.randomUUID();
+    private final UUID arJournalEntryId = UUID.randomUUID();
+    private final UUID customerId = UUID.randomUUID();
+    private final UUID revenueAccountId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
+                journalRepo, postingService, postingAccountResolver, financeSettingsService,
+                projectRepository, userContextService, costCategoryRepository, customerRepository,
+                invoiceService);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void approve_salesInvoiceOnAProjectWithAClient_raisesTheArInvoiceAndAdoptsItsEntry() {
+        ConstructionInvoice inv = pendingSalesInvoice(line("Piling works", "10", "1000", "18", "0"));
+        givenProjectClient(activeCustomer());
+        givenArInvoiceIssued();
+
+        service.approve(inv.getId());
+
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(inv.getArInvoiceId()).isEqualTo(arInvoiceId);
+        assertThat(inv.getJournalEntryId()).isEqualTo(arJournalEntryId);
+        verify(postingService, never()).postInternal(any(), anyString(), any());
+
+        CreateInvoiceRequest req = capturedArRequest();
+        assertThat(req.customerId()).isEqualTo(customerId);
+        assertThat(req.invoiceDate()).isEqualTo(inv.getIssueDate());
+        assertThat(req.dueDate()).isEqualTo(inv.getDueDate());
+        assertThat(req.notes()).contains(inv.getInvoiceNumber());
+        assertThat(req.lines()).singleElement().satisfies(l -> {
+            assertThat(l.description()).isEqualTo("Piling works");
+            assertThat(l.quantity()).isEqualByComparingTo("10");
+            assertThat(l.unitPrice()).isEqualByComparingTo("1000");
+            assertThat(l.taxRate()).isEqualByComparingTo("18");
+            assertThat(l.revenueAccountId()).isEqualTo(revenueAccountId);
+        });
+    }
+
+    @Test
+    void approve_discountedLine_isBilledAtItsNetSoTheTwoDocumentsAgree() {
+        // 10 x 1000 = 10000 subtotal, 5% discount = 500, so the AR line bills 9500 as one unit.
+        ConstructionInvoice inv = pendingSalesInvoice(line("Piling works", "10", "1000", "18", "5"));
+        givenProjectClient(activeCustomer());
+        givenArInvoiceIssued();
+
+        service.approve(inv.getId());
+
+        assertThat(capturedArRequest().lines()).singleElement().satisfies(l -> {
+            assertThat(l.quantity()).isEqualByComparingTo("1");
+            assertThat(l.unitPrice()).isEqualByComparingTo("9500");
+            assertThat(l.taxRate()).isEqualByComparingTo("18");
+        });
+    }
+
+    @Test
+    void approve_projectWithoutAClient_postsTheReceivableDirectly() {
+        ConstructionInvoice inv = pendingSalesInvoice(line("Piling works", "10", "1000", "18", "0"));
+        givenProject(null);
+        givenDirectPostingAccounts();
+
+        service.approve(inv.getId());
+
+        assertThat(inv.getArInvoiceId()).isNull();
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        verify(invoiceService, never()).createDraft(any());
+        verify(postingService).postInternal(any(PostJournalRequest.class), eq("CONSTRUCTION_INVOICE"),
+                eq(inv.getId()));
+    }
+
+    @Test
+    void approve_inactiveClient_fallsBackToPostingTheReceivableDirectly() {
+        ConstructionInvoice inv = pendingSalesInvoice(line("Piling works", "10", "1000", "18", "0"));
+        Customer inactive = activeCustomer();
+        inactive.setActive(false);
+        givenProjectClient(inactive);
+        givenDirectPostingAccounts();
+
+        service.approve(inv.getId());
+
+        assertThat(inv.getArInvoiceId()).isNull();
+        verify(invoiceService, never()).createDraft(any());
+        verify(postingService).postInternal(any(PostJournalRequest.class), anyString(), any());
+    }
+
+    @Test
+    void cancel_invoiceWithAMaterializedArInvoice_unwindsThroughIt() {
+        ConstructionInvoice inv = pendingSalesInvoice(line("Piling works", "10", "1000", "18", "0"));
+        inv.setStatus(ConstructionInvoiceStatus.APPROVED);
+        inv.setArInvoiceId(arInvoiceId);
+        inv.setJournalEntryId(arJournalEntryId);
+        UUID reversalId = UUID.randomUUID();
+        when(invoiceService.cancel(arInvoiceId, "Client withdrew the claim"))
+                .thenReturn(arInvoiceDto(arJournalEntryId, reversalId));
+
+        service.cancel(inv.getId(), "Client withdrew the claim");
+
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.CANCELLED);
+        assertThat(inv.getReversalJournalEntryId()).isEqualTo(reversalId);
+        verify(postingService, never()).reverse(any(), any());
+    }
+
+    private ConstructionInvoice pendingSalesInvoice(ConstructionInvoiceLine line) {
+        ConstructionInvoice inv = new ConstructionInvoice();
+        inv.setId(UUID.randomUUID());
+        inv.setInvoiceNumber("CINV-2026-0007");
+        inv.setType(ConstructionInvoiceType.SALES);
+        inv.setStatus(ConstructionInvoiceStatus.PENDING);
+        inv.setProjectId(PROJECT_ID);
+        inv.setIssueDate(LocalDate.of(2026, 8, 1));
+        inv.setDueDate(LocalDate.of(2026, 8, 31));
+        inv.setSubtotal(line.getSubtotal());
+        inv.setTaxAmount(line.getTaxAmount());
+        inv.setDiscountAmount(line.getDiscountAmount());
+        inv.setTotalAmount(line.getTotal());
+        inv.addLine(line);
+        when(invoiceRepo.findByIdWithLines(inv.getId())).thenReturn(Optional.of(inv));
+        return inv;
+    }
+
+    /** Builds a line the way {@code applyLinesAndTotals} would, from the same inputs. */
+    private ConstructionInvoiceLine line(String description, String quantity, String unitPrice,
+                                         String taxRate, String discountRate) {
+        BigDecimal qty = new BigDecimal(quantity);
+        BigDecimal price = new BigDecimal(unitPrice);
+        BigDecimal subtotal = qty.multiply(price);
+        BigDecimal discount = subtotal.multiply(new BigDecimal(discountRate))
+                .divide(BigDecimal.valueOf(100));
+        BigDecimal tax = subtotal.subtract(discount).multiply(new BigDecimal(taxRate))
+                .divide(BigDecimal.valueOf(100));
+
+        ConstructionInvoiceLine line = new ConstructionInvoiceLine();
+        line.setDescription(description);
+        line.setQuantity(qty);
+        line.setUnit("lot");
+        line.setUnitPrice(price);
+        line.setTaxRate(new BigDecimal(taxRate));
+        line.setTaxAmount(tax);
+        line.setDiscountRate(new BigDecimal(discountRate));
+        line.setDiscountAmount(discount);
+        line.setSubtotal(subtotal);
+        line.setTotal(subtotal.add(tax).subtract(discount));
+        return line;
+    }
+
+    private Customer activeCustomer() {
+        Customer customer = new Customer();
+        customer.setId(customerId);
+        customer.setCode("CUST-001");
+        customer.setName("Asset Homes Pvt Ltd");
+        customer.setActive(true);
+        return customer;
+    }
+
+    private void givenProject(UUID clientId) {
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setCustomerId(clientId);
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project));
+    }
+
+    private void givenProjectClient(Customer customer) {
+        givenProject(customer.getId());
+        when(customerRepository.findScopedById(customer.getId())).thenReturn(Optional.of(customer));
+    }
+
+    private void givenArInvoiceIssued() {
+        when(postingAccountResolver.resolve(PostingRole.DEFAULT_REVENUE))
+                .thenReturn(account(revenueAccountId));
+        UUID draftId = UUID.randomUUID();
+        when(invoiceService.createDraft(any(CreateInvoiceRequest.class)))
+                .thenReturn(arInvoiceDto(null, null, draftId));
+        when(invoiceService.issue(draftId)).thenReturn(arInvoiceDto(arJournalEntryId, null));
+    }
+
+    private void givenDirectPostingAccounts() {
+        lenient().when(postingAccountResolver.resolve(any(PostingRole.class)))
+                .thenAnswer(call -> account(UUID.randomUUID()));
+        JournalEntry je = new JournalEntry();
+        je.setId(UUID.randomUUID());
+        je.setEntryNumber("JE-2026-0100");
+        when(postingService.postInternal(any(PostJournalRequest.class), anyString(), any()))
+                .thenReturn(je);
+    }
+
+    private CreateInvoiceRequest capturedArRequest() {
+        ArgumentCaptor<CreateInvoiceRequest> captor = ArgumentCaptor.forClass(CreateInvoiceRequest.class);
+        verify(invoiceService).createDraft(captor.capture());
+        return captor.getValue();
+    }
+
+    private Account account(UUID id) {
+        Account account = new Account();
+        account.setId(id);
+        account.setCode("4000");
+        return account;
+    }
+
+    private InvoiceDto arInvoiceDto(UUID journalEntryId, UUID reversalJournalEntryId) {
+        return arInvoiceDto(journalEntryId, reversalJournalEntryId, arInvoiceId);
+    }
+
+    private InvoiceDto arInvoiceDto(UUID journalEntryId, UUID reversalJournalEntryId, UUID id) {
+        return new InvoiceDto(id, "INV-2026-0011", customerId, "Asset Homes Pvt Ltd",
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31), InvoiceStatus.ISSUED,
+                new BigDecimal("10000"), new BigDecimal("1800"), new BigDecimal("11800"),
+                BigDecimal.ZERO, new BigDecimal("11800"), journalEntryId, reversalJournalEntryId,
+                null, List.of());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
@@ -91,6 +91,7 @@ class ConstructionInvoicePdfAuthzTest {
                 null, null, null, null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
+                null,
                 List.of());
     }
 


### PR DESCRIPTION
Closes #450.

## What was wrong

Approving a SALES or SERVICE construction invoice posted DR Accounts Receivable / CR revenue + CR GST output straight to the ledger. The receivable existed in the ledger but as no document, so it never showed up in AR aging or customer statements and could not be settled by an ordinary receipt. `ConstructionInvoiceService` carried a `// TODO: option A AR materialization` marker at the posting site, and the spec recorded the blocker: option A needs to know who the project is billed to, and nothing in the model said that.

## What this adds

**The project's client.** `project.customer_id`, a nullable finance customer id (migration `053`). It is settable on project create and through the project patch map, validated against the tenant's customers on both paths, and returned on the project DTOs. Held as a plain id rather than an association, matching how the construction finance tables already reference core-domain records.

**The AR route on approval.** Where a sales or service invoice's project has a client, `postAndApprove` raises a draft AR invoice against that customer through `InvoiceService.createDraft`, issues it, and takes the issued invoice's journal entry as its own, recording the AR invoice on `construction_invoices.ar_invoice_id`. The receivable then lives in one place.

**Cancellation follows the same route.** An invoice with a materialized AR invoice is unwound by cancelling that invoice, which reverses the same entry and refuses if a receipt has already been applied. The reversal id is copied back onto the construction invoice.

**Line mapping.** An AR line has no discount column. A discounted construction line is therefore billed as a single unit priced at its net-of-discount amount, which makes the AR line's tax and total identical to the construction line's rather than letting the discount round differently. A line with no discount keeps its quantity and unit price.

## Backwards compatibility

A project with no client, or one naming a customer that no longer resolves or has been deactivated, keeps posting the receivable directly, exactly as before, with a warning logged in the missing/inactive case. Purchase and expense invoices are untouched. Nothing already approved changes behaviour, and the existing posting integration tests pass unchanged.

## Verification

`./gradlew build` on the lab box (`lab-node-116-f`), full suite against the Testcontainers CockroachDB, including the JaCoCo coverage gate:

```
> Task :jacocoTestReport
> Task :jacocoTestCoverageVerification
> Task :check
> Task :build

BUILD SUCCESSFUL in 7m 15s
10 actionable tasks: 10 executed
```

The finance/construction results from that run:

```
ConstructionInvoiceAutoApprovalIT               tests=3 failures=0 errors=0
ConstructionInvoicePostingIT                    tests=5 failures=0 errors=0
ConstructionInvoiceServiceIT                    tests=1 failures=0 errors=0
ConstructionPaymentServiceIT                    tests=1 failures=0 errors=0
ConstructionInvoicePdfServiceTest               tests=2 failures=0 errors=0
ConstructionInvoiceArMaterializationTest        tests=5 failures=0 errors=0
ConstructionInvoicePdfAuthzTest                 tests=2 failures=0 errors=0
```

New tests are plain JUnit + Mockito (`ConstructionInvoiceArMaterializationTest`), no new Spring context, covering: the AR invoice being raised and its entry adopted, the discounted line billed at its net, cancellation unwinding through the AR invoice, and the two fallback cases (no client, inactive client).

## Follow-on, not in this PR

`echno-core` and `echno-web` need the new `customerId` on the project payloads and `arInvoiceId` on the construction invoice DTO before the client can be set or the AR link surfaced in the UI.
