### PR TITLE
Clamp the transaction-retry backoff bounds at construction

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
@@ -61,6 +61,18 @@ public class TransactionRetryTemplate {
     /** Caps the doubling so a misconfigured backoff cannot overflow the shift. */
     private static final int MAX_BACKOFF_DOUBLINGS = 20;
 
+    /**
+     * The longest either configured backoff bound is allowed to be, in milliseconds.
+     *
+     * <p>Both bounds arrive from {@code application.yml} and are overridable per environment, so
+     * they are outside input. Two seconds is eight times the shipped cap and already the most a
+     * request thread should ever spend asleep between two attempts at the same unit of work: at
+     * the default four attempts it bounds the added latency at six seconds. It also leaves the
+     * arithmetic in {@link #backOff(int)} nowhere near the range where the shift or the
+     * {@code ceiling + 1} could overflow.
+     */
+    static final long MAX_CONFIGURABLE_BACKOFF_MILLIS = 2_000L;
+
     private final TransactionalWorkRunner runner;
     private final MeterRegistry meterRegistry;
     private final int maxAttempts;
@@ -76,8 +88,32 @@ public class TransactionRetryTemplate {
         this.runner = runner;
         this.meterRegistry = meterRegistry;
         this.maxAttempts = Math.max(1, maxAttempts);
-        this.initialBackoffMillis = Math.max(0L, initialBackoffMillis);
-        this.maxBackoffMillis = Math.max(0L, maxBackoffMillis);
+        this.initialBackoffMillis = clampBackoff("initial-backoff-millis", initialBackoffMillis);
+        this.maxBackoffMillis = clampBackoff("max-backoff-millis", maxBackoffMillis);
+    }
+
+    /**
+     * Brings a configured backoff bound inside the range a request thread can plausibly wait,
+     * and says so in the log when it has to.
+     *
+     * <p>The bounds were already floored at zero but had no ceiling, so a value such as
+     * {@code initial-backoff-millis: 1000000000000000000} was accepted intact and put a request
+     * thread to sleep for longer than anyone would wait for the response. Clamping here rather
+     * than saturating the arithmetic in {@link #backOff(int)} keeps the hot path free of special
+     * cases, and it closes the narrower overflow with it: with both bounds held to
+     * {@link #MAX_CONFIGURABLE_BACKOFF_MILLIS} the shifted term stays around 10<sup>10</sup>, so
+     * neither the left shift nor the {@code ceiling + 1} handed to
+     * {@link ThreadLocalRandom#nextLong(long)} can reach {@code Long.MAX_VALUE} and turn a
+     * retryable abort into an {@code IllegalArgumentException} thrown out of the catch block.
+     */
+    static long clampBackoff(String property, long configured) {
+        long clamped = Math.min(Math.max(0L, configured), MAX_CONFIGURABLE_BACKOFF_MILLIS);
+        if (clamped != configured) {
+            logger.warn("echno.transaction.retry.{} was configured as {} ms, which is outside the "
+                            + "supported range 0..{} ms; using {} ms instead",
+                    property, configured, MAX_CONFIGURABLE_BACKOFF_MILLIS, clamped);
+        }
+        return clamped;
     }
 
     /**
@@ -137,6 +173,9 @@ public class TransactionRetryTemplate {
      * Sleeps for a jittered, exponentially growing interval before the next attempt. Full
      * jitter rather than a fixed pause: two transactions that abort against each other and then
      * wait the same length of time simply collide again.
+     *
+     * <p>Both bounds were clamped at construction, so the arithmetic here stays well inside the
+     * range of a {@code long} and needs no saturation of its own.
      *
      * @return false when the wait was interrupted, in which case the caller should stop retrying
      */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -178,6 +178,8 @@ echno:
       # does that for the units of work that opt in. Attempts include the first try; the wait
       # between attempts doubles from the initial value and is fully jittered up to the cap, so
       # two transactions that abort against each other do not wake up together and collide again.
+      # Both backoff values are clamped to 0..2000 ms at startup, since they land on a request
+      # thread; an override outside that range is logged and replaced with the nearest bound.
       max-attempts: ${ECHNO_TXN_RETRY_MAX_ATTEMPTS:4}
       initial-backoff-millis: ${ECHNO_TXN_RETRY_INITIAL_BACKOFF_MS:25}
       max-backoff-millis: ${ECHNO_TXN_RETRY_MAX_BACKOFF_MS:250}

--- a/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
@@ -37,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * <p>Backoff is configured to zero here so the retries do not add wall-clock time to the build;
  * the jitter maths is bounded arithmetic and is exercised in production by the real defaults.
+ * The one exception is the extreme-bounds test, which has to let a real pause happen to show
+ * that the clamped ceiling both keeps the pause short and keeps it legal.
  */
 class TransactionRetryTemplateTest {
 
@@ -166,6 +168,58 @@ class TransactionRetryTemplateTest {
         assertThat(attempts).hasValue(2);
         assertThat(transactionManager.begun).isEqualTo(2);
         assertThat(transactionManager.committed).isEqualTo(1);
+    }
+
+    @Test
+    void stillRetriesWhenTheBackoffBoundsAreConfiguredAtTheirExtreme() {
+        // Long.MAX_VALUE on both bounds used to make the jitter ceiling overflow when it was
+        // incremented, so ThreadLocalRandom rejected the bound and the IllegalArgumentException
+        // replaced the serialization failure on its way out of the catch block: a retryable
+        // abort surfacing as a 500, which is what this template exists to prevent. The bounds
+        // are clamped at construction now, so the retry happens and the pause stays bounded.
+        TransactionRetryTemplate extreme = new TransactionRetryTemplate(
+                transactionalRunner(transactionManager), meterRegistry, MAX_ATTEMPTS,
+                Long.MAX_VALUE, Long.MAX_VALUE);
+        AtomicInteger attempts = new AtomicInteger();
+
+        long startedAt = System.nanoTime();
+        String result = extreme.execute(OPERATION, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw serializationFailure();
+            }
+            return "committed";
+        });
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertThat(result).isEqualTo("committed");
+        assertThat(attempts).hasValue(2);
+        assertThat(transactionManager.begun).isEqualTo(2);
+        // The clamp is what keeps this from being a geological sleep as well as a throw; the
+        // slack is generous because the assertion is about the bound, not about scheduling.
+        assertThat(elapsedMillis)
+                .isLessThanOrEqualTo(TransactionRetryTemplate.MAX_CONFIGURABLE_BACKOFF_MILLIS + 10_000L);
+    }
+
+    @Test
+    void clampsABackoffTooLongForARequestThreadToWait() {
+        long cap = TransactionRetryTemplate.MAX_CONFIGURABLE_BACKOFF_MILLIS;
+
+        // The shipped defaults and anything else sensible pass through untouched.
+        assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis", 25L)).isEqualTo(25L);
+        assertThat(TransactionRetryTemplate.clampBackoff("max-backoff-millis", 250L)).isEqualTo(250L);
+        assertThat(TransactionRetryTemplate.clampBackoff("max-backoff-millis", cap)).isEqualTo(cap);
+        assertThat(TransactionRetryTemplate.clampBackoff("max-backoff-millis", 0L)).isZero();
+
+        // A plausible typo in an environment override: an initial pause of roughly 31 years.
+        assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis",
+                1_000_000_000_000_000_000L)).isEqualTo(cap);
+        assertThat(TransactionRetryTemplate.clampBackoff("max-backoff-millis", Long.MAX_VALUE))
+                .isEqualTo(cap);
+
+        // The floor that was already there stays.
+        assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis", -1L)).isZero();
+        assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis", Long.MIN_VALUE))
+                .isZero();
     }
 
     /** A CockroachDB serializable abort in the shape Spring hands to application code. */


### PR DESCRIPTION
Closes #468.

## What was wrong

`echno.transaction.retry.initial-backoff-millis` and `max-backoff-millis` come from
`application.yml` and are overridable per environment (`ECHNO_TXN_RETRY_*`), so they are outside
input. The constructor clamped them from below with `Math.max(0L, ...)` but placed no ceiling on
them, so any value at all was accepted intact.

The arithmetic hole the review found is the small part of that. `backOff` computes

```java
long ceiling = Math.min(maxBackoffMillis, initialBackoffMillis << Math.min(attempt - 1, MAX_BACKOFF_DOUBLINGS));
if (ceiling <= 0L) { return true; }
long pause = ThreadLocalRandom.current().nextLong(ceiling + 1);
```

The `ceiling <= 0L` guard catches the usual case, a left shift that wraps negative. It does not
catch `ceiling == Long.MAX_VALUE`, where `ceiling + 1` wraps to `Long.MIN_VALUE` and
`nextLong(long)` rejects a non-positive bound with `IllegalArgumentException`. That throw happens
inside the `catch (RuntimeException failure)` block in `execute`, so it replaces the serialization
failure on its way out and reaches `GlobalExceptionHandler` unclassified: a retryable 40001 abort
surfacing as a 500, which is the outcome this template exists to remove.

The likelier failure needs no overflow at all. `initial-backoff-millis: 1000000000000000000` is a
plausible typo and produces a sleep of roughly 31 years on a request thread. No existing guard
touches it, and it is a worse outcome than the exception.

## The fix

Clamp both bounds to `0..2000 ms` at construction, and log a warning naming the property when a
supplied value has to be replaced.

Two seconds is eight times the shipped 250 ms cap, so nobody with a real reason to lengthen the
backoff is constrained by it, and at the default four attempts it bounds the added request latency
at six seconds.

Clamping at construction rather than saturating the multiply in `backOff` was deliberate:

- it fixes the likelier misconfiguration, which a saturated multiply leaves wide open, since a
  1000-second pause is perfectly representable and would simply be waited out;
- it keeps the hot path free of special cases;
- it closes the overflow as a side effect. With both bounds held at or below 2000, the shifted
  term reaches about 2×10<sup>9</sup> at the 20-doubling cap, nowhere near `Long.MAX_VALUE`, so
  `ceiling + 1` cannot wrap. The `ceiling <= 0L` guard stays as cheap defence.

The `application.yml` comment now records the accepted range.

## Verification

Three new assertions in `TransactionRetryTemplateTest`, all on the existing hand-built proxy, so
no new Spring context and no heap added to CI.

Both new tests were first run against the pre-fix `TransactionRetryTemplate` to confirm they
reproduce the reported behaviour rather than merely passing:

```
TransactionRetryTemplateTest > clampsABackoffTooLongForARequestThreadToWait() FAILED
TransactionRetryTemplateTest > stillRetriesWhenTheBackoffBoundsAreConfiguredAtTheirExtreme() FAILED
    java.lang.IllegalArgumentException at TransactionRetryTemplateTest.java:186
BUILD FAILED in 8s
```

That `IllegalArgumentException` is the reported bug, thrown out of the catch block exactly as
described. With the fix applied, on the same machine:

```
TransactionRetryTemplateTest > clampsABackoffTooLongForARequestThreadToWait() PASSED
TransactionRetryTemplateTest > stillRetriesWhenTheBackoffBoundsAreConfiguredAtTheirExtreme() PASSED
TransactionRetryTemplateTest > restartsTheTransactionAfterASerializationFailureAndSucceeds() PASSED
TransactionRetryTemplateTest > keepsRestartingUpToTheAttemptLimit() PASSED
TransactionRetryTemplateTest > reportsAConflictOnceTheAttemptsAreUsedUp() PASSED
TransactionRetryTemplateTest > doesNotRetryAFailureThatIsNotASerializationConflict() PASSED
TransactionRetryTemplateTest > doesNotRetryInsideACallersTransaction() PASSED
TransactionRetryTemplateTest > retriesTheNoResultForm() PASSED
BUILD SUCCESSFUL in 30s
```

The extreme-bounds test is the one place a real pause is allowed to happen, since the point is
that the clamped ceiling keeps the wait both short and legal. It asserts on the bound, not on
scheduling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction retry delays are now safely limited to a maximum of 2 seconds.
  * Invalid negative or oversized backoff settings are automatically adjusted to the nearest valid limit.
  * Retries continue to work reliably when extreme backoff values are configured.

* **Documentation**
  * Added configuration guidance describing retry backoff limits and startup warnings for adjusted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->