### PR TITLE
Separate the inspection kind from the trade it inspects

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
 import org.tornotron.echno_backend.inspection.InspectionType;
@@ -146,6 +147,7 @@ public class ComplianceGenerationService {
             inspection.setInspectionNumber(numberGen.next(DOC_TYPE));
             inspection.setTitle(rule.getName());
             inspection.setType(InspectionType.COMPLIANCE);
+            inspection.setCategory(InspectionCategory.COMPLIANCE);
             inspection.setStatus(InspectionStatus.SUGGESTED);
             inspection.setOrigin(InspectionOrigin.AI_GENERATED);
             inspection.setProjectId(projectId);

--- a/src/main/java/org/tornotron/echno_backend/inspection/DefectSeverity.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/DefectSeverity.java
@@ -1,0 +1,39 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How serious a defect raised during an inspection is. Replaces the free text the
+ * column previously held; the wire values are unchanged from the string union the
+ * web contract already documents ('critical' | 'major' | 'minor'), so promoting
+ * the field to an enum tightens validation without altering the API payload. The
+ * constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}.
+ */
+public enum DefectSeverity {
+    CRITICAL("critical"),
+    MAJOR("major"),
+    MINOR("minor");
+
+    private final String value;
+
+    DefectSeverity(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static DefectSeverity fromValue(String value) {
+        for (DefectSeverity severity : values()) {
+            if (severity.value.equalsIgnoreCase(value)) {
+                return severity;
+            }
+        }
+        throw new IllegalArgumentException("Unknown defect severity: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/DefectStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/DefectStatus.java
@@ -1,0 +1,39 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Resolution state of a defect raised during an inspection, defaulting to
+ * {@link #OPEN} exactly as the free-text column it replaces did. The wire values
+ * are unchanged from the string union the web contract already documents
+ * ('open' | 'in-progress' | 'resolved' | 'verified'); the constant name is the
+ * database representation stored by {@code @Enumerated(STRING)}.
+ */
+public enum DefectStatus {
+    OPEN("open"),
+    IN_PROGRESS("in-progress"),
+    RESOLVED("resolved"),
+    VERIFIED("verified");
+
+    private final String value;
+
+    DefectStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static DefectStatus fromValue(String value) {
+        for (DefectStatus status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown defect status: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionCategory.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionCategory.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Top-level grouping an inspection belongs to, and the axis the UI and reporting
+ * filter on. Distinct from {@link InspectionType}, which stays as the finer free
+ * label an inspector picks; the category is derived from it by
+ * {@link #defaultFor(InspectionType)} unless the caller states one explicitly.
+ * The wire value is the hyphenated lowercase form from {@link #getValue()}; the
+ * constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}, mirroring the other inspection enums.
+ */
+public enum InspectionCategory {
+    SAFETY("safety"),
+    QA_QC("qa-qc"),
+    COMPLIANCE("compliance"),
+    OTHER("other");
+
+    private final String value;
+
+    InspectionCategory(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionCategory fromValue(String value) {
+        for (InspectionCategory category : values()) {
+            if (category.value.equalsIgnoreCase(value)) {
+                return category;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection category: " + value);
+    }
+
+    /**
+     * The category an inspection falls into when only its {@link InspectionType}
+     * is known. This is the same mapping the Liquibase backfill applies to rows
+     * created before the category column existed, so a legacy row and a newly
+     * created one of the same type land in the same bucket.
+     *
+     * @param type the inspection type, may be null
+     * @return the matching category, or {@link #OTHER} when the type is null
+     */
+    public static InspectionCategory defaultFor(InspectionType type) {
+        if (type == null) {
+            return OTHER;
+        }
+        return switch (type) {
+            case SAFETY -> SAFETY;
+            case COMPLIANCE -> COMPLIANCE;
+            case QUALITY, STRUCTURAL, ELECTRICAL, PLUMBING, FINISHING, PROGRESS, FINAL -> QA_QC;
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionTrade.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionTrade.java
@@ -1,0 +1,53 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The construction stage or trade a QA/QC inspection is carried out against, one
+ * value per FR-QA requirement of the inspection functional spec. Nullable on an
+ * inspection and populated only for the {@link InspectionCategory#QA_QC} and
+ * {@link InspectionCategory#OTHER} categories; safety and compliance inspections
+ * leave it unset. The wire value is the hyphenated lowercase form from
+ * {@link #getValue()}; the constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}.
+ */
+public enum InspectionTrade {
+    PRE_CONSTRUCTION_DOCUMENTATION("pre-construction-documentation"),
+    SHUTTERING_FORMWORK("shuttering-formwork"),
+    REINFORCEMENT("reinforcement"),
+    RCC("rcc"),
+    MASONRY("masonry"),
+    PLASTERING("plastering"),
+    WATERPROOFING("waterproofing"),
+    FLOORING("flooring"),
+    FABRICATION("fabrication"),
+    ALUMINIUM_UPVC("aluminium-upvc"),
+    ELECTRICAL_FIXTURES("electrical-fixtures"),
+    PLUMBING_FIXTURES("plumbing-fixtures"),
+    SANITARY_FIXTURES("sanitary-fixtures"),
+    FINISHING("finishing"),
+    DIMENSIONAL_CHECK("dimensional-check"),
+    PROGRESS_CHECK("progress-check");
+
+    private final String value;
+
+    InspectionTrade(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static InspectionTrade fromValue(String value) {
+        for (InspectionTrade trade : values()) {
+            if (trade.value.equalsIgnoreCase(value)) {
+                return trade;
+            }
+        }
+        throw new IllegalArgumentException("Unknown inspection trade: " + value);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionCategoryConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionCategoryConverter.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
+
+/**
+ * Binds the hyphenated wire value of {@link InspectionCategory} (e.g. {@code qa-qc},
+ * {@code safety}) when it arrives as a query parameter on the list endpoint.
+ * Spring's default enum binding matches the constant name, not the wire value,
+ * so an explicit converter is registered.
+ */
+@Component
+public class StringToInspectionCategoryConverter implements Converter<String, InspectionCategory> {
+
+    @Override
+    public InspectionCategory convert(String source) {
+        return InspectionCategory.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionTradeConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToInspectionTradeConverter.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+
+/**
+ * Binds the hyphenated wire value of {@link InspectionTrade} (e.g. {@code rcc},
+ * {@code shuttering-formwork}) when it arrives as a query parameter on the list
+ * endpoint. Spring's default enum binding matches the constant name, not the wire
+ * value, so an explicit converter is registered.
+ */
+@Component
+public class StringToInspectionTradeConverter implements Converter<String, InspectionTrade> {
+
+    @Override
+    public InspectionTrade convert(String source) {
+        return InspectionTrade.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
@@ -10,9 +10,11 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.compliance.CompliancePhase;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 import org.tornotron.echno_backend.organization.Organization;
 
@@ -38,6 +40,7 @@ import java.util.UUID;
                 @Index(name = "idx_insp_project", columnList = "project_id"),
                 @Index(name = "idx_insp_status", columnList = "status"),
                 @Index(name = "idx_insp_type", columnList = "type"),
+                @Index(name = "idx_insp_category", columnList = "category"),
                 @Index(name = "idx_insp_result", columnList = "result"),
                 @Index(name = "idx_insp_scheduled_date", columnList = "scheduled_date"),
                 @Index(name = "idx_insp_inspector", columnList = "inspector_id")
@@ -60,6 +63,18 @@ public class Inspection implements TenantScopedEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     private InspectionType type;
+
+    // The authoritative grouping the UI and reporting filter on. Derived from the
+    // type when the caller does not state one, so a row created before this column
+    // existed and a new row of the same type land in the same bucket.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 30)
+    private InspectionCategory category = InspectionCategory.OTHER;
+
+    // The QA/QC stage or trade. Null on safety and compliance inspections.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade", length = 50)
+    private InspectionTrade trade;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionDefect.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+import org.tornotron.echno_backend.inspection.DefectStatus;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -12,9 +14,10 @@ import java.util.UUID;
 
 /**
  * A defect raised during an inspection. Owned by {@link Inspection} through the
- * {@code inspection_id} FK; the parent cascades persist and removal. The severity
- * and status are kept as text to match the web contract's inline string unions
- * ('critical' | 'major' | 'minor' and 'open' | 'in-progress' | 'resolved' | 'verified').
+ * {@code inspection_id} FK; the parent cascades persist and removal. Severity and
+ * status are enums whose wire values are the same string unions the web contract
+ * already documents ('critical' | 'major' | 'minor' and 'open' | 'in-progress' |
+ * 'resolved' | 'verified'), so the payload is unchanged from when they were text.
  */
 @Entity
 @Table(name = "inspection_defects",
@@ -38,8 +41,9 @@ public class InspectionDefect {
     @Column(nullable = false, length = 1000)
     private String description;
 
-    @Column(length = 20)
-    private String severity;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", length = 20)
+    private DefectSeverity severity;
 
     @Column(length = 300)
     private String location;
@@ -59,8 +63,9 @@ public class InspectionDefect {
     @Column(name = "target_date")
     private LocalDate targetDate;
 
-    @Column(length = 20)
-    private String status = "open";
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20)
+    private DefectStatus status = DefectStatus.OPEN;
 
     @Column(name = "resolved_date")
     private LocalDate resolvedDate;

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateInspectionRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 
 import java.time.LocalDate;
@@ -15,8 +17,9 @@ import java.util.List;
 /**
  * Creates a new inspection. Status is forced to {@code SCHEDULED} and the result
  * stays unset until the inspection is concluded through an update; neither is
- * accepted here. The summary counts are computed from the supplied check items
- * and defects.
+ * accepted here. The category falls back to the one derived from the type when it
+ * is omitted. The summary counts are computed from the supplied check items and
+ * defects.
  */
 @Schema(description = "Payload to schedule a new inspection, with its checklist items and any defects already known at scheduling time.")
 public record CreateInspectionRequest(
@@ -24,6 +27,10 @@ public record CreateInspectionRequest(
         @NotBlank @Size(max = 200) String title,
         @Schema(description = "Category of inspection.", example = "SAFETY")
         @NotNull InspectionType type,
+        @Schema(description = "Top-level grouping the inspection belongs to. Derived from the type when omitted.", example = "qa-qc")
+        InspectionCategory category,
+        @Schema(description = "QA/QC stage or trade the inspection covers. Left unset for safety and compliance inspections.", example = "reinforcement")
+        InspectionTrade trade,
         @Schema(description = "Id of the project this inspection is against.", example = "14")
         Long projectId,
         @Schema(description = "Site or building location of the inspection.", example = "Block C, Ground Floor")

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectDto.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.inspection.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+import org.tornotron.echno_backend.inspection.DefectStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,12 +13,12 @@ public record InspectionDefectDto(
         UUID id,
         String category,
         String description,
-        String severity,
+        DefectSeverity severity,
         String location,
         List<String> photos,
         String correctiveAction,
         String responsibleParty,
         LocalDate targetDate,
-        String status,
+        DefectStatus status,
         LocalDate resolvedDate
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDefectRequest.java
@@ -3,6 +3,8 @@ package org.tornotron.echno_backend.inspection.dtos;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+import org.tornotron.echno_backend.inspection.DefectStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,7 +20,7 @@ public record InspectionDefectRequest(
         @Schema(description = "Description of the defect.", example = "Honeycombing observed on column C4 at ground level")
         @NotBlank @Size(max = 1000) String description,
         @Schema(description = "Severity of the defect.", example = "major")
-        @Size(max = 20) String severity,
+        DefectSeverity severity,
         @Schema(description = "Location of the defect within the inspected area.", example = "Column C4, ground floor")
         @Size(max = 300) String location,
         @Schema(description = "URLs or references of photos attached to this defect.")
@@ -29,8 +31,8 @@ public record InspectionDefectRequest(
         @Size(max = 200) String responsibleParty,
         @Schema(description = "Target date for resolving the defect.", example = "2026-09-01")
         LocalDate targetDate,
-        @Schema(description = "Current resolution status of the defect.", example = "open")
-        @Size(max = 20) String status,
+        @Schema(description = "Current resolution status of the defect. Defaults to open when omitted.", example = "open")
+        DefectStatus status,
         @Schema(description = "Date the defect was actually resolved, if closed.", example = "null")
         LocalDate resolvedDate
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionDto.java
@@ -3,9 +3,11 @@ package org.tornotron.echno_backend.inspection.dtos;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.compliance.CompliancePhase;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 
 import java.time.LocalDate;
@@ -19,6 +21,8 @@ public record InspectionDto(
         String inspectionNumber,
         String title,
         InspectionType type,
+        InspectionCategory category,
+        InspectionTrade trade,
         InspectionStatus status,
         InspectionResult result,
         Long projectId,

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
@@ -6,8 +6,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 
 import java.time.LocalDate;
@@ -16,8 +18,9 @@ import java.util.List;
 
 /**
  * Full replacement of an inspection. Status is set directly and the result is
- * optional (set once the inspection is concluded). The check items and defects
- * are rebuilt from the payload and the summary counts recomputed from them.
+ * optional (set once the inspection is concluded). The category falls back to the
+ * one derived from the type when it is omitted. The check items and defects are
+ * rebuilt from the payload and the summary counts recomputed from them.
  */
 @Schema(description = "Payload to fully replace an existing inspection, including its status, result, checklist items and defects.")
 public record UpdateInspectionRequest(
@@ -25,6 +28,10 @@ public record UpdateInspectionRequest(
         @NotBlank @Size(max = 200) String title,
         @Schema(description = "Category of inspection.", example = "SAFETY")
         @NotNull InspectionType type,
+        @Schema(description = "Top-level grouping the inspection belongs to. Derived from the type when omitted.", example = "qa-qc")
+        InspectionCategory category,
+        @Schema(description = "QA/QC stage or trade the inspection covers. Left unset for safety and compliance inspections.", example = "reinforcement")
+        InspectionTrade trade,
         @Schema(description = "Current lifecycle status of the inspection.", example = "COMPLETED")
         @NotNull InspectionStatus status,
         @Schema(description = "Overall result once the inspection is concluded.", example = "PASSED")

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/InspectionSpecifications.java
@@ -2,8 +2,10 @@ package org.tornotron.echno_backend.inspection.repositories;
 
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 import org.tornotron.echno_backend.inspection.domain.Inspection;
 
@@ -23,6 +25,8 @@ public final class InspectionSpecifications {
     public static Specification<Inspection> withFilters(Long projectId,
                                                         InspectionStatus status,
                                                         InspectionType type,
+                                                        InspectionCategory category,
+                                                        InspectionTrade trade,
                                                         InspectionResult result) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
@@ -34,6 +38,12 @@ public final class InspectionSpecifications {
             }
             if (type != null) {
                 predicates.add(cb.equal(root.get("type"), type));
+            }
+            if (category != null) {
+                predicates.add(cb.equal(root.get("category"), category));
+            }
+            if (trade != null) {
+                predicates.add(cb.equal(root.get("trade"), trade));
             }
             if (result != null) {
                 predicates.add(cb.equal(root.get("result"), result));

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
@@ -10,8 +10,11 @@ import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.inspection.CheckItemStatus;
+import org.tornotron.echno_backend.inspection.DefectStatus;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 import org.tornotron.echno_backend.inspection.domain.Inspection;
 import org.tornotron.echno_backend.inspection.domain.InspectionCheckItem;
@@ -57,10 +60,13 @@ public class InspectionService {
     public Page<InspectionDto> findAll(Long projectId,
                                        InspectionStatus status,
                                        InspectionType type,
+                                       InspectionCategory category,
+                                       InspectionTrade trade,
                                        InspectionResult result,
                                        Pageable pageable) {
         return inspectionRepo.findAll(
-                        InspectionSpecifications.withFilters(projectId, status, type, result),
+                        InspectionSpecifications.withFilters(projectId, status, type, category,
+                                trade, result),
                         pageable)
                 .map(mapper::toDto);
     }
@@ -71,6 +77,8 @@ public class InspectionService {
         inspection.setInspectionNumber(numberGen.next(DOC_TYPE));
         inspection.setTitle(req.title());
         inspection.setType(req.type());
+        inspection.setCategory(categoryFor(req.category(), req.type()));
+        inspection.setTrade(req.trade());
         inspection.setStatus(InspectionStatus.SCHEDULED);
         inspection.setProjectId(req.projectId());
         inspection.setLocation(req.location());
@@ -104,6 +112,8 @@ public class InspectionService {
 
         inspection.setTitle(req.title());
         inspection.setType(req.type());
+        inspection.setCategory(categoryFor(req.category(), req.type()));
+        inspection.setTrade(req.trade());
         inspection.setStatus(req.status());
         inspection.setResult(req.result());
         inspection.setProjectId(req.projectId());
@@ -178,7 +188,7 @@ public class InspectionService {
                 defect.setCorrectiveAction(dr.correctiveAction());
                 defect.setResponsibleParty(dr.responsibleParty());
                 defect.setTargetDate(dr.targetDate());
-                defect.setStatus(dr.status() != null ? dr.status() : "open");
+                defect.setStatus(dr.status() != null ? dr.status() : DefectStatus.OPEN);
                 defect.setResolvedDate(dr.resolvedDate());
                 inspection.addDefect(defect);
                 defectCount++;
@@ -189,6 +199,16 @@ public class InspectionService {
         inspection.setPassedCheckPoints(passed);
         inspection.setFailedCheckPoints(failed);
         inspection.setDefectsFound(defectCount);
+    }
+
+    /**
+     * The category to store: the one the caller stated, or the one derived from the
+     * inspection type when the request leaves it out. Keeping the fallback here means
+     * a client that has not yet been updated for the taxonomy still produces rows in
+     * the right bucket.
+     */
+    private static InspectionCategory categoryFor(InspectionCategory requested, InspectionType type) {
+        return requested != null ? requested : InspectionCategory.defaultFor(type);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -12,8 +12,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
 import org.tornotron.echno_backend.inspection.InspectionType;
 import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
 import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
@@ -73,8 +75,8 @@ public class InspectionControllerWeb {
     @Operation(
             summary = "List inspections",
             description = "Returns a page of inspections in the current tenant. The projectId, status, "
-                    + "type and result parameters are optional filters; omitting all of them returns every "
-                    + "inspection, subject to paging."
+                    + "type, category, trade and result parameters are optional filters; omitting all of "
+                    + "them returns every inspection, subject to paging."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of matching inspections"),
@@ -83,9 +85,11 @@ public class InspectionControllerWeb {
     public Page<InspectionDto> list(@RequestParam(required = false) Long projectId,
                                     @RequestParam(required = false) InspectionStatus status,
                                     @RequestParam(required = false) InspectionType type,
+                                    @RequestParam(required = false) InspectionCategory category,
+                                    @RequestParam(required = false) InspectionTrade trade,
                                     @RequestParam(required = false) InspectionResult result,
                                     Pageable pageable) {
-        return service.findAll(projectId, status, type, result, pageable);
+        return service.findAll(projectId, status, type, category, trade, result, pageable);
     }
 
     @PutMapping("/{id}")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -295,4 +295,7 @@
     <!-- v4.0 - Finance: project client and the AR invoice materialized for sales/service billing -->
     <include file="db/changelog/v4.0/053-add-project-customer-and-ar-invoice-link.xml"/>
 
+    <!-- v4.0 - Inspection taxonomy: category discriminator, trade axis, defect severity/status enums -->
+    <include file="db/changelog/v4.0/054-add-inspection-taxonomy-and-defect-enums.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/054-add-inspection-taxonomy-and-defect-enums.xml
+++ b/src/main/resources/db/changelog/v4.0/054-add-inspection-taxonomy-and-defect-enums.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="054-01-add-inspection-category-and-trade" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="inspections" columnName="category"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Taxonomy columns on inspections. category is the top-level grouping
+            (SAFETY / QA_QC / COMPLIANCE / OTHER) the UI and reporting filter on, and is
+            indexed for that reason; trade is the QA/QC construction stage, populated
+            only for QA/QC (and optionally OTHER) rows. type is left untouched and keeps
+            working as the finer label. Existing rows take the OTHER default here and are
+            moved to their real category by the backfill in the next changeset.
+        </comment>
+
+        <addColumn tableName="inspections">
+            <column name="category" type="VARCHAR(30)" defaultValue="OTHER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="trade" type="VARCHAR(50)"/>
+        </addColumn>
+
+        <createIndex tableName="inspections" indexName="idx_insp_category">
+            <column name="category"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="054-02-backfill-inspection-category" author="echno">
+        <comment>
+            Derive category from the existing type for every row created before the column
+            existed. safety maps to SAFETY, compliance to COMPLIANCE, and the seven quality
+            and progress types to QA_QC, which covers all nine members of InspectionType, so
+            no row keeps the OTHER default by accident. Each statement is guarded on the row
+            still holding the default, making this a backfill rather than an overwrite.
+        </comment>
+
+        <sql>
+            UPDATE inspections SET category = 'SAFETY'
+            WHERE type = 'SAFETY' AND category = 'OTHER'
+        </sql>
+
+        <sql>
+            UPDATE inspections SET category = 'COMPLIANCE'
+            WHERE type = 'COMPLIANCE' AND category = 'OTHER'
+        </sql>
+
+        <sql>
+            UPDATE inspections SET category = 'QA_QC'
+            WHERE type IN ('QUALITY', 'STRUCTURAL', 'ELECTRICAL', 'PLUMBING',
+                           'FINISHING', 'PROGRESS', 'FINAL')
+              AND category = 'OTHER'
+        </sql>
+    </changeSet>
+
+    <changeSet id="054-03-blank-defect-severity-and-status" author="echno">
+        <comment>
+            Clear whitespace-only severity and status before the enum promotion below, so a
+            blank string is treated as "not recorded" rather than as an unmappable value.
+            severity is nullable and becomes NULL; status carries the OPEN default the entity
+            has always applied.
+        </comment>
+
+        <sql>
+            UPDATE inspection_defects SET severity = NULL
+            WHERE severity IS NOT NULL AND trim(severity) = ''
+        </sql>
+
+        <sql>
+            UPDATE inspection_defects SET status = 'open'
+            WHERE status IS NULL OR trim(status) = ''
+        </sql>
+    </changeSet>
+
+    <changeSet id="054-04-promote-defect-severity-to-enum" author="echno">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM inspection_defects
+                WHERE severity IS NOT NULL
+                  AND upper(replace(replace(trim(severity), '-', '_'), ' ', '_'))
+                      NOT IN ('CRITICAL', 'MAJOR', 'MINOR')
+            </sqlCheck>
+        </preConditions>
+
+        <comment>
+            Rewrite the free-text severity as the DefectSeverity constant name that
+            @Enumerated(STRING) reads. Matching is case-insensitive and tolerates hyphens,
+            underscores and spaces; already-normalised values map to themselves, so the
+            statement is idempotent. The precondition halts the migration if any row holds a
+            value outside the three severities rather than dropping it or guessing a bucket
+            for it, which would silently corrupt the row.
+        </comment>
+
+        <sql>
+            UPDATE inspection_defects
+            SET severity = upper(replace(replace(trim(severity), '-', '_'), ' ', '_'))
+            WHERE severity IS NOT NULL
+              AND upper(replace(replace(trim(severity), '-', '_'), ' ', '_'))
+                  IN ('CRITICAL', 'MAJOR', 'MINOR')
+        </sql>
+    </changeSet>
+
+    <changeSet id="054-05-promote-defect-status-to-enum" author="echno">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM inspection_defects
+                WHERE status IS NOT NULL
+                  AND upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+                      NOT IN ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'VERIFIED')
+            </sqlCheck>
+        </preConditions>
+
+        <comment>
+            The same promotion for status, against the four DefectStatus members. The
+            precondition halts on any value outside them for the same reason as the severity
+            changeset above.
+        </comment>
+
+        <sql>
+            UPDATE inspection_defects
+            SET status = upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+            WHERE status IS NOT NULL
+              AND upper(replace(replace(trim(status), '-', '_'), ' ', '_'))
+                  IN ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'VERIFIED')
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
@@ -39,8 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * End-to-end exercise of the inspection CRUD path against a real CockroachDB:
  * create derives the summary counts from the check items and defects, get and
- * list return them, update rebuilds the children and recomputes the counts, and
- * the org filter keeps one tenant's inspections invisible to another.
+ * list return them, update rebuilds the children and recomputes the counts, the
+ * category is derived from the type when the request omits it, and the org filter
+ * keeps one tenant's inspections invisible to another.
  *
  * <p>No {@code JpaAuditingConfig} import is needed: the created and updated
  * timestamps are populated by Hibernate's {@code @CreationTimestamp}/{@code
@@ -140,6 +141,8 @@ class InspectionServiceIT extends AbstractIntegrationTest {
         CreateInspectionRequest createReq = new CreateInspectionRequest(
                 "Third floor slab check",
                 InspectionType.QUALITY,
+                null,
+                InspectionTrade.RCC,
                 projectId,
                 "Block A, Level 3",
                 "Slab and columns",
@@ -166,19 +169,25 @@ class InspectionServiceIT extends AbstractIntegrationTest {
                 ),
                 List.of(
                         new InspectionDefectRequest("Finishing", "Uneven surface near grid B2",
-                                "minor", "Grid B2", List.of("defect-1.jpg"),
+                                DefectSeverity.MINOR, "Grid B2", List.of("defect-1.jpg"),
                                 "Re-level and re-finish", "Contractor",
-                                LocalDate.of(2026, 8, 25), "open", null)
+                                LocalDate.of(2026, 8, 25), null, null)
                 )
         );
 
         // create - counts derived from the children, status forced to SCHEDULED
         InspectionDto created = service.create(createReq);
         assertThat(created.status()).isEqualTo(InspectionStatus.SCHEDULED);
+        // category omitted on the request, so it is derived from the type
+        assertThat(created.category()).isEqualTo(InspectionCategory.QA_QC);
+        assertThat(created.trade()).isEqualTo(InspectionTrade.RCC);
         assertThat(created.result()).isNull();
         assertThat(created.inspectionNumber()).startsWith("INSP-");
         assertThat(created.checkItems()).hasSize(3);
         assertThat(created.defects()).hasSize(1);
+        assertThat(created.defects().getFirst().severity()).isEqualTo(DefectSeverity.MINOR);
+        // status omitted on the request, so it takes the OPEN default
+        assertThat(created.defects().getFirst().status()).isEqualTo(DefectStatus.OPEN);
         assertThat(created.attendees()).containsExactly("Site Engineer", "Safety Officer");
         assertThat(created.totalCheckPoints()).isEqualTo(3);
         assertThat(created.passedCheckPoints()).isEqualTo(2);
@@ -201,15 +210,22 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
         // tenant scoping - invisible to another organization
         enableOrgFilter(orgBId);
-        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isZero();
+        assertThat(service.findAll(null, null, null, null, null, null, pageable).getTotalElements())
+                .isZero();
         assertThat(inspectionRepo.findByIdScoped(id)).isEmpty();
 
         // visible and listable to the owning organization
         disableOrgFilter();
         enableOrgFilter(orgAId);
-        assertThat(service.findAll(null, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(service.findAll(null, null, null, null, null, null, pageable).getTotalElements())
+                .isEqualTo(1);
         assertThat(service.findAll(projectId, InspectionStatus.SCHEDULED,
-                InspectionType.QUALITY, null, pageable).getTotalElements()).isEqualTo(1);
+                InspectionType.QUALITY, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        // the taxonomy filters narrow on the derived category and the stated trade
+        assertThat(service.findAll(null, null, null, InspectionCategory.QA_QC,
+                InspectionTrade.RCC, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(service.findAll(null, null, null, InspectionCategory.SAFETY,
+                null, null, pageable).getTotalElements()).isZero();
         assertThat(inspectionRepo.findByIdScoped(id)).isPresent();
         disableOrgFilter();
 
@@ -217,6 +233,8 @@ class InspectionServiceIT extends AbstractIntegrationTest {
         UpdateInspectionRequest updateReq = new UpdateInspectionRequest(
                 "Third floor slab check",
                 InspectionType.QUALITY,
+                InspectionCategory.QA_QC,
+                InspectionTrade.RCC,
                 InspectionStatus.COMPLETED,
                 InspectionResult.PASSED,
                 projectId,
@@ -242,6 +260,7 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
         InspectionDto updated = service.update(id, updateReq);
         assertThat(updated.status()).isEqualTo(InspectionStatus.COMPLETED);
+        assertThat(updated.category()).isEqualTo(InspectionCategory.QA_QC);
         assertThat(updated.result()).isEqualTo(InspectionResult.PASSED);
         assertThat(updated.checkItems()).hasSize(1);
         assertThat(updated.defects()).isEmpty();

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyEnumsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyEnumsTest.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Wire-value round trips and the type-to-category derivation for the taxonomy
+ * enums. Plain JUnit, no Spring context: these are pure value objects.
+ */
+class InspectionTaxonomyEnumsTest {
+
+    @Test
+    void category_roundTripsThroughItsWireValue() {
+        for (InspectionCategory category : InspectionCategory.values()) {
+            assertThat(InspectionCategory.fromValue(category.getValue())).isEqualTo(category);
+            assertThat(InspectionCategory.fromValue(upper(category.getValue()))).isEqualTo(category);
+        }
+    }
+
+    @Test
+    void trade_roundTripsThroughItsWireValue() {
+        for (InspectionTrade trade : InspectionTrade.values()) {
+            assertThat(InspectionTrade.fromValue(trade.getValue())).isEqualTo(trade);
+            assertThat(InspectionTrade.fromValue(upper(trade.getValue()))).isEqualTo(trade);
+        }
+    }
+
+    @Test
+    void defectSeverity_roundTripsThroughItsWireValue() {
+        for (DefectSeverity severity : DefectSeverity.values()) {
+            assertThat(DefectSeverity.fromValue(severity.getValue())).isEqualTo(severity);
+            assertThat(DefectSeverity.fromValue(upper(severity.getValue()))).isEqualTo(severity);
+        }
+    }
+
+    @Test
+    void defectStatus_roundTripsThroughItsWireValue() {
+        for (DefectStatus status : DefectStatus.values()) {
+            assertThat(DefectStatus.fromValue(status.getValue())).isEqualTo(status);
+            assertThat(DefectStatus.fromValue(upper(status.getValue()))).isEqualTo(status);
+        }
+    }
+
+    @Test
+    void unknownValues_areRejected() {
+        assertThatThrownBy(() -> InspectionCategory.fromValue("structural"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown inspection category");
+        assertThatThrownBy(() -> InspectionTrade.fromValue("roofing"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown inspection trade");
+        assertThatThrownBy(() -> DefectSeverity.fromValue("catastrophic"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown defect severity");
+        assertThatThrownBy(() -> DefectStatus.fromValue("wont-fix"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown defect status");
+    }
+
+    @Test
+    void defectEnums_keepTheWireValuesTheWebContractAlreadyUses() {
+        assertThat(Arrays.stream(DefectSeverity.values()).map(DefectSeverity::getValue))
+                .containsExactly("critical", "major", "minor");
+        assertThat(Arrays.stream(DefectStatus.values()).map(DefectStatus::getValue))
+                .containsExactly("open", "in-progress", "resolved", "verified");
+    }
+
+    @Test
+    void everyType_derivesACategory() {
+        for (InspectionType type : InspectionType.values()) {
+            assertThat(InspectionCategory.defaultFor(type))
+                    .as("category for type %s", type)
+                    .isNotNull();
+        }
+    }
+
+    @Test
+    void categoryDerivation_followsTheSpecMapping() {
+        assertThat(InspectionCategory.defaultFor(InspectionType.SAFETY))
+                .isEqualTo(InspectionCategory.SAFETY);
+        assertThat(InspectionCategory.defaultFor(InspectionType.COMPLIANCE))
+                .isEqualTo(InspectionCategory.COMPLIANCE);
+        assertThat(InspectionCategory.defaultFor(InspectionType.QUALITY))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.STRUCTURAL))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.ELECTRICAL))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.PLUMBING))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.FINISHING))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.PROGRESS))
+                .isEqualTo(InspectionCategory.QA_QC);
+        assertThat(InspectionCategory.defaultFor(InspectionType.FINAL))
+                .isEqualTo(InspectionCategory.QA_QC);
+    }
+
+    @Test
+    void categoryDerivation_fallsBackToOtherWithoutAType() {
+        assertThat(InspectionCategory.defaultFor(null)).isEqualTo(InspectionCategory.OTHER);
+    }
+
+    private static String upper(String value) {
+        return value.toUpperCase(Locale.ROOT);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
@@ -1,0 +1,283 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the 054 taxonomy migration by running its own statements, read out of
+ * the changelog file itself, against a real CockroachDB. Seeding legacy-shaped rows
+ * and then applying the changelog's SQL is the only way to cover a backfill: by the
+ * time the application's Liquibase run has finished on a fresh database there are no
+ * rows for it to touch.
+ *
+ * <p>The Spring configuration is deliberately identical to {@link InspectionServiceIT}
+ * so both classes share one cached application context rather than starting a second.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
+
+    private static final String CHANGELOG =
+            "db/changelog/v4.0/054-add-inspection-taxonomy-and-defect-enums.xml";
+
+    private static final String BACKFILL_CATEGORY = "054-02-backfill-inspection-category";
+    private static final String BLANK_DEFECT_FIELDS = "054-03-blank-defect-severity-and-status";
+    private static final String PROMOTE_SEVERITY = "054-04-promote-defect-severity-to-enum";
+    private static final String PROMOTE_STATUS = "054-05-promote-defect-status-to-enum";
+
+    /** Changeset id to the SQL statements it runs, in declaration order. */
+    private static Map<String, List<String>> statements;
+
+    /** Changeset id to its precondition sqlCheck, where it has one. */
+    private static Map<String, String> preconditions;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeAll
+    static void readChangelog() throws Exception {
+        statements = new HashMap<>();
+        preconditions = new HashMap<>();
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        Document document;
+        try (InputStream in = InspectionTaxonomyMigrationIT.class.getClassLoader()
+                .getResourceAsStream(CHANGELOG)) {
+            assertThat(in).as("changelog %s on the test classpath", CHANGELOG).isNotNull();
+            document = builder.parse(new InputSource(in));
+        }
+
+        NodeList changeSets = document.getElementsByTagName("changeSet");
+        for (int i = 0; i < changeSets.getLength(); i++) {
+            Element changeSet = (Element) changeSets.item(i);
+            String id = changeSet.getAttribute("id");
+
+            List<String> sql = new ArrayList<>();
+            NodeList sqlNodes = changeSet.getElementsByTagName("sql");
+            for (int j = 0; j < sqlNodes.getLength(); j++) {
+                sql.add(sqlNodes.item(j).getTextContent().trim());
+            }
+            statements.put(id, sql);
+
+            NodeList checks = changeSet.getElementsByTagName("sqlCheck");
+            if (checks.getLength() > 0) {
+                preconditions.put(id, checks.item(0).getTextContent().trim());
+            }
+        }
+    }
+
+    @Test
+    void categoryBackfill_movesEveryLegacyTypeIntoItsCategory() {
+        Map<InspectionType, UUID> ids = new HashMap<>();
+        for (InspectionType type : InspectionType.values()) {
+            ids.put(type, insertLegacyInspection(type));
+        }
+
+        // Every row starts on the column default the migration adds it with.
+        for (UUID id : ids.values()) {
+            assertThat(readCategory(id)).isEqualTo("OTHER");
+        }
+
+        run(BACKFILL_CATEGORY);
+
+        for (InspectionType type : InspectionType.values()) {
+            assertThat(readCategory(ids.get(type)))
+                    .as("backfilled category for type %s", type)
+                    .isEqualTo(InspectionCategory.defaultFor(type).name());
+        }
+    }
+
+    @Test
+    void categoryBackfill_isIdempotentAndLeavesAStatedCategoryAlone() {
+        UUID id = insertLegacyInspection(InspectionType.QUALITY);
+
+        run(BACKFILL_CATEGORY);
+        assertThat(readCategory(id)).isEqualTo("QA_QC");
+
+        // A second application changes nothing, and a row already moved off the
+        // default is not revisited.
+        run(BACKFILL_CATEGORY);
+        assertThat(readCategory(id)).isEqualTo("QA_QC");
+    }
+
+    @Test
+    void defectPromotion_normalisesTheFreeTextTheColumnsHeld() {
+        UUID inspectionId = insertLegacyInspection(InspectionType.QUALITY);
+
+        UUID mixedCase = insertLegacyDefect(inspectionId, 0, "'Critical'", "'Open'");
+        UUID hyphenated = insertLegacyDefect(inspectionId, 1, "'major'", "'in-progress'");
+        UUID spaced = insertLegacyDefect(inspectionId, 2, "'MINOR'", "'In Progress'");
+        UUID underscored = insertLegacyDefect(inspectionId, 3, "'minor'", "'IN_PROGRESS'");
+        UUID blank = insertLegacyDefect(inspectionId, 4, "'   '", "'  '");
+        UUID unset = insertLegacyDefect(inspectionId, 5, "NULL", "NULL");
+
+        run(BLANK_DEFECT_FIELDS);
+        assertThat(unmappedCount(PROMOTE_SEVERITY)).isZero();
+        assertThat(unmappedCount(PROMOTE_STATUS)).isZero();
+        run(PROMOTE_SEVERITY);
+        run(PROMOTE_STATUS);
+
+        assertThat(readDefect(mixedCase)).containsExactly("CRITICAL", "OPEN");
+        assertThat(readDefect(hyphenated)).containsExactly("MAJOR", "IN_PROGRESS");
+        assertThat(readDefect(spaced)).containsExactly("MINOR", "IN_PROGRESS");
+        assertThat(readDefect(underscored)).containsExactly("MINOR", "IN_PROGRESS");
+
+        // A blank severity was never recorded, so it becomes null rather than a
+        // guessed bucket; a blank status takes the OPEN default the entity applies.
+        assertThat(readDefect(blank)).containsExactly(null, "OPEN");
+        assertThat(readDefect(unset)).containsExactly(null, "OPEN");
+
+        // No row was lost on the way through.
+        assertThat(defectCount(inspectionId)).isEqualTo(6);
+
+        // And the promoted values are what @Enumerated(STRING) reads back.
+        entityManager.clear();
+        InspectionDefect defect = entityManager.find(InspectionDefect.class, mixedCase);
+        assertThat(defect.getSeverity()).isEqualTo(DefectSeverity.CRITICAL);
+        assertThat(defect.getStatus()).isEqualTo(DefectStatus.OPEN);
+    }
+
+    @Test
+    void defectPromotion_isIdempotent() {
+        UUID inspectionId = insertLegacyInspection(InspectionType.QUALITY);
+        UUID defectId = insertLegacyDefect(inspectionId, 0, "'major'", "'resolved'");
+
+        run(BLANK_DEFECT_FIELDS);
+        run(PROMOTE_SEVERITY);
+        run(PROMOTE_STATUS);
+        assertThat(readDefect(defectId)).containsExactly("MAJOR", "RESOLVED");
+
+        run(PROMOTE_SEVERITY);
+        run(PROMOTE_STATUS);
+        assertThat(readDefect(defectId)).containsExactly("MAJOR", "RESOLVED");
+    }
+
+    @Test
+    void unmappableValues_tripThePreconditionInsteadOfBeingRewritten() {
+        UUID inspectionId = insertLegacyInspection(InspectionType.QUALITY);
+        UUID defectId = insertLegacyDefect(inspectionId, 0, "'catastrophic'", "'wont-fix'");
+
+        run(BLANK_DEFECT_FIELDS);
+
+        // Both preconditions see the unknown value, so the changeset halts the
+        // migration rather than dropping the row or coercing it into a bucket.
+        assertThat(unmappedCount(PROMOTE_SEVERITY)).isEqualTo(1);
+        assertThat(unmappedCount(PROMOTE_STATUS)).isEqualTo(1);
+
+        // Were it to run anyway, the update leaves the unknown value untouched.
+        run(PROMOTE_SEVERITY);
+        run(PROMOTE_STATUS);
+        assertThat(readDefect(defectId)).containsExactly("catastrophic", "wont-fix");
+    }
+
+    private void run(String changeSetId) {
+        List<String> sql = statements.get(changeSetId);
+        assertThat(sql).as("statements of changeset %s", changeSetId).isNotEmpty();
+        for (String statement : sql) {
+            entityManager.createNativeQuery(statement).executeUpdate();
+        }
+    }
+
+    private long unmappedCount(String changeSetId) {
+        String check = preconditions.get(changeSetId);
+        assertThat(check).as("precondition of changeset %s", changeSetId).isNotNull();
+        return ((Number) entityManager.createNativeQuery(check).getSingleResult()).longValue();
+    }
+
+    private UUID insertLegacyInspection(InspectionType type) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspections (id, inspection_number, title, type, scheduled_date) "
+                                + "VALUES (CAST(:id AS UUID), :number, :title, :type, :scheduledDate)")
+                .setParameter("id", id.toString())
+                .setParameter("number", "INSP-" + id.toString().substring(0, 8))
+                .setParameter("title", "Legacy " + type.getValue())
+                .setParameter("type", type.name())
+                .setParameter("scheduledDate", LocalDate.of(2026, 8, 20))
+                .executeUpdate();
+        return id;
+    }
+
+    /**
+     * Inserts a defect with the severity and status written as SQL literals, so a
+     * genuinely null column can be seeded alongside the free-text ones without
+     * binding an untyped null parameter.
+     */
+    private UUID insertLegacyDefect(UUID inspectionId, int lineOrder, String severity, String status) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO inspection_defects (id, inspection_id, description, severity, "
+                                + "corrective_action, status, line_order) "
+                                + "VALUES (CAST(:id AS UUID), CAST(:inspectionId AS UUID), :description, "
+                                + severity + ", :correctiveAction, " + status + ", :lineOrder)")
+                .setParameter("id", id.toString())
+                .setParameter("inspectionId", inspectionId.toString())
+                .setParameter("description", "Legacy defect " + lineOrder)
+                .setParameter("correctiveAction", "Rectify")
+                .setParameter("lineOrder", lineOrder)
+                .executeUpdate();
+        return id;
+    }
+
+    private String readCategory(UUID inspectionId) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT category FROM inspections WHERE id = CAST(:id AS UUID)")
+                .setParameter("id", inspectionId.toString())
+                .getSingleResult();
+    }
+
+    private List<String> readDefect(UUID defectId) {
+        Object[] row = (Object[]) entityManager.createNativeQuery(
+                        "SELECT severity, status FROM inspection_defects WHERE id = CAST(:id AS UUID)")
+                .setParameter("id", defectId.toString())
+                .getSingleResult();
+        List<String> values = new ArrayList<>();
+        values.add((String) row[0]);
+        values.add((String) row[1]);
+        return values;
+    }
+
+    private long defectCount(UUID inspectionId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "SELECT count(*) FROM inspection_defects "
+                                + "WHERE inspection_id = CAST(:id AS UUID)")
+                .setParameter("id", inspectionId.toString())
+                .getSingleResult()).longValue();
+    }
+}


### PR DESCRIPTION
Phase 0 of the inspection module extension (`docs/specs/2026-08-26-inspection-module.md`, sections 2 and 3.2). Taxonomy foundation only: no checklist templates, no NCRs, no BIM, no RBAC change. It unblocks Phase 1 and changes no behaviour for existing rows.

## What changed

**`InspectionCategory`** (`SAFETY`, `QA_QC`, `COMPLIANCE`, `OTHER`) is the new authoritative grouping: non-null on `Inspection`, defaulted to `OTHER`, indexed (`idx_insp_category`). `InspectionType` is untouched and stays as the finer free label. When a request omits the category, `InspectionCategory.defaultFor(type)` derives it with the same mapping the backfill applies, so a legacy row and a newly created one of the same type end up in the same bucket. `ComplianceGenerationService` sets `COMPLIANCE` explicitly.

**`InspectionTrade`** is the QA/QC stage axis, nullable, one value per FR-QA requirement: pre-construction documentation, shuttering/formwork, reinforcement, RCC, masonry, plastering, waterproofing, flooring, fabrication, aluminium/UPVC, electrical fixtures, plumbing fixtures, sanitary fixtures, finishing, dimensional check, progress check.

**`DefectSeverity`** and **`DefectStatus`** replace the free-text columns on `InspectionDefect`. Their wire values are exactly the string unions the web contract already documents (`critical | major | minor`, `open | in-progress | resolved | verified`), so the JSON payload is unchanged; what changes is that an unrecognised value is now rejected at the boundary instead of stored. `status` keeps its `OPEN` default.

`category` and `trade` are exposed on `InspectionDto` and accepted as optional fields on the create and update requests, and the list endpoint gains `category` and `trade` filters with the usual wire-value converters.

## The data migration, and what I did about the risk

`054-add-inspection-taxonomy-and-defect-enums.xml`, registered in `db.changelog-master.xml` (053 is the AR invoice work).

I queried the live staging database before writing it rather than assuming what was in there. On the compose staging on `.116` (`echno.in`), the whole `inspection_defects` table is two rows:

```
severity  count      status  count      total
NULL      2          open    2          2
```

and the inspections it belongs to are `COMPLIANCE` 6, `ELECTRICAL` 1, `FINISHING` 1, `SAFETY` 1, `STRUCTURAL` 1. The k8s staging (`ui-k8s.echno.in`) has zero inspection rows. So the real data is tame, but the migration is written for the messy case anyway, because production tenants will not be.

**Category backfill:** `safety` to `SAFETY`, `compliance` to `COMPLIANCE`, and `quality`, `structural`, `electrical`, `plumbing`, `finishing`, `progress`, `final` to `QA_QC`. That is all nine members of `InspectionType`, so no row keeps the `OTHER` default by accident. Each statement is guarded on the row still holding the default, which makes it a backfill rather than an overwrite and lets it run twice without harm.

**Defect promotion:** matching is case-insensitive and tolerates hyphens, underscores and spaces (`In Progress`, `in-progress` and `IN_PROGRESS` all reach `IN_PROGRESS`). Already-normalised values map to themselves, so the statements are idempotent.

**What happens to a value that maps to nothing.** Two cases, deliberately treated differently:

- A whitespace-only value is cleared first: severity becomes `NULL` (it is nullable, and blank means the severity was never recorded), status takes the `OPEN` default the entity has always applied. This is a judgement, not a guess: blank carries no information to lose.
- Anything else outside the known values (say a severity of `catastrophic`) trips a `HALT` precondition on the promoting changeset and stops the migration. It is not dropped and it is not coerced into the nearest bucket, because both would silently corrupt the row and neither would leave a trace anyone would notice. A deploy that stops is recoverable; a row quietly relabelled `MINOR` is not. If it fires, the fix is to look at the offending values and either extend the enum or clean them by hand, then re-run.

Both preconditions return 0 against the live staging data, so the migration applies there without stopping.

## Verification

Run on the lab box (`10.24.6.116`), not the laptop.

- `./gradlew check` (the whole suite plus the JaCoCo floor): `BUILD SUCCESSFUL in 7m 3s`.
- Inspection and compliance results: `InspectionServiceIT` 1/1, `InspectionTaxonomyEnumsTest` 9/9, `InspectionTaxonomyMigrationIT` 5/5, `ComplianceGenerationServiceIT` 1/1, `ComplianceGenerationServiceTest` 6/6, `OpenAiCompatibleComplianceServiceTest` 4/4, zero failures or errors throughout.
- The two `HALT` precondition queries run against the live staging database return `0` and `0`.

`InspectionTaxonomyMigrationIT` parses the changelog and executes **its own statements** against a real CockroachDB rather than a hand-copied version of them, seeding legacy row shapes first: by the time Liquibase has finished on a fresh database there are no rows for a backfill to touch. It covers every type mapping, idempotency of both halves, the blank and null cases, that no row is lost, that `@Enumerated(STRING)` reads the promoted values back, and that an unmappable value trips the precondition. It reuses `InspectionServiceIT`'s exact Spring configuration so the two share one cached context and the run stays inside the 1 GB test heap.

## echno-core

Checked, and nothing breaks. `InspectionSchema` and `InspectionDefectSchema` in `echno-core` are plain `z.object(...)` with no `.strict()` anywhere in `src/types`, and Zod strips unknown keys by default. The new `category` and `trade` fields are ignored by the current parser rather than rejected, so the web app keeps working against a backend that emits them. Surfacing them in the UI needs a core release adding the fields and the four new enums (spec section 9 lists this), which is a separate piece of work.