### PR TITLE
Review only, do not merge: replay of #463 (d3d8f73) for a deferred bot review

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatService.java
@@ -20,6 +20,7 @@ import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -72,6 +73,7 @@ public class ChatService {
     private final EmployeeRepository employeeRepository;
     private final AttachmentService attachmentService;
     private final ApplicationEventPublisher eventPublisher;
+    private final TransactionRetryTemplate transactionRetryTemplate;
 
     public ChatService(ChatRoomRepository roomRepository,
                        ChatParticipantRepository participantRepository,
@@ -82,7 +84,8 @@ public class ChatService {
                        UserContextService userContextService,
                        EmployeeRepository employeeRepository,
                        AttachmentService attachmentService,
-                       ApplicationEventPublisher eventPublisher) {
+                       ApplicationEventPublisher eventPublisher,
+                       TransactionRetryTemplate transactionRetryTemplate) {
         this.roomRepository = roomRepository;
         this.participantRepository = participantRepository;
         this.messageRepository = messageRepository;
@@ -93,6 +96,7 @@ public class ChatService {
         this.employeeRepository = employeeRepository;
         this.attachmentService = attachmentService;
         this.eventPublisher = eventPublisher;
+        this.transactionRetryTemplate = transactionRetryTemplate;
     }
 
     @Transactional(readOnly = true)
@@ -153,18 +157,27 @@ public class ChatService {
         return toRoomDto(saved, employeeId);
     }
 
-    /** Marks the room read for the caller by advancing their {@code lastReadAt} to now. */
-    @Transactional
+    /**
+     * Marks the room read for the caller by advancing their {@code lastReadAt} to now.
+     *
+     * <p>Run through the retry template rather than under a plain {@code @Transactional}: this
+     * reads the room row that every {@link #sendMessage} concurrently bumps, which is exactly
+     * the read-write pair CockroachDB resolves by aborting one side under {@code SERIALIZABLE}.
+     * The work is a single participant timestamp plus an after-commit event, so running it
+     * again from the start costs nothing and produces the same result.
+     */
     public void markRead(Long roomId) {
-        Long employeeId = resolveCurrentEmployeeId();
-        requireRoom(roomId);
-        ChatParticipant participant = requireParticipant(roomId, employeeId);
-        participant.setLastReadAt(LocalDateTime.now());
-        participantRepository.save(participant);
+        transactionRetryTemplate.executeWithoutResult("ChatService.markRead", () -> {
+            Long employeeId = resolveCurrentEmployeeId();
+            requireRoom(roomId);
+            ChatParticipant participant = requireParticipant(roomId, employeeId);
+            participant.setLastReadAt(LocalDateTime.now());
+            participantRepository.save(participant);
 
-        // Only the reader. An unread count is per viewer, so nobody else's room list changes
-        // when someone catches up on their own.
-        raise(ChatEventType.ROOM_UPDATED, roomId, null, employeeId, List.of(employeeId));
+            // Only the reader. An unread count is per viewer, so nobody else's room list changes
+            // when someone catches up on their own.
+            raise(ChatEventType.ROOM_UPDATED, roomId, null, employeeId, List.of(employeeId));
+        });
     }
 
     @Transactional(readOnly = true)
@@ -180,10 +193,18 @@ public class ChatService {
     /**
      * Posts a text (optionally reply) message with no attachments. Kept as the JSON path the
      * web uses today; the multipart overload below adds files.
+     *
+     * <p>This is the contended path: sending bumps the room's {@code updatedAt}, so two people
+     * talking in the same room write the same row and one of them gets aborted. The retry
+     * template runs the whole send again in a fresh transaction. Safe to repeat because the
+     * only effects are database writes and an event released after commit, so an aborted
+     * attempt leaves nothing behind. The multipart overload below is deliberately not wrapped:
+     * it uploads the attachments to object storage inside the transaction, and those uploads
+     * would be repeated (from streams already consumed) on a second attempt.
      */
-    @Transactional
     public ChatMessageDto sendMessage(Long roomId, String content, Long replyToId) {
-        return sendMessage(roomId, content, replyToId, null);
+        return transactionRetryTemplate.execute("ChatService.sendMessage",
+                () -> sendMessage(roomId, content, replyToId, null));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -105,6 +106,26 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleDuplicateIdempotencyKeyException(DuplicateIdempotencyKeyException ex, WebRequest request) {
         logger.error("Duplicate idempotency key exception: ", ex);
         return problem(HttpStatus.CONFLICT, "Duplicate Idempotency Key", ex.getMessage(), request);
+    }
+
+    /**
+     * A write that kept colliding with a concurrent change on the same rows and used up its
+     * serialization retries. 409 rather than 503: the service is healthy and every other
+     * request is being served, so signalling unavailability would be untrue and would push
+     * clients and proxies into backing off from the whole API. It is the same shape as the
+     * other "someone else got there first" answers here, and the retryable flag tells the
+     * client it may simply send the request again.
+     */
+    @ExceptionHandler({TransactionRetriesExhaustedException.class, CannotAcquireLockException.class})
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ProblemDetail handleSerializationConflict(Exception ex, WebRequest request) {
+        logger.warn("Serialization conflict, request not applied: {}", ex.getMessage());
+        ProblemDetail pd = problem(HttpStatus.CONFLICT, "Concurrent Update Conflict",
+                "Someone else changed the same records at the same time, so the request was not "
+                        + "applied. Please try again.", request);
+        pd.setProperty("retryable", true);
+        pd.setProperty("retryAfterSeconds", 1);
+        return pd;
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/org/tornotron/echno_backend/common/exception/TransactionRetriesExhaustedException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/TransactionRetriesExhaustedException.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Raised when a unit of work kept losing serialization conflicts and used up its retries.
+ * Distinct from the raw database abort so the request can be answered as the concurrency
+ * conflict it is instead of falling into the unknown-error bucket.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class TransactionRetriesExhaustedException extends RuntimeException {
+
+    public TransactionRetriesExhaustedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetector.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetector.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.common.retry;
+
+import java.sql.SQLException;
+
+/**
+ * Recognises the database's "you lost a serialization conflict, run it again" signal.
+ *
+ * <p>CockroachDB runs {@code SERIALIZABLE} and resolves a read-write conflict between two
+ * concurrent transactions by aborting one of them with {@code RETRY_SERIALIZABLE}, expecting
+ * the client to start it over. That is a normal outcome under contention rather than a fault,
+ * and it is reported with SQLSTATE {@code 40001}.
+ *
+ * <p>The test here is the SQLSTATE, never the message text. The wording the server puts around
+ * the code varies between versions and carries transaction ids and node addresses, so matching
+ * on it is brittle in exactly the situation where a false negative costs the user their write.
+ *
+ * <p>By the time the failure reaches application code Spring has wrapped it, typically as a
+ * {@code CannotAcquireLockException} over a Hibernate exception over the driver's
+ * {@link SQLException}, so the cause chain has to be walked. {@code SQLException} also keeps its
+ * siblings on a second chain of its own ({@link SQLException#getNextException()}), which the
+ * PostgreSQL driver uses for batch failures, so that chain is followed too.
+ */
+public final class SerializationFailureDetector {
+
+    /** SQLSTATE class 40, code 001: serialization failure. */
+    public static final String SERIALIZATION_FAILURE_SQL_STATE = "40001";
+
+    /** Guards against a cause chain that loops back on itself. */
+    private static final int MAX_CHAIN_DEPTH = 32;
+
+    private SerializationFailureDetector() {
+    }
+
+    /**
+     * Returns true when {@code throwable}, or anything it wraps, is a serialization failure the
+     * caller may safely run again.
+     */
+    public static boolean isSerializationFailure(Throwable throwable) {
+        Throwable current = throwable;
+        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
+            if (current instanceof SQLException sqlException && carriesSerializationState(sqlException)) {
+                return true;
+            }
+            Throwable cause = current.getCause();
+            current = (cause == current) ? null : cause;
+        }
+        return false;
+    }
+
+    private static boolean carriesSerializationState(SQLException sqlException) {
+        SQLException current = sqlException;
+        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
+            if (SERIALIZATION_FAILURE_SQL_STATE.equals(current.getSQLState())) {
+                return true;
+            }
+            SQLException next = current.getNextException();
+            current = (next == current) ? null : next;
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
@@ -1,0 +1,168 @@
+package org.tornotron.echno_backend.common.retry;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.tornotron.echno_backend.common.exception.TransactionRetriesExhaustedException;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+/**
+ * Runs a unit of work in a transaction and starts it over when the database aborts it with a
+ * serialization failure (SQLSTATE {@code 40001}).
+ *
+ * <p>Under {@code SERIALIZABLE} an abort is the database telling the client that its snapshot
+ * no longer holds and the whole transaction has to run again. Retrying a statement inside the
+ * aborted transaction achieves nothing: it is already doomed and every further statement on it
+ * fails. The restart therefore has to happen outside the transaction boundary.
+ *
+ * <p>This is a template rather than an aspect on purpose. An {@code @Around} aspect would have
+ * to be ordered ahead of Spring's transaction interceptor to sit outside it, and this
+ * application pins that interceptor at {@code Ordered.HIGHEST_PRECEDENCE} in
+ * {@code EchnoBackendApplication}, which is {@code Integer.MIN_VALUE}. No advice can be ordered
+ * ahead of it, so an annotation-driven retry would have run inside the transaction and quietly
+ * done nothing. Here the boundary is a method call: {@link TransactionalWorkRunner} opens and
+ * closes the transaction within {@code runInTransaction}, and the loop below sits around that
+ * call, so every attempt is a new transaction whatever the advisor ordering happens to be.
+ *
+ * <p>Only wrap work that is safe to run again from the start. Anything that has already changed
+ * the world outside the database by the time the commit fails, such as an object uploaded to
+ * storage, a mail sent or a payment charged, would be repeated by the retry.
+ *
+ * <p>Usage:
+ * <pre>
+ * public void markRead(Long roomId) {
+ *     retryTemplate.executeWithoutResult("ChatService.markRead", () -&gt; { ... });
+ * }
+ * </pre>
+ *
+ * <p>The wrapped method must not itself be {@code @Transactional}: the transaction belongs to
+ * the runner, one per attempt. Retries are counted per operation under
+ * {@code echno.transaction.retry.attempts} and give-ups under
+ * {@code echno.transaction.retry.exhausted}, so contention shows up on the dashboards before it
+ * shows up in a support ticket.
+ */
+@Component
+public class TransactionRetryTemplate {
+
+    private static final Logger logger = LoggerFactory.getLogger(TransactionRetryTemplate.class);
+
+    /** Counter for each restarted attempt, tagged with the operation that contended. */
+    private static final String ATTEMPTS_METRIC = "echno.transaction.retry.attempts";
+
+    /** Counter for each unit of work that used up its attempts and failed the request. */
+    private static final String EXHAUSTED_METRIC = "echno.transaction.retry.exhausted";
+
+    /** Caps the doubling so a misconfigured backoff cannot overflow the shift. */
+    private static final int MAX_BACKOFF_DOUBLINGS = 20;
+
+    private final TransactionalWorkRunner runner;
+    private final MeterRegistry meterRegistry;
+    private final int maxAttempts;
+    private final long initialBackoffMillis;
+    private final long maxBackoffMillis;
+
+    public TransactionRetryTemplate(
+            TransactionalWorkRunner runner,
+            MeterRegistry meterRegistry,
+            @Value("${echno.transaction.retry.max-attempts:4}") int maxAttempts,
+            @Value("${echno.transaction.retry.initial-backoff-millis:25}") long initialBackoffMillis,
+            @Value("${echno.transaction.retry.max-backoff-millis:250}") long maxBackoffMillis) {
+        this.runner = runner;
+        this.meterRegistry = meterRegistry;
+        this.maxAttempts = Math.max(1, maxAttempts);
+        this.initialBackoffMillis = Math.max(0L, initialBackoffMillis);
+        this.maxBackoffMillis = Math.max(0L, maxBackoffMillis);
+    }
+
+    /**
+     * Runs {@code work} in its own transaction, restarting it from the beginning on a
+     * serialization failure. {@code operation} names the unit of work for the logs and the
+     * retry metric; keep it a stable, low-cardinality label such as {@code ChatService.markRead}.
+     *
+     * @throws TransactionRetriesExhaustedException when every attempt was aborted
+     */
+    public <T> T execute(String operation, Supplier<T> work) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            // A caller already owns the transaction, so there is no boundary here to restart:
+            // an abort dooms their transaction, not one of ours. Run the work once and let the
+            // failure travel out to whoever opened the transaction.
+            return runner.runInTransaction(work);
+        }
+
+        Throwable lastFailure = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return runner.runInTransaction(work);
+            } catch (RuntimeException failure) {
+                if (!SerializationFailureDetector.isSerializationFailure(failure)) {
+                    throw failure;
+                }
+                lastFailure = failure;
+                if (attempt == maxAttempts) {
+                    break;
+                }
+                counter(ATTEMPTS_METRIC, "Transactions restarted after a database serialization failure",
+                        operation).increment();
+                logger.info("Serialization failure on {}, restarting the transaction (attempt {} of {})",
+                        operation, attempt + 1, maxAttempts);
+                if (!backOff(attempt)) {
+                    throw failure;
+                }
+            }
+        }
+
+        counter(EXHAUSTED_METRIC, "Units of work abandoned after using up their serialization retries",
+                operation).increment();
+        logger.warn("Gave up on {} after {} serialization failures", operation, maxAttempts, lastFailure);
+        throw new TransactionRetriesExhaustedException(
+                "The operation kept colliding with a concurrent change and was abandoned after "
+                        + maxAttempts + " attempts", lastFailure);
+    }
+
+    /** The no-result form of {@link #execute(String, Supplier)}. */
+    public void executeWithoutResult(String operation, Runnable work) {
+        execute(operation, () -> {
+            work.run();
+            return null;
+        });
+    }
+
+    /**
+     * Sleeps for a jittered, exponentially growing interval before the next attempt. Full
+     * jitter rather than a fixed pause: two transactions that abort against each other and then
+     * wait the same length of time simply collide again.
+     *
+     * @return false when the wait was interrupted, in which case the caller should stop retrying
+     */
+    private boolean backOff(int attempt) {
+        long ceiling = Math.min(maxBackoffMillis,
+                initialBackoffMillis << Math.min(attempt - 1, MAX_BACKOFF_DOUBLINGS));
+        if (ceiling <= 0L) {
+            return true;
+        }
+        long pause = ThreadLocalRandom.current().nextLong(ceiling + 1);
+        if (pause <= 0L) {
+            return true;
+        }
+        try {
+            Thread.sleep(pause);
+            return true;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private Counter counter(String name, String description, String operation) {
+        return Counter.builder(name)
+                .description(description)
+                .tag("operation", operation)
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/retry/TransactionalWorkRunner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/TransactionalWorkRunner.java
@@ -1,0 +1,36 @@
+package org.tornotron.echno_backend.common.retry;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+/**
+ * Runs a block of work inside one transaction, and nothing else.
+ *
+ * <p>This exists as a bean of its own so that {@link TransactionRetryTemplate} can open a
+ * transaction by calling through a proxy rather than by holding a {@code TransactionTemplate}.
+ * Two things depend on the transaction being declarative here:
+ *
+ * <ul>
+ *   <li>the transaction begins and ends entirely within a single call to
+ *       {@link #runInTransaction(Supplier)}, so a retry loop wrapped around that call is
+ *       outside the transaction boundary by construction;</li>
+ *   <li>{@code HibernateFilterConfig} advises {@code @Transactional} methods in this package
+ *       tree to enable the {@code orgFilter} tenant filter on the session. A programmatic
+ *       {@code TransactionTemplate} carries no such annotation, so a transaction opened that
+ *       way would run with tenant filtering off.</li>
+ * </ul>
+ *
+ * <p>Propagation is the default {@code REQUIRED}: if the caller already owns a transaction the
+ * work joins it, and {@link TransactionRetryTemplate} declines to retry in that case because
+ * there would be no boundary here to restart.
+ */
+@Component
+public class TransactionalWorkRunner {
+
+    @Transactional
+    public <T> T runInTransaction(Supplier<T> work) {
+        return work.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,6 +171,16 @@ echno:
       # which can differ from the internal URL the backend dials, so list every URL
       # the same realm may present.
       accepted-issuers: ${ECHNO_JWT_ACCEPTED_ISSUERS:}
+  transaction:
+    retry:
+      # CockroachDB runs SERIALIZABLE and aborts one side of a read-write conflict with
+      # SQLSTATE 40001, expecting the client to run the transaction again. TransactionRetryTemplate
+      # does that for the units of work that opt in. Attempts include the first try; the wait
+      # between attempts doubles from the initial value and is fully jittered up to the cap, so
+      # two transactions that abort against each other do not wake up together and collide again.
+      max-attempts: ${ECHNO_TXN_RETRY_MAX_ATTEMPTS:4}
+      initial-backoff-millis: ${ECHNO_TXN_RETRY_INITIAL_BACKOFF_MS:25}
+      max-backoff-millis: ${ECHNO_TXN_RETRY_MAX_BACKOFF_MS:250}
 
 
 spring:

--- a/src/test/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetectorTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetectorTest.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.common.retry;
+
+import org.junit.jupiter.api.Test;
+import org.hibernate.exception.LockAcquisitionException;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SerializationFailureDetector}. The point of the class is that it reads
+ * the SQLSTATE off the driver's exception rather than matching the server's wording, and that it
+ * finds that exception however deeply the layers above have wrapped it, so those are what is
+ * tested here: the real shape of a CockroachDB abort as it arrives from Spring, the driver's
+ * second (next-exception) chain, the codes that must not be mistaken for a retryable abort, and
+ * the chains that would otherwise make the walk loop forever.
+ */
+class SerializationFailureDetectorTest {
+
+    /** The wording CockroachDB puts on a serializable abort, for a realistic message. */
+    private static final String ABORT_MESSAGE =
+            "restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: "
+                    + "retry txn (RETRY_SERIALIZABLE - failed preemptive refresh)";
+
+    @Test
+    void findsTheSqlStateOnTheExceptionItself() {
+        assertThat(SerializationFailureDetector.isSerializationFailure(
+                new SQLException(ABORT_MESSAGE, "40001"))).isTrue();
+    }
+
+    @Test
+    void findsTheSqlStateThroughTheWrappingSpringAndHibernateExceptions() {
+        // The chain the live 500s arrived on: Spring's DataAccessException over Hibernate's
+        // JDBCException over the driver's SQLException.
+        SQLException driverFailure = new SQLException(ABORT_MESSAGE, "40001");
+        Throwable wrapped = new CannotAcquireLockException(
+                "Unable to commit against JDBC Connection",
+                new LockAcquisitionException("could not execute statement", driverFailure));
+
+        assertThat(SerializationFailureDetector.isSerializationFailure(wrapped)).isTrue();
+    }
+
+    @Test
+    void findsTheSqlStateOnTheDriversNextExceptionChain() {
+        // A batch failure reports the first statement's generic code and hangs the real one off
+        // getNextException, which is a separate chain from getCause.
+        SQLException batchFailure = new SQLException("batch entry failed", "XX000");
+        batchFailure.setNextException(new SQLException(ABORT_MESSAGE, "40001"));
+
+        assertThat(SerializationFailureDetector.isSerializationFailure(
+                new CannotAcquireLockException("batch", batchFailure))).isTrue();
+    }
+
+    @Test
+    void rejectsADifferentSqlState() {
+        // 23505 is a unique-constraint violation: a real conflict the caller must not repeat.
+        Throwable duplicateKey = new DataIntegrityViolationException(
+                "duplicate key value", new SQLException("duplicate key value", "23505"));
+
+        assertThat(SerializationFailureDetector.isSerializationFailure(duplicateKey)).isFalse();
+    }
+
+    @Test
+    void rejectsAFailureThatCarriesNoSqlExceptionAtAll() {
+        assertThat(SerializationFailureDetector.isSerializationFailure(
+                new IllegalStateException("nothing to do with the database"))).isFalse();
+        assertThat(SerializationFailureDetector.isSerializationFailure(null)).isFalse();
+    }
+
+    @Test
+    void terminatesOnASelfReferencingChain() {
+        SQLException selfReferencing = new SQLException("looping", "XX000");
+        selfReferencing.setNextException(selfReferencing);
+
+        assertThat(SerializationFailureDetector.isSerializationFailure(selfReferencing)).isFalse();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateIT.java
@@ -1,0 +1,99 @@
+package org.tornotron.echno_backend.common.retry;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the retry against a real CockroachDB rather than a stand-in: that the server's
+ * serializable abort really does arrive carrying SQLSTATE 40001 once the driver, Hibernate and
+ * Spring have each wrapped it, and that starting the transaction over lets the same work commit.
+ *
+ * <p>The abort is raised by {@code crdb_internal.force_retry}, the engine's own way of producing
+ * a genuine retryable error, so the test needs no second thread and no timing window. Only the
+ * first attempt asks for it; the second runs the write for real.
+ *
+ * <p>The context is a JPA slice with the two retry beans imported, which is the smallest thing
+ * that can exercise a real transaction boundary, and it is dropped after the class so it does
+ * not sit in the shared context cache for the rest of the run.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TransactionRetryTemplate.class, TransactionalWorkRunner.class, SimpleMeterRegistry.class})
+@TestPropertySource(properties = {
+        "echno.transaction.retry.initial-backoff-millis=0",
+        "echno.transaction.retry.max-backoff-millis=0"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class TransactionRetryTemplateIT extends AbstractIntegrationTest {
+
+    private static final String OPERATION = "TransactionRetryTemplateIT.persistOrganization";
+
+    @Autowired
+    private TransactionRetryTemplate transactionRetryTemplate;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    // The template opens its own transaction per attempt, so the test method must not already
+    // be in one; @DataJpaTest would otherwise wrap the whole method in a rolled-back transaction.
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void restartsTheTransactionOnARealSerializableAbortAndCommitsTheRetry() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        Long organizationId = transactionRetryTemplate.execute(OPERATION, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                // force_retry lives behind the unsafe-internals guard from CockroachDB v26 on.
+                // SET LOCAL keeps the relaxation inside this transaction, so the pooled
+                // connection goes back to the pool with the guard on.
+                entityManager.createNativeQuery("SET LOCAL allow_unsafe_internals = true").executeUpdate();
+                entityManager.createNativeQuery("SELECT crdb_internal.force_retry('1s')").getSingleResult();
+            }
+            Organization organization = new Organization();
+            organization.setOrganizationName("Retry Org");
+            organization.setOrganizationAddress("addr");
+            organization.setOrganizationEmail("retry-" + System.nanoTime() + "@example.test");
+            organization.setOrganizationPhone("0000000000");
+            entityManager.persist(organization);
+            entityManager.flush();
+            return organization.getId();
+        });
+
+        assertThat(attempts).hasValue(2);
+        assertThat(organizationId).isNotNull();
+        // Committed for real, not just returned: the row survives outside the template's transaction.
+        assertThat(organizationRepository.findById(organizationId)).isPresent();
+        assertThat(retryCount()).isEqualTo(1.0);
+    }
+
+    private double retryCount() {
+        return meterRegistry.find("echno.transaction.retry.attempts").counters().stream()
+                .mapToDouble(Counter::count)
+                .sum();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
@@ -1,0 +1,216 @@
+package org.tornotron.echno_backend.common.retry;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.tornotron.echno_backend.common.exception.TransactionRetriesExhaustedException;
+
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Unit tests for {@link TransactionRetryTemplate}.
+ *
+ * <p>The behaviour that matters is not that the work runs again, it is that it runs again in a
+ * <em>new</em> transaction: a serializable abort dooms the transaction it happened in, so
+ * repeating the work on the same one would fail identically. The tests therefore drive the real
+ * {@link TransactionalWorkRunner} through a real Spring {@link TransactionInterceptor} over a
+ * transaction manager that counts what it is asked to do, which shows each attempt beginning its
+ * own transaction and the failed ones rolling back. No application context is involved: the
+ * proxy is built by hand, which is both faster and keeps the test JVM's heap free for the suites
+ * that genuinely need a context.
+ *
+ * <p>Backoff is configured to zero here so the retries do not add wall-clock time to the build;
+ * the jitter maths is bounded arithmetic and is exercised in production by the real defaults.
+ */
+class TransactionRetryTemplateTest {
+
+    private static final int MAX_ATTEMPTS = 3;
+    private static final String OPERATION = "TestService.doWork";
+
+    private MeterRegistry meterRegistry;
+    private CountingTransactionManager transactionManager;
+    private TransactionRetryTemplate template;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        transactionManager = new CountingTransactionManager();
+        template = new TransactionRetryTemplate(
+                transactionalRunner(transactionManager), meterRegistry, MAX_ATTEMPTS, 0L, 0L);
+    }
+
+    @AfterEach
+    void clearTransactionState() {
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    void restartsTheTransactionAfterASerializationFailureAndSucceeds() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = template.execute(OPERATION, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw serializationFailure();
+            }
+            return "committed";
+        });
+
+        assertThat(result).isEqualTo("committed");
+        assertThat(attempts).hasValue(2);
+        // The point of the fix: two transactions, the aborted one rolled back and the retry
+        // committed, rather than two attempts sharing one doomed transaction.
+        assertThat(transactionManager.begun).isEqualTo(2);
+        assertThat(transactionManager.rolledBack).isEqualTo(1);
+        assertThat(transactionManager.committed).isEqualTo(1);
+        assertThat(counter("echno.transaction.retry.attempts")).isEqualTo(1.0);
+        assertThat(counter("echno.transaction.retry.exhausted")).isZero();
+    }
+
+    @Test
+    void keepsRestartingUpToTheAttemptLimit() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = template.execute(OPERATION, () -> {
+            if (attempts.incrementAndGet() < MAX_ATTEMPTS) {
+                throw serializationFailure();
+            }
+            return "committed";
+        });
+
+        assertThat(result).isEqualTo("committed");
+        assertThat(transactionManager.begun).isEqualTo(MAX_ATTEMPTS);
+        assertThat(counter("echno.transaction.retry.attempts")).isEqualTo(MAX_ATTEMPTS - 1.0);
+    }
+
+    @Test
+    void reportsAConflictOnceTheAttemptsAreUsedUp() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThatExceptionOfType(TransactionRetriesExhaustedException.class)
+                .isThrownBy(() -> template.execute(OPERATION, () -> {
+                    attempts.incrementAndGet();
+                    throw serializationFailure();
+                }))
+                .withMessageContaining(String.valueOf(MAX_ATTEMPTS))
+                .withCauseInstanceOf(CannotAcquireLockException.class);
+
+        assertThat(attempts).hasValue(MAX_ATTEMPTS);
+        assertThat(transactionManager.begun).isEqualTo(MAX_ATTEMPTS);
+        assertThat(transactionManager.rolledBack).isEqualTo(MAX_ATTEMPTS);
+        assertThat(transactionManager.committed).isZero();
+        assertThat(counter("echno.transaction.retry.exhausted")).isEqualTo(1.0);
+    }
+
+    @Test
+    void doesNotRetryAFailureThatIsNotASerializationConflict() {
+        AtomicInteger attempts = new AtomicInteger();
+        DataIntegrityViolationException duplicateKey = new DataIntegrityViolationException(
+                "duplicate key value", new SQLException("duplicate key value", "23505"));
+
+        assertThatExceptionOfType(DataIntegrityViolationException.class)
+                .isThrownBy(() -> template.execute(OPERATION, () -> {
+                    attempts.incrementAndGet();
+                    throw duplicateKey;
+                }))
+                .isSameAs(duplicateKey);
+
+        assertThat(attempts).hasValue(1);
+        assertThat(transactionManager.begun).isEqualTo(1);
+        assertThat(counter("echno.transaction.retry.attempts")).isZero();
+        assertThat(counter("echno.transaction.retry.exhausted")).isZero();
+    }
+
+    @Test
+    void doesNotRetryInsideACallersTransaction() {
+        // Nothing to restart: the boundary belongs to the caller and their transaction is
+        // already doomed, so the abort has to travel out to whoever opened it.
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThatExceptionOfType(CannotAcquireLockException.class)
+                .isThrownBy(() -> template.execute(OPERATION, () -> {
+                    attempts.incrementAndGet();
+                    throw serializationFailure();
+                }));
+
+        assertThat(attempts).hasValue(1);
+        assertThat(counter("echno.transaction.retry.attempts")).isZero();
+    }
+
+    @Test
+    void retriesTheNoResultForm() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        template.executeWithoutResult(OPERATION, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw serializationFailure();
+            }
+        });
+
+        assertThat(attempts).hasValue(2);
+        assertThat(transactionManager.begun).isEqualTo(2);
+        assertThat(transactionManager.committed).isEqualTo(1);
+    }
+
+    /** A CockroachDB serializable abort in the shape Spring hands to application code. */
+    private static CannotAcquireLockException serializationFailure() {
+        return new CannotAcquireLockException("Unable to commit against JDBC Connection",
+                new SQLException("restart transaction: retry txn (RETRY_SERIALIZABLE)", "40001"));
+    }
+
+    private double counter(String name) {
+        return meterRegistry.find(name).counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    /**
+     * The real runner behind the real transaction interceptor, so the {@code @Transactional}
+     * boundary under test is Spring's own and not a stand-in.
+     */
+    private static TransactionalWorkRunner transactionalRunner(PlatformTransactionManager manager) {
+        ProxyFactory factory = new ProxyFactory(new TransactionalWorkRunner());
+        factory.addAdvice(new TransactionInterceptor(manager, new AnnotationTransactionAttributeSource()));
+        return (TransactionalWorkRunner) factory.getProxy();
+    }
+
+    /** Records the transaction boundaries the interceptor asks for. */
+    private static final class CountingTransactionManager implements PlatformTransactionManager {
+
+        private int begun;
+        private int committed;
+        private int rolledBack;
+
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            begun++;
+            return new SimpleTransactionStatus(true);
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+            committed++;
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+            rolledBack++;
+        }
+    }
+}


### PR DESCRIPTION
## Review-only. Do not merge. This PR will be closed.

This carries no new change. It replays the diff that already merged into `development`
so an automated review can run over it, and it will be closed and its branch deleted
once that review has been read.

- Original PR: #463
- Merged commit: `d3d8f73` "Retry serializable aborts instead of returning 500"
- Branch base: `7c688ed`, the first parent of that commit, so the diff here is byte for
  byte what merged.

The original merged inside a window where the review bot's hourly allowance was already
spent. Its status check reported a pass with the summary "Review rate limited", so nothing
was actually reviewed. This recovers that review after the fact.

### What the change does

CockroachDB runs SERIALIZABLE and resolves a read/write conflict by aborting one side with
SQLSTATE 40001, expecting the client to run the transaction again. The abort escaped commit
as `CannotAcquireLockException`, fell into the unknown-error bucket of `GlobalExceptionHandler`
and reached the user as a 500. The change adds a bounded retry with fully jittered exponential
backoff, applies it to the two contended chat writes, and maps an exhausted conflict to 409.

### Two design decisions worth a reviewer's attention

**The retry sits outside the transaction boundary, and it has to.** An `@Around` aspect cannot
achieve that here: `EchnoBackendApplication` carries
`@EnableTransactionManagement(order = Ordered.HIGHEST_PRECEDENCE)`, which pins the transaction
advisor at `Integer.MIN_VALUE`, and no advice can be ordered ahead of that. An annotation-driven
retry would therefore have run inside the transaction and quietly done nothing. The boundary is
a method call instead: `TransactionalWorkRunner.runInTransaction` is invoked through the proxy,
and the retry loop wraps that call, so every attempt is a fresh transaction whatever the advisor
ordering turns out to be.

**`TransactionalWorkRunner` is declaratively `@Transactional` rather than a `TransactionTemplate`.**
`HibernateFilterConfig` advises `@Transactional` methods to enable the `orgFilter` tenant filter.
A programmatic transaction boundary would have run with tenant filtering off, which is a data
leak rather than a style difference.

### Other points to weigh

- The 409 versus 503 choice for a conflict that exhausts its retries.
- Which chat methods are safe to retry. The multipart `sendMessage` overload is deliberately
  excluded: it uploads attachments to object storage inside the transaction, and a retry would
  repeat those uploads from streams that have already been consumed.
- Retryability is decided by reading `getSQLState()` off the `SQLException`, walking both the
  cause chain and the driver's next-exception chain, rather than by matching server wording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending messages and marking messages as read during temporary database transaction conflicts.
  * Automatically retries eligible operations before reporting failure.
  * Returns a clear conflict response with retry guidance when attempts are exhausted.

* **Configuration**
  * Added settings to control retry attempts and backoff timing.

* **Monitoring**
  * Added metrics for transaction retries and exhausted retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->