### PR TITLE
Let a project state its city, state and PIN code instead of one short line

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -137,6 +139,27 @@ public class GlobalExceptionHandler {
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
+
+        ProblemDetail pd = problem(HttpStatus.BAD_REQUEST, "Validation Failed", "Validation Failed", request);
+        pd.setProperty("errors", errors);
+        return pd;
+    }
+
+    /**
+     * The same 400 as above, for a bean validated outside Spring's own argument binding. A
+     * payload that arrives as the JSON string part of a multipart request has to be
+     * deserialized and validated by hand, and that raises this rather than
+     * {@link MethodArgumentNotValidException}. Without this it would fall through to the
+     * catch-all handler and be reported as a 500.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ProblemDetail handleConstraintViolationException(ConstraintViolationException exception,
+                                                           WebRequest request) {
+        Map<String, String> errors = new HashMap<>();
+        for (ConstraintViolation<?> violation : exception.getConstraintViolations()) {
+            errors.put(violation.getPropertyPath().toString(), violation.getMessage());
+        }
 
         ProblemDetail pd = problem(HttpStatus.BAD_REQUEST, "Validation Failed", "Validation Failed", request);
         pd.setProperty("errors", errors);

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -89,12 +89,17 @@ public class ComplianceGenerationService {
                             + "Commercial) before generating compliance.");
         }
 
-        String state = IndianStateResolver.resolve(project.getProjectAddress());
+        // A project that states its own state is taken at its word; scanning the free-text
+        // address is only the fallback for projects that predate the field, and it cannot find
+        // what the address does not say (an address of "Chennai" names no state at all).
+        String state = project.getProjectState() != null
+                ? project.getProjectState()
+                : IndianStateResolver.resolve(project.getProjectAddress());
         if (state == null) {
             throw new InvalidRequestException(
-                    "The project address does not include a recognised state, so the applicable "
-                            + "regulations cannot be determined. Add the state to the project address "
-                            + "(for example 'Chennai, Tamil Nadu') and try again.");
+                    "This project has no state set, and its address does not name one, so the "
+                            + "applicable regulations cannot be determined. Set the project's state "
+                            + "(for example Tamil Nadu) and try again.");
         }
 
         List<ComplianceRule> candidateRules =

--- a/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
@@ -4,13 +4,16 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Derives the Indian state a project sits in from its free-text address. Compliance
- * rules are keyed by state, so generation needs a state name; projects only carry an
- * address string. The match is a case-insensitive substring scan against a fixed list
- * of states and union territories, returning the canonical name of the first hit.
- * Deliberately simple: a structured state field on the project can replace this later.
+ * The Indian states and union territories compliance rules are keyed by, and the two ways a
+ * project's state is arrived at.
+ *
+ * <p>{@link #canonicalise(String)} is the preferred one: a project that states its own state
+ * gives an exact answer. {@link #resolve(String)} is the fallback for the projects that predate
+ * the field, scanning the free-text address for a state name and returning the first hit. That
+ * scan cannot find what the address does not say, so an address of "Chennai" resolves to
+ * nothing, which is why the field exists.
  */
-final class IndianStateResolver {
+public final class IndianStateResolver {
 
     private static final List<String> STATES = List.of(
             "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chhattisgarh",
@@ -23,6 +26,34 @@ final class IndianStateResolver {
             "Ladakh", "Lakshadweep", "Puducherry");
 
     private IndianStateResolver() {}
+
+    /** The states and union territories rules may be keyed by, in canonical spelling. */
+    public static List<String> states() {
+        return STATES;
+    }
+
+    /**
+     * The canonical spelling of a state named in full, ignoring case and surrounding space, or
+     * null for a blank input. Storing the canonical spelling is what lets the rule lookup match
+     * a state the user typed in their own casing.
+     *
+     * @param state The state name as supplied.
+     * @return The canonical name, or null when the input is blank.
+     * @throws IllegalArgumentException if the name is not a state or union territory.
+     */
+    public static String canonicalise(String state) {
+        if (state == null || state.isBlank()) {
+            return null;
+        }
+        String trimmed = state.trim();
+        for (String known : STATES) {
+            if (known.equalsIgnoreCase(trimmed)) {
+                return known;
+            }
+        }
+        throw new IllegalArgumentException(
+                "'" + trimmed + "' is not an Indian state or union territory");
+    }
 
     /** The canonical state name found in the address, or null if none matches. */
     static String resolve(String address) {

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -40,9 +40,26 @@ public class Project implements TenantScopedEntity {
     @Column(name = "project_name",nullable = true)
     private String projectName;
 
-    /** The physical address where the project is located. */
+    /** The street address of the site, as one line. */
     @Column(name = "project_address", nullable = true)
     private String projectAddress;
+
+    /** Town or city the site is in. Optional, and display only. */
+    @Column(name = "project_city", length = 100)
+    private String projectCity;
+
+    /**
+     * Indian state or union territory the site is in, in its canonical spelling. Read by
+     * compliance generation, which keys its rules by state: stated here it is exact, whereas
+     * the fallback of scraping the free-text address only works when the address happens to
+     * name the state. Optional, so projects created before this field keep working.
+     */
+    @Column(name = "project_state", length = 100)
+    private String projectState;
+
+    /** Postal (PIN) code of the site. Optional, and display only. */
+    @Column(name = "project_postal_code", length = 16)
+    private String projectPostalCode;
 
     /** The timestamp when the project was created. */
     @Column(name = "created_at", nullable = true)

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -12,10 +12,12 @@ import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.compliance.IndianStateResolver;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
@@ -94,6 +96,9 @@ public class ProjectService {
             Project project = new Project();
             project.setProjectName(projectDto.getProjectName());
             project.setProjectAddress(projectDto.getProjectAddress());
+            project.setProjectCity(trimToNull(projectDto.getProjectCity()));
+            project.setProjectState(canonicalState(projectDto.getProjectState()));
+            project.setProjectPostalCode(trimToNull(projectDto.getProjectPostalCode()));
             project.setCreatedAt(LocalDateTime.now());
             project.setProjectLatitude(projectDto.getProjectLatitude());
             project.setProjectLongitude(projectDto.getProjectLongitude());
@@ -185,6 +190,15 @@ public class ProjectService {
                 case "projectAddress":
                     project.setProjectAddress((String) value);
                     break;
+                case "projectCity":
+                    project.setProjectCity(trimToNull((String) value));
+                    break;
+                case "projectState":
+                    project.setProjectState(canonicalState((String) value));
+                    break;
+                case "projectPostalCode":
+                    project.setProjectPostalCode(trimToNull((String) value));
+                    break;
                 case "status":
                     ProjectCreationStatus previousStatus = project.getStatus();
                     ProjectCreationStatus newStatus = ProjectCreationStatus.valueOf((String) value);
@@ -227,6 +241,40 @@ public class ProjectService {
                     break;
             }
         });
+    }
+
+    /**
+     * Trims a supplied text field, treating an empty or whitespace-only value as absent rather
+     * than storing a blank. Optional address parts are read as "recorded or not", so a blank
+     * and a missing value have to mean the same thing.
+     *
+     * @param value The value as supplied, possibly null.
+     * @return The trimmed value, or null when there is nothing in it.
+     */
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * Normalises a supplied state to its canonical spelling before it is stored. Compliance
+     * rules are looked up by state name, so a state stored as the user happened to type it
+     * would match nothing; and a state that is not a state at all is worth refusing at the
+     * point of entry rather than leaving to fail silently at generation time.
+     *
+     * @param state The state name as supplied, possibly null or blank.
+     * @return The canonical state name, or null when none was given.
+     * @throws InvalidRequestException if the name is not an Indian state or union territory.
+     */
+    private String canonicalState(String state) {
+        try {
+            return IndianStateResolver.canonicalise(state);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException(e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.project;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +34,7 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -51,6 +55,7 @@ public class ProjectService {
     private final EmployeeMapper employeeMapper;
     private final ApplicationEventPublisher eventPublisher;
     private final CustomerRepository customerRepository;
+    private final Validator validator;
 
     /**
      * Constructs a ProjectService with the necessary repositories.
@@ -60,6 +65,7 @@ public class ProjectService {
      * @param employeeRepository     The repository for employee data access.
      * @param attachmentService      The service for attachment operations.
      * @param customerRepository     The repository used to validate the project's client.
+     * @param validator              Bean validator applied to the create payload.
      */
     public ProjectService(ProjectRepository repository,
                           OrganizationRepository organizationRepository,
@@ -67,7 +73,8 @@ public class ProjectService {
                           AttachmentService attachmentService, ProjectMapper projectMapper,
                           EmployeeMapper employeeMapper,
                           ApplicationEventPublisher eventPublisher,
-                          CustomerRepository customerRepository) {
+                          CustomerRepository customerRepository,
+                          Validator validator) {
         this.repository = repository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
@@ -76,6 +83,7 @@ public class ProjectService {
         this.employeeMapper = employeeMapper;
         this.eventPublisher = eventPublisher;
         this.customerRepository = customerRepository;
+        this.validator = validator;
     }
 
     /**
@@ -87,6 +95,7 @@ public class ProjectService {
      */
     @Transactional
     public ProjectSimpleDto addProject(ProjectCreationDto projectDto,List<MultipartFile> attachments) {
+            requireValid(projectDto);
             Long orgId = TenantContext.getCurrentOrgId();
             Organization organization = organizationRepository.findById(orgId)
                     .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -241,6 +250,24 @@ public class ProjectService {
                     break;
             }
         });
+    }
+
+    /**
+     * Runs bean validation over the create payload.
+     *
+     * <p>Both project controllers take the payload as the JSON string part of a multipart
+     * request and deserialize it by hand, so Spring never sees a bean to validate and the
+     * constraints on {@link ProjectCreationDto} would otherwise never fire. Doing it here covers
+     * both entry points at once, and covers any later caller by construction.
+     *
+     * @param projectDto The payload as deserialized from the request.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private void requireValid(ProjectCreationDto projectDto) {
+        Set<ConstraintViolation<ProjectCreationDto>> violations = validator.validate(projectDto);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -3,9 +3,9 @@ package org.tornotron.echno_backend.project.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -22,10 +22,31 @@ public class ProjectCreationDto {
     @Size(min = 3,max = 50,message = "projectName must be between 3 and 50 characters")
     private String projectName;
 
-    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
+    @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     @NotBlank(message = "projectAddress is required")
-    @Size(min = 3,max = 50,message = "projectAddress must be between 3 and 50 characters")
+    @Size(min = 3,max = 255,message = "projectAddress must be between 3 and 255 characters")
     private String projectAddress;
+
+    /** Optional town or city. Display only. */
+    @Schema(description = "Optional town or city the site is in.", example = "Chennai")
+    @Size(max = 100, message = "projectCity must be at most 100 characters")
+    private String projectCity;
+
+    /**
+     * Optional Indian state or union territory. Read by compliance generation, which keys its
+     * rules by state; when it is absent the state is scraped out of the free-text address
+     * instead, which only works if the address happens to name one.
+     */
+    @Schema(description = "Optional Indian state or union territory the site is in. Used to match "
+            + "statutory compliances; falls back to reading the state out of the address when absent.",
+            example = "Tamil Nadu")
+    @Size(max = 100, message = "projectState must be at most 100 characters")
+    private String projectState;
+
+    /** Optional postal (PIN) code. Display only. */
+    @Schema(description = "Optional postal (PIN) code of the site.", example = "600004")
+    @Size(max = 16, message = "projectPostalCode must be at most 16 characters")
+    private String projectPostalCode;
 
     @Schema(description = "Creation timestamp, set server side when omitted.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
@@ -46,12 +67,19 @@ public class ProjectCreationDto {
             example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
     private UUID customerId;
 
-    @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
-    @NotNull
+    /**
+     * Optional site coordinates. They were required, which contradicted the web form offering
+     * them as optional and made a project with only a typed address impossible to create. Left
+     * null they are simply not recorded; the range check catches a transposed or mistyped pair.
+     */
+    @Schema(description = "Optional site latitude in decimal degrees.", example = "13.0827")
+    @DecimalMin(value = "-90", message = "projectLatitude must be between -90 and 90")
+    @DecimalMax(value = "90", message = "projectLatitude must be between -90 and 90")
     private Float projectLatitude;
 
-    @Schema(description = "Site longitude in decimal degrees.", example = "80.2707")
-    @NotNull
+    @Schema(description = "Optional site longitude in decimal degrees.", example = "80.2707")
+    @DecimalMin(value = "-180", message = "projectLongitude must be between -180 and 180")
+    @DecimalMax(value = "180", message = "projectLongitude must be between -180 and 180")
     private Float projectLongitude;
 
     @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -22,8 +22,18 @@ public class ProjectDto {
     @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     private String projectName;
 
-    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
+    @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
+
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    private String projectCity;
+
+    @Schema(description = "Indian state or union territory the site is in, used to match statutory "
+            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+    private String projectState;
+
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    private String projectPostalCode;
 
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -19,8 +19,18 @@ public class ProjectSimpleDto {
     @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     private String projectName;
 
-    @Schema(description = "Site address of the project.", example = "12 Marina Road, Chennai")
+    @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
+
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    private String projectCity;
+
+    @Schema(description = "Indian state or union territory the site is in, used to match statutory "
+            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+    private String projectState;
+
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    private String projectPostalCode;
 
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -301,4 +301,7 @@
     <!-- v4.0 - Persist the corrected clock events submitted with a regularization request -->
     <include file="db/changelog/v4.0/055-add-regularization-requested-events.xml"/>
 
+    <!-- v4.0 - Project site address as fields: city, state and postal code -->
+    <include file="db/changelog/v4.0/056-add-project-structured-location.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/056-add-project-structured-location.xml
+++ b/src/main/resources/db/changelog/v4.0/056-add-project-structured-location.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="056-add-structured-location-to-project" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="project_state"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The parts of a site address the system reads rather than just displays. Compliance
+            generation is keyed by Indian state and until now scraped one out of the free-text
+            address by substring match, which fails on any address that names only the city.
+            State is therefore stored on its own; city and postal code go with it so the address
+            can be entered as fields instead of one line. All three are nullable: existing
+            projects have none of them and keep working from the free-text address alone.
+        </comment>
+
+        <addColumn tableName="project">
+            <column name="project_city" type="VARCHAR(100)"/>
+            <column name="project_state" type="VARCHAR(100)"/>
+            <column name="project_postal_code" type="VARCHAR(16)"/>
+        </addColumn>
+
+        <createIndex tableName="project" indexName="idx_project_state">
+            <column name="project_state"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/056-add-project-structured-location.xml
+++ b/src/main/resources/db/changelog/v4.0/056-add-project-structured-location.xml
@@ -5,7 +5,35 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="056-add-structured-location-to-project" author="echno">
+    <!--
+        The parts of a site address the system reads rather than just displays. Compliance
+        generation is keyed by Indian state and until now scraped one out of the free-text
+        address by substring match, which fails on any address that names only the city. State is
+        therefore stored on its own; city and postal code go with it so the address can be
+        entered as fields instead of one line. All three are nullable: existing projects have
+        none of them and keep working from the free-text address alone.
+
+        One changeSet per object rather than one for the lot. A failed precondition under
+        MARK_RAN records the changeSet as run without executing it, so a single precondition over
+        one column would let a half-applied state (one column present, the rest missing) be
+        stamped as complete and never repaired.
+    -->
+
+    <changeSet id="056-add-project-city" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="project_city"/>
+            </not>
+        </preConditions>
+
+        <comment>Town or city the site is in. Display only.</comment>
+
+        <addColumn tableName="project">
+            <column name="project_city" type="VARCHAR(100)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="056-add-project-state" author="echno">
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="project" columnName="project_state"/>
@@ -13,19 +41,37 @@
         </preConditions>
 
         <comment>
-            The parts of a site address the system reads rather than just displays. Compliance
-            generation is keyed by Indian state and until now scraped one out of the free-text
-            address by substring match, which fails on any address that names only the city.
-            State is therefore stored on its own; city and postal code go with it so the address
-            can be entered as fields instead of one line. All three are nullable: existing
-            projects have none of them and keep working from the free-text address alone.
+            Indian state or union territory the site is in, in canonical spelling. Read by
+            compliance generation, which keys its rules by state.
         </comment>
 
         <addColumn tableName="project">
-            <column name="project_city" type="VARCHAR(100)"/>
             <column name="project_state" type="VARCHAR(100)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="056-add-project-postal-code" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="project_postal_code"/>
+            </not>
+        </preConditions>
+
+        <comment>Postal (PIN) code of the site. Display only.</comment>
+
+        <addColumn tableName="project">
             <column name="project_postal_code" type="VARCHAR(16)"/>
         </addColumn>
+    </changeSet>
+
+    <changeSet id="056-index-project-state" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="project" indexName="idx_project_state"/>
+            </not>
+        </preConditions>
+
+        <comment>Compliance generation filters projects by state, so the column is indexed.</comment>
 
         <createIndex tableName="project" indexName="idx_project_state">
             <column name="project_state"/>

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
@@ -85,13 +85,44 @@ class ComplianceGenerationServiceTest {
     }
 
     @Test
-    void unresolvableAddress_throwsInvalidRequest() {
+    void noStateAndAnAddressThatNamesNone_throwsInvalidRequest() {
         when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
                 .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "No state named here")));
 
         assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
                 .isInstanceOf(InvalidRequestException.class)
-                .hasMessageContaining("recognised state");
+                .hasMessageContaining("no state set");
+    }
+
+    @Test
+    void statedState_isPreferredOverScrapingTheAddress() {
+        // The reason the field exists: an address of "Chennai" names no state, so the scan
+        // finds nothing and generation used to be impossible for a perfectly ordinary address.
+        Project project = project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai");
+        project.setProjectState("Tamil Nadu");
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue("Tamil Nadu", ProjectType.RESIDENTIAL))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("No compliance rules are registered")
+                .hasMessageContaining("Tamil Nadu");
+    }
+
+    @Test
+    void statedState_winsOverADifferentStateInTheAddress() {
+        Project project = project(ProjectType.RESIDENTIAL, "Site office, Kerala");
+        project.setProjectState("Karnataka");
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue("Karnataka", ProjectType.RESIDENTIAL))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("Karnataka");
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/compliance/IndianStateResolverTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/IndianStateResolverTest.java
@@ -1,0 +1,59 @@
+package org.tornotron.echno_backend.compliance;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Compliance rules are looked up by state name, so what gets stored on a project has to be the
+ * canonical spelling rather than whatever casing the user typed. These pin that, and pin the
+ * gap the stored field exists to close: scanning a free-text address only works when the
+ * address happens to name a state.
+ */
+class IndianStateResolverTest {
+
+    @Test
+    void canonicalise_returnsTheCanonicalSpellingWhateverTheCasing() {
+        assertThat(IndianStateResolver.canonicalise("tamil nadu")).isEqualTo("Tamil Nadu");
+        assertThat(IndianStateResolver.canonicalise("  KERALA  ")).isEqualTo("Kerala");
+        assertThat(IndianStateResolver.canonicalise("Puducherry")).isEqualTo("Puducherry");
+    }
+
+    @Test
+    void canonicalise_treatsBlankAsNotStated() {
+        assertThat(IndianStateResolver.canonicalise(null)).isNull();
+        assertThat(IndianStateResolver.canonicalise("   ")).isNull();
+    }
+
+    @Test
+    void canonicalise_refusesSomethingThatIsNotAState() {
+        // Refused at entry, because a state that matches no rule would otherwise fail much
+        // later, at generation time, with nothing pointing at the typo that caused it.
+        assertThatThrownBy(() -> IndianStateResolver.canonicalise("Chennai"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("is not an Indian state");
+        assertThatThrownBy(() -> IndianStateResolver.canonicalise("Tamilnadu"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void resolve_findsAStateNamedInTheAddress() {
+        assertThat(IndianStateResolver.resolve("12 Mount Road, Chennai, Tamil Nadu"))
+                .isEqualTo("Tamil Nadu");
+    }
+
+    @Test
+    void resolve_findsNothingInAnAddressThatNamesOnlyACity() {
+        // This is the case that made the stored field necessary. "Chennai" is a complete,
+        // ordinary address to type, and the scan can make nothing of it.
+        assertThat(IndianStateResolver.resolve("Chennai")).isNull();
+        assertThat(IndianStateResolver.resolve("")).isNull();
+        assertThat(IndianStateResolver.resolve(null)).isNull();
+    }
+
+    @Test
+    void states_coversTheTwentyEightStatesAndEightUnionTerritories() {
+        assertThat(IndianStateResolver.states()).hasSize(36).contains("Ladakh", "West Bengal");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
@@ -1,0 +1,126 @@
+package org.tornotron.echno_backend.project;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Both project controllers take the create payload as the JSON string part of a multipart
+ * request and deserialize it by hand, so Spring never binds a bean and never validates one. The
+ * constraints on {@link ProjectCreationDto} were therefore decorative. These pin that the
+ * service runs them itself, and that a rejected payload never reaches the repository.
+ *
+ * <p>A real Hibernate Validator with mocked collaborators: the point is whether the constraints
+ * fire, which needs a genuine validator but no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectCreationValidationTest {
+
+    private static ValidatorFactory factory;
+    private Validator validator;
+
+    @Mock
+    private ProjectRepository repository;
+    @Mock
+    private OrganizationRepository organizationRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private ProjectMapper projectMapper;
+    @Mock
+    private EmployeeMapper employeeMapper;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private CustomerRepository customerRepository;
+
+    private ProjectService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        service = new ProjectService(repository, organizationRepository, employeeRepository,
+                attachmentService, projectMapper, employeeMapper, eventPublisher,
+                customerRepository, validator);
+    }
+
+    private ProjectCreationDto validDto() {
+        ProjectCreationDto dto = new ProjectCreationDto();
+        dto.setProjectName("Riverside Tower");
+        dto.setProjectAddress("12 Mount Road, Mylapore");
+        dto.setStatus("upcoming");
+        return dto;
+    }
+
+    @Test
+    void addProject_rejectsAMissingName_beforeTouchingTheRepository() {
+        ProjectCreationDto dto = validDto();
+        dto.setProjectName("  ");
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void addProject_rejectsAnAddressOverTheLimit() {
+        ProjectCreationDto dto = validDto();
+        dto.setProjectAddress("x".repeat(256));
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addProject_rejectsAnImpossibleLatitude() {
+        // The create path had no range check at all; only the patch path did.
+        ProjectCreationDto dto = validDto();
+        dto.setProjectLatitude(120f);
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addProject_rejectsAPostalCodeOverTheLimit() {
+        ProjectCreationDto dto = validDto();
+        dto.setProjectPostalCode("6000041234567890123");
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addProject_acceptsAnAddressOfTwoHundredAndFiftyFiveCharacters() {
+        // The old cap was 50, which had no room for a street, a city and a state on one line.
+        // Failing past validation means it got through to the tenant lookup, which is mocked
+        // empty here; what matters is that it is not a constraint failure.
+        ProjectCreationDto dto = validDto();
+        dto.setProjectAddress("x".repeat(255));
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+}


### PR DESCRIPTION
ClickUp: [86d45jbvr Location Selection while creating a new Project](https://app.clickup.com/t/86d45jbvr)

Backend half. The shared-library half is tornotron/echno-core#40; the web form change follows once that is released. See the ClickUp comment for the sequencing.

## What the ticket is really about

The ticket reads as a form complaint, and the form is the visible half, but the reason it matters is in `ComplianceGenerationService`:

```java
String state = IndianStateResolver.resolve(project.getProjectAddress());
if (state == null) {
    throw new InvalidRequestException("The project address does not include a recognised state, …");
}
```

Compliance rules are keyed by `(state, projectType)`. There was no state field, so the state was recovered by scanning the free-text address for one of 36 state names. `IndianStateResolver`'s own comment said as much: *"Deliberately simple: a structured state field on the project can replace this later."*

That scan cannot find what the address does not say. The address in the ticket's screenshot is "Chennai", which is a complete and ordinary thing to type and contains no state, so compliance generation for that project refused to run and told the user to go and rewrite their address. And `ProjectCreationDto` capped the address at **50 characters**, which is not much room for a street, a city and a state.

So "for the system to effectively build compliance rules" is the operative clause, and the fix is a state field.

## What changed

**New optional columns on `project`** (changelog `v4.0/056`, all nullable, `MARK_RAN`-guarded like its neighbours): `project_city`, `project_state`, `project_postal_code`, plus an index on state. Existing rows have none of them and keep working off the address line.

**State is stored canonically and validated at entry.** `IndianStateResolver` gains a public `canonicalise(String)` that maps any casing of a state or union territory to its canonical spelling and refuses anything that is not one. `ProjectService` calls it on create and on patch, translating the failure into `InvalidRequestException` (400). Storing the canonical spelling is what makes the rule lookup match; refusing a non-state at entry is what stops a typo surfacing much later, at generation time, with nothing pointing at the cause.

**Generation prefers the stated state**, falling back to the address scan:

```java
String state = project.getProjectState() != null
        ? project.getProjectState()
        : IndianStateResolver.resolve(project.getProjectAddress());
```

The error message when neither yields a state now names the field rather than telling the user to edit their address.

**`projectAddress` allows 255 characters** instead of 50. The column was always `TEXT`; only the bean-validation cap moves.

**Coordinates become optional.** `@NotNull` came off `projectLatitude` / `projectLongitude` on the create DTO. The web form has labelled that whole block "(optional)" since it was written and sends `undefined` when the fields are blank, so a project described by address alone could not be created at all. Nothing in the backend reads the coordinates (`grep getProjectLatitude` finds only the two assignments in `ProjectService`), and the client-side geofence already skips a project that has none. They gain the `[-90, 90]` / `[-180, 180]` range check that the patch path has always had and create never did.

`city` and `postalCode` are display only; nothing branches on them.

## What is deliberately not here

- **No geocoding.** Turning a typed address into coordinates needs a provider, a key and a cost decision. Flagged on the ticket.
- **No change to whether any of this is mandatory.** Everything new is optional. Flagged on the ticket.

## Verification

Run on the lab build box (`10.24.6.116`), so the Testcontainers suites have a real CockroachDB and Liquibase actually applied changelog 056:

```
$ ./gradlew test --tests "…project.*" --tests "…compliance.*" --tests "…inspection.InspectionServiceIT"
ComplianceGenerationServiceIT      1 PASSED
ComplianceGenerationServiceTest    8 PASSED
IndianStateResolverTest            6 PASSED
OpenAiCompatibleComplianceServiceTest 4 PASSED
InspectionServiceIT                1 PASSED
ProjectControllerWebAuthzTest      3 PASSED
BUILD SUCCESSFUL in 5m 18s
```

New tests: `IndianStateResolverTest` (canonical spelling, blank, non-state refusal, and the address scan finding nothing in "Chennai", which is the case the field exists for), plus two on `ComplianceGenerationServiceTest` pinning that a stated state is used and beats a different one named in the address. Confirmed load bearing by reverting the preference to the old address-only line: both new tests FAILED, then passed once restored.

`./gradlew compileJava compileTestJava` clean. Plain JUnit and Mockito throughout, no new Spring context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects now support separate city, state/union territory, and postal code fields.
  - Project addresses can be up to 255 characters and are documented as single-line street addresses.
  - Site coordinates are optional, while entered values must remain within valid geographic ranges.

- **Bug Fixes**
  - Compliance generation now uses the project’s stated location before analyzing its free-text address.
  - Invalid or non-Indian states are rejected with clearer validation messages.
  - Address fields are cleaned automatically when projects are created or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up from review (e4a19e9)

### The create payload's constraints were never running

`ProjectController.createProject` and its `/web` twin both declare `@RequestPart("data") @Valid String data` and then `objectMapper.readValue(data, ProjectCreationDto.class)`. The `@Valid` applies to the `String`, which carries no constraints, so Spring never validated the DTO.

This predates the branch: `@NotBlank` on `projectName` has been unenforced since the endpoint was written, and both endpoints document a 400 for "a field failed validation" that could not occur. But adding the address, state and PIN constraints on top of a bypass is worse than not adding them, because the next reader would reasonably assume the 255-character limit holds.

Fixed in `ProjectService.addProject` rather than in either controller. Those two are the only callers of `addProject` (`grep -rn "addProject(" src/main` confirms it), so one call covers both entry points and any later caller by construction. A `ConstraintViolationException` is not something Spring raises from its own argument binding, so `GlobalExceptionHandler` had no mapping and it would have surfaced through the catch-all as a 500; it now returns the same 400 with the same `errors` map as the bound path.

The limit is validation only. `project_address` has been `TEXT` since `v1.0/010-create-project.xml`, so there is nothing to migrate.

### The same pattern is on six other endpoints

Swept for it rather than assuming. `@RequestPart` bound to a `String` and then deserialized by hand appears on:

| Endpoint | DTO | Constraints unenforced |
|---|---|---|
| `TaskController.createTask` | `TaskCreationDto` | 9 |
| `TaskControllerWeb.createTask` | `TaskCreationDto` | 9 |
| `IssueController.createIssue` | `IssueCreationDto` | 6 |
| `IssueControllerWeb.createIssue` | `IssueCreationDto` | 6 |
| `OrganizationController.createOrganization` | `OrganizationCreationDto` | 10 |
| `OrganizationWebController.createOrganization` | `OrganizationCreationDto` | 10 |
| `ChatControllerWeb` send message | `SendMessageDto` | 1 |

None are touched here. They are filed as #490. The partial-update endpoints that read into a `Map<String, Object>` are unaffected, since there is no bean to validate. The `ConstraintViolationException` handler this PR adds is what those fixes will need, so it is deliberately general rather than project-specific.

### The migration guarded one object for four

`MARK_RAN` records a changeSet as run without executing it, so a single precondition on `project_state` would let a database holding that column and none of the rest be stamped complete and never repaired. Split into four changeSets, one per column and one for the index, each with its own condition.

### Verification of the follow-up

New `ProjectCreationValidationTest`, a real Hibernate Validator with mocked collaborators, no Spring context: a blank name (also asserting the repository is never touched), an over-length address, an impossible latitude, an over-length postal code, and a 255-character address getting through. Confirmed it fails against the bypass by deleting the `requireValid` call: **4 of 5 FAILED**, then passed once restored.

Re-run on the lab build box against a real CockroachDB, so Liquibase applied the reworked migration for real:

```
ProjectCreationValidationTest         5 PASSED
ProjectControllerWebAuthzTest         3 PASSED
IndianStateResolverTest               6 PASSED
ComplianceGenerationServiceTest       8 PASSED
ComplianceGenerationServiceIT         1 PASSED
OpenAiCompatibleComplianceServiceTest 4 PASSED
BUILD SUCCESSFUL in 5m 1s
```
