### PR TITLE
Map plans to DTOs inside the service transaction, and fix the billing builder defaults

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/Feature.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/Feature.java
@@ -52,6 +52,7 @@ public class Feature {
     private Boolean isActive = true;
 
     @OneToMany(mappedBy = "feature")
+    @Builder.Default
     private Set<PlanFeature> planFeatures = new HashSet<>();
 
 

--- a/src/main/java/org/tornotron/echno_backend/billing/Plan.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/Plan.java
@@ -70,7 +70,11 @@ public class Plan {
     @Builder.Default
     private Integer sortOrder = 0;
 
+    // Without @Builder.Default the builder ignores this initializer and leaves the collection
+    // null, so addFeature throws on a builder-constructed plan and every caller has to remember
+    // to pass an empty set of its own.
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private Set<PlanFeature> planFeatures = new HashSet<>();
 
     public void addFeature(PlanFeature planFeature) {

--- a/src/main/java/org/tornotron/echno_backend/billing/Subscription.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/Subscription.java
@@ -71,7 +71,8 @@ public class Subscription {
 
     private String externalSubscriptionId;
 
-    @OneToMany(mappedBy = "subscription",cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private Set<SubscriptionItem> subscriptionItems = new HashSet<>();
 
     public boolean isActive() {

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
@@ -10,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.tornotron.echno_backend.billing.Plan;
 import org.tornotron.echno_backend.billing.dto.*;
 import org.tornotron.echno_backend.billing.services.PlanService;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -49,8 +48,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
     })
     public ResponseEntity<List<PlanDto>> getPublicPlans() {
-        List<Plan> plans = planService.getAllPublicPlans();
-        return ResponseEntity.ok(BillingMapper.toPlanDtoList(plans));
+        return ResponseEntity.ok(planService.getAllPublicPlans());
     }
 
     /**
@@ -71,8 +69,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
     })
     public ResponseEntity<List<PlanDto>> getAllPlans() {
-        List<Plan> plans = planService.getAllPlans();
-        return ResponseEntity.ok(BillingMapper.toPlanDtoList(plans));
+        return ResponseEntity.ok(planService.getAllPlans());
     }
 
     /**
@@ -94,8 +91,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<PlanDto> getPlanById(@PathVariable Long id) {
-        Plan plan = planService.getPlanById(id);
-        return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.ok(planService.getPlanById(id));
     }
 
     /**
@@ -117,8 +113,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code")
     })
     public ResponseEntity<PlanDto> getPlanByCode(@PathVariable String code) {
-        Plan plan = planService.getPlanByCode(code);
-        return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.ok(planService.getPlanByCode(code));
     }
 
     /**
@@ -142,8 +137,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
     })
     public ResponseEntity<PlanDto> createPlan(@Valid @RequestBody PlanCreateDto dto) {
-        Plan plan = planService.createPlan(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(dto));
     }
 
     /**
@@ -168,8 +162,7 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<PlanDto> updatePlan(@PathVariable Long id, @Valid @RequestBody PlanCreateDto dto) {
-        Plan plan = planService.updatePlan(id, dto);
-        return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.ok(planService.updatePlan(id, dto));
     }
 
     /**
@@ -246,8 +239,7 @@ public class PlanController {
     public ResponseEntity<PlanDto> assignFeatureToPlan(
             @PathVariable Long planId,
             @Valid @RequestBody PlanFeatureAssignDto dto) {
-        Plan plan = planService.assignFeatureToPlan(planId, dto);
-        return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.ok(planService.assignFeatureToPlan(planId, dto));
     }
 
     /**
@@ -274,7 +266,6 @@ public class PlanController {
     public ResponseEntity<PlanDto> removeFeatureFromPlan(
             @PathVariable Long planId,
             @PathVariable String featureCode) {
-        Plan plan = planService.removeFeatureFromPlan(planId, featureCode);
-        return ResponseEntity.ok(BillingMapper.toPlanDto(plan));
+        return ResponseEntity.ok(planService.removeFeatureFromPlan(planId, featureCode));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/billing/services/PlanService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/PlanService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.billing.Feature;
 import org.tornotron.echno_backend.billing.Plan;
 import org.tornotron.echno_backend.billing.PlanFeature;
+import org.tornotron.echno_backend.billing.dto.BillingMapper;
 import org.tornotron.echno_backend.billing.dto.PlanCreateDto;
+import org.tornotron.echno_backend.billing.dto.PlanDto;
 import org.tornotron.echno_backend.billing.dto.PlanFeatureAssignDto;
 import org.tornotron.echno_backend.billing.repositories.FeatureRepository;
 import org.tornotron.echno_backend.billing.repositories.PlanRepository;
@@ -17,6 +19,18 @@ import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 
 import java.util.List;
 
+/**
+ * Plan administration: reading plans with their assigned features, and creating, updating and
+ * deactivating them.
+ *
+ * <p>Entities never leave this class. Every method a caller can reach returns a DTO built while
+ * the persistence context is still open, because {@code spring.jpa.open-in-view} is off and
+ * {@link Plan#getPlanFeatures()} is a lazy collection: mapping a plan anywhere outside a
+ * transaction throws {@code LazyInitializationException}. The reads here happen to use fetch-join
+ * queries, which is what kept the old controller-side mapping working, but that is a property of
+ * the queries rather than of the call site, and it is one query change away from the failure that
+ * took down the subscription endpoints in #472.
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -25,26 +39,63 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final FeatureRepository featureRepository;
 
-    public List<Plan> getAllPublicPlans() {
-        return planRepository.findPublicPlansWithFeatures();
+    /**
+     * Returns the plans that are both public and active, ordered for display.
+     *
+     * @return The public plans, each with its assigned features.
+     */
+    @Transactional(readOnly = true)
+    public List<PlanDto> getAllPublicPlans() {
+        return BillingMapper.toPlanDtoList(planRepository.findPublicPlansWithFeatures());
     }
 
-    public List<Plan> getAllPlans() {
-        return planRepository.findAllWithFeatures();
+    /**
+     * Returns every plan, including the private and inactive ones.
+     *
+     * @return All plans, each with its assigned features.
+     */
+    @Transactional(readOnly = true)
+    public List<PlanDto> getAllPlans() {
+        return BillingMapper.toPlanDtoList(planRepository.findAllWithFeatures());
     }
 
-    public Plan getPlanById(Long id) {
+    /**
+     * Returns a single plan by its numeric id.
+     *
+     * @param id The id of the plan to read.
+     * @return The plan with its assigned features.
+     * @throws PlanNotFoundException if no plan has that id.
+     */
+    @Transactional(readOnly = true)
+    public PlanDto getPlanById(Long id) {
+        return BillingMapper.toPlanDto(loadPlanById(id));
+    }
+
+    /**
+     * Returns a single active plan by its unique code.
+     *
+     * @param code The code of the plan to read, such as {@code professional-monthly}.
+     * @return The plan with its assigned features.
+     * @throws PlanNotFoundException if no active plan has that code.
+     */
+    @Transactional(readOnly = true)
+    public PlanDto getPlanByCode(String code) {
+        return BillingMapper.toPlanDto(planRepository.findByCodeWithFeatures(code)
+                .orElseThrow(() -> new PlanNotFoundException("Plan with code '" + code + "' was not found")));
+    }
+
+    /**
+     * Loads a plan entity with its features initialized, for the methods here that go on to
+     * change it. Private on purpose: an entity handed out of this class would be mapped against
+     * a closed persistence context.
+     */
+    private Plan loadPlanById(Long id) {
         return planRepository.findByIdWithFeatures(id)
                 .orElseThrow(() -> new PlanNotFoundException("Plan with ID " + id + " was not found"));
     }
 
-    public Plan getPlanByCode(String code) {
-        return planRepository.findByCodeWithFeatures(code)
-                .orElseThrow(() -> new PlanNotFoundException("Plan with code '" + code + "' was not found"));
-    }
-
     @Transactional
-    public Plan createPlan(PlanCreateDto dto) {
+    public PlanDto createPlan(PlanCreateDto dto) {
         Plan plan = Plan.builder()
                 .code(dto.getCode())
                 .name(dto.getName())
@@ -60,12 +111,12 @@ public class PlanService {
 
         plan = planRepository.save(plan);
         log.info("Created plan: {}", plan.getCode());
-        return plan;
+        return BillingMapper.toPlanDto(plan);
     }
 
     @Transactional
-    public Plan updatePlan(Long id, PlanCreateDto dto) {
-        Plan plan = getPlanById(id);
+    public PlanDto updatePlan(Long id, PlanCreateDto dto) {
+        Plan plan = loadPlanById(id);
 
         plan.setCode(dto.getCode());
         plan.setName(dto.getName());
@@ -80,12 +131,12 @@ public class PlanService {
 
         plan = planRepository.save(plan);
         log.info("Updated plan: {}", plan.getCode());
-        return plan;
+        return BillingMapper.toPlanDto(plan);
     }
 
     @Transactional
     public void deactivatePlan(Long id) {
-        Plan plan = getPlanById(id);
+        Plan plan = loadPlanById(id);
         plan.setIsActive(false);
         planRepository.save(plan);
         log.info("Deactivated plan: {}", plan.getCode());
@@ -101,8 +152,8 @@ public class PlanService {
     }
 
     @Transactional
-    public Plan assignFeatureToPlan(Long planId, PlanFeatureAssignDto dto) {
-        Plan plan = getPlanById(planId);
+    public PlanDto assignFeatureToPlan(Long planId, PlanFeatureAssignDto dto) {
+        Plan plan = loadPlanById(planId);
 
         Feature feature = featureRepository.findByCodeAndIsActiveTrue(dto.getFeatureCode())
                 .orElseThrow(() -> new ResourceNotFoundException(
@@ -128,12 +179,12 @@ public class PlanService {
         plan = planRepository.save(plan);
 
         log.info("Assigned feature {} to plan {}", dto.getFeatureCode(), plan.getCode());
-        return plan;
+        return BillingMapper.toPlanDto(plan);
     }
 
     @Transactional
-    public Plan removeFeatureFromPlan(Long planId, String featureCode) {
-        Plan plan = getPlanById(planId);
+    public PlanDto removeFeatureFromPlan(Long planId, String featureCode) {
+        Plan plan = loadPlanById(planId);
 
         Plan finalPlan = plan;
         PlanFeature planFeature = plan.getPlanFeatures().stream()
@@ -146,6 +197,6 @@ public class PlanService {
         plan = planRepository.save(plan);
 
         log.info("Removed feature {} from plan {}", featureCode, plan.getCode());
-        return plan;
+        return BillingMapper.toPlanDto(plan);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/billing/BillingEntityDefaultsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/BillingEntityDefaultsTest.java
@@ -1,0 +1,67 @@
+package org.tornotron.echno_backend.billing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the collection defaults on the billing entities.
+ *
+ * <p>Lombok's builder ignores a field initializer unless the field carries
+ * {@code @Builder.Default}, so {@code Plan.builder().build()} used to leave {@code planFeatures}
+ * null. Nothing returned a 500 over it, because {@code BillingMapper.toPlanDto} null-checks the
+ * collection, but {@code Plan.addFeature} threw a NullPointerException on any plan that came off
+ * the builder rather than out of the database, and callers had to remember to pass an empty set
+ * to work around it.
+ *
+ * <p>Hibernate instantiates entities through the no-args constructor, so that path is asserted
+ * too: an initializer that only the builder honours would be a different bug of the same shape.
+ * No Spring context here on purpose, this is plain object construction.
+ */
+class BillingEntityDefaultsTest {
+
+    @Test
+    void aBuiltPlanStartsWithAnEmptyFeatureSet() {
+        Plan plan = Plan.builder().code("starter").name("Starter").build();
+
+        assertThat(plan.getPlanFeatures()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void aBuiltPlanAcceptsAFeatureWithoutABuilderWorkaround() {
+        Plan plan = Plan.builder().code("starter").name("Starter").build();
+        PlanFeature planFeature = PlanFeature.builder()
+                .feature(Feature.builder().code("report-export").name("PDF Report Export").build())
+                .enabled(true)
+                .build();
+
+        plan.addFeature(planFeature);
+
+        assertThat(plan.getPlanFeatures()).containsExactly(planFeature);
+        assertThat(planFeature.getPlan()).isSameAs(plan);
+    }
+
+    @Test
+    void aNewPlanStartsWithAnEmptyFeatureSet() {
+        assertThat(new Plan().getPlanFeatures()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void aBuiltFeatureStartsWithAnEmptyPlanFeatureSet() {
+        Feature feature = Feature.builder().code("report-export").name("PDF Report Export").build();
+
+        assertThat(feature.getPlanFeatures()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void aBuiltSubscriptionStartsWithAnEmptyItemSet() {
+        Subscription subscription = Subscription.builder().userId(1L).build();
+
+        assertThat(subscription.getSubscriptionItems()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void aNewSubscriptionStartsWithAnEmptyItemSet() {
+        assertThat(new Subscription().getSubscriptionItems()).isNotNull().isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
@@ -18,12 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.billing.components.SubscriptionCache;
 import org.tornotron.echno_backend.billing.dto.BillingMapper;
+import org.tornotron.echno_backend.billing.dto.PlanCreateDto;
+import org.tornotron.echno_backend.billing.dto.PlanDto;
+import org.tornotron.echno_backend.billing.dto.PlanFeatureAssignDto;
 import org.tornotron.echno_backend.billing.dto.PlanFeatureDto;
 import org.tornotron.echno_backend.billing.dto.SubscriptionDto;
 import org.tornotron.echno_backend.billing.enums.BillingPeriod;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
+import org.tornotron.echno_backend.billing.repositories.PlanRepository;
 import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
+import org.tornotron.echno_backend.billing.services.PlanService;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
@@ -31,7 +36,6 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -39,34 +43,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Pins the transaction boundary the subscription endpoints depend on. With
- * {@code spring.jpa.open-in-view} off, a controller that hands a Subscription entity to
+ * Pins the transaction boundary the billing endpoints depend on. With
+ * {@code spring.jpa.open-in-view} off, a controller that hands an entity to
  * {@code BillingMapper} maps against a closed persistence context, and the lazy
  * {@code Subscription.plan} and {@code Plan.planFeatures} reads throw
  * {@link LazyInitializationException}. The endpoints therefore take their DTOs from
- * {@link SubscriptionService}, which maps inside its own transaction.
+ * {@link SubscriptionService} and {@link PlanService}, which map inside their own transactions.
  *
- * <p>Every test here runs without the ambient rolled-back transaction, so the service is
- * called exactly as an HTTP request calls it, with nothing open around it.
+ * <p>Every test here runs without the ambient rolled-back transaction, so the services are
+ * called exactly as an HTTP request calls them, with nothing open around them.
+ *
+ * <p>Both halves share this one context on purpose. The test JVM caps its heap and Spring keeps
+ * every distinct test context it builds, so a second slice for the plan half would cost heap for
+ * no coverage the plan tests could not get here.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
-@Import({SubscriptionService.class, SubscriptionCache.class})
+@Import({SubscriptionService.class, SubscriptionCache.class, PlanService.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-class SubscriptionMappingIT extends AbstractIntegrationTest {
+class BillingMappingIT extends AbstractIntegrationTest {
 
     private static final Long SUBSCRIBED_USER = 991_001L;
     private static final Long UNSUBSCRIBED_USER = 991_002L;
     private static final String CURRENT_PLAN = "mapping-it-plan-a";
     private static final String TARGET_PLAN = "mapping-it-plan-b";
     private static final String FEATURE_CODE = "MAPPING_IT_FEATURE";
+    private static final String CREATED_PLAN = "mapping-it-plan-c";
 
     @Autowired
     private SubscriptionRepository subscriptionRepository;
 
     @Autowired
     private SubscriptionService subscriptionService;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    @Autowired
+    private PlanService planService;
 
     @Autowired
     private SubscriptionCache subscriptionCache;
@@ -166,6 +181,115 @@ class SubscriptionMappingIT extends AbstractIntegrationTest {
         assertFullyMapped(dto, TARGET_PLAN);
     }
 
+    /**
+     * The plan half of the same regression. {@code findById} does not fetch-join the features,
+     * so a plan entity mapped after its session closes fails exactly as a subscription does.
+     * PlanController used to map plan entities itself and survived only because every read on
+     * PlanService happens to use a {@code ...WithFeatures} query.
+     */
+    @Test
+    void mappingAPlanEntityOutsideATransaction_throwsLazyInitialization() {
+        Long planId = inCommittedTx(() -> planRepository.findByCodeWithFeatures(CURRENT_PLAN)
+                .orElseThrow()
+                .getId());
+
+        Plan plan = inCommittedTx(() -> planRepository.findById(planId).orElseThrow());
+
+        assertThatThrownBy(() -> BillingMapper.toPlanDto(plan))
+                .isInstanceOf(LazyInitializationException.class);
+    }
+
+    @Test
+    void getPlanById_returnsAFullyMappedDto() {
+        Long planId = inCommittedTx(() -> planRepository.findByCodeWithFeatures(CURRENT_PLAN)
+                .orElseThrow()
+                .getId());
+
+        assertFullyMapped(planService.getPlanById(planId), CURRENT_PLAN);
+    }
+
+    @Test
+    void getPlanByCode_returnsAFullyMappedDto() {
+        assertFullyMapped(planService.getPlanByCode(CURRENT_PLAN), CURRENT_PLAN);
+    }
+
+    @Test
+    void getAllPlans_returnsFullyMappedDtos() {
+        List<PlanDto> plans = planService.getAllPlans();
+
+        assertFullyMapped(planOf(plans, CURRENT_PLAN), CURRENT_PLAN);
+    }
+
+    @Test
+    void getAllPublicPlans_returnsFullyMappedDtos() {
+        List<PlanDto> plans = planService.getAllPublicPlans();
+
+        assertFullyMapped(planOf(plans, CURRENT_PLAN), CURRENT_PLAN);
+    }
+
+    /**
+     * A plan straight off the builder has no features yet, so this also pins the
+     * {@code @Builder.Default} on {@code Plan.planFeatures}: without it the collection is null
+     * here and the very next assignFeatureToPlan would throw.
+     */
+    @Test
+    void createPlan_returnsAFullyMappedDtoWithNoFeatures() {
+        PlanDto created = planService.createPlan(createDto());
+
+        assertThat(created.getId()).isNotNull();
+        assertThat(created.getCode()).isEqualTo(CREATED_PLAN);
+        assertThat(created.getFeatures()).isEmpty();
+    }
+
+    @Test
+    void assignFeatureToPlan_returnsAFullyMappedDtoOnABuilderConstructedPlan() {
+        PlanDto created = planService.createPlan(createDto());
+
+        PlanFeatureAssignDto assignment = new PlanFeatureAssignDto();
+        assignment.setFeatureCode(FEATURE_CODE);
+        assignment.setEnabled(true);
+
+        PlanDto assigned = planService.assignFeatureToPlan(created.getId(), assignment);
+
+        assertFullyMapped(assigned, CREATED_PLAN);
+    }
+
+    @Test
+    void removeFeatureFromPlan_returnsAMappedDtoWithoutTheFeature() {
+        Long planId = inCommittedTx(() -> planRepository.findByCodeWithFeatures(CURRENT_PLAN)
+                .orElseThrow()
+                .getId());
+
+        PlanDto updated = planService.removeFeatureFromPlan(planId, FEATURE_CODE);
+
+        assertThat(updated.getCode()).isEqualTo(CURRENT_PLAN);
+        assertThat(updated.getFeatures()).isEmpty();
+    }
+
+    private PlanCreateDto createDto() {
+        PlanCreateDto dto = new PlanCreateDto();
+        dto.setCode(CREATED_PLAN);
+        dto.setName("Mapping IT created plan");
+        dto.setMonthlyPrice(new BigDecimal("50.00"));
+        dto.setAnnualPrice(new BigDecimal("500.00"));
+        return dto;
+    }
+
+    private PlanDto planOf(List<PlanDto> plans, String code) {
+        return plans.stream()
+                .filter(plan -> code.equals(plan.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No plan with code " + code + " in " + plans));
+    }
+
+    private void assertFullyMapped(PlanDto dto, String expectedPlanCode) {
+        assertThat(dto.getId()).isNotNull();
+        assertThat(dto.getCode()).isEqualTo(expectedPlanCode);
+        assertThat(dto.getFeatures())
+                .extracting(PlanFeatureDto::getFeatureCode)
+                .containsExactly(FEATURE_CODE);
+    }
+
     private void assertFullyMapped(SubscriptionDto dto, String expectedPlanCode) {
         assertThat(dto.getId()).isNotNull();
         assertThat(dto.getPlan()).isNotNull();
@@ -183,7 +307,6 @@ class SubscriptionMappingIT extends AbstractIntegrationTest {
                 .annualPrice(new BigDecimal("1000.00"))
                 .isActive(true)
                 .isPublic(true)
-                .planFeatures(new HashSet<>())
                 .build();
         plan.addFeature(PlanFeature.builder().feature(feature).enabled(true).build());
         entityManager.persist(plan);


### PR DESCRIPTION
Closes #476.

Four findings were recorded together because they share a cause: the billing package maps entities
to DTOs in places that depend on some *other* query having fetch-joined the right graph. That
dependency is invisible at the call site, so it breaks silently when someone edits a query for an
unrelated reason, which is how the four 500s in #472 happened.

Three are addressed here. The fourth was measured and needs no change; a fifth item, the
entity-caching one, is deliberately left, with the reasoning below.

## 1. PlanController mapped plan entities outside the transaction

Same shape as the controller fixed in #472. `PlanController` called `BillingMapper.toPlanDto`
itself, after the persistence context had closed, and `Plan.planFeatures` is a lazy `@OneToMany`.
It worked only because every read on `PlanService` happens to go through a `...WithFeatures`
fetch-join query and every write returned a plan whose collection had been initialised inside the
transaction. One query change away from the `LazyInitializationException` that took down the
subscription endpoints.

Fixed the same way #472 was: `PlanService` now returns `PlanDto` and builds it while its own
transaction is open, and the reads carry `@Transactional(readOnly = true)`. The entity loader is
private, so no plan entity leaves the service, and the controller no longer imports `Plan` or
`BillingMapper` at all.

`FeatureController` was rechecked and is genuinely safe: `toFeatureDto` reads only scalar fields.

## 2. Missing `@Builder.Default` on the entity collections

`Plan.builder().build()` left `planFeatures` null rather than empty, so `Plan.addFeature` threw a
`NullPointerException` on any builder-constructed plan. Nothing returned a 500 over it because
`toPlanDto` null-checks the collection, which is why it went unnoticed, and callers worked around
it by passing an empty set to the builder by hand.

Added `@Builder.Default` on `Plan.planFeatures`, `Subscription.subscriptionItems`, and
`Feature.planFeatures`. The third was not in the issue but is the same defect one file over in the
same package, on the inverse side of the same relation, and the compiler was warning about all
three. The remaining `@Builder` warnings in the build belong to other packages and are left alone.

`BillingMappingIT.persistPlan` no longer needs its `.planFeatures(new HashSet<>())` workaround.

## 3. `getSubscriptionHistory` N+1: measured, and it is not one

The read is `findByUserIdOrderByCreatedAtDesc`, which has no fetch join, so a static reading says
each row pulls its plan, that plan's features and each feature separately: three extra queries per
row. The codebase sets `hibernate.default_batch_fetch_size=100`, which flattens exactly this
pattern, so this was measured before being touched.

Counted with Hibernate `Statistics.getPrepareStatementCount()` around the service call, on
CockroachDB, with each subscription on a **distinct** plan (the worst case: shared plans would let
the persistence context serve later rows from memory):

```
default_batch_fetch_size in effect: 100
rows=1   dtos=1   statements=4
rows=5   dtos=5   statements=4
rows=20  dtos=20  statements=4
rows=50  dtos=50  statements=4
rows=150 dtos=150 statements=6
rows=250 dtos=250 statements=8
```

Four statements from one row to fifty: one for the subscriptions, then one batched select each for
the plans, the plan features and the features. Past the batch size it grows by two per further
hundred rows, which is the plans and the plan features taking a second and third batch while the
one shared feature still loads in a single select. The cost is per association and per batch, never
three per row, so the fetch join would buy nothing here and would cost the usual duplicate-row
inflation of a collection join.

**Changed nothing here.** The measurement harness was temporary and is not part of this branch.

## 4. `SubscriptionCache` caches entities: left in place, deliberately

The cache holds `Subscription` entities, which is safe only because the query behind it
fetch-joins the whole graph. Caching DTOs would remove that dependency. Having looked at what it
takes, it is not the contained change it appears to be, and it should be its own piece of work:

- **It needs a new field on a public response DTO.** Quota checks call
  `usageRecordRepository.sumUsageForPeriod(userId, featureId, ...)` and `UsageRecord.featureId` is
  a plain `Long` column, not a relation. No DTO carries a feature id, so `PlanFeatureDto` would
  need one, and that field then appears on every plan and subscription response.
- **It would freeze fields that are deliberately computed fresh.** `SubscriptionDto.active`,
  `inTrial` and `expired` are derived from `Instant.now()` inside `toSubscriptionDto`. Today the
  cache holds the entity and those are recomputed on every call. Cached as a DTO they are pinned
  for the five-minute TTL, so a subscription that lapses inside the window keeps reporting
  `expired=false`. That is a behaviour change in exactly the entitlement fields the paywall work
  will read.
- **Two mutation paths would have to change with it.** `changeSubscription` and
  `cancelSubscription` currently mutate the instance the cache handed them and save it. They would
  have to load the entity fresh instead, which is a better shape but is a separate change.

The loader's Javadoc already warns not to weaken the query behind the cache. That is the weaker
guarantee the issue calls it, and it holds until this is done properly.

## Verification

`PlanService` and `PlanController` are covered by the existing billing IT rather than a new one:
the test JVM caps its heap at 1024m and Spring keeps every distinct test context, so a second
`@DataJpaTest` slice would cost heap for coverage this one can already give. `SubscriptionMappingIT`
is renamed `BillingMappingIT` and now covers both halves in the one context, still under
`@Transactional(propagation = NOT_SUPPORTED)` so every service call happens with nothing open
around it, exactly as an HTTP request calls it. A test that ran inside a transaction would pass
against the broken code and prove nothing.

`mappingAPlanEntityOutsideATransaction_throwsLazyInitialization` is the plan-side twin of the
existing subscription regression test: it loads a plan through `findById`, which does not
fetch-join, and asserts that mapping it after the session closes throws. That is the failure the
old controller was one query change away from.

```
BillingMappingIT > mappingAPlanEntityOutsideATransaction_throwsLazyInitialization() PASSED
BillingMappingIT > mappingASubscriptionEntityOutsideATransaction_throwsLazyInitialization() PASSED
BillingMappingIT > getPlanById_returnsAFullyMappedDto() PASSED
BillingMappingIT > getPlanByCode_returnsAFullyMappedDto() PASSED
BillingMappingIT > getAllPlans_returnsFullyMappedDtos() PASSED
BillingMappingIT > getAllPublicPlans_returnsFullyMappedDtos() PASSED
BillingMappingIT > createPlan_returnsAFullyMappedDtoWithNoFeatures() PASSED
BillingMappingIT > assignFeatureToPlan_returnsAFullyMappedDtoOnABuilderConstructedPlan() PASSED
BillingMappingIT > removeFeatureFromPlan_returnsAMappedDtoWithoutTheFeature() PASSED
BillingMappingIT > getActiveSubscription_returnsAFullyMappedDto() PASSED
BillingMappingIT > getSubscriptionHistory_returnsFullyMappedDtos() PASSED
BillingMappingIT > createSubscription_returnsAFullyMappedDto() PASSED
BillingMappingIT > changeSubscription_returnsAFullyMappedDto() PASSED
BUILD SUCCESSFUL in 4m 41s
```

`BillingEntityDefaultsTest` covers item 2 as plain object construction, no Spring context. It was
run against the pre-fix entities first, to confirm it reproduces the reported behaviour rather
than merely passing:

```
BillingEntityDefaultsTest > aBuiltPlanStartsWithAnEmptyFeatureSet() FAILED
BillingEntityDefaultsTest > aBuiltPlanAcceptsAFeatureWithoutABuilderWorkaround() FAILED
    java.lang.NullPointerException at BillingEntityDefaultsTest.java:38
```

That NPE is `Plan.addFeature` on a builder-constructed plan, which is the bug. With the
annotations in place, all six pass. The no-args-constructor cases pass either way and are asserted
so an initializer only the builder honours would show up as a different bug of the same shape.
