### PR TITLE
Cap the unbounded list reads no client consumes

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/pagination/UnpagedResultCap.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/UnpagedResultCap.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+/**
+ * Hard ceiling for the list endpoints that still answer with a bare JSON array rather than a
+ * {@code Page}.
+ *
+ * <p>Those endpoints load every row their table holds, map every one to a DTO and serialise the
+ * lot, so the response grows with the tenant's history and nothing bounds it. Batch fetching keeps
+ * the query <em>count</em> flat as a result set grows but cannot bound the row <em>count</em>.
+ * Capping the read fixes the unbounded part without changing the response shape, which is what
+ * lets it ship ahead of the client work that moves these callers onto the paginated endpoints.
+ *
+ * <p>A capped response is never silently truncated. Every response carries {@link #TOTAL_HEADER}
+ * with the true row count, and one that did not fit also carries {@link #CAPPED_HEADER}. The count
+ * comes from the {@code Page} the service already returns, so the signal is exact rather than
+ * inferred from the returned size.
+ */
+public final class UnpagedResultCap {
+
+    /**
+     * Most rows an uncapped list endpoint may return in one response.
+     *
+     * <p>Set well above any plausible reference-data table and well below the point where DTO
+     * mapping and serialisation cost real memory, so it bites only where the caller should have
+     * been paging anyway.
+     */
+    public static final int MAX_ROWS = 500;
+
+    /** Response header carrying the true total row count, capped or not. */
+    public static final String TOTAL_HEADER = "X-Total-Count";
+
+    /** Response header present only when rows were left out because the cap was reached. */
+    public static final String CAPPED_HEADER = "X-Result-Capped";
+
+    private UnpagedResultCap() {
+    }
+
+    /**
+     * The single page a capped read should request: the first {@link #MAX_ROWS} rows in the
+     * repository's default order.
+     *
+     * @return A {@code PageRequest} for page zero sized at the cap.
+     */
+    public static PageRequest firstPage() {
+        return PageRequest.of(0, MAX_ROWS);
+    }
+
+    /**
+     * Wraps a capped read as the bare-array response its callers already expect, annotated with
+     * the true total and, when rows were dropped, an explicit truncation flag.
+     *
+     * @param page The single page a capped read produced.
+     * @param <T>  The DTO type.
+     * @return 200 OK carrying the page content and the count headers.
+     */
+    public static <T> ResponseEntity<List<T>> respond(Page<T> page) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(TOTAL_HEADER, Long.toString(page.getTotalElements()));
+        if (page.getTotalElements() > page.getNumberOfElements()) {
+            headers.add(CAPPED_HEADER, "true");
+        }
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 /**
  * REST controller for managing employees.
@@ -102,14 +103,15 @@ public class EmployeeController {
     @PreAuthorize("hasAuthority('employee:read') or hasAuthority('employee:admin')")
     @Operation(
             summary = "List all employees",
-            description = "Returns every employee the caller is permitted to see."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee read or admin authority")
     })
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
-        return new ResponseEntity<>(employeeService.displayAllEmployees(),HttpStatus.OK);
+        return UnpagedResultCap.respond(employeeService.displayAllEmployees(
+                0, UnpagedResultCap.MAX_ROWS, null, null, null));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -249,8 +249,14 @@ public class EmployeeService {
     /**
      * Retrieves a page of employees, ordered alphabetically by name.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Number of employees per page.
+     * <p>Every filter is optional: pass null or blank to leave that filter off.
+     *
+     * @param pageNo     Zero-based page index.
+     * @param pageSize   Number of employees per page.
+     * @param search     Case-insensitive substring to match against the employee, or null for no
+     *                   name filter.
+     * @param status     {@code EmployeeStatus} name to restrict to, or null for any status.
+     * @param department Department to restrict to, or null for any department.
      * @return A page of employee DTOs.
      */
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteUpdate
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/grns")
@@ -76,16 +77,15 @@ public class GoodsReceivedNoteController {
     @PreAuthorize("hasAuthority('grn:read') or hasAuthority('grn:admin')")
     @Operation(
             summary = "List all goods received notes",
-            description = "Returns every GRN as an unpaged list. Use the paginated variant for large "
-                    + "result sets."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List of GRNs"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
     })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getAllGrns() {
-        List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns();
-        return ResponseEntity.ok(grns);
+        return UnpagedResultCap.respond(
+                goodsReceivedNoteService.getAllGrns(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/indents")
@@ -74,14 +75,14 @@ public class IndentController {
     @PreAuthorize("hasAuthority('indent:read') or hasAuthority('indent:admin')")
     @Operation(
             summary = "List all indents",
-            description = "Returns every indent for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indents returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority")
     })
     public ResponseEntity<List<IndentDto>> getAllIndents() {
-        return new ResponseEntity<>(indentService.getAllIndents(), HttpStatus.OK);
+        return UnpagedResultCap.respond(indentService.getAllIndents(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/indent-items")
@@ -69,15 +70,15 @@ public class IndentItemController {
     @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
     @Operation(
             summary = "List all indent items",
-            description = "Returns every indent item for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
     })
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
-        List<IndentItemDto> indentItems = indentItemService.getAllIndentItems();
-        return ResponseEntity.ok(indentItems);
+        return UnpagedResultCap.respond(
+                indentItemService.getAllIndentItems(UnpagedResultCap.firstPage()));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/indent-items/web")
@@ -65,15 +66,15 @@ public class IndentItemControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all indent items",
-            description = "Returns every indent item for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indent items returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
-        List<IndentItemDto> indentItems = indentItemService.getAllIndentItems();
-        return ResponseEntity.ok(indentItems);
+        return UnpagedResultCap.respond(
+                indentItemService.getAllIndentItems(UnpagedResultCap.firstPage()));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.indentItem;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
@@ -65,11 +67,20 @@ public class IndentItemService {
         return indentItemMapper.toDto(indentItem);
     }
 
+    /**
+     * Retrieves indent items one page at a time.
+     *
+     * <p>Replaces an unpaginated read of the whole table. Indent items accumulate with every
+     * indent a tenant raises, so the row count has no ceiling and the only safe read is a
+     * bounded one.
+     *
+     * @param pageable The page to fetch.
+     * @return A page of indent item DTOs.
+     */
     @Transactional(readOnly = true)
-    public List<IndentItemDto> getAllIndentItems() {
-        return indentItemRepository.findAll().stream()
-                .map(indentItem -> indentItemMapper.toDto(indentItem))
-                .collect(Collectors.toList());
+    public Page<IndentItemDto> getAllIndentItems(Pageable pageable) {
+        return indentItemRepository.findAll(pageable)
+                .map(indentItem -> indentItemMapper.toDto(indentItem));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
@@ -19,6 +19,7 @@ import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransacti
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/inventory-transactions")
@@ -65,16 +66,15 @@ public class InventoryTransactionController {
     @PreAuthorize("hasAuthority('inventory-transaction:read') or hasAuthority('inventory-transaction:admin')")
     @Operation(
             summary = "List all inventory transactions",
-            description = "Returns every inventory transaction as an unpaged list. Use the paginated "
-                    + "variant for large ledgers."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List of transactions"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
     })
     public ResponseEntity<List<InventoryTransactionDto>> getAllTransactions() {
-        List<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions();
-        return ResponseEntity.ok(transactions);
+        return UnpagedResultCap.respond(
+                inventoryTransactionService.getAllTransactions(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransacti
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/inventory-transactions/web")
@@ -58,15 +59,15 @@ public class InventoryTransactionControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List inventory transactions",
-            description = "Returns every inventory transaction in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Inventory transactions returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<InventoryTransactionDto>> getAllTransactions() {
-        List<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions();
-        return ResponseEntity.ok(transactions);
+        return UnpagedResultCap.respond(
+                inventoryTransactionService.getAllTransactions(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionService.java
@@ -55,13 +55,6 @@ public class InventoryTransactionService {
         return inventoryTransactionMapper.toDto(transaction);
     }
 
-    @Transactional(readOnly = true)
-    public List<InventoryTransactionDto> getAllTransactions() {
-        return inventoryTransactionRepository.findAll().stream()
-                .map(transaction -> inventoryTransactionMapper.toDto(transaction))
-                .collect(Collectors.toList());
-    }
-
     /**
      * Retrieves transactions one page at a time, newest first.
      *

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
@@ -19,6 +19,7 @@ import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresh
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/materials")
@@ -81,15 +82,14 @@ public class MaterialController {
     @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
     @Operation(
             summary = "List all materials",
-            description = "Returns every material in the organization's catalogue, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Materials returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority")
     })
     public ResponseEntity<List<MaterialDto>> getAllMaterials() {
-        List<MaterialDto> materials = materialService.getAllMaterials();
-        return ResponseEntity.ok(materials);
+        return UnpagedResultCap.respond(materialService.getAllMaterials(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumption
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/material-consumptions")
@@ -79,15 +80,15 @@ public class MaterialConsumptionController {
     @PreAuthorize("hasAuthority('material-consumption:read') or hasAuthority('material-consumption:admin')")
     @Operation(
             summary = "List all material consumptions",
-            description = "Returns every material consumption record in the organization, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Consumptions returned"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
     })
     public ResponseEntity<List<MaterialConsumptionDto>> getAllMaterialConsumptions() {
-        List<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions();
-        return ResponseEntity.ok(consumptions);
+        return UnpagedResultCap.respond(
+                materialConsumptionService.getAllMaterialConsumptions(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.payable.dto.PaymentRecordDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/payables")
@@ -91,15 +92,14 @@ public class PayableController {
     @PreAuthorize("hasAuthority('payable:read') or hasAuthority('payable:admin')")
     @Operation(
             summary = "List payables",
-            description = "Returns every payable in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
     })
     public ResponseEntity<List<PayableDto>> getAllPayables() {
-        List<PayableDto> payables = payableService.getAllPayables();
-        return ResponseEntity.ok(payables);
+        return UnpagedResultCap.respond(payableService.getAllPayables(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.payable.dto.PaymentRecordDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/payables/web")
@@ -90,15 +91,14 @@ public class PayableControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List payables",
-            description = "Returns every payable in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Payables returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<PayableDto>> getAllPayables() {
-        List<PayableDto> payables = payableService.getAllPayables();
-        return ResponseEntity.ok(payables);
+        return UnpagedResultCap.respond(payableService.getAllPayables(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
@@ -173,18 +173,6 @@ public class PayableService {
     }
 
     /**
-     * Returns every payable visible to the current organization.
-     *
-     * @return The list of payable DTOs.
-     */
-    @Transactional(readOnly = true)
-    public List<PayableDto> getAllPayables() {
-        return payableRepository.findAll().stream()
-                .map(payable -> payableMapper.toDto(payable))
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Returns a page of payables, newest first.
      *
      * @param pageNo The zero-based page index.

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/PdfReportService.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/PdfReportService.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 import org.tornotron.echno_backend.task.TaskService;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 @Service
@@ -16,9 +15,16 @@ public class PdfReportService {
         this.taskService = taskService;
     }
 
+    /**
+     * The task status breakdown shown on the PDF report.
+     *
+     * <p>Delegates to a database aggregate rather than loading every task and grouping in memory,
+     * so the figure stays correct and the cost stays flat however much history a tenant has.
+     *
+     * @return Status name to task count.
+     */
     public Map<String, Long> statusCount() {
-        return taskService.getAllTasks().stream()
-                .collect(Collectors.groupingBy(t -> t.getStatus() == null ? "Unknown" : t.getStatus().toString(), Collectors.counting()));
+        return taskService.countTasksByStatus();
     }
 
 

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
@@ -24,6 +24,10 @@ import org.tornotron.echno_backend.task.TaskService;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.springframework.data.domain.Page;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.task.dto.TaskDto;
 
 @RestController
 @RequestMapping("/api/v1/generate-report")
@@ -62,16 +66,33 @@ public class ReportController {
         this.indentService = indentService;
     }
 
+    /**
+     * Assembles the template context.
+     *
+     * <p>Tasks and indents are read one capped page at a time rather than whole. Both tables grow
+     * with everything a tenant ever records, so an uncapped read would load, map and render every
+     * row a client has accumulated. The true totals go into the context alongside the capped
+     * lists, so the report states its real counts and says when it is showing only part of them.
+     */
     private Context populateContext() {
+        Page<TaskDto> tasks = taskService.getAllTasks(0, UnpagedResultCap.MAX_ROWS);
+        Page<IndentDto> indents = indentService.getAllIndents(0, UnpagedResultCap.MAX_ROWS);
+
         Context ctx = new Context();
-        ctx.setVariable("tasks", taskService.getAllTasks());
+        ctx.setVariable("tasks", tasks.getContent());
+        ctx.setVariable("taskTotal", tasks.getTotalElements());
         ctx.setVariable("counts", pdfReportService.statusCount());
         ctx.setVariable("delayedCounts", pdfReportService.statusCount());
         ctx.setVariable("category", categoryService);
         ctx.setVariable("dateConverter", dateConversion);
         ctx.setVariable("project",projectService);
         ctx.setVariable("organization",organizationService);
-        ctx.setVariable("indents", indentService.getAllIndents());
+        ctx.setVariable("indents", indents.getContent());
+        ctx.setVariable("indentTotal", indents.getTotalElements());
+        ctx.setVariable("truncated",
+                tasks.getTotalElements() > tasks.getNumberOfElements()
+                        || indents.getTotalElements() > indents.getNumberOfElements());
+        ctx.setVariable("rowCap", UnpagedResultCap.MAX_ROWS);
         return ctx;
     }
 
@@ -79,8 +100,10 @@ public class ReportController {
     @GetMapping("/pdf")
     @Operation(
             summary = "Generate a PDF report",
-            description = "Renders and returns a PDF covering all tasks, their status breakdown, projects "
-                    + "and indents in the current tenant."
+            description = "Renders and returns a PDF covering the current tenant's tasks, their status "
+                    + "breakdown, projects and indents. The task and indent sections show at most "
+                    + "500 rows each; the report states the true totals and flags itself when it "
+                    + "is showing only part of them."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "PDF report generated and returned as an attachment"),

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderUpdateDto;
 import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/purchase-orders")
@@ -73,15 +74,15 @@ public class PurchaseOrderController {
     @GetMapping
     @Operation(
             summary = "List all purchase orders",
-            description = "Returns every purchase order for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<PurchaseOrderDto>> getAllPurchaseOrders() {
-        List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
-        return ResponseEntity.ok(purchaseOrders);
+        return UnpagedResultCap.respond(
+                purchaseOrderService.getAllPurchaseOrders(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemRespon
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemUpdateDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/purchase-order-items")
@@ -72,15 +73,15 @@ public class PurchaseOrderItemController {
     @GetMapping
     @Operation(
             summary = "List all purchase order items",
-            description = "Returns every purchase order line item for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
-        List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getAllPurchaseOrderItems();
-        return ResponseEntity.ok(items);
+        return UnpagedResultCap.respond(
+                purchaseOrderItemService.getAllPurchaseOrderItems(UnpagedResultCap.firstPage()));
     }
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemRespon
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemUpdateDto;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/purchase-order-items/web")
@@ -68,15 +69,15 @@ public class PurchaseOrderItemControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all purchase order items",
-            description = "Returns every purchase order line item for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order items returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
-        List<PurchaseOrderItemResponseDto> items = purchaseOrderItemService.getAllPurchaseOrderItems();
-        return ResponseEntity.ok(items);
+        return UnpagedResultCap.respond(
+                purchaseOrderItemService.getAllPurchaseOrderItems(UnpagedResultCap.firstPage()));
     }
 
     @GetMapping("/purchase-order/{purchaseOrderId}")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -93,11 +95,20 @@ public class PurchaseOrderItemService {
         return convertToResponseDto(item);
     }
 
+    /**
+     * Retrieves purchase order items one page at a time.
+     *
+     * <p>Replaces an unpaginated read of the whole table. Line items accumulate with every
+     * purchase order a tenant raises, so the row count has no ceiling and the only safe read is
+     * a bounded one.
+     *
+     * @param pageable The page to fetch.
+     * @return A page of purchase order item DTOs.
+     */
     @Transactional(readOnly = true)
-    public List<PurchaseOrderItemResponseDto> getAllPurchaseOrderItems() {
-        return purchaseOrderItemRepository.findAll().stream()
-                .map(this::convertToResponseDto)
-                .collect(Collectors.toList());
+    public Page<PurchaseOrderItemResponseDto> getAllPurchaseOrderItems(Pageable pageable) {
+        return purchaseOrderItemRepository.findAll(pageable)
+                .map(this::convertToResponseDto);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/site-transfers")
@@ -78,15 +79,15 @@ public class SiteTransferController {
     @PreAuthorize("hasAuthority('site-transfer:read') or hasAuthority('site-transfer:admin')")
     @Operation(
             summary = "List all site transfers",
-            description = "Returns every site transfer in the organization, without pagination."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
     })
     public ResponseEntity<List<SiteTransferDto>> getAllSiteTransfers() {
-        List<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers();
-        return ResponseEntity.ok(transfers);
+        return UnpagedResultCap.respond(
+                siteTransferService.getAllSiteTransfers(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/storage-locations")
@@ -77,15 +78,15 @@ public class StorageLocationController {
     @PreAuthorize("hasAuthority('storage-location:read') or hasAuthority('storage-location:admin')")
     @Operation(
             summary = "List all storage locations",
-            description = "Returns every storage location in the caller's organization, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Storage locations returned"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
     })
     public ResponseEntity<List<StorageLocationDto>> getAllStorageLocations() {
-        List<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations();
-        return ResponseEntity.ok(storageLocations);
+        return UnpagedResultCap.respond(
+                storageLocationService.getAllStorageLocations(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
@@ -3,7 +3,9 @@ package org.tornotron.echno_backend.task;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.tornotron.echno_backend.IssueComment.IssueComment;
+import org.tornotron.echno_backend.task.enums.TaskStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +33,25 @@ public interface TaskRepository extends JpaRepository<Task,Long> {
     List<Task> findByProject_Id(Long projectId);
 
     List<Task> findAllByProject_IdAndOrganization_Id(Long projectId, Long organizationId);
+
+    /**
+     * Counts the current tenant's tasks by status.
+     *
+     * <p>Aggregated in the database rather than by loading every task and grouping in memory, so
+     * the cost stays flat as a tenant's task history grows. The tenant filter applies to the query
+     * exactly as it does to a finder.
+     *
+     * @return One row per status present, each carrying the status and its count.
+     */
+    @Query("select t.status as status, count(t) as total from Task t group by t.status")
+    List<TaskStatusCount> countByStatus();
+
+    /** Row of {@link #countByStatus()}: one task status and how many tasks hold it. */
+    interface TaskStatusCount {
+        TaskStatus getStatus();
+
+        long getTotal();
+    }
 
 
 //    List<Task> findTaskByEmployee_IdAndProject_Id(@NotNull(message = "employeeId is required") Long employeeId, @NotNull(message = "projectId is required") Long projectId);

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -173,15 +173,20 @@ public class TaskService {
     }
 
     /**
-     * Retrieves a list of all tasks.
+     * Counts the current tenant's tasks by status.
      *
-     * @return A list of all task DTOs.
+     * <p>Replaces a full-table read that grouped in memory. The grouping happens in the database,
+     * so the work is proportional to the number of distinct statuses rather than to the number of
+     * tasks.
+     *
+     * @return Status name to task count, with a null status reported as {@code Unknown}.
      */
     @Transactional(readOnly = true)
-    public List<TaskDto> getAllTasks() {
-        return taskRepository.findAll().stream()
-                .map(task -> taskMapper.toDto(task))
-                .toList();
+    public Map<String, Long> countTasksByStatus() {
+        return taskRepository.countByStatus().stream()
+                .collect(Collectors.toMap(
+                        row -> row.getStatus() == null ? "Unknown" : row.getStatus().toString(),
+                        TaskRepository.TaskStatusCount::getTotal));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.vendor.dto.*;
 
 import java.util.List;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 @RestController
 @RequestMapping("/api/v1/vendors")
@@ -75,15 +76,14 @@ public class VendorController {
     @PreAuthorize("hasAuthority('vendor:read') or hasAuthority('vendor:admin')")
     @Operation(
             summary = "List vendors",
-            description = "Returns every vendor in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendors returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority")
     })
     public ResponseEntity<List<VendorDto>> getAllVendors() {
-        List<VendorDto> vendors = vendorService.getAllVendors();
-        return ResponseEntity.ok(vendors);
+        return UnpagedResultCap.respond(vendorService.getAllVendors(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/resources/templates/report/report.html
+++ b/src/main/resources/templates/report/report.html
@@ -42,13 +42,15 @@
 <!-- activity summary -->
 <table class="activity-table">
     <tr>
-        <td><div class="box">Task Updates<strong th:text="${#lists.size(tasks)}">0</strong></div></td>
+        <td><div class="box">Task Updates<strong th:text="${taskTotal ?: 0}">0</strong></div></td>
         <td><div class="box">Issues Created<strong th:text="${issuesCount ?: 0}">0</strong></div></td>
         <td><div class="box">Attendance Logged<strong th:text="${attendanceCount ?: 0}">0</strong></div></td>
     </tr>
 </table>
 
 <!-- tasks -->
+<p class="truncation-note" th:if="${truncated}"
+   th:text="|Showing the first ${rowCap} tasks and indents. This tenant has ${taskTotal} tasks and ${indentTotal} indents in total.|"></p>
 <div th:each="task : ${tasks}">
     <div class="task-block" th:classappend="${task.getProgress() == 100 ? 'completed' : (task.getProgress() > 0 ? 'inprogress' : 'notstarted')}">
         <div class="section-heading">

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/UnpagedResultCapTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/UnpagedResultCapTest.java
@@ -1,0 +1,85 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the promise that makes capping safe to ship ahead of the client work: a capped response
+ * never lies about how much there is. Plain JUnit, no Spring context.
+ */
+class UnpagedResultCapTest {
+
+    @Test
+    @DisplayName("a result that fits carries the total and no truncation flag")
+    void completeResultIsNotFlagged() {
+        Page<String> page = new PageImpl<>(
+                List.of("a", "b", "c"), PageRequest.of(0, UnpagedResultCap.MAX_ROWS), 3);
+
+        ResponseEntity<List<String>> response = UnpagedResultCap.respond(page);
+
+        assertThat(response.getBody()).containsExactly("a", "b", "c");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("3");
+        assertThat(response.getHeaders().containsKey(UnpagedResultCap.CAPPED_HEADER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("a truncated result reports the true total and flags itself")
+    void truncatedResultIsFlagged() {
+        List<String> content = IntStream.range(0, UnpagedResultCap.MAX_ROWS)
+                .mapToObj(Integer::toString)
+                .toList();
+        Page<String> page = new PageImpl<>(
+                content, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), 4321);
+
+        ResponseEntity<List<String>> response = UnpagedResultCap.respond(page);
+
+        assertThat(response.getBody()).hasSize(UnpagedResultCap.MAX_ROWS);
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("4321");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER)).isEqualTo("true");
+    }
+
+    @Test
+    @DisplayName("a result sitting exactly on the cap is not mistaken for a truncated one")
+    void exactlyFullResultIsNotFlagged() {
+        List<String> content = IntStream.range(0, UnpagedResultCap.MAX_ROWS)
+                .mapToObj(Integer::toString)
+                .toList();
+        Page<String> page = new PageImpl<>(
+                content, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), UnpagedResultCap.MAX_ROWS);
+
+        ResponseEntity<List<String>> response = UnpagedResultCap.respond(page);
+
+        assertThat(response.getHeaders().containsKey(UnpagedResultCap.CAPPED_HEADER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("an empty result still reports a total")
+    void emptyResultReportsZero() {
+        Page<String> page = new PageImpl<>(
+                List.of(), PageRequest.of(0, UnpagedResultCap.MAX_ROWS), 0);
+
+        ResponseEntity<List<String>> response = UnpagedResultCap.respond(page);
+
+        assertThat(response.getBody()).isEmpty();
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("0");
+        assertThat(response.getHeaders().containsKey(UnpagedResultCap.CAPPED_HEADER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("the capped read asks for the first page at the cap")
+    void firstPageIsSizedAtTheCap() {
+        PageRequest request = UnpagedResultCap.firstPage();
+
+        assertThat(request.getPageNumber()).isZero();
+        assertThat(request.getPageSize()).isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+}


### PR DESCRIPTION
Part one of #473. Caps the unbounded list reads that **no client consumes today**, so nothing here changes a response shape echno-core or echno-web depends on.

## The inventory behind this

I checked all 26 call sites against both clients before touching anything. The count of 26 is right, once you discard two `findAll()` grep hits that are not repository calls (`CompanyBankAccountService`'s own method declaration, and the controller calling it).

The useful discovery: **19 of the 26 already have a paginated sibling on the same controller.** The bare `@GetMapping` collection root is the unpaginated one; `/all` or `/paginated` alongside it already returns a `Page`. So most of the work is pointing the caller at the endpoint that already exists.

Splitting by consumer:

| Group | Count | Handled |
|---|---|---|
| Read by echno-web today | 17 | **Not touched here.** Sequences behind a core release. |
| Read by nothing | 6 | Capped here |
| Mobile non-`/web` twins | 14 controllers | Capped here |
| Bounded by nature | 6 | Left as-is, documented in the follow-up PR |

## What "capped" means

`UnpagedResultCap` holds a 500-row ceiling and a response helper. The response shape does not change: it is still a bare JSON array, which is why this can ship ahead of any client work.

A capped response is **never silently truncated**. `X-Total-Count` always carries the true row count and `X-Result-Capped` marks a response that left rows out. The count comes from the `Page` the service already returns, so the signal is exact rather than inferred from the returned size.

One knock-on worth knowing: the paginated overloads all sort explicitly (newest first for the transactional tables, alphabetically for the reference ones) where the old `findAll()` had no ordering guarantee at all. So the capped subset is deterministic and, for the transactional tables, it is the most recent 500 rather than an arbitrary 500.

## The mobile twins are capped, not removed

Fourteen non-`/web` controllers call the same services. I found no caller for any of them: echno-core uses `/web` paths exclusively, and the Flutter client has not been pushed to since November 2025.

That is an **inference, not a proof** (the local Flutter checkout has no Dart sources to grep). Deleting a published API surface is irreversible, capping removes the unbounded read either way, and removal loses nothing by waiting. So they are capped. Removal stays a separate decision.

## Two things fixed along the way

**The PDF report.** It read every task and every indent in the tenant to render itself. Worse, its status breakdown loaded every task and grouped in memory. The breakdown is now a `GROUP BY` in the database, which is both correct and flat. The task and indent sections are capped, and because the report prints a "Task Updates" figure, it now prints the **true** total rather than the size of what it fetched, and says when it is showing only part.

**Dead code.** `PayableService`, `InventoryTransactionService` and `TaskService` lose their unpaginated reads, their last callers now being capped. `PurchaseOrderItemService` and `IndentItemService` gain the paginated read they lacked.

## Not in scope

The 17 endpoints echno-web reads. Those need backend, then a core release, then web, in that order, and are held back deliberately.

Two separate defects found while scoping and filed on their own: #478 (`GET /tasks/web` silently returns only the first 10 tasks) and tornotron/echno-web#269 (the app shell fetches four whole collections on every route).

## Verification

- `./gradlew compileJava` clean.
- Full `./gradlew test` on lab `.116` (Testcontainers, CockroachDB v26.2.4), compared against a back-to-back run of pristine `origin/development` on the same box so the result means something.
- The guardrail in the follow-up PR was run with an empty allowlist and reported **exactly** the 24 expected call sites, which is what confirms this inventory is complete.

Refs #473
