### PR TITLE
Let org role-holders read the nine controllers they can already write

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -53,7 +53,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List issue comments",
             description = "Returns a single page of issue comments. The pageNo and pageSize parameters "
@@ -70,7 +70,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get an issue comment by id",
             description = "Returns a single issue comment."
@@ -85,7 +85,7 @@ public class IssueCommentControllerWeb {
     }
 
     @GetMapping("/issueId/{issueId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List comments for an issue",
             description = "Returns every comment left on the given issue."

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -35,21 +35,21 @@ public class AssetControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all assets",
             description = "Returns every asset in the caller's current tenant organization, unpaginated."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Assets returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<List<AssetDto>> readAllAssets() {
         return new ResponseEntity<>(assetService.getAllAssets(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List assets, paginated",
             description = "Returns a page of assets for the caller's current tenant organization. The "
@@ -57,7 +57,7 @@ public class AssetControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of assets returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<Page<AssetDto>> readAllAssetsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
@@ -66,14 +66,14 @@ public class AssetControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get an asset by id",
             description = "Returns a single asset, including its resolved vendor and storage location."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Asset found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })
     public ResponseEntity<AssetDto> readAnAsset(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -74,7 +74,7 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List categories",
             description = "Returns a single page of work categories. The pageNo and pageSize parameters "
@@ -82,7 +82,7 @@ public class CategoryControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of categories returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
@@ -99,14 +99,14 @@ public class CategoryControllerWeb {
      * @return A {@link ResponseEntity} containing the category DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a category by id",
             description = "Returns a single work category."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Category found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No category with the given id")
     })
     public ResponseEntity<?> readACategory(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
@@ -36,7 +36,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all expenses",
             description = "Returns every expense for the current tenant, unpaginated."
@@ -50,7 +50,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List expenses, paginated and filterable",
             description = "Returns a single page of expenses. Supports a free-text search over the expense "
@@ -69,7 +69,7 @@ public class ExpenseControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get an expense by id",
             description = "Returns a single expense with its category, amount and optional links."

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -45,7 +45,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all issues",
             description = "Returns every issue in the current tenant, unpaginated."
@@ -60,7 +60,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List issues, paginated and filtered",
             description = "Returns a single page of issues, optionally filtered by project, a free-text "
@@ -85,7 +85,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/stats")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get issue counts",
             description = "Returns the total matching issue count and a per-status breakdown, computed "
@@ -104,7 +104,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List issues for a project",
             description = "Returns every issue raised against tasks belonging to the given project."
@@ -119,7 +119,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get an issue by id",
             description = "Returns a single issue including its comments and attachments."
@@ -180,7 +180,7 @@ public class IssueControllerWeb {
     }
 
     @GetMapping("/taskId/{taskId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List issues for a task",
             description = "Returns every issue raised against the given task."

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
@@ -36,7 +36,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all receipts",
             description = "Returns every receipt for the current tenant, unpaginated."
@@ -50,7 +50,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List receipts, paginated and filterable",
             description = "Returns a single page of receipts. Supports a free-text search over the receipt "
@@ -69,7 +69,7 @@ public class ReceiptControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a receipt by id",
             description = "Returns a single receipt with its payer, tax breakdown and optional links."

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -36,7 +36,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all stock adjustments",
             description = "Returns every stock adjustment document recorded for the organization, without "
@@ -44,14 +44,14 @@ public class StockAdjustmentControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustments returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<List<StockAdjustmentDto>> readAllStockAdjustments() {
         return new ResponseEntity<>(stockAdjustmentService.getAll(), HttpStatus.OK);
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List stock adjustments, paginated",
             description = "Returns a single page of stock adjustments ordered by creation time, most recent "
@@ -59,7 +59,7 @@ public class StockAdjustmentControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of stock adjustments returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<Page<StockAdjustmentDto>> readAllStockAdjustmentsPaginated(
             @RequestParam(defaultValue = "0") int pageNo,
@@ -68,7 +68,7 @@ public class StockAdjustmentControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a stock adjustment by id",
             description = "Returns a single stock adjustment document, including its header fields and line "
@@ -76,7 +76,7 @@ public class StockAdjustmentControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
     })
     public ResponseEntity<StockAdjustmentDto> readAStockAdjustment(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -35,7 +35,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all subcontracts",
             description = "Returns every subcontract for the current tenant, unpaginated."
@@ -49,7 +49,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping("/paginated")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List subcontracts, paginated and filterable",
             description = "Returns a single page of subcontracts. Supports a free-text search over "
@@ -69,7 +69,7 @@ public class SubContractControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a subcontract by id",
             description = "Returns a single subcontract, including its milestones, ratings and payment totals."

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -87,7 +87,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the list of task DTOs and HTTP status 200 (OK).
      */
     @GetMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List tasks",
             description = "Returns a single page of tasks. The pageNo and pageSize parameters control "
@@ -105,7 +105,7 @@ public class TaskControllerWeb {
     }
 
     @GetMapping("/projectId/{projectId}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List tasks for a project",
             description = "Returns every task belonging to the given project."
@@ -126,7 +126,7 @@ public class TaskControllerWeb {
      * @return A {@link ResponseEntity} containing the task DTO and HTTP status 200 (OK).
      */
     @GetMapping("{id}")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a task by id",
             description = "Returns a single task including its creator, assignees, category, issues and "

--- a/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
@@ -1,0 +1,175 @@
+package org.tornotron.echno_backend.common.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.IssueComment.IssueCommentControllerWeb;
+import org.tornotron.echno_backend.IssueComment.IssueCommentService;
+import org.tornotron.echno_backend.asset.AssetControllerWeb;
+import org.tornotron.echno_backend.asset.AssetService;
+import org.tornotron.echno_backend.category.CategoryControllerWeb;
+import org.tornotron.echno_backend.category.CategoryService;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.expense.ExpenseControllerWeb;
+import org.tornotron.echno_backend.expense.ExpenseService;
+import org.tornotron.echno_backend.issue.IssueControllerWeb;
+import org.tornotron.echno_backend.issue.IssueService;
+import org.tornotron.echno_backend.receipt.ReceiptControllerWeb;
+import org.tornotron.echno_backend.receipt.ReceiptService;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentControllerWeb;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentService;
+import org.tornotron.echno_backend.subcontract.SubContractControllerWeb;
+import org.tornotron.echno_backend.subcontract.SubContractService;
+import org.tornotron.echno_backend.task.TaskControllerWeb;
+import org.tornotron.echno_backend.task.TaskService;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Locks in read/write guard symmetry across the controllers that carried the asymmetry fixed
+ * for projects in #399: their reads gated on tenant membership alone while their writes gated
+ * on the system-admin or project-manager org role. A caller holding that role without a
+ * recorded ORG_MEMBER_ authority, the bootstrap admin being the known example, could therefore
+ * write these resources but got 403 reading them.
+ *
+ * <p>Every read below must accept either branch, membership or the elevated role. The
+ * role-without-membership case is the one that was broken; if any of these read guards is
+ * narrowed back to membership alone, that parameterized case fails for the offending path.
+ *
+ * <p>Deliberately one @WebMvcTest over all nine controllers rather than nine separate slices.
+ * Spring caches a context per distinct slice and the test JVM is capped at 1024m, so nine new
+ * contexts would be a real cost; this adds exactly one. @orgSecurity is mocked so each branch
+ * is exercised without building JWT authorities.
+ */
+@WebMvcTest({
+        AssetControllerWeb.class,
+        ExpenseControllerWeb.class,
+        ReceiptControllerWeb.class,
+        SubContractControllerWeb.class,
+        StockAdjustmentControllerWeb.class,
+        CategoryControllerWeb.class,
+        TaskControllerWeb.class,
+        IssueControllerWeb.class,
+        IssueCommentControllerWeb.class
+})
+@Import(ReadWriteGuardSymmetryTest.TestSecurityConfig.class)
+class ReadWriteGuardSymmetryTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean private AssetService assetService;
+    @MockitoBean private ExpenseService expenseService;
+    @MockitoBean private ReceiptService receiptService;
+    @MockitoBean private SubContractService subContractService;
+    @MockitoBean private StockAdjustmentService stockAdjustmentService;
+    @MockitoBean private CategoryService categoryService;
+    @MockitoBean private TaskService taskService;
+    @MockitoBean private IssueService issueService;
+    @MockitoBean private IssueCommentService issueCommentService;
+
+    // Named to match the @orgSecurity bean the @PreAuthorize SpEL references.
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    // RPTExchangeFilter also depends on this cache; mocked for the same reason.
+    @MockitoBean private RPTCache rptCache;
+
+    /** The list endpoint of each controller whose read guard was widened. */
+    static Stream<String> widenedReadEndpoints() {
+        return Stream.of(
+                "/api/v1/assets/web",
+                "/api/v1/expenses/web",
+                "/api/v1/receipts/web",
+                "/api/v1/sub-contracts/web",
+                "/api/v1/stock-adjustments/web",
+                "/api/v1/category/web",
+                "/api/v1/tasks/web",
+                "/api/v1/issues/web",
+                "/api/v1/issues/comments/web"
+        );
+    }
+
+    @BeforeEach
+    void stubEmptyResults() {
+        // The handlers that page call getContent() on the result, so these cannot be left null.
+        when(assetService.getAllAssets()).thenReturn(List.of());
+        when(expenseService.getAll()).thenReturn(List.of());
+        when(receiptService.getAll()).thenReturn(List.of());
+        when(subContractService.getAll()).thenReturn(List.of());
+        when(stockAdjustmentService.getAll()).thenReturn(List.of());
+        when(issueService.getAllIssues()).thenReturn(List.of());
+        when(categoryService.getAllCategories(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(taskService.getAllTasks(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(issueCommentService.getAllIssueComments(anyInt(), anyInt())).thenReturn(Page.empty());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("widenedReadEndpoints")
+    void read_isOk_forARoleHolderThatIsNotRecordedAsAMember(String path) throws Exception {
+        // The case broken before this change: writes were allowed, reads were 403.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("widenedReadEndpoints")
+    void read_isOk_forAMemberWithoutAnElevatedRole(String path) throws Exception {
+        // The widening must not cost plain members their existing access.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("widenedReadEndpoints")
+    void read_isForbidden_forACallerWithNeitherMembershipNorRole(String path) throws Exception {
+        // Both branches are tenant-scoped, so an outsider is still refused. This is what keeps
+        // the widening from becoming "any authenticated caller may read".
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #470. Applies the fix from #399 to the nine controllers that carry the same pattern.

## Problem

#399 fixed a read/write guard asymmetry on `ProjectControllerWeb`, but only there. A sweep found the pattern copied to nine more controllers: reads gate on `@orgSecurity.isMemberOfCurrentTenant()` while create, update and delete on the same controller gate on `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')`.

`ORG_MEMBER_{orgId}` and `ORG_{orgId}_ROLE_{role}` are separate authorities, coming from a Keycloak group and its subgroup respectively, so holding the role does not imply membership. A role-holder without a recorded membership, the bootstrap `admin@echno.com` being the known example, could create and delete these resources while getting 403 listing them. Read was stricter than write: it granted the more dangerous operation and refused the safer one.

## Change

29 read guards widened to accept either branch, across asset, expense, receipt, subcontract, stockAdjustment, category, task, issue and IssueComment. All nine used the same role pair, so the fix is uniform and identical to #399.

Also corrected eight OpenAPI 403 descriptions that still said the caller must be a member, on reads that now accept the role too.

## Why this cannot leak across tenants

Both branches of the widened guard are tenant-scoped, and neither is a global role check:

- `isMemberOfCurrentTenant()` reads `TenantContext.getCurrentOrgId()`, returns false when it is null, and checks the authority `ORG_MEMBER_{orgId}`.
- `hasAnyOrgRoleForCurrentTenant(...)` does the same and checks `ORG_{orgId}_ROLE_{role}`.

The org id is baked into the authority string in both cases, so `system-admin` in tenant A grants nothing in tenant B. Row scoping is enforced separately anyway: `HibernateFilterConfig` enables the `orgFilter` on every `@Transactional` method in the package tree using the same `TenantContext` org id, and the entities behind these controllers carry `@Filter(name = "orgFilter", condition = "organization_id = :organizationId")`.

So the widening admits more callers **within one tenant** and none across tenants. The `read_isForbidden_forACallerWithNeitherMembershipNorRole` case pins that it does not degrade to "any authenticated caller may read".

## Deliberately out of scope

**`POST createIssue` and `POST createIssueComment` keep their membership-only guard.** They are writes deliberately open to any member, since raising an issue or commenting is not an administrative action. A mechanical sweep would have caught them; they are not part of this asymmetry.

**`employee`, `leave` and `billing` untouched.** These are mixed too, but their splits were made on purpose in named commits that restricted certain reads to management (`db73ff6`, `5a5e62f`, `2469761`, `5c453b1`). Their remaining membership-only reads are the ordinary any-member case. #470 records this so a later sweep does not widen reads that were narrowed deliberately.

## Tests

`ReadWriteGuardSymmetryTest` covers all nine controllers, parameterized over their nine list endpoints, with three cases each:
- role without membership, the case broken today
- membership without role, so the widening costs plain members nothing
- neither, so an outsider is still refused

Deliberately **one** `@WebMvcTest` listing all nine controllers rather than nine separate slices. Spring caches a context per distinct slice and the test JVM is capped at `maxHeapSize=1024m`, so nine new contexts would be a real cost; this adds exactly one.

Verified on the lab build box: 27 tests pass. Reverting only the 29 guards makes exactly the 9 role-without-membership cases fail while the other 18 still pass, so the test targets this bug specifically and is load bearing.