### PR TITLE
Fix an inspection's project at creation instead of letting an edit move it

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/UpdateInspectionRequest.java
@@ -17,10 +17,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * Full replacement of an inspection. Status is set directly and the result is
- * optional (set once the inspection is concluded). The category falls back to the
- * one derived from the type when it is omitted. The check items and defects are
- * rebuilt from the payload and the summary counts recomputed from them.
+ * Full replacement of an inspection, apart from the project it is against, which
+ * is fixed at creation. Status is set directly and the result is optional (set
+ * once the inspection is concluded). The category falls back to the one derived
+ * from the type when it is omitted. The check items and defects are rebuilt from
+ * the payload and the summary counts recomputed from them.
  */
 @Schema(description = "Payload to fully replace an existing inspection, including its status, result, checklist items and defects.")
 public record UpdateInspectionRequest(
@@ -36,7 +37,9 @@ public record UpdateInspectionRequest(
         @NotNull InspectionStatus status,
         @Schema(description = "Overall result once the inspection is concluded.", example = "PASSED")
         InspectionResult result,
-        @Schema(description = "Id of the project this inspection is against.", example = "14")
+        @Schema(description = "Id of the project this inspection is against. Fixed when the inspection is "
+                + "created: send the stored id or omit the field. A different id is rejected with 400.",
+                example = "14")
         Long projectId,
         @Schema(description = "Site or building location of the inspection.", example = "Block C, Ground Floor")
         @Size(max = 300) String location,

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -104,11 +105,28 @@ public class InspectionService {
         return mapper.toDto(saved);
     }
 
+    /**
+     * Replaces an inspection, except for the project it is against. The project is
+     * chosen when the inspection is created and is fixed from then on: a statutory
+     * approval has to keep a permanent, traceable relationship with the project it
+     * was obtained for, and a compliance inspection is additionally identified by
+     * its project (the duplicate check is keyed on project plus rule code), so
+     * moving one would let the same compliance be generated twice for the original
+     * project.
+     *
+     * @param id  Id of the inspection to replace.
+     * @param req The replacement payload. Its project id may repeat the stored one
+     *            or be omitted, but it may not name a different project.
+     * @throws ResourceNotFoundException if no such inspection exists in this tenant.
+     * @throws InvalidRequestException   if the payload names a different project.
+     */
     @Transactional
     public InspectionDto update(UUID id, UpdateInspectionRequest req) {
         Inspection inspection = inspectionRepo.findByIdScoped(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Inspection with ID " + id + " was not found"));
+
+        requireSameProject(inspection, req.projectId());
 
         inspection.setTitle(req.title());
         inspection.setType(req.type());
@@ -116,7 +134,6 @@ public class InspectionService {
         inspection.setTrade(req.trade());
         inspection.setStatus(req.status());
         inspection.setResult(req.result());
-        inspection.setProjectId(req.projectId());
         inspection.setLocation(req.location());
         inspection.setAreaInspected(req.areaInspected());
         inspection.setDrawingReference(req.drawingReference());
@@ -139,6 +156,27 @@ public class InspectionService {
         Inspection saved = inspectionRepo.saveAndFlush(inspection);
         log.info("Updated inspection {}", saved.getInspectionNumber());
         return mapper.toDto(saved);
+    }
+
+    /**
+     * Rejects an update that would move an inspection to another project. A payload
+     * that omits the project, or repeats the one already stored, passes: the web
+     * client sends the whole record back on every save, so the stored id arriving
+     * unchanged is the normal case rather than an attempt to reassign. Only a
+     * genuinely different id is refused.
+     *
+     * @param inspection The inspection being replaced.
+     * @param projectId  The project id carried by the request, possibly null.
+     * @throws InvalidRequestException if the two disagree.
+     */
+    private void requireSameProject(Inspection inspection, Long projectId) {
+        if (projectId == null || projectId.equals(inspection.getProjectId())) {
+            return;
+        }
+        throw new InvalidRequestException(
+                "Inspection " + inspection.getInspectionNumber() + " belongs to project "
+                        + inspection.getProjectId() + " and cannot be moved to project "
+                        + projectId + ". The project is fixed when the inspection is created.");
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -97,11 +97,13 @@ public class InspectionControllerWeb {
     @Operation(
             summary = "Update an inspection",
             description = "Updates the status, result, checklist items and defects of an existing "
-                    + "inspection identified by id."
+                    + "inspection identified by id. The project the inspection is against is fixed "
+                    + "when it is created and cannot be changed here."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Inspection updated"),
-            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body, or the "
+                    + "payload names a different project"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
     })

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionProjectImmutabilityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionProjectImmutabilityTest.java
@@ -1,0 +1,147 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the project on an inspection as fixed from creation. A statutory approval
+ * has to keep a permanent relationship with the project it was obtained for, and
+ * a compliance inspection is additionally identified by its project, so an update
+ * that repoints one is refused rather than silently applied.
+ *
+ * <p>Plain Mockito on purpose: the rule is a comparison inside the service and
+ * needs no Spring context, and every distinct context the suite loads is cached
+ * for the life of the JVM.
+ */
+@ExtendWith(MockitoExtension.class)
+class InspectionProjectImmutabilityTest {
+
+    private static final UUID INSPECTION_ID = UUID.fromString("11111111-2222-3333-4444-555555555555");
+    private static final Long STORED_PROJECT = 14L;
+
+    @Mock
+    private InspectionRepository inspectionRepo;
+    @Mock
+    private EntryNumberGenerator numberGen;
+    @Mock
+    private InspectionMapper mapper;
+    @Mock
+    private TenantEntityHelper tenantEntityHelper;
+
+    @InjectMocks
+    private InspectionService service;
+
+    @Test
+    void update_rejectsAMoveToAnotherProject() {
+        Inspection stored = storedInspection();
+        when(inspectionRepo.findByIdScoped(INSPECTION_ID)).thenReturn(Optional.of(stored));
+
+        assertThatThrownBy(() -> service.update(INSPECTION_ID, requestForProject(99L)))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("INSP-0007")
+                .hasMessageContaining("cannot be moved to project 99");
+
+        // The refusal has to happen before anything is written, or a rejected
+        // request would still leave the other fields replaced.
+        assertThat(stored.getProjectId()).isEqualTo(STORED_PROJECT);
+        assertThat(stored.getTitle()).isEqualTo("Building Plan Approval");
+        verify(inspectionRepo, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void update_acceptsThePayloadThatRepeatsTheStoredProject() {
+        // The web client sends the whole record back on every save, so the stored
+        // id arriving unchanged is the normal edit, not an attempted reassignment.
+        Inspection stored = storedInspection();
+        when(inspectionRepo.findByIdScoped(INSPECTION_ID)).thenReturn(Optional.of(stored));
+        when(inspectionRepo.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.update(INSPECTION_ID, requestForProject(STORED_PROJECT));
+
+        assertThat(stored.getProjectId()).isEqualTo(STORED_PROJECT);
+        assertThat(stored.getTitle()).isEqualTo("Site check");
+        verify(inspectionRepo).saveAndFlush(stored);
+    }
+
+    @Test
+    void update_leavesTheProjectInPlaceWhenThePayloadOmitsIt() {
+        Inspection stored = storedInspection();
+        when(inspectionRepo.findByIdScoped(INSPECTION_ID)).thenReturn(Optional.of(stored));
+        when(inspectionRepo.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.update(INSPECTION_ID, requestForProject(null));
+
+        assertThat(stored.getProjectId()).isEqualTo(STORED_PROJECT);
+        verify(inspectionRepo).saveAndFlush(stored);
+    }
+
+    @Test
+    void update_stillReportsAnInspectionThatDoesNotExist() {
+        when(inspectionRepo.findByIdScoped(INSPECTION_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(INSPECTION_ID, requestForProject(99L)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    private Inspection storedInspection() {
+        Inspection inspection = new Inspection();
+        inspection.setInspectionNumber("INSP-0007");
+        inspection.setTitle("Building Plan Approval");
+        inspection.setType(InspectionType.COMPLIANCE);
+        inspection.setCategory(InspectionCategory.COMPLIANCE);
+        inspection.setStatus(InspectionStatus.SUGGESTED);
+        inspection.setOrigin(InspectionOrigin.AI_GENERATED);
+        inspection.setComplianceRuleRef("TN-RES-001");
+        inspection.setProjectId(STORED_PROJECT);
+        return inspection;
+    }
+
+    private UpdateInspectionRequest requestForProject(Long projectId) {
+        return new UpdateInspectionRequest(
+                "Site check",
+                InspectionType.QUALITY,
+                InspectionCategory.QA_QC,
+                InspectionTrade.RCC,
+                InspectionStatus.COMPLETED,
+                InspectionResult.PASSED,
+                projectId,
+                "Block A",
+                "Level 3",
+                "STR-03",
+                LocalDate.of(2026, 8, 25),
+                "09:30",
+                null, null, 60,
+                100L,
+                200L,
+                "Client Rep",
+                List.of("Site Engineer"),
+                "Clear",
+                "30C",
+                List.of(),
+                List.of());
+    }
+}


### PR DESCRIPTION
ClickUp: [86d45ju6b Approval should be mapped to a fixed project](https://app.clickup.com/t/86d45ju6b)

Backend half. The frontend half is tornotron/echno-web#283.

## What it actually was

`InspectionService.update` wrote `req.projectId()` onto the record with no comparison at all:

```java
inspection.setProjectId(req.projectId());   // straight overwrite
```

and `PUT /api/v1/inspections/web/{id}` is a full replacement that the web client always sends a `projectId` on. So any caller with `system-admin` or `project-manager` could repoint an inspection at any other project in the tenant.

Two things ride on that association:

1. A legally mandated pre-construction approval is obtained for one project. If the record can be moved, its value as a compliance record goes with it.
2. AI-generated compliance inspections are **identified** by their project. `ComplianceGenerationService` skips a rule it has already produced using `existsByProjectIdAndComplianceRuleRefAndOrganization_Id(projectId, ruleCode, orgId)`. Move one and the original project looks as though the compliance was never generated, so the next regeneration creates a duplicate, while `complianceRuleRef`, `compliancePhase`, `riskLevel` and `aiRationale` stay pointing at rules for the project it left.

## What changed

`update` compares before it writes:

```java
requireSameProject(inspection, req.projectId());
```

- A different id is refused with `InvalidRequestException`, which the global handler maps to 400. The check runs before the first setter, so a rejected request cannot leave the other fields replaced.
- A matching id passes. The web client sends the whole record back on every save, so the stored id arriving unchanged is the normal edit, not an attempted reassignment.
- An omitted id passes and leaves the stored project alone. That also closes a smaller hole: a payload without `projectId` used to null the project out.

The `@Schema` on `UpdateInspectionRequest.projectId`, the record's own docblock and the controller's `@Operation` now say the project is fixed, matching how `ExpenseUpdateDto` and `UpdateCustomerRequest` document their own immutable fields.

Nothing is removed from the wire: `projectId` stays on the request so existing clients keep working, and the create path is untouched.

## Verification

New `InspectionProjectImmutabilityTest`, plain JUnit and Mockito, no Spring context (the suite caches every distinct context and the test JVM heap is capped, so this rule did not warrant one):

```
InspectionProjectImmutabilityTest > update_rejectsAMoveToAnotherProject() PASSED
InspectionProjectImmutabilityTest > update_acceptsThePayloadThatRepeatsTheStoredProject() PASSED
InspectionProjectImmutabilityTest > update_leavesTheProjectInPlaceWhenThePayloadOmitsIt() PASSED
InspectionProjectImmutabilityTest > update_stillReportsAnInspectionThatDoesNotExist() PASSED
```

Confirmed load bearing by restoring the old `setProjectId` line and dropping the guard: `update_rejectsAMoveToAnotherProject` and `update_leavesTheProjectInPlaceWhenThePayloadOmitsIt` both FAILED, then passed again once restored.

Full inspection package on the lab build box (`10.24.6.116`), where Testcontainers has a Docker daemon:

```
$ ./gradlew test --tests "org.tornotron.echno_backend.inspection.*"
InspectionProjectImmutabilityTest  4 PASSED
InspectionServiceIT                1 PASSED
InspectionTaxonomyEnumsTest        9 PASSED
InspectionTaxonomyMigrationIT      5 PASSED
BUILD SUCCESSFUL in 4m 47s
```

`./gradlew compileJava compileTestJava` clean.
