### PR TITLE
Run the constraints on the organization and chat create payloads

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -6,7 +6,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -26,6 +29,7 @@ import org.tornotron.echno_backend.chat.dto.ReactionRequestDto;
 import org.tornotron.echno_backend.chat.dto.SendMessageDto;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Employee-facing chat: rooms an employee belongs to and the messages within them. Every
@@ -46,12 +50,33 @@ public class ChatControllerWeb {
     private final ChatService chatService;
     private final ObjectMapper objectMapper;
     private final ChatStreamService chatStreamService;
+    private final Validator validator;
 
     public ChatControllerWeb(ChatService chatService, ObjectMapper objectMapper,
-                             ChatStreamService chatStreamService) {
+                             ChatStreamService chatStreamService, Validator validator) {
         this.chatService = chatService;
         this.objectMapper = objectMapper;
         this.chatStreamService = chatStreamService;
+        this.validator = validator;
+    }
+
+    /**
+     * Runs bean validation over a payload this class deserialized itself.
+     *
+     * <p>The multipart send takes its payload as the JSON string part of the request and reads it
+     * by hand, so Spring never binds a bean and never validates one. The JSON send next to it
+     * takes a bound {@code @Valid @RequestBody}, which Spring does validate, so this is the only
+     * place a {@link SendMessageDto} arrives unchecked. It cannot move into the service, which
+     * takes the message fields as separate arguments rather than the payload.
+     *
+     * @param dto The payload as deserialized from the request.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private void requireValid(SendMessageDto dto) {
+        Set<ConstraintViolation<SendMessageDto>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
     @GetMapping("/rooms/web")
@@ -175,6 +200,7 @@ public class ChatControllerWeb {
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments)
             throws JsonProcessingException {
         SendMessageDto dto = objectMapper.readValue(data, SendMessageDto.class);
+        requireValid(dto);
         return new ResponseEntity<>(
                 chatService.sendMessage(roomId, dto.getContent(), dto.getReplyToId(), attachments),
                 HttpStatus.CREATED);

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.organization;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +34,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -55,6 +59,7 @@ public class OrganizationService {
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
     private final org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity;
     private final OrganizationOnboardingSeeder onboardingSeeder;
+    private final Validator validator;
 
     /**
      * Constructs an {@code OrganizationService} with the necessary dependencies.
@@ -64,8 +69,9 @@ public class OrganizationService {
      * @param keycloakGroupService The service for managing Keycloak groups.
      * @param subscriptionService The service for handling subscription billing.
      * @param onboardingSeeder Seeds the per-organization finance defaults for a new organization.
+     * @param validator Bean validator applied to the create payload.
      */
-    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, OrganizationOnboardingSeeder onboardingSeeder) {
+    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, OrganizationOnboardingSeeder onboardingSeeder, Validator validator) {
         this.repository = repository;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
@@ -76,15 +82,37 @@ public class OrganizationService {
         this.organizationMapper = organizationMapper;
         this.orgSecurity = orgSecurity;
         this.onboardingSeeder = onboardingSeeder;
+        this.validator = validator;
+    }
+
+    /**
+     * Runs bean validation over the create payload.
+     *
+     * <p>Both organization controllers take the payload as the JSON string part of a multipart
+     * request and deserialize it by hand, so Spring never binds a bean and never validates one,
+     * and the constraints on {@link OrganizationCreationDto} would otherwise never fire. Doing it
+     * here covers both entry points at once, and covers any later caller by construction.
+     *
+     * @param organizationCreationDto The payload as deserialized from the request.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private void requireValid(OrganizationCreationDto organizationCreationDto) {
+        Set<ConstraintViolation<OrganizationCreationDto>> violations =
+                validator.validate(organizationCreationDto);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
     /**
      * Creates and persists a new organization based on the provided data.
      * @param organizationCreationDto A DTO containing the details for the new organization.
      * @return An {@link OrganizationSimpleDto} representing the newly created organization.
+     * @throws ConstraintViolationException if the payload fails its own constraints.
      */
     @Transactional
     public OrganizationSimpleDto addOrganization(OrganizationCreationDto organizationCreationDto, List<MultipartFile> attachments) {
+        requireValid(organizationCreationDto);
         if(repository.existsByOrganizationEmail(organizationCreationDto.getOrganizationEmail())){
             throw new DuplicateResourceException("Organization with email '" + organizationCreationDto.getOrganizationEmail() + "' already exists");
         }

--- a/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationCreationDto.java
@@ -11,24 +11,44 @@ import java.time.LocalDateTime;
 @Data
 public class OrganizationCreationDto {
 
+    /**
+     * The minimum is two rather than three: the form has never had one, and two-letter company
+     * names are ordinary.
+     */
     @NotBlank(message = "organization is required")
-    @Size(min = 3, max = 50, message = "organization name must be between 3 and 50 characters")
+    @Size(min = 2, max = 50, message = "organization name must be between 2 and 50 characters")
     private String organizationName;
 
+    /**
+     * The column is TEXT and the form offers a three-row textarea, so the cap is the column's
+     * rather than the fifty characters that were written here and never ran. A postal address
+     * with a street, an area, a city and a PIN code does not fit in fifty.
+     */
     @NotBlank(message = "organizationAddress is required")
-    @Size(min = 3, max = 50, message = "organizationAddress must be between 3 and 50 characters")
+    @Size(min = 3, max = 255, message = "organizationAddress must be between 3 and 255 characters")
     private String organizationAddress;
 
+    /**
+     * The top-level domain runs to 24 characters rather than six. Six refuses .construction,
+     * .engineering, .contractors and .consulting, which are exactly the domains this product's
+     * customers register.
+     */
     @NotBlank(message = "organizationEmail is required")
     @Pattern(
-            regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
+            regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,24}$",
             message = "Invalid email address format"
     )
     @Size(max = 255, message = "organizationEmail must be at most 255 characters")
     private String organizationEmail;
 
+    /**
+     * The form sends E.164, which is a leading plus and eight to fifteen digits, so the string is
+     * nine to sixteen characters. The old window of ten to fifteen counted the digits and forgot
+     * the plus, refusing a valid fifteen-digit international number, and its message named a
+     * field that does not exist on this payload.
+     */
     @NotBlank(message = "organizationPhone is required")
-    @Size(min = 10,max = 15,message = "memberPhone must be between 10 and 15 characters")
+    @Size(min = 9, max = 16, message = "organizationPhone must be between 9 and 16 characters")
     private String organizationPhone;
 
     @Size(max = 255, message = "organizationWebsite must be at most 255 characters")

--- a/src/test/java/org/tornotron/echno_backend/chat/ChatMessageValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/ChatMessageValidationTest.java
@@ -1,0 +1,85 @@
+package org.tornotron.echno_backend.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.chat.dto.SendMessageDto;
+import org.tornotron.echno_backend.chat.realtime.ChatStreamService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The multipart send takes its payload as the JSON string part of the request and deserializes
+ * it by hand, so the {@code @NotBlank} on {@link SendMessageDto#getContent()} never fired there,
+ * while the endpoint documented a 400 for blank content. The JSON send beside it binds a
+ * {@code @Valid @RequestBody} and has always been checked; these pin that the two now agree.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChatMessageValidationTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private ChatService chatService;
+    @Mock
+    private ChatStreamService chatStreamService;
+
+    private ChatControllerWeb controller;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        controller = new ChatControllerWeb(chatService, new ObjectMapper(), chatStreamService,
+                validator);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    @Test
+    void sendMessageWithAttachments_rejectsBlankContent_withoutSendingAnything() throws Exception {
+        assertThatThrownBy(() -> controller.sendMessageWithAttachments(
+                7L, "{\"content\":\"   \"}", List.of()))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(chatService, never()).sendMessage(ArgumentMatchers.anyLong(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.any(), ArgumentMatchers.any());
+    }
+
+    @Test
+    void sendMessageWithAttachments_rejectsAbsentContent() throws Exception {
+        assertThatThrownBy(() -> controller.sendMessageWithAttachments(
+                7L, "{\"replyToId\":1198}", List.of()))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(chatService, never()).sendMessage(ArgumentMatchers.anyLong(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.any(), ArgumentMatchers.any());
+    }
+
+    @Test
+    void sendMessageWithAttachments_passesRealContentThrough() throws Exception {
+        controller.sendMessageWithAttachments(
+                7L, "{\"content\":\"Concrete pour on block C is done.\",\"replyToId\":1198}",
+                List.of());
+
+        verify(chatService).sendMessage(7L, "Concrete pour on block C is done.", 1198L, List.of());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreationValidationTest.java
@@ -1,0 +1,193 @@
+package org.tornotron.echno_backend.organization;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.organization.dto.OrganizationCreationDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Both organization controllers take the create payload as the JSON string part of a multipart
+ * request and deserialize it by hand, so Spring never binds a bean and never validates one. The
+ * ten constraints on {@link OrganizationCreationDto} were therefore decorative. These pin that
+ * the service runs them itself, and that a rejected payload never reaches the repository.
+ *
+ * <p>A real Hibernate Validator with mocked collaborators: whether the constraints fire needs a
+ * genuine validator, but no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationCreationValidationTest {
+
+    private static ValidatorFactory factory;
+    private Validator validator;
+
+    @Mock
+    private OrganizationRepository repository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private FileStorageService fileStorageService;
+    @Mock
+    private KeycloakGroupService keycloakGroupService;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private UserContextService userContextService;
+    @Mock
+    private EmployeeService employeeService;
+    @Mock
+    private OrganizationMapper organizationMapper;
+    @Mock
+    private OrganizationSecurityService orgSecurity;
+    @Mock
+    private OrganizationOnboardingSeeder onboardingSeeder;
+
+    private OrganizationService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        service = new OrganizationService(repository, attachmentService, fileStorageService,
+                keycloakGroupService, subscriptionService, userContextService, employeeService,
+                organizationMapper, orgSecurity, onboardingSeeder, validator);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private OrganizationCreationDto validDto() {
+        OrganizationCreationDto dto = new OrganizationCreationDto();
+        dto.setOrganizationName("Meridian Builders");
+        dto.setOrganizationAddress("Plot 47, Sector 18, Gurugram");
+        dto.setOrganizationEmail("site@meridianbuilders.com");
+        dto.setOrganizationPhone("+919876543210");
+        return dto;
+    }
+
+    @Test
+    void addOrganization_rejectsABlankName_beforeTouchingTheRepository() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationName("  ");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(repository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addOrganization_rejectsAMalformedEmail() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationEmail("site-at-meridianbuilders");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(repository, never()).save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void addOrganization_rejectsAMissingEmail() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationEmail(null);
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_rejectsABlankAddress() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationAddress("");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_rejectsAMissingPhone() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationPhone(null);
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_rejectsAWebsiteOverTheLimit() {
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationWebsite("https://" + "x".repeat(250) + ".com");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_acceptsATwoLetterName() {
+        // The old minimum of three refused "3M", "HP" and "GE"; the form has never had one.
+        // Failing past validation means it reached the duplicate-email check, which is mocked
+        // here; what matters is that it is not a constraint failure.
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationName("3M");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_acceptsAFullPostalAddress() {
+        // Sixty-seven characters, which the old cap of fifty would have refused.
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationAddress(
+                "Plot 47, Sector 18, Udyog Vihar Phase IV, Gurugram, Haryana 122015");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_acceptsALongTopLevelDomain() {
+        // The old pattern capped the top-level domain at six characters, refusing exactly the
+        // domains this product's customers register.
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationEmail("site@meridian.construction");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void addOrganization_acceptsAFifteenDigitInternationalNumber() {
+        // E.164 allows fifteen digits, and the form sends the leading plus, so the string is
+        // sixteen characters. The old maximum of fifteen refused it.
+        OrganizationCreationDto dto = validDto();
+        dto.setOrganizationPhone("+123456789012345");
+
+        assertThatThrownBy(() -> service.addOrganization(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import jakarta.validation.Validation;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
 import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -48,7 +49,8 @@ class OrganizationServiceBatchAuthzTest {
     private OrganizationService service() {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
-                organizationMapper, orgSecurity, onboardingSeeder);
+                organizationMapper, orgSecurity, onboardingSeeder,
+                Validation.buildDefaultValidatorFactory().getValidator());
     }
 
     private OrganizationPatchDto patch(long id) {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import jakarta.validation.Validation;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -59,7 +60,8 @@ class OrganizationServiceOnboardingTest {
     private OrganizationService service() {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
-                organizationMapper, orgSecurity, onboardingSeeder);
+                organizationMapper, orgSecurity, onboardingSeeder,
+                Validation.buildDefaultValidatorFactory().getValidator());
     }
 
     private OrganizationCreationDto creationDto() {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import jakarta.validation.Validator;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
@@ -46,6 +47,8 @@ class OrganizationServiceScopingTest {
     @Mock private OrganizationMapper organizationMapper;
     @Mock private OrganizationSecurityService orgSecurity;
     @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+
+    @Mock private Validator validator;
 
     @InjectMocks private OrganizationService service;
 


### PR DESCRIPTION
Part of #490. Organization and chat. #492 covers task and issue; the attendance sites the issue's survey did not catch follow in a third PR. The three are independent and can land in any order.

## The bug

`OrganizationController`, `OrganizationWebController` and the chat multipart send all declare their handler the same way:

```java
public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data, …) {
    OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
```

The `@Valid` is on the `String`. A `String` carries no constraints, so it validates nothing, and the DTO that comes out of `readValue` is never validated at all. Ten constraints on `OrganizationCreationDto` and the `@NotBlank` on `SendMessageDto.content` have never once run, while each endpoint's `@ApiResponses` advertises a 400 for a field that failed validation.

## The fix

For organization, the shape #488 used for projects: validate in the service, at the single shared caller, so the `/web` twin and the base controller are covered by one change rather than two that can drift.

**Chat deliberately does not follow it.** `ChatService.sendMessage(roomId, content, replyToId, files)` takes the message fields as separate arguments, so no `SendMessageDto` ever crosses the service boundary and there is nothing there to validate. The JSON send next to the multipart one already binds a `@Valid @RequestBody SendMessageDto` that Spring validates, so the controller is the only place a payload arrives unchecked, and there is no twin for it to drift away from. It validates there, with the reasoning written next to it.

The `ConstraintViolationException` to 400 mapping in `GlobalExceptionHandler` already exists (#488 added it), so nothing is added there.

## Constraints that were themselves wrong

Four of the ten. A rule that has never run has never been compared against a real request.

**`organizationAddress`, capped at 50.** The column is `TEXT`, and the form renders a three-row `<Textarea>` with no `maxLength` and no length check of its own, which is an explicit invitation to type more. "Plot 47, Sector 18, Udyog Vihar Phase IV, Gurugram, Haryana 122015" is 67 characters. A 50-character cap on an address field reads as a copy of the one on the name. It takes the column's cap instead. This is the same correction #488 made to the project address, for the same reason.

**`organizationPhone`, `@Size(min = 10, max = 15)`.** The form's field is a `PhoneInput` producing E.164 with no spaces or dashes, and its own validator is `/^\+?[1-9]\d{7,14}$/`, so the value is a leading plus and eight to fifteen digits: nine to sixteen characters. The old window counted the digits and forgot the plus, so a valid fifteen-digit international number was refused at sixteen characters, and a short national number was refused at nine. The window is nine to sixteen. Its message also read "memberPhone must be…", naming a field that does not exist on this payload.

**`organizationEmail`, TLD capped at `{2,6}`.** That refuses `.construction` (12), `.engineering` (11), `.contractors` (12), `.solutions` (9) and `.consulting` (10). For a construction product those are not exotic. The bound runs to 24. The client-side validator is `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`, so the client would have accepted every one of them.

**`organizationName`, `@Size(min = 3)`.** Refuses "3M", "HP", "GE". The form has never asked for a minimum. Two.

The local-part class `[a-zA-Z0-9._%+-]+` is left as it is, but it is worth noting it rejects RFC-legal locals containing an apostrophe or an ampersand, which the client accepts. Rare enough on a company address to leave rather than rewrite the pattern in a PR about enforcement.

## What newly returns 400

**Organization: nothing on either create path.** Both the `organizations/new` page and the onboarding page go through the same `organization-form.tsx`, which requires name, address, email and phone, sends the phone as E.164 and drops an empty website to `undefined` rather than `""`. Every payload it produces passes, including the ones the four corrections above were made for. Without those corrections, real addresses, `.construction` domains, 15-digit numbers and two-letter names would all have started failing, which is the point of making them.

**Chat: nothing at all.** The attachment-only message was the case worth checking, and it is not reachable. `chat-composer.tsx` is the only sender in the web app that can attach files, and it guards `const trimmed = value.trim(); if (!trimmed) return;` *before* it assembles the attachments, with the send button separately disabled on `!value.trim()`; selecting files does not enable it. The floating composer has no file input and always takes the JSON branch. So a user who attaches a photo and types no caption cannot send in the first place. The `@NotBlank` closes the gap for any other client rather than changing what this one does.

## Verification

```
$ ./gradlew test --tests "*OrganizationCreationValidationTest*" --tests "*ChatMessageValidationTest*" --tests "*OrganizationService*Test*"
ChatMessageValidationTest              3 PASSED
OrganizationCreationValidationTest    10 PASSED
OrganizationServiceBatchAuthzTest      2 PASSED
OrganizationServiceOnboardingTest      1 PASSED
OrganizationServiceScopingTest         2 PASSED
BUILD SUCCESSFUL in 2m 34s
```

Confirmed load bearing by commenting out the two `requireValid` calls and rerunning: all eight rejection tests FAILED, the five widening guards still passed (they are there to catch the caps being tightened again, not to prove enforcement). Restored, all 13 pass.

The three pre-existing `OrganizationService` tests take the new constructor argument. The two that build the service by hand are given a real validator rather than a mock, which also confirms their fixture payload is one the constraints accept.

Plain JUnit, Mockito and a real Hibernate `Validator` built in the test, no Spring context, following `ProjectCreationValidationTest`.
