### PR TITLE
Guard against unbounded repository reads, and record the deliberate ones

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/services/FeatureService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/FeatureService.java
@@ -23,6 +23,16 @@ public class FeatureService {
         return featureRepository.findByIsActiveTrueOrderByCategory();
     }
 
+    /**
+     * Returns the whole billing feature catalogue, including features not currently on sale.
+     *
+     * <p>Deliberately unpaginated. The catalogue is a fixed enum-like table describing what the
+     * product can sell; it changes when the product changes, not with tenant activity, and it is
+     * not per-tenant data. Callers need it whole in order to resolve a subscription's feature
+     * codes.
+     *
+     * @return Every feature in the catalogue.
+     */
     public List<Feature> getAllFeatures() {
         return featureRepository.findAll();
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/bank/service/CompanyBankAccountService.java
@@ -26,6 +26,16 @@ public class CompanyBankAccountService {
     private final CompanyBankAccountMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
 
+    /**
+     * Returns every bank account the tenant has registered, active and closed.
+     *
+     * <p>Deliberately unpaginated. The set is bounded by how many accounts a company operates,
+     * which is a decision it makes, not by how long it has operated or how much it has moved
+     * through them. Payments and receipts against these accounts are separate tables and are
+     * paged.
+     *
+     * @return Every company bank account in the current tenant.
+     */
     @Transactional(readOnly = true)
     public List<CompanyBankAccountDto> findAll() {
         return mapper.toDtos(repository.findAll());

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/service/CostCategoryService.java
@@ -34,6 +34,17 @@ public class CostCategoryService {
     private final AccountRepository accountRepo;
     private final TenantEntityHelper tenantEntityHelper;
 
+    /**
+     * Returns the tenant's cost categories, optionally only the active ones.
+     *
+     * <p>Deliberately unpaginated. Cost categories are the breakdown structure a tenant costs its
+     * work against, so the count follows how finely it chooses to categorise and not how much work
+     * it has done. Spend against the categories accumulates in the expense and payable tables,
+     * which are the ones that grow.
+     *
+     * @param activeOnly Whether to omit deactivated categories.
+     * @return The matching cost categories, ordered by name.
+     */
     @Transactional(readOnly = true)
     public List<CostCategoryDto> findAll(boolean activeOnly) {
         return mapper.toDtos(activeOnly

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountCsvService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountCsvService.java
@@ -43,6 +43,11 @@ public class AccountCsvService {
 
     /**
      * Exports the whole chart of accounts (active and inactive) as CSV, ordered by code.
+     *
+     * <p>Deliberately unpaginated on both counts. The chart is bounded by the accounting structure
+     * a tenant defines rather than by what it records, and an export that returned part of the
+     * chart would be wrong rather than merely incomplete: the file is meant to round-trip through
+     * {@link #importCsv(String)}, which resolves parent references by code across the whole set.
      */
     @Transactional(readOnly = true)
     public String exportCsv() {
@@ -105,6 +110,9 @@ public class AccountCsvService {
         }
 
         // Existing accounts by code, so we can update in place and resolve parent references.
+        // Read whole rather than paged: a parent reference may point at any account in the chart,
+        // so a partial map would silently reparent rows. The chart is bounded by the tenant's
+        // accounting structure, not by its transaction volume.
         Map<String, Account> byCode = new HashMap<>();
         for (Account a : repo.findAll()) {
             byCode.put(a.getCode(), a);

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/AccountService.java
@@ -40,6 +40,17 @@ public class AccountService {
     private final AccountCodeGenerator codeGenerator;
     private final TenantEntityHelper tenantEntityHelper;
 
+    /**
+     * Returns the whole chart of accounts, active and inactive.
+     *
+     * <p>Deliberately unpaginated. A chart of accounts is bounded by the accounting structure a
+     * tenant defines rather than by anything it records against that structure: adding a year of
+     * trading adds journal entries, not accounts. Transaction volume lives in {@code JournalEntry},
+     * which is paged. Callers also need the chart whole, because a partial chart misreports every
+     * rolled-up total computed from it.
+     *
+     * @return Every account in the current tenant's chart.
+     */
     @Transactional(readOnly = true)
     public List<AccountDto> findAllAccounts() {
         return  mapper.toDtos(repo.findAll());
@@ -54,6 +65,10 @@ public class AccountService {
      * Returns the full chart of accounts as a nested tree, ordered by code.
      * Includes inactive accounts (flagged via {@code active}). Built from a
      * single fetch and assembled in memory to avoid per-node lazy queries.
+     *
+     * <p>Deliberately unpaginated, for the reason given on {@link #findAllAccounts()}, and here
+     * the whole read is also structural: a tree cannot be assembled from a page, because a node
+     * on one page may have its parent on another.
      */
     @Transactional(readOnly = true)
     public List<AccountTreeDto> findAccountTree() {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -121,6 +121,11 @@ public class LeavePolicyService {
     /**
      * Lists all leave policies visible to the current tenant.
      *
+     * <p>Deliberately unpaginated. A leave policy is a leave type the organization defines
+     * (annual, sick, casual and so on), so the count follows how the organization chooses to
+     * structure its leave and not its headcount or how long it has been running. The rows that
+     * grow with either of those are leave requests and balances, which are separate tables.
+     *
      * @return Every policy for the current organization.
      */
     @Transactional(readOnly = true)

--- a/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/EndpointAuthorizationTest.java
@@ -2,11 +2,10 @@ package org.tornotron.echno_backend.architecture;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
-import org.junit.jupiter.api.Test;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,7 +24,14 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
  * guarded it is removed from this set. The rule keeps the gap from growing and
  * forces every new controller to be guarded. A deliberately public endpoint must
  * use {@code @PreAuthorize("permitAll()")} rather than be left un-annotated.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's own
+ * cache, which every architecture test in this package shares and which holds it behind a soft
+ * reference. See {@link UnboundedRepositoryReadTest} for why that matters in a 1 GB test JVM.
  */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
 class EndpointAuthorizationTest {
 
     /**
@@ -44,19 +50,11 @@ class EndpointAuthorizationTest {
                 }
             };
 
-    private static final JavaClasses PRODUCTION_CLASSES = new ClassFileImporter()
-            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
-            .importPackages("org.tornotron.echno_backend");
-
-    @Test
-    void everyControllerEndpointHasAnAuthorizationGuard() {
-        ArchRule rule = methods()
-                .that().areDeclaredInClassesThat().areAnnotatedWith(RestController.class)
-                .and().areDeclaredInClassesThat(NOT_GRANDFATHERED)
-                .and().areMetaAnnotatedWith(RequestMapping.class)
-                .should().beAnnotatedWith(PreAuthorize.class)
-                .orShould().beDeclaredInClassesThat().areAnnotatedWith(PreAuthorize.class);
-
-        rule.check(PRODUCTION_CLASSES);
-    }
+    @ArchTest
+    static final ArchRule everyControllerEndpointHasAnAuthorizationGuard = methods()
+            .that().areDeclaredInClassesThat().areAnnotatedWith(RestController.class)
+            .and().areDeclaredInClassesThat(NOT_GRANDFATHERED)
+            .and().areMetaAnnotatedWith(RequestMapping.class)
+            .should().beAnnotatedWith(PreAuthorize.class)
+            .orShould().beDeclaredInClassesThat().areAnnotatedWith(PreAuthorize.class);
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/UnboundedRepositoryReadTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/UnboundedRepositoryReadTest.java
@@ -1,0 +1,184 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet against unbounded repository reads: no production class may call a Spring Data
+ * {@code findAll()} that has no limit on how many rows it returns.
+ *
+ * <p>An unbounded read loads every row its table holds, maps every one and serialises the lot,
+ * so the cost grows with a tenant's history and nothing stops it. The
+ * {@code hibernate.default_batch_fetch_size} setting keeps the query <em>count</em> flat as a
+ * result set grows but cannot bound the row <em>count</em>, which makes this the one scale axis
+ * batch fetching does nothing for. It is invisible on a demo tenant and it is the first thing to
+ * fall over on a client with a few years of tasks, issues, materials and attendance behind them.
+ *
+ * <p>The rule bans the call itself rather than trying to prove that a controller returns its
+ * result. Proving reachability through the service layer needs transitive call-graph analysis,
+ * which fails for the wrong reasons and points at the wrong line. Banning the call has no false
+ * positives, catches the CSV and PDF paths a controller-shaped rule would miss, and fails at the
+ * line that introduced the problem.
+ *
+ * <p>Both the no-argument {@code findAll()} and {@code findAll(Sort)} count. Sorting an unbounded
+ * read still returns every row, and it is exactly the variant an earlier audit's grep walked past.
+ * {@code findAll(Pageable)} and {@code findAll(Example, Pageable)} are bounded and are not matched.
+ *
+ * <p>{@link #ALLOWED} names the classes that may still make the call, each with the reason. Split
+ * into two halves that are read differently: the permanent entries are bounded by the nature of
+ * what they read, and the temporary ones are simply not fixed yet. Row counts today are not a
+ * reason for either. On a per-client production model one tenant's small reference table is
+ * another's long tail, so an entry earns the permanent half only when the ceiling comes from what
+ * the table <em>is</em>.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} rather than importing the class graph itself. ArchUnit
+ * holds a graph of this size in memory, and the test JVM is capped at 1 GB while already caching
+ * a Spring context per distinct test configuration, so a second private import is not free. The
+ * annotation routes through ArchUnit's own cache, which is shared across every architecture test
+ * with the same import spec and holds it behind a soft reference, so the collector can reclaim it
+ * under pressure rather than the suite running out of heap.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class UnboundedRepositoryReadTest {
+
+    /**
+     * Classes permitted to make an unbounded repository read.
+     *
+     * <p>Do NOT add to this set to make a build pass. Bound the read instead: take a
+     * {@code Pageable}, or cap it with
+     * {@code org.tornotron.echno_backend.common.pagination.UnpagedResultCap}.
+     */
+    private static final Set<String> ALLOWED = Set.of(
+            // --- Deliberate and permanent. Bounded by what the table is, not by how big it is today.
+
+            // The chart of accounts: bounded by the accounting structure a tenant defines. Volume
+            // lives in JournalEntry, which is paged. A partial chart would misreport every total.
+            "AccountService",
+            // Chart-of-accounts import and export, same structure. A partial extract would be wrong.
+            "AccountCsvService",
+            // A tenant's own bank accounts: bounded by how many accounts a company operates, not by
+            // how long it has operated.
+            "CompanyBankAccountService",
+            // The cost-category reference table: bounded by the tenant's cost breakdown structure.
+            "CostCategoryService",
+            // The billing feature catalogue: a fixed enum-like table shipped with the product.
+            "FeatureService",
+            // Leave types a tenant defines (annual, sick, casual): bounded by policy design, not by
+            // headcount and not by elapsed time.
+            "LeavePolicyService",
+
+            // --- Temporary. Genuinely unbounded, waiting on the client work that moves each caller
+            // onto the paginated endpoint that already exists. Tracked by issue #473. Every entry
+            // here is a table that grows with a tenant's site activity and never shrinks.
+
+            "AssetService",
+            "EmployeeService",
+            "ExpenseService",
+            "GoodsReceivedNoteService",
+            "IndentService",
+            "IssueService",
+            "MaterialConsumptionService",
+            "MaterialService",
+            "PurchaseOrderService",
+            "ReceiptService",
+            "SiteTransferService",
+            "StockAdjustmentService",
+            "StorageLocationService",
+            "SubContractService",
+            "VendorService"
+    );
+
+    private static final DescribedPredicate<JavaClass> NOT_ALLOWED =
+            new DescribedPredicate<>("not allowed an unbounded repository read") {
+                @Override
+                public boolean test(JavaClass javaClass) {
+                    return !ALLOWED.contains(javaClass.getSimpleName());
+                }
+            };
+
+    private static final DescribedPredicate<JavaCall<?>> UNBOUNDED_FIND_ALL =
+            new DescribedPredicate<>("an unbounded repository findAll") {
+                @Override
+                public boolean test(JavaCall<?> call) {
+                    if (!"findAll".equals(call.getTarget().getName())) {
+                        return false;
+                    }
+                    if (!call.getTargetOwner().isAssignableTo(Repository.class)) {
+                        return false;
+                    }
+                    List<JavaClass> parameters = call.getTarget().getRawParameterTypes();
+                    if (parameters.isEmpty()) {
+                        return true;
+                    }
+                    return parameters.size() == 1
+                            && Sort.class.getName().equals(parameters.get(0).getName());
+                }
+            };
+
+    @ArchTest
+    static final ArchRule noProductionClassReadsAWholeTable = noClasses()
+            .that(NOT_ALLOWED)
+            .should().callMethodWhere(UNBOUNDED_FIND_ALL)
+            .because("an unpaginated findAll loads every row a tenant has, so the response and "
+                    + "the memory it costs grow without bound; take a Pageable, or cap the read "
+                    + "with UnpagedResultCap");
+
+    /**
+     * Keeps the allowlist honest in the other direction: an entry that no longer makes the call
+     * has to go.
+     *
+     * <p>Without this, entries outlive the reads they excused and the set stops describing
+     * anything. It is also what makes the ratchet tighten: fixing a read and leaving its entry
+     * behind fails here, so the list can only shrink.
+     */
+    @ArchTest
+    static void theAllowlistHasNoStaleEntries(JavaClasses productionClasses) {
+        Set<String> stillReadingWholeTables = productionClasses.stream()
+                .filter(javaClass -> javaClass.getCodeUnitCallsFromSelf().stream()
+                        .anyMatch(UNBOUNDED_FIND_ALL))
+                .map(JavaClass::getSimpleName)
+                .collect(Collectors.toSet());
+
+        assertThat(ALLOWED)
+                .as("every allowlist entry must still make an unbounded read; remove the ones that "
+                        + "no longer do")
+                .isSubsetOf(stillReadingWholeTables);
+    }
+
+    /**
+     * The allowlist matches on simple name, following the {@link EndpointAuthorizationTest}
+     * precedent. That is only safe while no two production classes share one, so this asserts it,
+     * rather than leaving a future duplicate to exempt an unrelated class in silence.
+     */
+    @ArchTest
+    static void noAllowlistEntryIsAmbiguous(JavaClasses productionClasses) {
+        Map<String, Long> countsBySimpleName = productionClasses.stream()
+                .map(JavaClass::getSimpleName)
+                .filter(ALLOWED::contains)
+                .collect(Collectors.groupingBy(name -> name, Collectors.counting()));
+
+        assertThat(countsBySimpleName)
+                .as("an allowlisted simple name must identify exactly one class")
+                .allSatisfy((name, count) -> assertThat(count)
+                        .describedAs("classes named %s", name)
+                        .isEqualTo(1L));
+    }
+}


### PR DESCRIPTION
Part two of #473, stacked on #483. The guardrail, plus the record of which unbounded reads are deliberate.

**Review #483 first**; this one's allowlist assumes its deletions have landed.

## The rule

The issue suggested asserting that no controller returns a bare `List<T>` fed by an unpaginated `findAll()`. I did not build that one. Proving reachability from a repository call, through the service layer, to a controller return type needs transitive call-graph analysis, which is where architecture rules turn fragile: they fail for the wrong reasons and point at the wrong line.

The rule here is simpler and strictly stronger:

> No production class may call a Spring Data `findAll()` that has no limit on the rows it returns.

It has no false positives, it catches the CSV and PDF paths a controller-shaped rule would miss, and it fails at the line that introduced the problem rather than somewhere downstream.

`findAll(Sort)` counts too. Sorting an unbounded read still returns every row, and it is exactly the variant the original audit's grep walked past: that grep found 26 sites and missed three more, in the chart of accounts and the cost-category table. `findAll(Pageable)` is bounded and is not matched.

Modelled on `EndpointAuthorizationTest`, the ratchet already in this package that has been driven to an empty allowlist. Pure ArchUnit over compiled classes, no Spring context.

## A heap regression I caused, and the fix

Worth reading before reviewing the test, because it changed how both architecture tests are written.

My first version imported its own class graph with `ClassFileImporter`, exactly as `EndpointAuthorizationTest` already did. That took the suite from clean to **18 failures**, all of them `Failed to load ApplicationContext` or `Could not open JPA EntityManager` downstream of an `OutOfMemoryError`. Not one was an assertion failure, which is what makes this failure mode easy to misread as flakiness or a slow runner.

I did not assume it was pre-existing. Same box, same command, back to back:

| | classes | tests | failures | OOM | result |
|---|---|---|---|---|---|
| `origin/development` | 97 | 463 | 0 | 0 | SUCCESSFUL |
| this branch, first version | | 467 | 18 | 2 | FAILED |

The cause: ArchUnit holds a full ~1100-class graph in memory, two test classes each held their own as a **strong** static reference, and the test JVM is capped at `maxHeapSize = 1024m` with no `forkEvery`, so a single JVM also accumulates a cached Spring context per distinct test configuration for the whole run.

The fix is not "import it once". `archunit-junit5:1.3.0` builds its own cache with `CacheBuilder.newBuilder().softValues()`, so a graph obtained through `@AnalyzeClasses` is **soft-referenced and reclaimable** under exactly this pressure, and shared across every test with the same import spec. Both architecture tests now use `@AnalyzeClasses` with `@ArchTest` members. Same rules, same allowlist, same assertions; only the import path changed. The architecture run also dropped from 3m39s to 2m01s.

Two follow-on notes for reviewers:

- `@AnalyzeClasses` should be the house style for this package. A third architecture test written the obvious way would hit this again.
- The suite has thin headroom under a 1024m cap with no `forkEvery`. My branch tipped it, but 463 tests accumulating in one JVM is already close to the line. That is worth its own look, and deliberately **not** changed here: the cap is documented against the 2 vCPU / 7 GB CI runner and raising it is a shared decision.

## Evidence the rule works

Run with the allowlist emptied, it reported exactly 24 call sites: the 21 `findAll()` calls remaining after the other PR, plus the 3 `findAll(Sort)` calls. That matches the hand-built inventory line for line, which is the real proof the rule catches what it claims to rather than passing vacuously.

Two further rules keep the allowlist honest in the other direction. One fails if an entry no longer makes the call, so entries cannot 