### PR TITLE
Let a member list their own organizations without a tenant-scoped role

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -152,12 +152,23 @@ public class OrganizationService {
     }
 
     /**
-     * Retrieves a paginated list of all organizations, sorted by their ID in ascending order.
-     * @return A {@link Page} of {@link OrganizationDto}s.
+     * Retrieves the organizations the currently authenticated user belongs to.
+     *
+     * <p>This method is the row filter for the organization picker, not the endpoint guard.
+     * It resolves the caller from the security context and returns only organizations that
+     * have an employee record for that user, so the caller's identity decides the result set
+     * and a relaxed guard cannot widen it.
+     *
+     * @return A {@link List} of {@link OrganizationDto}s the caller is a member of, empty if none.
      */
     @Transactional(readOnly = true)
     public List<OrganizationDto> getAllOrganization() {
         User user = userContextService.getCurrentUser();
+        if (user == null) {
+            // Authenticated against Keycloak but with no local user record yet, which happens
+            // between first login and the user being provisioned. They belong to nothing yet.
+            return List.of();
+        }
         return repository.findAllByUserEmail(user.getEmail()).stream()
                 .map(org -> organizationMapper.toDto(org))
                 .collect(Collectors.toList());

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -70,21 +70,29 @@ public class OrganizationWebController {
     }
 
     /**
-     * Retrieves a paginated list of organizations that the authenticated user is a member of.
-     * Returns only organizations where the user has ORG_MEMBER_{id} authority.
+     * Retrieves the organizations that the authenticated user is a member of.
+     *
+     * <p>This is the organization picker: it is called before a tenant has been chosen, so the
+     * guard is authentication alone and deliberately not tenant-scoped. Any check reading
+     * {@link org.tornotron.echno_backend.common.multitenancy.TenantContext} would be circular
+     * here, because the caller is asking which tenants they may select. The result is narrowed
+     * to the caller's own organizations by {@code OrganizationService.getAllOrganization},
+     * which queries by the authenticated user's identity rather than trusting this guard.
      *
      * @return A {@link ResponseEntity} containing the list of organization DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "List the current user's organizations",
-            description = "Returns the organizations the caller is a member of, filtered to those where "
-                    + "the caller holds an organization membership authority for the current tenant."
+            description = "Returns the organizations the caller is a member of. Any authenticated "
+                    + "caller may request it and receives only their own organizations, those where "
+                    + "they hold an employee record. No tenant needs to be selected first, since this "
+                    + "is the endpoint that populates the organization picker."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of the caller's organizations"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of the caller's organizations, empty if they belong to none"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Caller is not authenticated")
     })
     public ResponseEntity<List<OrganizationDto>> readAllOrganizations() {
         return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganization());

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
@@ -1,0 +1,86 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.organization.dto.OrganizationDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the row filtering behind the organization picker.
+ *
+ * <p>These matter because the endpoint guard for this list is authentication alone. The
+ * narrowing to the caller's own organizations therefore has to come from here, and these tests
+ * are what make that load bearing: the service queries by the authenticated user's identity and
+ * never lists organizations wholesale. Plain Mockito with no Spring context, so it adds nothing
+ * to the cached-context heap budget.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationServiceScopingTest {
+
+    @Mock private OrganizationRepository repository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private KeycloakGroupService keycloakGroupService;
+    @Mock private SubscriptionService subscriptionService;
+    @Mock private UserContextService userContextService;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationMapper organizationMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+
+    @InjectMocks private OrganizationService service;
+
+    @Test
+    void getAllOrganization_queriesByTheAuthenticatedUsersOwnIdentity() {
+        User caller = new User();
+        caller.setEmail("member@echno.com");
+        when(userContextService.getCurrentUser()).thenReturn(caller);
+
+        Organization owned = new Organization();
+        owned.setId(7L);
+        when(repository.findAllByUserEmail("member@echno.com")).thenReturn(List.of(owned));
+
+        OrganizationDto dto = new OrganizationDto();
+        dto.setId(7L);
+        when(organizationMapper.toDto(owned)).thenReturn(dto);
+
+        List<OrganizationDto> result = service.getAllOrganization();
+
+        assertThat(result).extracting(OrganizationDto::getId).containsExactly(7L);
+        // The filter is the caller's identity. Nothing here lists organizations wholesale,
+        // so relaxing the endpoint guard cannot widen the result set.
+        verify(repository).findAllByUserEmail("member@echno.com");
+        verify(repository, never()).findAll();
+    }
+
+    @Test
+    void getAllOrganization_isEmptyWhenThereIsNoLocalUserRecord() {
+        // Authenticated against Keycloak but not yet provisioned locally. The old role guard
+        // hid this path; with the relaxed guard it is reachable and must not blow up.
+        when(userContextService.getCurrentUser()).thenReturn(null);
+
+        List<OrganizationDto> result = service.getAllOrganization();
+
+        assertThat(result).isEmpty();
+        verify(repository, never()).findAllByUserEmail(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationWebControllerAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationWebControllerAuthzTest.java
@@ -1,0 +1,137 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.organization.dto.OrganizationDto;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for the organization list endpoint, the screen that populates
+ * the organization picker.
+ *
+ * <p>The guard here has to be authentication alone. This endpoint answers "which organizations
+ * am I in", so it runs before a tenant has been selected: any check reading TenantContext is
+ * circular and fails closed, which is what produced the 403 on the Organizations page. These
+ * tests pin that the endpoint is reachable with no tenant set and no elevated role, and that
+ * the tenant-scoped role service is not consulted for it at all.
+ *
+ * <p>The result is narrowed to the caller's own organizations inside OrganizationService, by a
+ * query on the authenticated user's identity, so the relaxed guard cannot widen what comes back.
+ * OrganizationServiceScopingTest covers that filtering.
+ */
+@WebMvcTest(OrganizationWebController.class)
+@Import(OrganizationWebControllerAuthzTest.TestSecurityConfig.class)
+class OrganizationWebControllerAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OrganizationService organizationService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references on the other
+    // endpoints of this controller.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    // RPTExchangeFilter also depends on this cache; mocked for the same reason.
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    @AfterEach
+    void clearTenant() {
+        // The picker is requested with no tenant chosen, which is the state that broke it.
+        TenantContext.clear();
+    }
+
+    @Test
+    void readAllOrganizations_isOk_forAPlainMemberWithNoRoleAndNoTenantSelected() throws Exception {
+        // The case failing in production: a member holding no system-admin role, on the picker
+        // screen, so TenantContext is empty. Under the old tenant-scoped role guard this was 403.
+        OrganizationDto org = new OrganizationDto();
+        org.setId(7L);
+        org.setOrganizationName("Asset Homes");
+        when(organizationService.getAllOrganization()).thenReturn(List.of(org));
+
+        mockMvc.perform(get("/api/v1/organization/web").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(7))
+                .andExpect(jsonPath("$[0].organizationName").value("Asset Homes"));
+    }
+
+    @Test
+    void readAllOrganizations_doesNotConsultTheTenantScopedRoleService() throws Exception {
+        // Guards against a tenant-scoped check being reintroduced here. Anything reading
+        // TenantContext is circular on the picker, since the caller is choosing the tenant.
+        when(organizationService.getAllOrganization()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/organization/web").with(jwt()))
+                .andExpect(status().isOk());
+
+        verifyNoInteractions(orgSecurity);
+    }
+
+    @Test
+    void readAllOrganizations_returnsAnEmptyListForAMemberOfNothing() throws Exception {
+        // Belonging to no organization is a legitimate 200 with nothing in it, not a refusal.
+        when(organizationService.getAllOrganization()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/organization/web").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void readAllOrganizations_isRefused_forAnAnonymousCaller() throws Exception {
+        // Relaxing the guard to isAuthenticated() must still keep out an unauthenticated caller.
+        // The refusal is asserted rather than a specific status: the running application answers
+        // 401 through the bearer-token entry point of its resource server, while this slice has
+        // no such entry point and falls back to 403. The status is a property of that shared
+        // configuration, not of this endpoint's guard, so pinning it here would test the harness.
+        mockMvc.perform(get("/api/v1/organization/web"))
+                .andExpect(status().is4xxClientError());
+
+        // What this endpoint's guard owns: an anonymous request never reaches the handler.
+        verifyNoInteractions(organizationService);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Fixes the live 403 on the Organizations page reported in #464.

## Problem

`OrganizationWebController.readAllOrganizations` was guarded by `@PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")` while its Javadoc, `@Operation` description and method name all describe a membership lookup. The guard is what runs, and it was wrong in two independent ways.

A plain member could not list the organizations they belong to. That is the one question this endpoint exists to answer.

It was also circular. `hasAnyOrgRoleForCurrentTenant` reads `TenantContext.getCurrentOrgId()` and returns false when it is null. This is the organization picker, the screen a user is on before a tenant is settled, so the guard demanded a role scoped to the tenant the caller had not chosen yet, and failed closed. On staging this produced a 403 on every poll for 77 minutes against 114 successful calls from the same session.

## Where the row filtering actually lives, and why relaxing the guard is safe

This was the thing to establish before touching the guard, since if the `@PreAuthorize` had been doing double duty as the row filter then relaxing it would widen what comes back. It was not.

`OrganizationService.getAllOrganization` resolves the caller from the security context and queries:

```java
User user = userContextService.getCurrentUser();
return repository.findAllByUserEmail(user.getEmail())
```

backed by

```sql
SELECT DISTINCT o FROM Organization o JOIN o.employees e JOIN e.user u WHERE u.email = :email
```

The result set is decided by the caller's own identity, taken from the JWT subject via `getCurrentKeycloakId`, not by anything the guard asserts. A caller who reaches this handler receives exactly the organizations they hold an employee record in, whatever the guard let through. There is no unfiltered `findAll` on this path. So the widening changes who may ask the question, never whose rows come back.

Two supporting points:

- `Organization` deliberately carries no `orgFilter`, unlike the tenant-scoped entities. It is the tenant root, so filtering it by the current tenant would be the same circularity in the persistence layer.
- The identity used is independent of `TenantContext` and of the JWT group claims, which is what makes it work on a screen where no tenant is selected.

`OrganizationServiceScopingTest` pins this, so the filtering stays load bearing rather than being incidental.

## Fix

Guard on `isAuthenticated()`, matching `createOrganization` on the same controller.

Return an empty list when there is no local `User` record. That path was unreachable behind the role guard and would have thrown a `NullPointerException` on `user.getEmail()`; a caller authenticated against Keycloak but not yet provisioned locally belongs to no organization, which is a legitimate empty 200.

Corrected the Javadoc and OpenAPI text, which claimed the filtering came from an `ORG_MEMBER_{id}` authority. It comes from the employee join. Also corrected the documented failure code from 403 to 401.

## Not the same bug as #399

#399 fixed the inverse asymmetry on `ProjectControllerWeb`, a read gated on membership next to writes gated on a role. This one is a read that should accept membership accepting only a role, and the circularity is specific to the picker. The nine controllers carrying the #399 pattern are handled separately and were not swept up here.

## Tests

`OrganizationWebControllerAuthzTest` (web slice, `@orgSecurity` mocked, `TenantContext` cleared):
- member with no role and no tenant selected gets their organizations back, the case failing in production
- the tenant-scoped role service is not consulted for this endpoint at all, which is what stops the circularity being reintroduced
- a member of nothing gets an empty 200 rather than a refusal
- an anonymous caller never reaches the handler

`OrganizationServiceScopingTest` (plain Mockito, no Spring context, so no addition to the cached-context heap budget):
- the query goes through the caller's own identity and never `findAll`
- no local user record yields an empty list instead of a `NullPointerException`

Verified on the lab build box. All 6 new tests pass. Reverting only the guard makes 3 of the 4 web-slice tests fail with the production 403, so they are load bearing. The wider run of `*Organization*`, `*AuthzTest*` and `EndpointAuthorizationTest` is green at 70 tests, including the tenant-isolation suite.