### PR TITLE
Apply the submitted corrections when a regularization is approved

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
@@ -67,6 +67,17 @@ public class AttendanceRegularization implements TenantScopedEntity {
     @Column(name = "missing_events", columnDefinition = "TEXT")
     private String missingEvents;
 
+    /**
+     * The corrected clock events the employee submitted with the request, serialized as JSON.
+     *
+     * <p>Held until the request is approved, at which point they are written onto the attendance
+     * record. Before this was stored the times were applied only when the project auto-approved
+     * regularizations and were dropped entirely when a manager's approval was required, so an
+     * approved request left the day exactly as broken as it was found.
+     */
+    @Column(name = "requested_events", columnDefinition = "TEXT")
+    private String requestedEvents;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceRegularizationMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceRegularizationMapper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import org.tornotron.echno_backend.attendance.AttendanceRegularization;
 import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +50,32 @@ public class AttendanceRegularizationMapper {
         if (json == null || json.isBlank()) return Collections.emptyList();
         try {
             return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Serializes the corrected clock events submitted with a request so they survive until approval.
+     *
+     * <p>Returns {@code null} for an absent or empty list, matching the nullable column, and also on
+     * a serialization failure: a request that cannot carry its corrections is still a valid request
+     * for the reason the employee gave, and the manager can enter the times by hand.
+     */
+    public String serializeRequestedEvents(List<ClockEventCreationDto> events) {
+        if (events == null || events.isEmpty()) return null;
+        try {
+            return objectMapper.writeValueAsString(events);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Reads back the corrected clock events stored by {@link #serializeRequestedEvents}. */
+    public List<ClockEventCreationDto> deserializeRequestedEvents(String json) {
+        if (json == null || json.isBlank()) return Collections.emptyList();
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<ClockEventCreationDto>>() {});
         } catch (Exception e) {
             return Collections.emptyList();
         }

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -15,7 +15,9 @@ import org.tornotron.echno_backend.organization.OrganizationRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -97,12 +99,19 @@ public class AttendanceRegularizationService {
                 .status(settings.getRegularizationApprovalRequired()
                         ? RegularizationStatus.PENDING : RegularizationStatus.APPROVED)
                 .missingEvents(regularizationMapper.serializeMissingEvents(dto.getMissingEvents()))
+                // Kept whichever path the request takes. When approval is required the events sit
+                // here until the manager decides; without them an approval had nothing to apply.
+                .requestedEvents(regularizationMapper.serializeRequestedEvents(dto.getCorrectedEvents()))
                 .organization(org)
                 .build();
 
-        // If auto-approved, apply corrected events
-        if (!settings.getRegularizationApprovalRequired() && dto.getCorrectedEvents() != null) {
+        // Auto-approving projects take effect immediately, so the corrections are written now.
+        if (!settings.getRegularizationApprovalRequired()) {
             applyCorrectedEvents(attendance, dto.getCorrectedEvents(), org);
+            if (attendance.getShiftTiming() != null) {
+                calculationService.recalculate(attendance, attendance.getShiftTiming());
+            }
+            attendanceRepository.save(attendance);
         }
 
         return regularizationMapper.toDto(regularizationRepository.save(regularization));
@@ -139,10 +148,17 @@ public class AttendanceRegularizationService {
 
         if (dto.getStatus() == RegularizationStatus.APPROVED) {
             Attendance attendance = regularization.getAttendance();
+            // Write the times the employee asked for before recomputing. Approval used to recompute
+            // over the events that already existed, which for a day with no clock-in at all meant
+            // recomputing over nothing and leaving the record exactly as broken as it was.
+            applyCorrectedEvents(
+                    attendance,
+                    regularizationMapper.deserializeRequestedEvents(regularization.getRequestedEvents()),
+                    regularization.getOrganization());
             if (attendance.getShiftTiming() != null) {
                 calculationService.recalculate(attendance, attendance.getShiftTiming());
-                attendanceRepository.save(attendance);
             }
+            attendanceRepository.save(attendance);
         }
 
         return regularizationMapper.toDto(regularizationRepository.save(regularization));
@@ -164,10 +180,34 @@ public class AttendanceRegularizationService {
         return regularizationMapper.toDto(regularization);
     }
 
+    /**
+     * Writes the employee's corrected clock events onto the attendance record.
+     *
+     * <p>An event type already present is left alone. A regularization exists to supply what is
+     * missing, not to overwrite a real clock event, and skipping duplicates keeps the operation safe
+     * to reach twice, for instance when a rejected request is resubmitted and then approved.
+     *
+     * @param attendance      the record being corrected
+     * @param correctedEvents the events to add; {@code null} or empty is a no-op
+     * @param org             the owning organization, stamped onto each new event
+     */
     private void applyCorrectedEvents(Attendance attendance,
                                        List<ClockEventCreationDto> correctedEvents,
                                        Organization org) {
+        if (correctedEvents == null || correctedEvents.isEmpty()) {
+            return;
+        }
+        if (attendance.getClockEvents() == null) {
+            attendance.setClockEvents(new ArrayList<>());
+        }
+        Set<ClockEventType> existing = attendance.getClockEvents().stream()
+                .map(ClockEvent::getEventType)
+                .collect(Collectors.toSet());
+
         for (ClockEventCreationDto req : correctedEvents) {
+            if (req.getEventType() == null || !existing.add(req.getEventType())) {
+                continue;
+            }
             ClockEvent event = ClockEvent.builder()
                     .attendance(attendance)
                     .eventType(req.getEventType())

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -298,4 +298,7 @@
     <!-- v4.0 - Inspection taxonomy: category discriminator, trade axis, defect severity/status enums -->
     <include file="db/changelog/v4.0/054-add-inspection-taxonomy-and-defect-enums.xml"/>
 
+    <!-- v4.0 - Persist the corrected clock events submitted with a regularization request -->
+    <include file="db/changelog/v4.0/055-add-regularization-requested-events.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/055-add-regularization-requested-events.xml
+++ b/src/main/resources/db/changelog/v4.0/055-add-regularization-requested-events.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="055-add-regularization-requested-events" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="attendance_regularization" columnName="requested_events"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Persist the corrected clock events the employee submits with a regularization request.
+            Until now they were applied only on the auto-approve path and discarded entirely when the
+            project required manager approval, so an approved request never restored the times the
+            employee had entered. Stored as JSON alongside missing_events, which uses the same shape.
+        </comment>
+
+        <addColumn tableName="attendance_regularization">
+            <column name="requested_events" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -14,9 +14,12 @@ import org.tornotron.echno_backend.attendance.AttendanceRegularizationRepository
 import org.tornotron.echno_backend.attendance.AttendanceRepository;
 import org.tornotron.echno_backend.attendance.AttendanceSettings;
 import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.ClockEvent;
 import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -25,6 +28,9 @@ import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,8 +47,8 @@ import static org.mockito.Mockito.when;
  * calculation services, and the mapper are mocked. The focus is the submission and
  * processing gates the service owns: refusing self-service when disabled, enforcing the
  * monthly cap, blocking a duplicate pending request, choosing PENDING vs auto-APPROVED from
- * the settings, applying corrected events only on auto-approve, and refusing to re-action a
- * request that is no longer PENDING (recalculating attendance only on approval).
+ * the settings, carrying the submitted corrections through to approval, and refusing to
+ * re-action a request that is no longer PENDING (recalculating attendance only on approval).
  */
 @ExtendWith(MockitoExtension.class)
 class AttendanceRegularizationServiceTest {
@@ -255,6 +261,128 @@ class AttendanceRegularizationServiceTest {
         verify(attendanceRepository).save(attendance);
         assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
         assertThat(pending.getApprovedBy()).isEqualTo(APPROVER);
+    }
+
+    private ClockEventCreationDto correctedEvent(ClockEventType type, int hour) {
+        ClockEventCreationDto event = new ClockEventCreationDto();
+        event.setEventType(type);
+        event.setEventTimestamp(LocalDate.of(2024, 5, 10).atTime(hour, 0));
+        return event;
+    }
+
+    /**
+     * The corrections have to be stored even when a manager still has to approve. They used to be
+     * applied on the auto-approve path only and dropped otherwise, so an approved request restored
+     * nothing.
+     */
+    @Test
+    void submitRequest_approvalRequired_persistsTheSubmittedCorrections() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+        when(regularizationMapper.serializeRequestedEvents(any())).thenReturn("[serialized]");
+
+        RegularizationRequestDto dto = requestDto();
+        List<ClockEventCreationDto> corrections =
+                List.of(correctedEvent(ClockEventType.MORNING_CLOCK_IN, 9));
+        dto.setCorrectedEvents(corrections);
+
+        service.submitRequest(dto, REQUESTER);
+
+        verify(regularizationMapper).serializeRequestedEvents(corrections);
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getRequestedEvents()).isEqualTo("[serialized]");
+    }
+
+    /**
+     * Approval has to write the times the employee entered. Recomputing over the events that were
+     * already there is a no-op for a day that had no events at all, which is the case a
+     * regularization exists to fix.
+     */
+    @Test
+    void processRegularization_approve_appliesTheStoredCorrections() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        attendance.setClockEvents(new ArrayList<>());
+        AttendanceRegularization pending = AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING)
+                .attendance(attendance)
+                .organization(organization())
+                .requestedEvents("[stored]")
+                .build();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+        when(regularizationMapper.deserializeRequestedEvents("[stored]")).thenReturn(List.of(
+                correctedEvent(ClockEventType.MORNING_CLOCK_IN, 9),
+                correctedEvent(ClockEventType.EVENING_CLOCK_OUT, 18)));
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.APPROVED);
+
+        service.processRegularization(REG_ID, action, APPROVER);
+
+        assertThat(attendance.getClockEvents())
+                .extracting(ClockEvent::getEventType)
+                .containsExactly(ClockEventType.MORNING_CLOCK_IN, ClockEventType.EVENING_CLOCK_OUT);
+        assertThat(attendance.getClockEvents())
+                .extracting(ClockEvent::getEventTimestamp)
+                .containsExactly(
+                        LocalDateTime.of(2024, 5, 10, 9, 0),
+                        LocalDateTime.of(2024, 5, 10, 18, 0));
+        assertThat(attendance.getClockEvents()).allMatch(ClockEvent::getIsRegularized);
+        verify(calculationService).recalculate(eq(attendance), any(ShiftTiming.class));
+        verify(attendanceRepository).save(attendance);
+    }
+
+    /**
+     * A correction never overwrites a real clock event, and applying twice is harmless: a rejected
+     * request can be resubmitted and then approved.
+     */
+    @Test
+    void processRegularization_approve_leavesAnExistingEventAlone() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        ClockEvent real = ClockEvent.builder()
+                .eventType(ClockEventType.MORNING_CLOCK_IN)
+                .eventTimestamp(LocalDateTime.of(2024, 5, 10, 8, 45))
+                .build();
+        attendance.setClockEvents(new ArrayList<>(List.of(real)));
+        AttendanceRegularization pending = AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING)
+                .attendance(attendance)
+                .organization(organization())
+                .requestedEvents("[stored]")
+                .build();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+        when(regularizationMapper.deserializeRequestedEvents("[stored]")).thenReturn(List.of(
+                correctedEvent(ClockEventType.MORNING_CLOCK_IN, 9),
+                correctedEvent(ClockEventType.EVENING_CLOCK_OUT, 18)));
+
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(RegularizationStatus.APPROVED);
+
+        service.processRegularization(REG_ID, action, APPROVER);
+
+        assertThat(attendance.getClockEvents()).hasSize(2);
+        assertThat(attendance.getClockEvents().get(0).getEventTimestamp())
+                .isEqualTo(LocalDateTime.of(2024, 5, 10, 8, 45));
+        assertThat(attendance.getClockEvents().get(1).getEventType())
+                .isEqualTo(ClockEventType.EVENING_CLOCK_OUT);
     }
 
     @Test


### PR DESCRIPTION
ClickUp [86d45k05b](https://app.clickup.com/t/86d45k05b) - Modify Regularization workflow. This is the concrete bug found while triaging that ticket; the calendar redesign itself is blocked on a design decision and is not in this PR.

## The bug

`AttendanceRegularizationService.submitRequest` applied the employee's corrected clock events on one path only:

```java
if (!settings.getRegularizationApprovalRequired() && dto.getCorrectedEvents() != null) {
    applyCorrectedEvents(attendance, dto.getCorrectedEvents(), org);
}
```

Nothing else on the entity held them, so when `regularizationApprovalRequired` was true, which is the default, `dto.getCorrectedEvents()` went out of scope with the request and the times were gone.

`processRegularization` then approved without them:

```java
if (dto.getStatus() == RegularizationStatus.APPROVED) {
    Attendance attendance = regularization.getAttendance();
    if (attendance.getShiftTiming() != null) {
        calculationService.recalculate(attendance, attendance.getShiftTiming());
        attendanceRepository.save(attendance);
    }
}
```

It recomputes the record from the clock events already present. For the case a regularization exists to fix, a day with no clock-in at all, that is a recompute over nothing. The employee files a request, enters the hours they worked, the manager approves, and the day is exactly as broken as before. It works only when the project is set to auto-approve, which is why it has gone unnoticed.

## Changes

**`requested_events`, a nullable TEXT column on `attendance_regularization`** (Liquibase `v4.0/055`, guarded by a `columnExists` precondition). The submitted events are serialized to JSON on submit, the same treatment `missing_events` already gets, and read back on approval. Serialization failure yields `null` rather than throwing: a request that cannot carry its corrections is still a valid request for the reason given, and the manager can enter the times by hand.

**Approval applies them**, then recomputes, then saves.

**`applyCorrectedEvents` skips an event type already on the record.** A regularization supplies what is missing rather than overwriting a real clock event, and skipping duplicates makes the method safe to reach twice, which it now can be: a rejected request may be resubmitted and then approved. It also tolerates a null or empty list and a record whose clock-event collection has not been initialised.

**The auto-approve path now recomputes and saves too.** It was adding events and leaving the derived status, worked hours and the late / early flags stale until something else happened to touch the record.

## Not in this PR

Deliberately kept to the bug. Raised on the ticket instead:

- The calendar redesign is blocked. A regularization request is keyed by `attendanceId`, and a day nobody clocked in for has no attendance row, so the dates the calendar most needs to be clickable cannot be requested against. Resolving that means a new by-date endpoint, a job that materialises absent rows, or opening up self mark-absent. That is a design decision.
- `AttendanceRegularizationDto` carries no employee name, project or attendance date, but the manager's pending queue renders columns for all three, so its "Employees" tile falls back to an internal id and its "Projects" tile always reads zero.
- There is no per-employee regularization endpoint, so the employee's own list is assembled by fetching 90 days of attendance and filtering client-side, silently capping the history.

## Verification

Run on `lab-node-116-f`.

```
./gradlew compileJava compileTestJava    BUILD SUCCESSFUL
./gradlew test --tests "*attendance*"    BUILD SUCCESSFUL
./gradlew test                           BUILD SUCCESSFUL in 7m 1s
```

The three new cases were run against the pre-fix service to confirm they are not vacuous:

```
submitRequest_approvalRequired_persistsTheSubmittedCorrections()  FAILED
processRegularization_approve_appliesTheStoredCorrections()       FAILED
processRegularization_approve_leavesAnExistingEventAlone()        FAILED
```

All eleven pass against the fix. The tests are plain JUnit and Mockito added to the existing `AttendanceRegularizationServiceTest`, so no new Spring context is loaded and the CI heap is unaffected.