### PR TITLE
Review only, do not merge: replay of #462 (7c688ed) for a deferred bot review

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
@@ -118,8 +118,9 @@ public class InventoryTransactionController {
             summary = "Get a material's movement history (timeline, paginated)",
             description = "Returns the material's stock movements as a timeline, oldest movement first, one "
                     + "page at a time. Each entry carries the storage location, project, movement type and its "
-                    + "stock direction, the quantity changed, the timestamp and the source reference, so a "
-                    + "caller can show where the material has been, when, and how much."
+                    + "stock direction, the quantity changed, the stock level either side of it, the timestamp, "
+                    + "the source reference and the employee who booked it, so a caller can show where the "
+                    + "material has been, when, how much, and on whose hand."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of movement-history entries for the material"),

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -108,8 +108,9 @@ public class InventoryTransactionControllerWeb {
             summary = "Get a material's movement history (timeline, paged)",
             description = "Returns the material's stock movements as a timeline, oldest movement first, "
                     + "one page at a time. Each entry carries the storage location, project, movement type "
-                    + "and its stock direction, the quantity changed, the timestamp and the source reference "
-                    + "so the caller can show where the material has been, when, and how much."
+                    + "and its stock direction, the quantity changed, the stock level either side of it, the "
+                    + "timestamp, the source reference and the employee who booked it, so the caller can show "
+                    + "where the material has been, when, how much, and on whose hand."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of movement-history entries returned"),

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
@@ -22,9 +22,24 @@ public interface InventoryTransactionRepository extends JpaRepository<InventoryT
      * as a forward-running timeline. The id is a stable tie-break when two movements share a
      * transaction date. Tenant scoping is applied by the {@code orgFilter} Hibernate filter,
      * as with the other ledger reads.
+     *
+     * <p>The storage location, project and creator are fetch-joined because the timeline DTO
+     * reads a field off each one. All three are {@code @ManyToOne}, so the fetch join stays a
+     * to-one join: it neither multiplies rows nor pushes Hibernate into in-memory pagination,
+     * and it keeps the page to one statement instead of one per row per association. They are
+     * LEFT joins because {@code storageLocation} and {@code createdBy} are nullable. Deliberately
+     * no collection is fetched here, which is what would break paging.
+     *
+     * <p>The count query is spelled out because a derived count cannot be built from a query
+     * carrying fetch joins.
      */
-    @Query("SELECT it FROM InventoryTransaction it WHERE it.material.id = :materialId " +
-           "ORDER BY it.transactionDate ASC, it.id ASC")
+    @Query(value = "SELECT it FROM InventoryTransaction it " +
+                   "LEFT JOIN FETCH it.storageLocation " +
+                   "LEFT JOIN FETCH it.project " +
+                   "LEFT JOIN FETCH it.createdBy " +
+                   "WHERE it.material.id = :materialId " +
+                   "ORDER BY it.transactionDate ASC, it.id ASC",
+           countQuery = "SELECT COUNT(it) FROM InventoryTransaction it WHERE it.material.id = :materialId")
     Page<InventoryTransaction> findMovementHistoryByMaterial(@Param("materialId") Long materialId, Pageable pageable);
 
     List<InventoryTransaction> findByTransactionType(InventoryTransactionType transactionType);

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
@@ -88,8 +88,10 @@ public class InventoryTransactionService {
      *
      * <p>Backs the Location module timeline (issue #256): each entry carries where the material
      * moved (storage location), the project, when, the movement type and its stock direction,
-     * the quantity changed and the source reference. Ordered oldest-first so the page reads as a
-     * forward-running timeline, with the id as a stable tie-break within one transaction date.
+     * the quantity changed, the stock level either side of it, the source reference and the employee
+     * who booked it. Ordered oldest-first so the page reads as a forward-running timeline, with the id
+     * as a stable tie-break within one transaction date. The finder fetch-joins the associations the
+     * entry reads, so a page costs one query rather than one per row.
      *
      * @param materialId The material whose movements are listed.
      * @param pageNo Zero-based page index.

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
@@ -10,13 +10,14 @@ import java.time.LocalDateTime;
 /**
  * One entry in a material's movement history: a single stock movement condensed to the
  * fields a timeline needs, namely where the material was, when, in what direction and by
- * how much. Used by the Location module timeline (issue #256) to answer "where has this
- * material been, when, and how much".
+ * how much, the running balance around it and who booked it. Used by the Location module
+ * timeline (issue #256) to answer "where has this material been, when, how much, and on
+ * whose hand".
  */
 @Data
 @Schema(description = "A single movement of a material for its timeline history: the storage location it "
-        + "applied to, when it happened, the movement type and its stock direction, the quantity changed "
-        + "and the source reference.")
+        + "applied to, when it happened, the movement type and its stock direction, the quantity changed, "
+        + "the stock level either side of it, the source reference and the employee who booked it.")
 public class MaterialMovementHistoryDto {
 
     @Schema(description = "Unique transaction id.", example = "5012")
@@ -45,9 +46,22 @@ public class MaterialMovementHistoryDto {
     @Schema(description = "Project name.", example = "Tower B fit-out")
     private String projectName;
 
+    @Schema(description = "Stock level at the storage location immediately before this movement.",
+            example = "115.0")
+    private Double openingStock;
+
     @Schema(description = "Signed change applied by this movement. Positive for stock in, negative for stock out.",
             example = "-15.0")
     private Double quantityChanged;
+
+    @Schema(description = "Stock level at the storage location immediately after this movement.",
+            example = "100.0")
+    private Double closingStock;
+
+    @Schema(description = "Display name of the employee who booked the movement. For automated movements this "
+            + "is the actor who triggered the source event. Null when the ledger row records no creator.",
+            example = "Asha Menon")
+    private String createdByName;
 
     @Schema(description = "Source document reference for the movement, for example a GRN or challan number.",
             example = "GRN-2026-0042")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/mapper/InventoryTransactionMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/mapper/InventoryTransactionMapper.java
@@ -27,12 +27,15 @@ public interface InventoryTransactionMapper {
     /**
      * Condenses a ledger row to a movement-history timeline entry. The movement direction is
      * read from the transaction type's {@code stockEffect}, so the sign metadata lives in one
-     * place rather than being inferred at the call site.
+     * place rather than being inferred at the call site. The creator flattens to a display
+     * name, the same way the storage location and project flatten to theirs, so the timeline
+     * carries no nested employee payload; a null {@code createdBy} leaves the name null.
      */
     @Mapping(source = "transactionType.stockEffect", target = "direction")
     @Mapping(source = "storageLocation.id", target = "storageLocationId")
     @Mapping(source = "storageLocation.locationName", target = "storageLocationName")
     @Mapping(source = "project.id", target = "projectId")
     @Mapping(source = "project.projectName", target = "projectName")
+    @Mapping(source = "createdBy.employeeName", target = "createdByName")
     MaterialMovementHistoryDto toMovementHistoryDto(InventoryTransaction transaction);
 }

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/MaterialMovementHistoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/MaterialMovementHistoryIT.java
@@ -2,20 +2,28 @@ package org.tornotron.echno_backend.inventoryTransaction;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.hibernate.Hibernate;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialMovementHistoryDto;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType.StockEffect;
+import org.tornotron.echno_backend.inventoryTransaction.mapper.InventoryTransactionMapper;
+import org.tornotron.echno_backend.inventoryTransaction.mapper.InventoryTransactionMapperImpl;
 import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,8 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Verifies the material movement-history finder that backs the Location module timeline
  * (issue #256): it returns only the requested material's ledger rows, oldest movement first,
- * and each row resolves its storage location and carries a movement direction. Runs against a
- * real CockroachDB through the shared Testcontainer.
+ * each row resolving its storage location, project, running balance, creator and movement
+ * direction, and it does so without a per-row query. Runs against a real CockroachDB through
+ * the shared Testcontainer.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -38,8 +47,166 @@ class MaterialMovementHistoryIT extends AbstractIntegrationTest {
     @PersistenceContext
     private EntityManager entityManager;
 
+    /**
+     * The mapper is built by hand rather than injected: this is a repository slice, so the
+     * MapStruct bean is not in the context. {@code toMovementHistoryDto} maps every field
+     * from a source path of its own and never delegates to the employee mapper, so the
+     * uninjected collaborator on the generated implementation is not reached.
+     */
+    private final InventoryTransactionMapper mapper = new InventoryTransactionMapperImpl();
+
     @Test
     void movementHistory_returnsMaterialRowsOldestFirstWithLocationAndDirection() {
+        Fixture fixture = persistFixture();
+
+        Page<InventoryTransaction> page =
+                repository.findMovementHistoryByMaterial(fixture.cementId, PageRequest.of(0, 10));
+
+        List<InventoryTransaction> rows = page.getContent();
+
+        // Only the cement rows, and all of them.
+        assertThat(rows).hasSize(4);
+        assertThat(rows).allSatisfy(row -> assertThat(row.getMaterial().getId()).isEqualTo(fixture.cementId));
+        assertThat(page.getTotalElements()).isEqualTo(4);
+
+        // Oldest movement first.
+        assertThat(rows).extracting(InventoryTransaction::getReferenceNumber)
+                .containsExactly("GRN-1", "TRF-2", "USE-3", "ADJ-4");
+        assertThat(rows).extracting(InventoryTransaction::getTransactionDate).isSorted();
+
+        // Storage location resolves on each row.
+        assertThat(rows).extracting(row -> row.getStorageLocation().getLocationName())
+                .containsExactly("Site A main store", "Site A yard", "Site A main store", "Site A yard");
+
+        // Direction comes from the transaction type's stock effect.
+        assertThat(rows).extracting(row -> row.getTransactionType().getStockEffect())
+                .containsExactly(StockEffect.INCREASE, StockEffect.DECREASE, StockEffect.DECREASE, StockEffect.EITHER);
+    }
+
+    @Test
+    void movementHistory_dtoCarriesBalanceProjectAndCreator() {
+        Fixture fixture = persistFixture();
+
+        List<MaterialMovementHistoryDto> history =
+                repository.findMovementHistoryByMaterial(fixture.cementId, PageRequest.of(0, 10))
+                        .map(mapper::toMovementHistoryDto)
+                        .getContent();
+
+        assertThat(history).hasSize(4);
+
+        MaterialMovementHistoryDto received = history.get(0);
+        assertThat(received.getReferenceNumber()).isEqualTo("GRN-1");
+        assertThat(received.getOpeningStock()).isEqualTo(0.0);
+        assertThat(received.getQuantityChanged()).isEqualTo(100.0);
+        assertThat(received.getClosingStock()).isEqualTo(100.0);
+        assertThat(received.getCreatedByName()).isEqualTo("Asha Menon");
+        assertThat(received.getStorageLocationName()).isEqualTo("Site A main store");
+        assertThat(received.getProjectName()).isEqualTo("Timeline Project");
+        assertThat(received.getDirection()).isEqualTo(StockEffect.INCREASE);
+
+        // The balance chains across the timeline, and the creator alternates.
+        assertThat(history).extracting(MaterialMovementHistoryDto::getOpeningStock)
+                .containsExactly(0.0, 100.0, 80.0, 65.0);
+        assertThat(history).extracting(MaterialMovementHistoryDto::getClosingStock)
+                .containsExactly(100.0, 80.0, 65.0, 70.0);
+        assertThat(history).extracting(MaterialMovementHistoryDto::getCreatedByName)
+                .containsExactly("Asha Menon", "Ravi Kumar", "Asha Menon", "Ravi Kumar");
+    }
+
+    @Test
+    void movementHistory_leavesTheCreatorNameNullWhenTheRowHasNoCreator() {
+        Fixture fixture = persistFixture();
+
+        InventoryTransaction anonymous = new InventoryTransaction();
+        anonymous.setOrganization(entityManager.getReference(Organization.class, fixture.orgId));
+        anonymous.setProject(entityManager.getReference(Project.class, fixture.projectId));
+        anonymous.setMaterial(entityManager.getReference(Material.class, fixture.cementId));
+        anonymous.setStorageLocation(entityManager.getReference(StorageLocation.class, fixture.mainStoreId));
+        anonymous.setTransactionType(InventoryTransactionType.OPENING_BALANCE);
+        anonymous.setQuantityChanged(0.0);
+        anonymous.setOpeningStock(0.0);
+        anonymous.setClosingStock(0.0);
+        anonymous.setTransactionDate(LocalDateTime.of(2026, 7, 1, 9, 0));
+        anonymous.setReferenceNumber("OB-0");
+        entityManager.persist(anonymous);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<MaterialMovementHistoryDto> history =
+                repository.findMovementHistoryByMaterial(fixture.cementId, PageRequest.of(0, 10))
+                        .map(mapper::toMovementHistoryDto)
+                        .getContent();
+
+        // The uncredited opening balance predates the rest, so it leads the timeline.
+        assertThat(history.get(0).getReferenceNumber()).isEqualTo("OB-0");
+        assertThat(history.get(0).getCreatedByName()).isNull();
+    }
+
+    /**
+     * Pins the fetch join. Every association the timeline DTO reads is initialised by the page
+     * query itself, and the statement count does not grow with the number of rows on the page:
+     * a page of two rows and a page of four, both covering the same locations and creators,
+     * issue exactly the same number of statements. Without the fetch join the four-row page
+     * would issue six more than the two-row one.
+     */
+    @Test
+    void movementHistory_doesNotQueryPerRow() {
+        Fixture fixture = persistFixture();
+
+        SessionFactory sessionFactory = entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics statistics = sessionFactory.getStatistics();
+        boolean statisticsWereEnabled = statistics.isStatisticsEnabled();
+        statistics.setStatisticsEnabled(true);
+        try {
+            long twoRowPage = statementsToReadHistory(statistics, fixture.cementId, 2);
+            long fourRowPage = statementsToReadHistory(statistics, fixture.cementId, 4);
+
+            assertThat(fourRowPage)
+                    .as("statements for a four-row page (%d) must match a two-row page (%d): "
+                            + "a per-row query would make the larger page cost more",
+                            fourRowPage, twoRowPage)
+                    .isEqualTo(twoRowPage);
+        } finally {
+            statistics.setStatisticsEnabled(statisticsWereEnabled);
+        }
+    }
+
+    /**
+     * Reads one page of the history and reports how many statements it took, touching every
+     * association the DTO mapping touches. Asserts on the way through that none of them needed
+     * a lazy load, which is what the fetch join is there to guarantee.
+     */
+    private long statementsToReadHistory(Statistics statistics, Long materialId, int pageSize) {
+        entityManager.clear();
+        statistics.clear();
+
+        List<InventoryTransaction> rows =
+                repository.findMovementHistoryByMaterial(materialId, PageRequest.of(0, pageSize)).getContent();
+
+        assertThat(rows).hasSize(pageSize);
+        assertThat(rows).allSatisfy(row -> {
+            assertThat(Hibernate.isInitialized(row.getStorageLocation())).isTrue();
+            assertThat(Hibernate.isInitialized(row.getProject())).isTrue();
+            assertThat(Hibernate.isInitialized(row.getCreatedBy())).isTrue();
+        });
+
+        // Read the fields the mapper reads, so any deferred load would show up in the count.
+        rows.forEach(row -> {
+            row.getStorageLocation().getLocationName();
+            row.getProject().getProjectName();
+            row.getCreatedBy().getEmployeeName();
+        });
+
+        return statistics.getPrepareStatementCount();
+    }
+
+    /**
+     * Four cement movements with a chained balance, alternating between two storage locations
+     * and two creators, plus one steel movement that must not leak into the history. The two
+     * locations and two creators alternate so that a two-row page already covers the same
+     * distinct set of related rows a four-row page does.
+     */
+    private Fixture persistFixture() {
         Organization org = new Organization();
         org.setOrganizationName("History Org");
         org.setOrganizationAddress("addr");
@@ -69,37 +236,28 @@ class MaterialMovementHistoryIT extends AbstractIntegrationTest {
         entityManager.persist(mainStore);
         entityManager.persist(yard);
 
+        Employee asha = employee(org, "Asha Menon", "asha@example.test");
+        Employee ravi = employee(org, "Ravi Kumar", "ravi@example.test");
+        entityManager.persist(asha);
+        entityManager.persist(ravi);
+
         // Insert out of date order to prove the query, not the insert order, decides the timeline.
         LocalDateTime base = LocalDateTime.of(2026, 8, 1, 9, 0);
-        persistTransaction(org, project, cement, yard, InventoryTransactionType.USE, -15.0, base.plusDays(2), "USE-3");
-        persistTransaction(org, project, cement, mainStore, InventoryTransactionType.GRN, 100.0, base, "GRN-1");
-        persistTransaction(org, project, cement, mainStore, InventoryTransactionType.TRANSFER_OUT, -20.0, base.plusDays(1), "TRF-2");
+        persistTransaction(org, project, cement, mainStore, asha, InventoryTransactionType.USE,
+                80.0, -15.0, 65.0, base.plusDays(2), "USE-3");
+        persistTransaction(org, project, cement, mainStore, asha, InventoryTransactionType.GRN,
+                0.0, 100.0, 100.0, base, "GRN-1");
+        persistTransaction(org, project, cement, yard, ravi, InventoryTransactionType.TRANSFER_OUT,
+                100.0, -20.0, 80.0, base.plusDays(1), "TRF-2");
+        persistTransaction(org, project, cement, yard, ravi, InventoryTransactionType.ADJUST,
+                65.0, 5.0, 70.0, base.plusDays(3), "ADJ-4");
         // A different material must not leak into the history.
-        persistTransaction(org, project, steel, yard, InventoryTransactionType.GRN, 5.0, base.plusDays(1), "GRN-STEEL");
+        persistTransaction(org, project, steel, yard, ravi, InventoryTransactionType.GRN,
+                0.0, 5.0, 5.0, base.plusDays(1), "GRN-STEEL");
         entityManager.flush();
         entityManager.clear();
 
-        Page<InventoryTransaction> page =
-                repository.findMovementHistoryByMaterial(cement.getId(), PageRequest.of(0, 10));
-
-        List<InventoryTransaction> rows = page.getContent();
-
-        // Only the cement rows, and all of them.
-        assertThat(rows).hasSize(3);
-        assertThat(rows).allSatisfy(row -> assertThat(row.getMaterial().getId()).isEqualTo(cement.getId()));
-
-        // Oldest movement first.
-        assertThat(rows).extracting(InventoryTransaction::getReferenceNumber)
-                .containsExactly("GRN-1", "TRF-2", "USE-3");
-        assertThat(rows).extracting(InventoryTransaction::getTransactionDate).isSorted();
-
-        // Storage location resolves on each row.
-        assertThat(rows).extracting(row -> row.getStorageLocation().getLocationName())
-                .containsExactly("Site A main store", "Site A main store", "Site A yard");
-
-        // Direction comes from the transaction type's stock effect.
-        assertThat(rows).extracting(row -> row.getTransactionType().getStockEffect())
-                .containsExactly(StockEffect.INCREASE, StockEffect.DECREASE, StockEffect.DECREASE);
+        return new Fixture(org.getId(), project.getId(), cement.getId(), mainStore.getId());
     }
 
     private StorageLocation location(Organization org, Project project, String name) {
@@ -111,18 +269,44 @@ class MaterialMovementHistoryIT extends AbstractIntegrationTest {
         return location;
     }
 
+    private Employee employee(Organization org, String name, String email) {
+        User user = new User();
+        user.setKeycloakId("kc-" + email);
+        user.setName(name);
+        entityManager.persist(user);
+
+        Employee employee = new Employee();
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("unspecified");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(email);
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        employee.setOrganization(org);
+        return employee;
+    }
+
     private void persistTransaction(Organization org, Project project, Material material,
-                                    StorageLocation location, InventoryTransactionType type,
-                                    double quantityChanged, LocalDateTime when, String reference) {
+                                    StorageLocation location, Employee createdBy,
+                                    InventoryTransactionType type, double openingStock,
+                                    double quantityChanged, double closingStock,
+                                    LocalDateTime when, String reference) {
         InventoryTransaction txn = new InventoryTransaction();
         txn.setOrganization(org);
         txn.setProject(project);
         txn.setMaterial(material);
         txn.setStorageLocation(location);
+        txn.setCreatedBy(createdBy);
         txn.setTransactionType(type);
+        txn.setOpeningStock(openingStock);
         txn.setQuantityChanged(quantityChanged);
+        txn.setClosingStock(closingStock);
         txn.setTransactionDate(when);
         txn.setReferenceNumber(reference);
         entityManager.persist(txn);
+    }
+
+    /** Ids of the fixture rows, read back after the persistence context is cleared. */
+    private record Fixture(Long orgId, Long projectId, Long cementId, Long mainStoreId) {
     }
 }


### PR DESCRIPTION
## Review-only. Do not merge. This PR will be closed.

This carries no new change. It replays the diff that already merged into `development`
so an automated review can run over it, and it will be closed and its branch deleted
once that review has been read.

- Original PR: #462
- Merged commit: `7c688ed` "fix(inventory): complete the movement-history entry and fetch its associations"
- Branch base: `f8d0e84`, the first parent of that commit, so the diff here is byte for
  byte what merged.

The original merged inside a window where the review bot's hourly allowance was already
spent. Its status check reported a pass with the summary "Review rate limited", so nothing
was actually reviewed. This recovers that review after the fact.

### What the change does

The movement-history entry omitted the running balance and the creator although the ledger
row carries both, so a timeline built on it could not show the per-row balance line. Adds
`openingStock`, `closingStock` and `createdByName`, with the creator flattened to a display
name the same way the storage location and project already flatten to theirs, and left null
for a row with no recorded creator.

The finder also fetched nothing. `project`, `storageLocation` and `createdBy` are all lazy
`@ManyToOne` and the mapper reads a field off each, so a page cost one query plus two per row
before the change and would have cost three per row after it. All three are now
`LEFT JOIN FETCH`-ed, which stays a to-one join, so it neither multiplies rows nor forces
Hibernate to paginate in memory. The count query is written out explicitly because a derived
count cannot be built from a query carrying fetch joins.

### Points to weigh

- Whether the explicit `countQuery` stays in step with the main query, and what happens if
  one is edited without the other.
- Whether the fetch joins interact correctly with pagination and with the `orgFilter` tenant
  filter.
- Null handling on the flattened creator name.
