### PR TITLE
Map subscriptions to DTOs inside the service transaction

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
@@ -10,16 +10,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.tornotron.echno_backend.billing.Subscription;
 import org.tornotron.echno_backend.billing.dto.*;
-import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import javax.naming.AuthenticationException;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/billing/subscriptions/web")
@@ -35,7 +32,6 @@ import java.util.Optional;
 public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
-    private final SubscriptionRepository subscriptionRepository;
     private final UserContextService userContextService;
 
     /**
@@ -57,10 +53,9 @@ public class SubscriptionController {
     })
     public ResponseEntity<SubscriptionDto> getCurrentSubscription() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
-        Optional<Subscription> subscription = subscriptionService.getActiveSubscription(userId);
-        return subscription
-                .map(sub -> ResponseEntity.ok(BillingMapper.toSubscriptionDto(sub)))
-                .orElse(ResponseEntity.noContent().build());
+        return subscriptionService.getActiveSubscription(userId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     /**
@@ -80,8 +75,7 @@ public class SubscriptionController {
     })
     public ResponseEntity<List<SubscriptionDto>> getSubscriptionHistory() throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
-        List<Subscription> subscriptions = subscriptionRepository.findByUserIdOrderByCreatedAtDesc(userId);
-        return ResponseEntity.ok(BillingMapper.toSubscriptionDtoList(subscriptions));
+        return ResponseEntity.ok(subscriptionService.getSubscriptionHistory(userId));
     }
 
     /**
@@ -107,8 +101,8 @@ public class SubscriptionController {
     public ResponseEntity<SubscriptionDto> createSubscription(@Valid @RequestBody SubscriptionCreateDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
-        Subscription subscription = subscriptionService.createSubscription(userId, dto.getPlanCode(), dto.getBillingPeriod());
-        return ResponseEntity.status(HttpStatus.CREATED).body(BillingMapper.toSubscriptionDto(subscription));
+        SubscriptionDto subscription = subscriptionService.createSubscription(userId, dto.getPlanCode(), dto.getBillingPeriod());
+        return ResponseEntity.status(HttpStatus.CREATED).body(subscription);
     }
 
     /**
@@ -133,8 +127,7 @@ public class SubscriptionController {
     public ResponseEntity<SubscriptionDto> changeSubscription(@Valid @RequestBody SubscriptionChangeDto dto)
             throws AuthenticationException {
         Long userId = userContextService.getCurrentUserIdOrThrow();
-        Subscription subscription = subscriptionService.changeSubscription(userId, dto.getNewPlanCode());
-        return ResponseEntity.ok(BillingMapper.toSubscriptionDto(subscription));
+        return ResponseEntity.ok(subscriptionService.changeSubscription(userId, dto.getNewPlanCode()));
     }
 
     /**
@@ -240,10 +233,9 @@ public class SubscriptionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
     })
     public ResponseEntity<SubscriptionDto> getUserSubscription(@PathVariable Long userId) {
-        Optional<Subscription> subscription = subscriptionService.getActiveSubscription(userId);
-        return subscription
-                .map(sub -> ResponseEntity.ok(BillingMapper.toSubscriptionDto(sub)))
-                .orElse(ResponseEntity.noContent().build());
+        return subscriptionService.getActiveSubscription(userId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     /**
@@ -266,8 +258,7 @@ public class SubscriptionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
     })
     public ResponseEntity<List<SubscriptionDto>> getUserSubscriptionHistory(@PathVariable Long userId) {
-        List<Subscription> subscriptions = subscriptionRepository.findByUserIdOrderByCreatedAtDesc(userId);
-        return ResponseEntity.ok(BillingMapper.toSubscriptionDtoList(subscriptions));
+        return ResponseEntity.ok(subscriptionService.getSubscriptionHistory(userId));
     }
 
     /**
@@ -296,8 +287,8 @@ public class SubscriptionController {
     public ResponseEntity<SubscriptionDto> createSubscriptionForUser(
             @PathVariable Long userId,
             @Valid @RequestBody SubscriptionCreateDto dto) {
-        Subscription subscription = subscriptionService.createSubscription(userId, dto.getPlanCode(), dto.getBillingPeriod());
-        return ResponseEntity.status(HttpStatus.CREATED).body(BillingMapper.toSubscriptionDto(subscription));
+        SubscriptionDto subscription = subscriptionService.createSubscription(userId, dto.getPlanCode(), dto.getBillingPeriod());
+        return ResponseEntity.status(HttpStatus.CREATED).body(subscription);
     }
 
     /**
@@ -325,8 +316,7 @@ public class SubscriptionController {
     public ResponseEntity<SubscriptionDto> changeSubscriptionForUser(
             @PathVariable Long userId,
             @Valid @RequestBody SubscriptionChangeDto dto) {
-        Subscription subscription = subscriptionService.changeSubscription(userId, dto.getNewPlanCode());
-        return ResponseEntity.ok(BillingMapper.toSubscriptionDto(subscription));
+        return ResponseEntity.ok(subscriptionService.changeSubscription(userId, dto.getNewPlanCode()));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.billing.*;
 import org.tornotron.echno_backend.billing.components.SubscriptionCache;
+import org.tornotron.echno_backend.billing.dto.BillingMapper;
 import org.tornotron.echno_backend.billing.dto.FeatureAccessResultDto;
+import org.tornotron.echno_backend.billing.dto.SubscriptionDto;
 import org.tornotron.echno_backend.billing.enums.BillingPeriod;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
@@ -22,6 +24,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -32,6 +35,12 @@ import java.util.Optional;
  * windows are computed per {@link QuotaPeriod} (hourly through annual, plus an all-time
  * bucket). Creating, changing, and canceling a subscription each evict the user's cache
  * entry so the next access re-reads the current state.
+ *
+ * <p>Entities never leave this class. Every method that a caller can reach returns a DTO
+ * built while the persistence context is still open, because {@code spring.jpa.open-in-view}
+ * is off and {@link Subscription#getPlan()} and {@link Plan#getPlanFeatures()} are both lazy:
+ * mapping a subscription anywhere outside a transaction throws
+ * {@code LazyInitializationException}.
  */
 @Service
 @Slf4j
@@ -44,14 +53,39 @@ public class SubscriptionService {
     private final SubscriptionCache subscriptionCache;
 
     /**
-     * Returns the user's active subscription, serving it from the cache when present.
-     *
-     * <p>On a cache miss it queries the repository and, if found, populates the cache.
+     * Returns the user's active subscription as a DTO.
      *
      * @param userId The ID of the user whose subscription to resolve.
      * @return The active subscription, or empty if the user has none.
      */
-    public Optional<Subscription> getActiveSubscription(Long userId) {
+    @Transactional(readOnly = true)
+    public Optional<SubscriptionDto> getActiveSubscription(Long userId) {
+        return loadActiveSubscription(userId).map(BillingMapper::toSubscriptionDto);
+    }
+
+    /**
+     * Returns every subscription the user has ever held, most recently created first.
+     *
+     * @param userId The ID of the user whose subscriptions to list.
+     * @return The user's subscription history, newest first, empty if they have none.
+     */
+    @Transactional(readOnly = true)
+    public List<SubscriptionDto> getSubscriptionHistory(Long userId) {
+        return BillingMapper.toSubscriptionDtoList(
+                subscriptionRepository.findByUserIdOrderByCreatedAtDesc(userId));
+    }
+
+    /**
+     * Loads the user's active subscription entity, serving it from the cache when present.
+     *
+     * <p>On a cache miss it queries the repository and, if found, populates the cache. The
+     * query fetch-joins the plan, its plan features and each feature, so a cached instance
+     * carries them initialized and stays mappable after its session closes; keep it that way.
+     *
+     * @param userId The ID of the user whose subscription to resolve.
+     * @return The active subscription, or empty if the user has none.
+     */
+    private Optional<Subscription> loadActiveSubscription(Long userId) {
 
         Subscription cached = subscriptionCache.get(userId);
         if(cached != null) {
@@ -78,8 +112,9 @@ public class SubscriptionService {
      * @param featureCode The code of the feature to check.
      * @return The access result, describing whether access is allowed and, for quota features, the current usage against the limit.
      */
+    @Transactional(readOnly = true)
     public FeatureAccessResultDto checkFeatureAccess(Long userId, String featureCode) {
-        Optional<Subscription> subscriptionOptional = getActiveSubscription(userId);
+        Optional<Subscription> subscriptionOptional = loadActiveSubscription(userId);
 
         if(subscriptionOptional.isEmpty()) {
             return FeatureAccessResultDto.noSubscription();
@@ -188,7 +223,7 @@ public class SubscriptionService {
      */
     @Transactional
     public void recordUsage(Long userId, String featureCode, Long amount) {
-        Optional<Subscription> subscriptionOptional = getActiveSubscription(userId);
+        Optional<Subscription> subscriptionOptional = loadActiveSubscription(userId);
         if(subscriptionOptional.isEmpty()) {
             log.warn("Attempted to record usage for user without active subscription: {}", userId);
             return;
@@ -240,13 +275,13 @@ public class SubscriptionService {
      * @param userId The ID of the user to subscribe.
      * @param planCode The code of the plan to subscribe to.
      * @param billingPeriod The billing period that sets the current period length.
-     * @return The created subscription.
+     * @return The created subscription, as a DTO.
      * @throws DuplicateResourceException if the user already has an active subscription.
      * @throws PlanNotFoundException if no plan with the given code exists.
      */
     @Transactional
-    public Subscription createSubscription(Long userId, String planCode, BillingPeriod billingPeriod) {
-        if (getActiveSubscription(userId).isPresent()) {
+    public SubscriptionDto createSubscription(Long userId, String planCode, BillingPeriod billingPeriod) {
+        if (loadActiveSubscription(userId).isPresent()) {
             throw new DuplicateResourceException(
                     "User " + userId + " already has an active subscription; use change-plan to switch plans instead");
         }
@@ -279,7 +314,7 @@ public class SubscriptionService {
         log.info("Created subscription {} for user {} on plan {} ({})", 
                 subscription.getId(), userId, planCode, billingPeriod);
 
-        return subscription;
+        return BillingMapper.toSubscriptionDto(subscription);
     }
 
     /**
@@ -290,13 +325,13 @@ public class SubscriptionService {
      *
      * @param userId The ID of the user whose plan to change.
      * @param newPlanCode The code of the new plan; it must be active.
-     * @return The updated subscription.
+     * @return The updated subscription, as a DTO.
      * @throws NoActiveSubscriptionException if the user has no active subscription.
      * @throws PlanNotFoundException if no active plan with the given code exists.
      */
     @Transactional
-    public Subscription changeSubscription(Long userId,String newPlanCode) {
-        Subscription currentSubscription = getActiveSubscription(userId)
+    public SubscriptionDto changeSubscription(Long userId,String newPlanCode) {
+        Subscription currentSubscription = loadActiveSubscription(userId)
                 .orElseThrow(() -> new NoActiveSubscriptionException("User " + userId + " has no active subscription"));
 
         Plan newPlan = planRepository.findByCodeAndIsActiveTrue(newPlanCode)
@@ -310,7 +345,7 @@ public class SubscriptionService {
         log.info("Changed subscription {} for user {} to plan {}",
                 currentSubscription.getId(), userId, newPlanCode);
 
-        return currentSubscription;
+        return BillingMapper.toSubscriptionDto(currentSubscription);
 
     }
 
@@ -328,7 +363,7 @@ public class SubscriptionService {
     @Transactional
     public void cancelSubscription(Long userId, boolean immediate) {
 
-       Subscription subscription = getActiveSubscription(userId)
+       Subscription subscription = loadActiveSubscription(userId)
                .orElseThrow(() -> new NoActiveSubscriptionException("User " + userId + " has no active subscription"));
 
        if(immediate) {

--- a/src/test/java/org/tornotron/echno_backend/billing/SubscriptionMappingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/SubscriptionMappingIT.java
@@ -1,0 +1,209 @@
+package org.tornotron.echno_backend.billing;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.LazyInitializationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.billing.components.SubscriptionCache;
+import org.tornotron.echno_backend.billing.dto.BillingMapper;
+import org.tornotron.echno_backend.billing.dto.PlanFeatureDto;
+import org.tornotron.echno_backend.billing.dto.SubscriptionDto;
+import org.tornotron.echno_backend.billing.enums.BillingPeriod;
+import org.tornotron.echno_backend.billing.enums.FeatureType;
+import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
+import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the transaction boundary the subscription endpoints depend on. With
+ * {@code spring.jpa.open-in-view} off, a controller that hands a Subscription entity to
+ * {@code BillingMapper} maps against a closed persistence context, and the lazy
+ * {@code Subscription.plan} and {@code Plan.planFeatures} reads throw
+ * {@link LazyInitializationException}. The endpoints therefore take their DTOs from
+ * {@link SubscriptionService}, which maps inside its own transaction.
+ *
+ * <p>Every test here runs without the ambient rolled-back transaction, so the service is
+ * called exactly as an HTTP request calls it, with nothing open around it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({SubscriptionService.class, SubscriptionCache.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class SubscriptionMappingIT extends AbstractIntegrationTest {
+
+    private static final Long SUBSCRIBED_USER = 991_001L;
+    private static final Long UNSUBSCRIBED_USER = 991_002L;
+    private static final String CURRENT_PLAN = "mapping-it-plan-a";
+    private static final String TARGET_PLAN = "mapping-it-plan-b";
+    private static final String FEATURE_CODE = "MAPPING_IT_FEATURE";
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private SubscriptionService subscriptionService;
+
+    @Autowired
+    private SubscriptionCache subscriptionCache;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        subscriptionCache.evictAll();
+        inCommittedTx(() -> {
+            Feature feature = Feature.builder()
+                    .code(FEATURE_CODE)
+                    .name("Mapping IT feature")
+                    .featureType(FeatureType.BOOLEAN)
+                    .isActive(true)
+                    .build();
+            entityManager.persist(feature);
+
+            Plan current = persistPlan(CURRENT_PLAN, feature);
+            persistPlan(TARGET_PLAN, feature);
+
+            Instant now = Instant.now();
+            entityManager.persist(Subscription.builder()
+                    .userId(SUBSCRIBED_USER)
+                    .plan(current)
+                    .status(SubscriptionStatus.ACTIVE)
+                    .currentPeriodStart(now)
+                    .currentPeriodEnd(now.plus(30, ChronoUnit.DAYS))
+                    .build());
+
+            entityManager.flush();
+        });
+    }
+
+    @AfterEach
+    void cleanup() {
+        subscriptionCache.evictAll();
+        inCommittedTx(() -> {
+            executeUpdate("DELETE FROM usage_record WHERE user_id IN ("
+                    + SUBSCRIBED_USER + ", " + UNSUBSCRIBED_USER + ")");
+            executeUpdate("DELETE FROM subscription WHERE user_id IN ("
+                    + SUBSCRIBED_USER + ", " + UNSUBSCRIBED_USER + ")");
+            executeUpdate("DELETE FROM plan_feature WHERE plan_id IN "
+                    + "(SELECT id FROM plan WHERE code LIKE 'mapping-it-plan-%')");
+            executeUpdate("DELETE FROM plan WHERE code LIKE 'mapping-it-plan-%'");
+            executeUpdate("DELETE FROM feature WHERE code = '" + FEATURE_CODE + "'");
+        });
+        TenantContext.clear();
+    }
+
+    /**
+     * The regression this class exists for: mapping a subscription entity after its session
+     * has closed, which is what the controller used to do, cannot work. Anything that moves
+     * the mapping back out of a transaction fails here.
+     */
+    @Test
+    void mappingASubscriptionEntityOutsideATransaction_throwsLazyInitialization() {
+        List<Subscription> subscriptions =
+                inCommittedTx(() -> subscriptionRepository.findByUserIdOrderByCreatedAtDesc(SUBSCRIBED_USER));
+
+        assertThatThrownBy(() -> BillingMapper.toSubscriptionDtoList(subscriptions))
+                .isInstanceOf(LazyInitializationException.class);
+    }
+
+    @Test
+    void getActiveSubscription_returnsAFullyMappedDto() {
+        SubscriptionDto dto = subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
+
+        assertFullyMapped(dto, CURRENT_PLAN);
+    }
+
+    @Test
+    void getSubscriptionHistory_returnsFullyMappedDtos() {
+        List<SubscriptionDto> history = subscriptionService.getSubscriptionHistory(SUBSCRIBED_USER);
+
+        assertThat(history).hasSize(1);
+        assertFullyMapped(history.get(0), CURRENT_PLAN);
+    }
+
+    @Test
+    void createSubscription_returnsAFullyMappedDto() {
+        SubscriptionDto dto = subscriptionService.createSubscription(
+                UNSUBSCRIBED_USER, TARGET_PLAN, BillingPeriod.MONTHLY);
+
+        assertFullyMapped(dto, TARGET_PLAN);
+    }
+
+    @Test
+    void changeSubscription_returnsAFullyMappedDto() {
+        SubscriptionDto dto = subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);
+
+        assertFullyMapped(dto, TARGET_PLAN);
+    }
+
+    private void assertFullyMapped(SubscriptionDto dto, String expectedPlanCode) {
+        assertThat(dto.getId()).isNotNull();
+        assertThat(dto.getPlan()).isNotNull();
+        assertThat(dto.getPlan().getCode()).isEqualTo(expectedPlanCode);
+        assertThat(dto.getPlan().getFeatures())
+                .extracting(PlanFeatureDto::getFeatureCode)
+                .containsExactly(FEATURE_CODE);
+    }
+
+    private Plan persistPlan(String code, Feature feature) {
+        Plan plan = Plan.builder()
+                .code(code)
+                .name(code)
+                .monthlyPrice(new BigDecimal("100.00"))
+                .annualPrice(new BigDecimal("1000.00"))
+                .isActive(true)
+                .isPublic(true)
+                .planFeatures(new HashSet<>())
+                .build();
+        plan.addFeature(PlanFeature.builder().feature(feature).enabled(true).build());
+        entityManager.persist(plan);
+        return plan;
+    }
+
+    private void executeUpdate(String sql) {
+        entityManager.createNativeQuery(sql).executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        inCommittedTx((Supplier<Void>) () -> {
+            work.run();
+            return null;
+        });
+    }
+
+    private <T> T inCommittedTx(Supplier<T> work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return tt.execute(status -> work.get());
+    }
+}


### PR DESCRIPTION
Closes #472.

## The bug

`SubscriptionController` built its own DTOs from `Subscription` entities. `spring.jpa.open-in-view` is `false` (correctly), so the persistence context is already closed when the mapper runs, and `BillingMapper.toSubscriptionDto` reads two lazy associations: `Subscription.plan` (`@ManyToOne(LAZY)`) and, one level down, `Plan.planFeatures` plus `PlanFeature.feature`. First call, 500.

Reproduced against `development` before touching anything. Two distinct failure modes, matching the four call sites named in the issue:

Subscription history (lines 84 and 270), where `findByUserIdOrderByCreatedAtDesc` has no fetch join, so `plan` is still a proxy:

```
org.hibernate.LazyInitializationException: Could not initialize proxy [...billing.Plan#3] - no session
	at org.tornotron.echno_backend.billing.Plan$HibernateProxy.getCode(Unknown Source)
	at org.tornotron.echno_backend.billing.dto.BillingMapper.toPlanDto(BillingMapper.java:19)
	at org.tornotron.echno_backend.billing.dto.BillingMapper.toSubscriptionDto(BillingMapper.java:94)
```

Change-plan (lines 137 and 329), where the new plan is a real entity loaded by `findByCodeAndIsActiveTrue` but its feature collection is not initialised, so it fails one level deeper:

```
org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role:
  org.tornotron.echno_backend.billing.Plan.planFeatures: could not initialize proxy - no Session
	at org.hibernate.collection.spi.PersistentSet.iterator(PersistentSet.java:166)
	at org.tornotron.echno_backend.billing.dto.BillingMapper.toPlanDto(BillingMapper.java:34)
```

## The fix

`SubscriptionService` now returns `SubscriptionDto` and builds it while its own transaction is still open, which is how the other 96 controllers get their DTOs. The entity loader is private, so no `Subscription` leaves the service, and the controller no longer injects `SubscriptionRepository`. `checkFeatureAccess` walks the same lazy graph outside any transaction and gets `@Transactional(readOnly = true)` for the same reason.

The two cheaper options were considered and rejected. Annotating the controller `@Transactional` works but leaves a controller holding a persistence context, and this controller was already the only one in the codebase mapping entities itself. A fetch join or `@EntityGraph` on the repository methods also works but fixes four call sites rather than the reason they broke, and the payment and paywall work lands on this same surface next.

## Endpoint sweep

All eight mapping call sites on the controller had the same shape, not the four the issue named. The other four (`/current`, `POST` create, and their admin twins at lines 62, 111, 245, 300) happened to work because `findActiveSubscriptionByUserId` and `findByCodeWithFeatures` fetch-join the whole graph. They were one query change away from the same 500, and are moved too.

## Tests

`SubscriptionMappingIT` runs with the ambient transaction disabled (`@Transactional(propagation = NOT_SUPPORTED)`), so the service is called with nothing open around it, the way an HTTP request calls it. A test that ran inside a transaction would pass against the broken code.

- `mappingASubscriptionEntityOutsideATransaction_throwsLazyInitialization` keeps the failure pinned: it loads entities in a committed transaction, lets the session close, and asserts the mapper still throws. Moving the mapping back out of a transaction fails here.
- Four tests assert each surface now returns a DTO carrying its plan and the plan's features.

It needs a context with a real database because a `LazyInitializationException` requires a genuine Hibernate proxy whose session has closed, and because `@Transactional` is inert without Spring's proxy. `@DirtiesContext(AFTER_CLASS)` releases the context so the extra `@DataJpaTest` configuration does not sit in the 1 GB test JVM for the rest of the run.

`./gradlew check` on lab node `.116`: 422 tests, BUILD SUCCESSFUL, JaCoCo floor gate passed.

## Noted, not changed

- `getSubscriptionHistory` maps N subscriptions and its query does not fetch-join, so it is N+1 inside the transaction. Correct, but a fetch-join variant would be worth adding if a user ever accumulates many subscriptions.
- `PlanController` and `FeatureController` also map entities themselves. `PlanController` survives only because every `PlanService` read uses a `... WithFeatures` fetch-join query and every write returns a plan whose collection was already touched; `FeatureController` is safe because `toFeatureDto` reads only scalars. Neither is broken today, but `PlanController` is one non-fetch-joined query away from this same bug.
- `Plan.planFeatures` has no `@Builder.Default`, so `Plan.builder().build()` leaves it null rather than an empty set. `BillingMapper.toPlanDto` null-checks it, so nothing fails today, but `PlanService.createPlan` returns a plan with a null collection.
- `SubscriptionCache` caches entities rather than DTOs. Every cached instance is fully initialised because the query behind it fetch-joins, which the loader's Javadoc now says out loud, but caching DTOs would remove the dependency entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Subscription details, history, creation, and plan changes now consistently return complete subscription information, including plan and feature data.
  * Subscription access and management remain available through current-user and administrator endpoints with existing response behavior.

* **Tests**
  * Added integration coverage to verify subscription information remains complete when accessed through real request-like workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->