### PR TITLE
Tolerate a small refresh-token reuse count on the realm

### DIFF
--- a/src/main/resources/keycloak-templates/init-keycloak.json.template
+++ b/src/main/resources/keycloak-templates/init-keycloak.json.template
@@ -11,6 +11,7 @@
   "bruteForceProtected": true,
   "failureFactor": 5,
   "revokeRefreshToken": true,
+  "refreshTokenMaxReuse": 2,
   "clients": [
     {
       "clientId": "${KEYCLOAK_CLIENT_ID}",


### PR DESCRIPTION
Set `refreshTokenMaxReuse` to `2` on `echno-realm`. `revokeRefreshToken` stays `true`.

## Why

Anand was signed out mid-form on staging today. Two independent refresh triggers in `echno-web` exchanged the same refresh token in the same second when his backgrounded Safari tab woke: next-auth's built-in `visibilitychange` refetch, and our own BFF recovery path. With `refreshTokenMaxReuse: 0` and `revokeRefreshToken: true`, Keycloak reads the second exchange as a replayed credential and revokes the entire chain, so the session dies. Keycloak logged `Maximum allowed refresh token reuse exceeded`, then `Session doesn't have required client`.

The application-side races are being fixed separately in `echno-web`. This change removes the source of the fatality: a benign concurrent double exchange stops destroying the session. It is defence in depth, not a substitute for the app fix.

## The security trade-off

This is not free. A non-zero `refreshTokenMaxReuse` weakens detection of a genuinely stolen refresh token, because a limited number of replays are now tolerated rather than triggering revocation. The judgement is that `2` is a small tolerance that absorbs benign client concurrency while `revokeRefreshToken: true` continues to do the substantive work (every exchange still rotates the token, and a reuse beyond the tolerance still revokes the chain).

## Scope

Only the one field. `accessTokenLifespan` (300), `ssoSessionIdleTimeout` (1800) and `ssoSessionMaxLifespan` (36000) are untouched; they are absent from this template and stay on the Keycloak defaults the realm already runs.

## Why this file and not `echno-deployment`

The realm-level security settings are codified here, not in the IaC repo. `KeycloakConfigGenerator` renders `keycloak-templates/init-keycloak.json.template` into `keycloak.config.output-path` at startup, and `KeycloakInitializer` consumes it two ways:

- fresh realm: `initKeycloakRealm()` imports the whole representation, so the value is set at realm creation;
- existing realm: `syncRealmSecuritySettings()` already copies `refreshTokenMaxReuse` onto the live realm when the config carries it (null-guarded, so its absence was a no-op until now). No initializer change is needed.

`echno-deployment` carries no realm token settings on any branch. Its Keycloak surface is the seed role (roles, groups, users by `partialImport`, clients deliberately untouched) and the env wiring in `backend.env.j2`. So a rebuild from the IaC reproduces this only because the value travels in the backend image.

## What it means for the other environments

All environments share this one template, because they all run the same `echno-backend` image against realm `echno-realm`:

- **Compose staging at IITM (`.116`, `echno.in`)**: picks the value up on the next backend deploy.
- **k8s staging (`ui-k8s.echno.in`)**: same image, `keycloak.realm: echno-realm` in `k8s/helm/echno/values.yaml`, no separate realm config. Picks it up when the backend pod rolls.
- **Per-client production (DO)**: also the same image and template. Production realms are **not** defined separately, so this is not a change that needs repeating per client, but it does mean production inherits the relaxed tolerance automatically rather than by an explicit decision.

That last point is worth a deliberate call. Unlike `registrationAllowed` and the dev client, which are env-gated properties, `refreshTokenMaxReuse` is hardcoded in the template and cannot currently be set per environment. If production should keep `0` while staging runs `2`, this needs a `${KEYCLOAK_REFRESH_TOKEN_MAX_REUSE}` placeholder plus a property with a default, in the same shape as `keycloak.registration-allowed`. Flagging it rather than assuming either way.

## Applying it to the running staging realm

Nothing here touches a live realm. Deployment sequencing is deliberately left to a separate, approved step:

- **Compose staging on `.116`**: merge `development` into `staging`; the PR-closed trigger on `staging` runs `.github/workflows/deploy-staging-iitm.yml`, which builds the image to GHCR and reruns the Ansible playbook. The backend reconciles the realm on start.
- **k8s staging**: dispatch `.github/workflows/deploy-k8s.yml` with flavor `self-managed`; Argo CD rolls the new tag and the backend reconciles on start.

No `kcadm` step is required. The reconcile is what applies it, which is also what makes it survive a realm rebuild.

## Validation

Rendered the template through the same substitutions `KeycloakConfigGenerator.generateRealmConfig()` performs and parsed the result: valid JSON, `refreshTokenMaxReuse = 2`, `revokeRefreshToken = True`, and the three untouched fields confirmed absent. Verified against `org.keycloak.representations.idm.RealmRepresentation` (26.0.7) that the JSON name binds to a real property:

```
protected java.lang.Integer refreshTokenMaxReuse;
public java.lang.Integer getRefreshTokenMaxReuse();
public void setRefreshTokenMaxReuse(java.lang.Integer);
```

`./gradlew processResources --offline` exits 0 and the template lands in `build/resources/main/keycloak-templates/` with the new field.
