### PR TITLE
fix(attendance): pin the clock timestamp contract to local wall-clock time

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -27,8 +29,11 @@ public class AttendanceCheckInDto {
             example = "5")
     private Long shiftTimingId;
 
-    @Schema(description = "Timestamp of the check-in event.", example = "2026-01-15T09:02:00")
+    @Schema(
+            description = "Site-local wall-clock time of the event, with no timezone offset. A value carrying an offset or a trailing Z is rejected: the field has no offset to store it in, so accepting one would silently shift the recorded time and, near midnight, the attendance date with it.",
+            example = "2026-01-15T09:02:00")
     @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime eventTimestamp;
 
     @Schema(description = "Latitude captured at check-in.", example = "13.0827")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -23,8 +25,11 @@ public class AttendanceClockEventDto {
     @NotNull
     private ClockEventType eventType;
 
-    @Schema(description = "Timestamp of the event.", example = "2026-01-15T13:00:00")
+    @Schema(
+            description = "Site-local wall-clock time of the event, with no timezone offset. A value carrying an offset or a trailing Z is rejected: the field has no offset to store it in, so accepting one would silently shift the recorded time and, near midnight, the attendance date with it.",
+            example = "2026-01-15T13:00:00")
     @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime eventTimestamp;
 
     @Schema(description = "Latitude captured for the event.", example = "13.0827")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -19,8 +21,11 @@ public class ClockEventCreationDto {
     @NotNull
     private ClockEventType eventType;
 
-    @Schema(description = "Timestamp the event actually occurred.", example = "2026-01-15T18:00:00")
+    @Schema(
+            description = "Site-local wall-clock time of the event, with no timezone offset. A value carrying an offset or a trailing Z is rejected: the field has no offset to store it in, so accepting one would silently shift the recorded time and, near midnight, the attendance date with it.",
+            example = "2026-01-15T18:00:00")
     @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime eventTimestamp;
 
     @Schema(description = "Latitude captured for the event.", example = "13.0827")

--- a/src/test/java/org/tornotron/echno_backend/attendance/AttendanceTimestampContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/AttendanceTimestampContractTest.java
@@ -1,0 +1,95 @@
+package org.tornotron.echno_backend.attendance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.attendance.dto.AttendanceCheckInDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceClockEventDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the wire contract for the attendance clock timestamps.
+ *
+ * <p>{@code eventTimestamp} is a site-local wall-clock time. It is declared as a
+ * {@link LocalDateTime}, which carries no offset, so an offset-bearing value has no
+ * meaning here. Jackson's default leniency accepts one anyway and silently discards
+ * the offset, which shifts the stored time by the caller's offset and, near midnight,
+ * moves the derived attendance date onto the wrong day. These tests assert the payload
+ * is rejected instead.
+ *
+ * <p>Plain Jackson, no Spring context: the behaviour under test comes from the field
+ * annotations, not from the container.
+ */
+class AttendanceTimestampContractTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("check-in accepts a local wall-clock timestamp verbatim")
+    void checkInAcceptsLocalWallClock() throws Exception {
+        String json = """
+                {"employeeId":42,"projectId":12,"eventTimestamp":"2026-08-27T09:00:00"}""";
+
+        AttendanceCheckInDto dto = objectMapper.readValue(json, AttendanceCheckInDto.class);
+
+        assertThat(dto.getEventTimestamp()).isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0, 0));
+    }
+
+    @Test
+    @DisplayName("check-in rejects a UTC timestamp instead of silently dropping the Z")
+    void checkInRejectsOffsetBearingTimestamp() {
+        String json = """
+                {"employeeId":42,"projectId":12,"eventTimestamp":"2026-08-27T03:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, AttendanceCheckInDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("clock event rejects a UTC timestamp")
+    void clockEventRejectsOffsetBearingTimestamp() {
+        String json = """
+                {"attendanceId":7,"eventType":"EVENING_CLOCK_OUT","eventTimestamp":"2026-08-27T12:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, AttendanceClockEventDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("regularization clock event rejects a UTC timestamp")
+    void regularizationClockEventRejectsOffsetBearingTimestamp() {
+        String json = """
+                {"eventType":"EVENING_CLOCK_OUT","projectId":12,"eventTimestamp":"2026-08-27T12:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, ClockEventCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("a midnight-adjacent local timestamp keeps its own calendar date")
+    void midnightAdjacentTimestampKeepsItsDate() throws Exception {
+        String json = """
+                {"employeeId":42,"projectId":12,"eventTimestamp":"2026-08-27T00:30:00"}""";
+
+        AttendanceCheckInDto dto = objectMapper.readValue(json, AttendanceCheckInDto.class);
+
+        assertThat(dto.getEventTimestamp().toLocalDate()).isEqualTo(java.time.LocalDate.of(2026, 8, 27));
+    }
+}


### PR DESCRIPTION
**Step 1 of 3.** Chain is: this backend PR → echno-core PR + release → echno-web version bump.
Paired core PR: tornotron/echno-core#42. Issue: tornotron/echno-core#41.

## What was wrong

`eventTimestamp` arrives on three payloads and lands in a `java.time.LocalDateTime`, which carries no offset. Jackson is lenient by default, so given `"2026-08-27T03:30:00.000Z"` it strips the `Z` and keeps `03:30`. Nothing warns; the recorded wall-clock time is just shifted by whatever offset the caller was in.

Verified against the running staging box rather than assumed. `echno-backend` runs with no `TZ` set, so the container clock is UTC, and the seeded clock events on `.116` have `event_timestamp` equal to their server-set `created_at` to within 200ms. Both are UTC. The field is read everywhere else as if it were the site's own clock.

That reading happens in two places, and both are wrong by the offset:

- `AttendanceService` derives the day from the punch: `LocalDate attendanceDate = dto.getEventTimestamp().toLocalDate()`. A 00:30 punch in IST is stored as 19:00 the day before, so the row is filed on the wrong date and the employee reads as absent.
- `AttendanceCalculationService` compares `clockIn.getEventTimestamp().toLocalTime()` against `shift.getStartTime()` and `shift.getEndTime()`. Those are `LocalTime` columns an organization fills in with its own clock; the seeded shift on staging is `09:00:00`–`18:00:00`, lunch `13:00`–`14:00`. So `isLateArrival` and `isEarlyCheckout` are wrong on every record. Durations are unaffected, since an offset cancels in a subtraction.

## The change

State the contract instead of leaving it to Jackson's leniency. `eventTimestamp` is a site-local wall-clock time, and a value carrying an offset is now rejected rather than truncated:

```java
@JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
private LocalDateTime eventTimestamp;
```

on `AttendanceCheckInDto`, `AttendanceClockEventDto` and `ClockEventCreationDto`. The `@Schema` descriptions say the same thing, so the generated OpenAPI carries it too.

No pattern is supplied on purpose. Without one the deserializer keeps `ISO_LOCAL_DATE_TIME`, so optional seconds and fractional seconds still parse; `lenient = FALSE` only removes the branch that discards a trailing `Z`.

## Why local wall-clock rather than an instant

The alternative was to move both sides to a real instant: `Instant` or `OffsetDateTime` on the entity, `timestamptz` on the column, `.toISOString()` unchanged in core. That is more correct in the abstract and it is the right answer the day attendance spans zones.

It is not the right answer today, for one concrete reason: nothing in the attendance domain is written in instants. `ShiftTiming` is four `LocalTime` columns. `attendanceDate` is a `LocalDate`. Late marks, early departures, half-days and the monthly summary are all questions about the site's own clock. Moving to an instant means converting back to a local time at every one of those points, which needs a zone attached to the organization or the project. There is no such column, no UI to set it, and no value to backfill it with, so shipping the instant means either blocking on that product work while the corruption continues, or inventing a default, which is this option with more moving parts and a false air of correctness.

What this gives up is the case where the client's zone differs from the site's. A supervisor in Dubai regularizing a Chennai site's attendance at 09:00 on their own clock writes 09:00 Chennai, an hour and a half out, and because no offset is stored the error cannot be spotted or repaired afterwards. For a single-country business that case does not arise; when it does, the migration path is to capture the client's IANA zone as an additional field first, which makes the discrepancy visible and keeps the instant reachable.

## Compatibility, and why this is safe to land first

This rejects what the currently deployed frontend sends. Between deploying this and deploying the paired core release plus the web bump, check-in returns 400.

That window is acceptable here. There is no production environment yet: `echno.xyz` is dark, staging is IITM on `echno.in`, and the whole database holds one attendance record and two clock events. A loud 400 for a few minutes is better than continuing to write shifted times. It should still not reach an environment with real users before the other two steps land.

## Verification

`AttendanceTimestampContractTest`, plain JUnit and a Jackson `ObjectMapper`, no Spring context, so nothing is added to the cached-context heap.

Against `development`, three of the five fail:

```
check-in rejects a UTC timestamp instead of silently dropping the Z FAILED
clock event rejects a UTC timestamp FAILED
regularization clock event rejects a UTC timestamp FAILED
5 tests completed, 3 failed
```

With the change, all five pass, and the wider suite is unaffected:

```
./gradlew test --tests "org.tornotron.echno_backend.attendance.*"
BUILD SUCCESSFUL in 5m 15s
```

## Out of scope, reported not fixed

`MovementRecordCreationDto.startTime` and `endTime` are the same shape, fed by a `datetime-local` input through `movement-create.ts`. They do not feed `attendanceDate` or the shift comparison, so they are left for a separate change rather than widening this one. The full sibling list is on the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attendance timestamps now strictly accept site-local date and time values without timezone offsets.
  * Values containing timezone offsets or a trailing “Z” are rejected instead of being silently shifted.
  * Midnight-adjacent timestamps preserve their intended calendar date.

* **Documentation**
  * API documentation now clearly describes the required timezone-free timestamp format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->