### PR TITLE
Stop the web task listing at ten rows without saying so

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -17,6 +17,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.task.dto.TaskCreationDto;
@@ -80,28 +81,70 @@ public class TaskControllerWeb {
     }
 
     /**
-     * Retrieves a paginated list of all tasks.
+     * Lists the current tenant's tasks as a bare array, capped rather than paged.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of tasks per page (default is 10).
-     * @return A {@link ResponseEntity} containing the list of task DTOs and HTTP status 200 (OK).
+     * <p>This used to accept {@code pageNo} and {@code pageSize} defaulting to the first ten rows
+     * and then answer with {@code page.getContent()}, so a caller that passed no parameters, which
+     * is every caller the web client has, received ten tasks and no indication that more existed.
+     * The list looked complete and was not. The parameters are gone rather than re-tuned: keeping
+     * them on an endpoint that discards the page envelope is what made the truncation silent.
+     *
+     * <p>The read is bounded by {@link UnpagedResultCap} and never silently truncated. Every
+     * response carries the true row count in {@code X-Total-Count}, and one that did not fit also
+     * carries {@code X-Result-Capped}. A caller that needs to walk past the cap has
+     * {@link #readAllTasksPaginated} for it.
+     *
+     * @return A {@link ResponseEntity} containing the task DTOs and the count headers.
      */
     @GetMapping
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List tasks",
-            description = "Returns a single page of tasks. The pageNo and pageSize parameters control "
-                    + "paging; only the page content is returned, without paging metadata."
+            description = "Returns the current tenant's tasks as a bare array, capped at "
+                    + "500 rows. The response always carries the true total in X-Total-Count, and "
+                    + "carries X-Result-Capped when rows were left out, so a caller can tell a "
+                    + "complete result from a capped one. Use /paginated to page beyond the cap."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Tasks returned, capped at 500 rows"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<List<TaskDto>> readAllTasks() {
+        logger.info("All Tasks Retrieved Successfully");
+        return UnpagedResultCap.respond(service.getAllTasks(0, UnpagedResultCap.MAX_ROWS));
+    }
+
+    /**
+     * Lists tasks as a real {@link Page}, with the paging metadata intact.
+     *
+     * <p>The honest counterpart to {@link #readAllTasks}: a caller gets {@code totalElements},
+     * {@code totalPages} and the page index alongside the content, so a truncated result describes
+     * itself. Mirrors {@code GET /issues/web/paginated}.
+     *
+     * @param pageNo    Zero-based page index.
+     * @param pageSize  Rows per page, clamped to the result cap.
+     * @param projectId Optional project filter.
+     * @param search    Optional case-insensitive match on title or description.
+     * @return A {@link ResponseEntity} containing the page of task DTOs.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List tasks, paginated and filtered",
+            description = "Returns a single page of tasks with the paging metadata included, "
+                    + "optionally filtered by project or by a free-text search on title and "
+                    + "description. pageSize is clamped to 500."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of tasks returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<TaskDto>> readAllTasks(@RequestParam(defaultValue = "0") int pageNo,
-                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<TaskDto> tasks = service.getAllTasks(pageNo, pageSize);
-        logger.info("All Tasks Retrieved Successfully");
-        return new ResponseEntity<>(tasks.getContent(), HttpStatus.OK);
+    public ResponseEntity<Page<TaskDto>> readAllTasksPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) String search) {
+        return ResponseEntity.ok(service.getTasksPaginated(pageNo, pageSize, projectId, search));
     }
 
     @GetMapping("/projectId/{projectId}")

--- a/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskRepository.java
@@ -2,8 +2,11 @@ package org.tornotron.echno_backend.task;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.IssueComment.IssueComment;
 import org.tornotron.echno_backend.task.enums.TaskStatus;
 
@@ -33,6 +36,32 @@ public interface TaskRepository extends JpaRepository<Task,Long> {
     List<Task> findByProject_Id(Long projectId);
 
     List<Task> findAllByProject_IdAndOrganization_Id(Long projectId, Long organizationId);
+
+    /**
+     * Finds tasks under optional project and free-text filters, one page at a time.
+     *
+     * <p>Every filter is optional: a null argument drops its clause, so the query serves the
+     * unfiltered listing as well as a project-scoped or searched one. The search pattern is a
+     * pre-lowercased {@code %...%} LIKE built by the service, which escapes any wildcard the user
+     * typed; {@code ESCAPE '\'} is what makes that escaping take effect.
+     *
+     * <p>The tenant filter applies to this query exactly as it does to a derived finder.
+     *
+     * @param projectId Optional project id.
+     * @param search    Optional lower-cased LIKE pattern for title or description.
+     * @param pageable  The page to return.
+     * @return A page of matching tasks.
+     */
+    @Query("""
+            SELECT t FROM Task t WHERE
+              (:projectId IS NULL OR t.project.id = :projectId) AND
+              (:search IS NULL
+                 OR LOWER(t.title) LIKE :search ESCAPE '\\'
+                 OR LOWER(t.description) LIKE :search ESCAPE '\\')
+            """)
+    Page<Task> search(@Param("projectId") Long projectId,
+                      @Param("search") String search,
+                      Pageable pageable);
 
     /**
      * Counts the current tenant's tasks by status.

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.project.ProjectProgressCalculator;
 import org.tornotron.echno_backend.employee.Employee;
@@ -170,6 +171,48 @@ public class TaskService {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "id"));
         return taskRepository.findAll(pageable)
                 .map(task -> taskMapper.toDto(task));
+    }
+
+    /**
+     * Retrieves a page of tasks under optional project and free-text filters.
+     *
+     * <p>Unlike {@link #getAllTasks(int, int)} the caller keeps the {@link Page}, so the total row
+     * count and the page index survive to the response and a truncated result says so. Newest
+     * first, because a task list is read from the recent end.
+     *
+     * @param pageNo    Zero-based page index; a negative value is treated as zero.
+     * @param pageSize  Rows per page, clamped to {@link UnpagedResultCap#MAX_ROWS} so one request
+     *                  cannot re-create the unbounded read this endpoint exists to replace.
+     * @param projectId Optional project filter; null means every project.
+     * @param search    Optional case-insensitive match on title or description; blank means none.
+     * @return A {@link Page} of task DTOs.
+     */
+    @Transactional(readOnly = true)
+    public Page<TaskDto> getTasksPaginated(int pageNo, int pageSize, Long projectId, String search) {
+        int page = Math.max(pageNo, 0);
+        int size = Math.clamp(pageSize, 1, UnpagedResultCap.MAX_ROWS);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        return taskRepository.search(projectId, searchPattern(search), pageable)
+                .map(task -> taskMapper.toDto(task));
+    }
+
+    /**
+     * Builds a lower-cased {@code %...%} LIKE pattern for a search term, or null when there is no
+     * term to match on. Wildcards the user typed are escaped so a bare {@code %} matches a literal
+     * percent sign rather than every row.
+     *
+     * @param value The raw search term.
+     * @return The LIKE pattern, or null when the term is absent or blank.
+     */
+    private static String searchPattern(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String escaped = value.trim().toLowerCase()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return "%" + escaped + "%";
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
@@ -1,0 +1,170 @@
+package org.tornotron.echno_backend.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.task.dto.TaskDto;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The listing behaviour of {@code GET /api/v1/tasks/web} and its paginated counterpart.
+ *
+ * <p>Guards the defect these tests were written for: the bare listing took a {@code pageSize} that
+ * defaulted to ten and then answered with {@code page.getContent()}, so a caller that passed no
+ * parameters received the ten lowest-id tasks in the tenant and nothing in the response said more
+ * existed. Every web caller passed no parameters.
+ *
+ * <p>Plain JUnit and Mockito rather than a Spring slice: the behaviour under test is which page the
+ * handler asks for and what it puts on the response, none of which needs a container. The test JVM
+ * caches a context per distinct test configuration and is capped at 1 GB, so a context that buys
+ * nothing is a context that costs an unrelated test its heap.
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskControllerWebListingTest {
+
+    @Mock
+    private TaskService service;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private TaskControllerWeb controller;
+
+    private static List<TaskDto> tasks(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> {
+                    TaskDto dto = new TaskDto();
+                    dto.setId((long) i);
+                    dto.setTitle("Task " + i);
+                    return dto;
+                })
+                .toList();
+    }
+
+    /**
+     * Stubs the service so it honours the page it was asked for, the way the repository does.
+     *
+     * <p>A stub that returns the whole list whatever page is requested would pass against the
+     * truncating controller too, which is exactly the blind spot that let the defect ship: the
+     * behaviour under test is the size of the page the handler asks for, so the stub has to be
+     * sensitive to it.
+     */
+    private void serviceHolding(int taskCount) {
+        List<TaskDto> all = tasks(taskCount);
+        when(service.getAllTasks(anyInt(), anyInt())).thenAnswer(invocation -> {
+            int pageNo = invocation.getArgument(0);
+            int pageSize = invocation.getArgument(1);
+            int from = Math.min(pageNo * pageSize, all.size());
+            int to = Math.min(from + pageSize, all.size());
+            return new PageImpl<>(all.subList(from, to), PageRequest.of(pageNo, pageSize), all.size());
+        });
+    }
+
+    @Test
+    void theBareListingDoesNotStopAtTheFirstTenTasks() {
+        serviceHolding(12);
+
+        ResponseEntity<List<TaskDto>> response = controller.readAllTasks();
+
+        assertThat(response.getBody())
+                .as("a tenant with twelve tasks must see twelve, not the first ten")
+                .hasSize(12);
+    }
+
+    @Test
+    void theBareListingReachesTasksWellPastTheOldTenRowPage() {
+        serviceHolding(400);
+
+        ResponseEntity<List<TaskDto>> response = controller.readAllTasks();
+
+        assertThat(response.getBody())
+                .as("the tasks a project owns are not necessarily the lowest ids in the tenant")
+                .hasSize(400)
+                .last()
+                .extracting(TaskDto::getId)
+                .isEqualTo(400L);
+    }
+
+    @Test
+    void theBareListingAsksForTheResultCapRatherThanAPageOfTen() {
+        when(service.getAllTasks(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        controller.readAllTasks();
+
+        ArgumentCaptor<Integer> pageNo = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> pageSize = ArgumentCaptor.forClass(Integer.class);
+        verify(service).getAllTasks(pageNo.capture(), pageSize.capture());
+
+        assertThat(pageNo.getValue()).isZero();
+        assertThat(pageSize.getValue())
+                .as("the ten-row default is what made the truncation silent")
+                .isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void theBareListingReportsTheTrueTotalOnEveryResponse() {
+        serviceHolding(12);
+
+        ResponseEntity<List<TaskDto>> response = controller.readAllTasks();
+
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("12");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER))
+                .as("a complete result must not claim to be capped")
+                .isNull();
+    }
+
+    @Test
+    void theBareListingSaysSoWhenRowsWereLeftOut() {
+        List<TaskDto> capped = tasks(UnpagedResultCap.MAX_ROWS);
+        when(service.getAllTasks(anyInt(), anyInt()))
+                .thenReturn(new PageImpl<>(capped, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), 900));
+
+        ResponseEntity<List<TaskDto>> response = controller.readAllTasks();
+
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER))
+                .as("a truncated result must describe itself rather than look complete")
+                .isEqualTo("true");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("900");
+    }
+
+    @Test
+    void thePaginatedListingKeepsThePageEnvelope() {
+        Page<TaskDto> page = new PageImpl<>(tasks(20), PageRequest.of(1, 20), 137);
+        when(service.getTasksPaginated(eq(1), eq(20), isNull(), isNull())).thenReturn(page);
+
+        ResponseEntity<Page<TaskDto>> response = controller.readAllTasksPaginated(1, 20, null, null);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTotalElements()).isEqualTo(137);
+        assertThat(response.getBody().getNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void thePaginatedListingPassesTheProjectAndSearchFiltersThrough() {
+        when(service.getTasksPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
+
+        controller.readAllTasksPaginated(0, 20, 7L, "slab");
+
+        verify(service).getTasksPaginated(0, 20, 7L, "slab");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/task/TaskServicePaginationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskServicePaginationTest.java
@@ -1,0 +1,145 @@
+package org.tornotron.echno_backend.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Paging and filter handling in {@link TaskService#getTasksPaginated}.
+ *
+ * <p>The endpoint this backs replaces a listing that silently truncated, so the two things worth
+ * pinning are that it cannot be talked into an unbounded read by a large {@code pageSize}, and that
+ * a wildcard in the search term matches a literal character rather than every row.
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskServicePaginationTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private AttachmentService attachmentService;
+
+    @Mock
+    private TaskMapper taskMapper;
+
+    @InjectMocks
+    private TaskService service;
+
+    private Pageable capturePageable() {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        org.mockito.Mockito.verify(taskRepository).search(any(), any(), pageable.capture());
+        return pageable.getValue();
+    }
+
+    private String captureSearchPattern() {
+        ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(taskRepository).search(any(), pattern.capture(), any());
+        return pattern.getValue();
+    }
+
+    @Test
+    void aPageSizeAboveTheCapIsClampedToIt() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 100_000, null, null);
+
+        assertThat(capturePageable().getPageSize())
+                .as("one request must not be able to re-create the unbounded read")
+                .isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void aPageSizeOfZeroIsRaisedToOneRatherThanRejectedByPageRequest() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 0, null, null);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void aNegativePageIndexIsTreatedAsTheFirstPage() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(-3, 20, null, null);
+
+        assertThat(capturePageable().getPageNumber()).isZero();
+    }
+
+    @Test
+    void theListingIsOrderedNewestFirst() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 20, null, null);
+
+        assertThat(capturePageable().getSort().getOrderFor("id"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.DESC);
+    }
+
+    @Test
+    void aBlankSearchTermDropsTheSearchClauseRatherThanMatchingNothing() {
+        when(taskRepository.search(any(), isNull(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 20, null, "   ");
+
+        assertThat(captureSearchPattern()).isNull();
+    }
+
+    @Test
+    void aSearchTermIsLowerCasedAndWrappedForALikeMatch() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 20, null, "  Slab  ");
+
+        assertThat(captureSearchPattern()).isEqualTo("%slab%");
+    }
+
+    @Test
+    void aWildcardInTheSearchTermIsEscapedSoItMatchesItself() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 20, null, "100%");
+
+        assertThat(captureSearchPattern())
+                .as("an unescaped % would turn a search into a full listing")
+                .isEqualTo("%100\\%%");
+    }
+
+    @Test
+    void anUnderscoreInTheSearchTermIsEscapedSoItIsNotASingleCharacterWildcard() {
+        when(taskRepository.search(any(), any(), any())).thenReturn(Page.empty());
+
+        service.getTasksPaginated(0, 20, null, "block_a");
+
+        assertThat(captureSearchPattern()).isEqualTo("%block\\_a%");
+    }
+}


### PR DESCRIPTION
Fixes #478. **Step 1 of 3** (backend → core release → web).

## The defect

`GET /api/v1/tasks/web` took `pageNo`/`pageSize` defaulting to ten, then answered with `page.getContent()`. The envelope went in the bin, so a caller got a bare array with no total and no way to tell a complete result from a truncated one. No caller passed the parameters, so on any tenant with more than ten tasks every screen fed by this endpoint showed ten and looked finished: the all-tasks page, the dashboard's active-task count, the material-consumption task picker, and every per-project task view, since `useTasksByProject` filters that same truncated list client-side.

## What changed

The paging parameters are gone from the bare listing rather than re-tuned. Keeping them on an endpoint that discards the envelope is what made the truncation silent, and a larger default would only have moved the cliff. The listing is now bounded by `UnpagedResultCap`, the mechanism already used for the other bare-array list endpoints: `X-Total-Count` on every response, `X-Result-Capped` when rows were left out. A capped result says so.

Honest paging gets its own endpoint. `GET /tasks/web/paginated` returns a real `Page<TaskDto>`, optionally filtered by project or a free-text search on title and description, mirroring `/issues/web/paginated`. Page size is clamped to the same cap so one request cannot re-create the unbounded read, and search terms have their LIKE wildcards escaped.

No new unbounded read: the added repository query takes a `Pageable`, and the ArchUnit ratchet is untouched.

## Verification

`TaskControllerWebListingTest` stubs the service so it honours the page it was asked for. A stub that ignores the requested size passes against the truncating controller too, which is the blind spot that let this ship. Against the pre-fix controller body, five of the seven fail:

```
theBareListingDoesNotStopAtTheFirstTenTasks()          FAILED
theBareListingReachesTasksWellPastTheOldTenRowPage()   FAILED
theBareListingAsksForTheResultCapRatherThanAPageOfTen() FAILED
theBareListingReportsTheTrueTotalOnEveryResponse()     FAILED
theBareListingSaysSoWhenRowsWereLeftOut()              FAILED
```

The two `/paginated` tests pass in that run only because the endpoint they exercise is still present; without this change it does not exist.

All pass with the fix, alongside `TaskServicePaginationTest` (clamping, ordering, wildcard escaping) and the architecture ratchets.

## What this does not fix

`useTasksByProject` still fetches the full list and filters in the browser. Moving it onto `GET /tasks/web/projectId/{projectId}`, which already exists, is a pure echno-core change and lands in step 2.