### PR TITLE
Run the constraints on the task and issue create payloads

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.issue;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,17 +44,58 @@ public class IssueService {
     private final AttachmentService attachmentService;
     private final IssueMapper issueMapper;
     private final EmployeeRepository employeeRepository;
+    private final Validator validator;
 
-    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository) {
+    /**
+     * Constructs an IssueService with the necessary collaborators.
+     *
+     * @param issueRepository    The repository for issue data access.
+     * @param taskRepository     The repository used to resolve the task an issue is raised against.
+     * @param attachmentService  The service for attachment operations.
+     * @param issueMapper        The mapper between issues and their DTOs.
+     * @param employeeRepository The repository used to resolve the creator and the assignee.
+     * @param validator          Bean validator applied to the create payload.
+     */
+    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository, Validator validator) {
         this.issueRepository = issueRepository;
         this.taskRepository = taskRepository;
         this.attachmentService = attachmentService;
         this.issueMapper = issueMapper;
         this.employeeRepository = employeeRepository;
+        this.validator = validator;
     }
 
+    /**
+     * Runs bean validation over the create payload.
+     *
+     * <p>Both issue controllers take the payload as the JSON string part of a multipart request
+     * and deserialize it by hand, so Spring never binds a bean and never validates one, and the
+     * constraints on {@link IssueCreationDto} would otherwise never fire. Doing it here covers
+     * both entry points at once, and covers any later caller by construction.
+     *
+     * @param issueCreationDto The payload as deserialized from the request.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private void requireValid(IssueCreationDto issueCreationDto) {
+        Set<ConstraintViolation<IssueCreationDto>> violations = validator.validate(issueCreationDto);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+    }
+
+    /**
+     * Creates a new issue against a task, with any attachments that came with it.
+     *
+     * @param issueCreationDto DTO containing the details for the new issue.
+     * @param attachments      Files uploaded with the issue, or null when there are none.
+     * @return The created issue.
+     * @throws ConstraintViolationException if the payload fails its own constraints.
+     * @throws ResourceNotFoundException if the task, the creator or the assignee is not found in
+     *                                   this organization.
+     */
     @Transactional
     public IssueSimpleDto addIssue(IssueCreationDto issueCreationDto, List<MultipartFile> attachments) {
+        requireValid(issueCreationDto);
         Task task = taskRepository.findByIdAndOrganization_Id(issueCreationDto.getTaskId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task with ID " + issueCreationDto.getTaskId() + " was not found in this organization"));
         Employee creator = employeeRepository.findByIdAndOrganizationId(issueCreationDto.getCreatedById(), TenantContext.getCurrentOrgId())

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -11,14 +11,20 @@ import lombok.Data;
 @Data
 public class IssueCreationDto {
 
+    /** The column is VARCHAR(255); the cap matches it rather than the shorter figure that never ran. */
     @NotBlank
-    @Size(min = 3,max = 50,message = "Title must be between 3 and 50 characters")
+    @Size(min = 3, max = 255, message = "Title must be between 3 and 255 characters")
     private String title;
 
     private Long taskId;
 
+    /**
+     * The column is TEXT. The cap sits well above what the form offers rather than at the 500
+     * that was written here and never ran, and the message no longer claims a minimum of ten
+     * that the constraint never asked for.
+     */
     @NotBlank
-    @Size(min = 5, max = 500, message = "Description must be between 10 and 500 characters")
+    @Size(min = 5, max = 2000, message = "Description must be between 5 and 2000 characters")
     private String description;
 
     // The web client (echno-core) sends this field as "issueType"; accept both

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.task;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +50,7 @@ public class TaskService {
     private final CategoryRepository categoryRepository;
     private final AttachmentService attachmentService;
     private final TaskMapper taskMapper;
+    private final Validator validator;
 
 
     /**
@@ -56,19 +60,42 @@ public class TaskService {
      * @param employeeRepository The repository for employee data access.
      * @param projectRepository  The repository for project data access.
      * @param categoryRepository The repository for category data access.
+     * @param attachmentService  The service for attachment operations.
+     * @param taskMapper         The mapper between tasks and their DTOs.
+     * @param validator          Bean validator applied to the create payload.
      */
     public TaskService(TaskRepository taskRepository,
                        EmployeeRepository employeeRepository,
                        ProjectRepository projectRepository,
                        CategoryRepository categoryRepository,
                        AttachmentService attachmentService,
-                       TaskMapper taskMapper) {
+                       TaskMapper taskMapper,
+                       Validator validator) {
         this.taskRepository = taskRepository;
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
         this.categoryRepository = categoryRepository;
         this.attachmentService = attachmentService;
         this.taskMapper = taskMapper;
+        this.validator = validator;
+    }
+
+    /**
+     * Runs bean validation over the create payload.
+     *
+     * <p>Both task controllers take the payload as the JSON string part of a multipart request
+     * and deserialize it by hand, so Spring never binds a bean and never validates one, and the
+     * constraints on {@link TaskCreationDto} would otherwise never fire. Doing it here covers
+     * both entry points at once, and covers any later caller by construction.
+     *
+     * @param taskCreationDto The payload as deserialized from the request.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private void requireValid(TaskCreationDto taskCreationDto) {
+        Set<ConstraintViolation<TaskCreationDto>> violations = validator.validate(taskCreationDto);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
 
@@ -76,6 +103,7 @@ public class TaskService {
      * Creates a new task.
      *
      * @param taskCreationDto DTO containing the details for the new task.
+     * @throws jakarta.validation.ConstraintViolationException if the payload fails its own constraints.
      * @throws ResourceNotFoundException if the creator, project, or category is not found.
      * @throws InvalidRequestException if required fields like creatorId, projectId, or categoryId are missing,
      *                                 or if assigned employees do not belong to the project's organization.
@@ -83,6 +111,7 @@ public class TaskService {
      */
     @Transactional
     public TaskSimpleDto addTask(TaskCreationDto taskCreationDto, List<MultipartFile> attachments) {
+        requireValid(taskCreationDto);
         Task task = new Task();
         task.setTitle(taskCreationDto.getTitle());
         task.setStartDate(taskCreationDto.getStartDate());

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class TaskCreationDto {
     @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
     @NotBlank(message = "title is required")
-    @Size(min = 3, max = 50, message = "title must be between 3 and 50 characters")
+    @Size(min = 3, max = 255, message = "title must be between 3 and 255 characters")
     private String title;
 
     @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
@@ -36,20 +36,25 @@ public class TaskCreationDto {
     @NotNull(message = "projectId is required(type: Long)")
     private Long projectId;
 
-    @Schema(description = "Ids of the employees assigned to the task.", example = "[7, 9]")
-    @NotNull(message = "assigneeIds is required(type: List<Long>)")
+    /**
+     * Optional. The service has always skipped an absent or empty list, so a task nobody is
+     * assigned to yet is a state it supports; requiring the field contradicted that.
+     */
+    @Schema(description = "Ids of the employees assigned to the task. Optional; a task may start "
+            + "with nobody assigned.", example = "[7, 9]")
     private List<Long> assigneeIds;
 
     @Schema(description = "Id of the category the task is filed under.", example = "3")
     @NotNull(message = "categoryId is required(type: Long)")
     private Long categoryId;
 
-    @Schema(description = "Initial completion of the task, as a fraction from 0 to 1.", example = "0.0")
+    @Schema(description = "Initial completion of the task, as a percentage from 0 to 100.", example = "0")
     @NotNull(message = "progress is required(type: Double)")
     private Double progress;
 
-    @Schema(description = "Free-text tags applied to the task.", example = "[\"concrete\", \"structural\"]")
-    @NotNull(message = "tags is required(type: List<String>)")
+    /** Optional, on the same footing as the assignees: the service skips an absent or empty list. */
+    @Schema(description = "Free-text tags applied to the task. Optional.",
+            example = "[\"concrete\", \"structural\"]")
     private List<String> tags;
 
     @Schema(description = "Initial task status.", example = "TODO")

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
@@ -1,0 +1,161 @@
+package org.tornotron.echno_backend.issue;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Both issue controllers take the create payload as the JSON string part of a multipart request
+ * and deserialize it by hand, so Spring never binds a bean and never validates one. The
+ * constraints on {@link IssueCreationDto} were therefore decorative. These pin that the service
+ * runs them itself, and that a rejected payload never reaches the repository.
+ *
+ * <p>A real Hibernate Validator with mocked collaborators: whether the constraints fire needs a
+ * genuine validator, but no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class IssueCreationValidationTest {
+
+    private static ValidatorFactory factory;
+    private Validator validator;
+
+    @Mock
+    private IssueRepository issueRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private IssueMapper issueMapper;
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    private IssueService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        service = new IssueService(issueRepository, taskRepository, attachmentService,
+                issueMapper, employeeRepository, validator);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private IssueCreationDto validDto() {
+        IssueCreationDto dto = new IssueCreationDto();
+        dto.setTitle("Honeycombing on the block A raft");
+        dto.setDescription("Voids visible along the north edge of the pour after stripping.");
+        dto.setType("quality");
+        dto.setStatus("open");
+        dto.setTaskId(11L);
+        dto.setCreatedById(5L);
+        return dto;
+    }
+
+    @Test
+    void addIssue_rejectsABlankTitle_beforeTouchingTheRepository() {
+        IssueCreationDto dto = validDto();
+        dto.setTitle("  ");
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(issueRepository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addIssue_rejectsABlankDescription() {
+        IssueCreationDto dto = validDto();
+        dto.setDescription("   ");
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(issueRepository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addIssue_rejectsADescriptionUnderFiveCharacters() {
+        // The message claimed a minimum of ten while the constraint said five. The constraint
+        // never ran, so the two had never been compared against a real request.
+        IssueCreationDto dto = validDto();
+        dto.setDescription("wet");
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addIssue_rejectsAMissingType() {
+        IssueCreationDto dto = validDto();
+        dto.setType(null);
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addIssue_rejectsAMissingStatus() {
+        IssueCreationDto dto = validDto();
+        dto.setStatus(null);
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addIssue_rejectsATitleOverTheColumnWidth() {
+        IssueCreationDto dto = validDto();
+        dto.setTitle("x".repeat(256));
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addIssue_acceptsATitleOfTwoHundredAndFiftyFiveCharacters() {
+        // The old cap was 50 while the column has always been VARCHAR(255), and the cap never
+        // ran, so longer titles have been accepted for as long as the endpoint existed. Failing
+        // past validation means it reached the task lookup, which is mocked empty here; what
+        // matters is that it is not a constraint failure.
+        IssueCreationDto dto = validDto();
+        dto.setTitle("x".repeat(255));
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addIssue_acceptsALongDescription() {
+        // The column is TEXT and the 500 cap never ran, so descriptions past it have been
+        // accepted all along; enforcing the old figure would start refusing them.
+        IssueCreationDto dto = validDto();
+        dto.setDescription("x".repeat(1500));
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
@@ -1,0 +1,178 @@
+package org.tornotron.echno_backend.task;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.dto.TaskCreationDto;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Both task controllers take the create payload as the JSON string part of a multipart request
+ * and deserialize it by hand, so Spring never binds a bean and never validates one. The
+ * constraints on {@link TaskCreationDto} were therefore decorative, while the endpoints
+ * documented a 400 for a field that failed validation. These pin that the service runs them
+ * itself, and that a rejected payload never reaches the repository.
+ *
+ * <p>A real Hibernate Validator with mocked collaborators: whether the constraints fire needs a
+ * genuine validator, but no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskCreationValidationTest {
+
+    private static ValidatorFactory factory;
+    private Validator validator;
+
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private TaskMapper taskMapper;
+
+    private TaskService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        service = new TaskService(taskRepository, employeeRepository, projectRepository,
+                categoryRepository, attachmentService, taskMapper, validator);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private TaskCreationDto validDto() {
+        TaskCreationDto dto = new TaskCreationDto();
+        dto.setTitle("Pour foundation slab, block A");
+        dto.setStatus("upcoming");
+        dto.setCreatorId(5L);
+        dto.setProjectId(42L);
+        dto.setCategoryId(3L);
+        dto.setProgress(0.0);
+        dto.setAssigneeIds(List.of(7L));
+        dto.setTags(List.of("concrete"));
+        return dto;
+    }
+
+    @Test
+    void addTask_rejectsABlankTitle_beforeTouchingTheRepository() {
+        TaskCreationDto dto = validDto();
+        dto.setTitle("  ");
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(taskRepository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addTask_rejectsATitleUnderThreeCharacters() {
+        TaskCreationDto dto = validDto();
+        dto.setTitle("ab");
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_rejectsATitleOverTheColumnWidth() {
+        TaskCreationDto dto = validDto();
+        dto.setTitle("x".repeat(256));
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_rejectsAMissingCreatorId() {
+        TaskCreationDto dto = validDto();
+        dto.setCreatorId(null);
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(taskRepository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addTask_rejectsAMissingProjectId() {
+        TaskCreationDto dto = validDto();
+        dto.setProjectId(null);
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_rejectsAMissingCategoryId() {
+        TaskCreationDto dto = validDto();
+        dto.setCategoryId(null);
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_rejectsAMissingStatus() {
+        // Without this the status went straight into TaskStatus.valueOf and raised a
+        // NullPointerException, which the handler reports as a 500.
+        TaskCreationDto dto = validDto();
+        dto.setStatus(null);
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_acceptsATaskWithNoAssigneesAndNoTags() {
+        // Both were @NotNull, which contradicted the service's own handling: it has always
+        // skipped an absent or empty list. Failing past validation means it reached the tenant
+        // lookup, which is mocked empty here; what matters is that it is not a constraint failure.
+        TaskCreationDto dto = validDto();
+        dto.setAssigneeIds(null);
+        dto.setTags(null);
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addTask_acceptsATitleOfTwoHundredAndFiftyFiveCharacters() {
+        // The old cap was 50 while the column has always been VARCHAR(255), and the cap never
+        // ran, so titles longer than 50 have been accepted for as long as the endpoint existed.
+        TaskCreationDto dto = validDto();
+        dto.setTitle("x".repeat(255));
+
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+}


### PR DESCRIPTION
Part of #490. Task and issue only; organization and chat follow in their own PRs so a problem in one area does not hold up the others.

## The bug

`TaskController`, `TaskControllerWeb`, `IssueController` and `IssueControllerWeb` all declare their create endpoint the same way:

```java
public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data, …) {
    TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
```

The `@Valid` is on the `String`. A `String` carries no constraints, so it validates nothing, and the DTO that comes out of `readValue` is never validated at all. Nine constraints on `TaskCreationDto` and six on `IssueCreationDto` have never once run, while each endpoint's `@ApiResponses` advertises a 400 for a field that failed validation, which could not happen.

## The fix

The shape #488 used for projects: validate in the service, at the single shared caller, so the `/web` twin and the base controller are covered by one change rather than two that can drift.

```java
private void requireValid(TaskCreationDto taskCreationDto) {
    Set<ConstraintViolation<TaskCreationDto>> violations = validator.validate(taskCreationDto);
    if (!violations.isEmpty()) {
        throw new ConstraintViolationException(violations);
    }
}
```

The `ConstraintViolationException` to 400 mapping in `GlobalExceptionHandler` already exists (#488 added it), so nothing is added there.

## Constraints that were themselves wrong

A rule that has never run has never been tested against a real request, and three of these are simply incorrect. Enforcing them as written would have started refusing payloads the product means to accept.

**Title, capped at 50 on both task and issue.** Both columns have always been `VARCHAR(255)`, and neither form caps the field: `task-form.tsx` and `issue-form.tsx` check a *minimum* of five characters and put no `maxLength` on the input. Titles over 50 have therefore been accepted for as long as the endpoints have existed. "Install and commission the rooftop HVAC units on Block B" is 56 characters. Both caps move to the column width.

**Issue description, capped at 500 with a message claiming a minimum of ten.** The column is `TEXT`. The form asks for at least twenty characters, offers no ceiling, and its own copy pushes towards prose. 500 characters is about one paragraph, so any issue report carrying reproduction steps would start failing. The cap moves to 2000 and the message stops claiming a minimum the constraint never asked for.

**`assigneeIds` and `tags`, required on a task.** This contradicts the service, which has always guarded both with `if (… != null && !…isEmpty())` and skipped them when absent. A task nobody has been assigned to yet is a state the code supports and the patch path can produce. Both become optional.

## One thing that is documentation, not validation

`TaskCreationDto.progress` is documented as "a fraction from 0 to 1". It is a percentage. `task-form.tsx` clamps the input with `Math.min(100, Math.max(0, …))` and every view renders it as `` `${task.progress}%` ``. The `@Schema` description says so now. No constraint was added: the patch path has never range-checked progress either, and pinning a range here on a value whose units the OpenAPI document has been describing wrongly is worth doing deliberately rather than as a side effect.

## What newly returns 400

This is the point of the change, but it is worth being exact about who is affected.

**Nothing on the ordinary create path.** `validateForm` in both web forms already refuses a blank title, a missing category, a missing employee and a description under twenty characters, and both send `status` and `progress` unconditionally. Every payload the normal flow produces still passes.

**The "Save as Draft" button on the issue form will start failing.** `handleSaveDraft` skips `validateForm` entirely and checks only the employee id and the title:

```js
function handleSaveDraft() {
  if (!currentEmployee?.id) { …; return; }
  if (!form.title.trim()) { toast.error('Please fill in the title before saving draft'); return; }
  props.onSubmit({ fields: form, attachments, isDraft: true });
}
```

`description` starts as `''` and the page sends it unconditionally, so the wire carries `"description": ""`, which `@NotBlank` refuses. Saving an issue draft with no description written yet currently succeeds and will return a 400. The form itself demands at least twenty characters on the ordinary path, so the constraint is right and the draft button is the thing that is wrong; it needs either its own endpoint or a pass through `validateForm`. Filed on the web repo, and worth landing there before this reaches a user-facing environment.

**The task form's draft button is unaffected**, despite skipping validation the same way: `addTask` already throws `InvalidRequestException` for a null `creatorId`, `projectId` or `categoryId`, so a draft missing a category is already a 400 today. The only change there is which 400 it is.

A title of one or two characters, reachable through either draft button, also starts failing `@Size(min = 3)`. Both forms ask for five on the ordinary path, so the constraint is looser than the product's own rule.

## Verification

```
$ ./gradlew test --tests "*TaskCreationValidationTest*" --tests "*IssueCreationValidationTest*"
IssueCreationValidationTest    8 PASSED
TaskCreationValidationTest     9 PASSED
BUILD SUCCESSFUL in 2m 47s
```

Confirmed load bearing by commenting out the two `requireValid` calls and rerunning: all 13 rejection tests FAILED, the two widening guards still passed (they are there to catch the caps being tightened again, not to prove enforcement). Restored, all 17 pass.

Plain JUnit, Mockito and a real Hibernate `Validator` built in the test, no Spring context, following `ProjectCreationValidationTest`.
