### PR TITLE
Serve the navigation palette from a search endpoint

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/search/SearchController.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchController.java
@@ -1,0 +1,73 @@
+package org.tornotron.echno_backend.search;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Quick search for the web client's navigation palette.
+ *
+ * <p>One endpoint across projects, tasks and issues rather than one per kind, because the consumer
+ * is a single search box that shows a single ranked list. Three endpoints would mean three requests
+ * per keystroke and three loading states to reconcile in the browser, and would push ranking across
+ * kinds back into the client. The three kinds already share one read-authorization rule, so nothing
+ * is given up by serving them together.
+ */
+@RestController
+@RequestMapping("/api/v1/search/web")
+@Validated
+@Tag(
+        name = "Search",
+        description = "Quick search across the records the web client's navigation palette can jump "
+                + "to. Returns a small ranked set of matches rather than a page of a collection, "
+                + "because a search box wants what matches rather than what comes first."
+)
+public class SearchController {
+
+    private final SearchService searchService;
+
+    /**
+     * Constructs the controller with its service.
+     *
+     * @param searchService The cross-entity search.
+     */
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    /**
+     * Finds projects, tasks and issues matching a term.
+     *
+     * @param q     The search term. Anything shorter than two characters returns nothing.
+     * @param limit Rows per kind, defaulting to ten and clamped to twenty-five.
+     * @return The matching hits, grouped by kind and ranked within each.
+     */
+    @GetMapping
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Search projects, tasks and issues",
+            description = "Returns records of any of the three kinds whose name contains the term, "
+                    + "case-insensitively, with at most limit rows of each kind. A term shorter "
+                    + "than two characters returns an empty list without querying. Each hit carries "
+                    + "only its kind, id, title and owning project, which is what a navigation "
+                    + "result needs to be shown and followed."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Matching hits returned, possibly none"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<List<SearchHit>> search(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Integer limit) {
+        return ResponseEntity.ok(searchService.search(q, limit));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/search/SearchHit.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchHit.java
@@ -1,0 +1,34 @@
+package org.tornotron.echno_backend.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * One row of a quick-search result: enough to render a line and follow it, and nothing else.
+ *
+ * <p>The consumer is a navigation palette, so a hit needs a kind to pick an icon by, a label to
+ * show, and the ids needed to build a link. Returning the full DTO of each entity instead would put
+ * the transfer cost back where this endpoint exists to remove it, and would leak fields the palette
+ * has no reason to hold.
+ *
+ * @param type      Which kind of record this is.
+ * @param id        The record's own id.
+ * @param title     The record's display name.
+ * @param projectId The project the record hangs off, so a link can be built without a second
+ *                  lookup. Equal to {@code id} for a project, and null for an issue that was
+ *                  raised outside any task.
+ */
+@Schema(description = "A single quick-search hit: the minimum needed to show a result and link to it.")
+public record SearchHit(
+
+        @Schema(description = "Which kind of record this is.", example = "TASK")
+        SearchHitType type,
+
+        @Schema(description = "The record's own id.", example = "108")
+        Long id,
+
+        @Schema(description = "The record's display name.", example = "Pour foundation slab, block A")
+        String title,
+
+        @Schema(description = "Project the record belongs to, for building the link.", example = "42")
+        Long projectId) {
+}

--- a/src/main/java/org/tornotron/echno_backend/search/SearchHitType.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchHitType.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.search;
+
+/** The kind of record a {@link SearchHit} names. */
+public enum SearchHitType {
+
+    /** A project. {@code projectId} repeats the hit's own id. */
+    PROJECT,
+
+    /** A task. {@code projectId} names the project it belongs to. */
+    TASK,
+
+    /** An issue. {@code projectId} names the project of the task it was raised against. */
+    ISSUE
+}

--- a/src/main/java/org/tornotron/echno_backend/search/SearchRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchRepository.java
@@ -1,0 +1,82 @@
+package org.tornotron.echno_backend.search;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.project.Project;
+
+import java.util.List;
+
+/**
+ * The read model behind quick search: one query per searchable kind, each returning
+ * {@link SearchHit} rows directly.
+ *
+ * <p>Deliberately its own repository rather than three methods spread across
+ * {@code ProjectRepository}, {@code TaskRepository} and {@code IssueRepository}. Search is a
+ * feature with one consumer and one shape, and keeping its three queries together is what makes
+ * them stay consistent with each other. The declared domain type is only what Spring Data needs to
+ * bootstrap the interface; every method carries an explicit {@code @Query}, so none of them is
+ * derived from it.
+ *
+ * <p>Each query projects straight into the record rather than loading entities and mapping them.
+ * A palette needs a name and an id, and fetching whole aggregates to throw all but two fields away
+ * is the cost this endpoint exists to avoid.
+ *
+ * <p>The tenant filter applies to these queries exactly as it does to a derived finder, so a hit
+ * can only ever come from the caller's own organization.
+ *
+ * <p>Every search pattern is a pre-lowercased {@code %...%} LIKE built by {@link SearchService},
+ * which escapes any wildcard the user typed; {@code ESCAPE '\'} is what gives that escaping effect.
+ * Bounding comes from the {@link Pageable} the service passes, never from the caller directly.
+ */
+public interface SearchRepository extends Repository<Project, Long> {
+
+    /**
+     * Finds projects whose name matches.
+     *
+     * @param search   Lower-cased LIKE pattern.
+     * @param pageable The row limit to apply.
+     * @return Matching projects as search hits, shortest name first.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.search.SearchHit(
+                     org.tornotron.echno_backend.search.SearchHitType.PROJECT, p.id, p.projectName, p.id)
+            FROM Project p
+            WHERE LOWER(p.projectName) LIKE :search ESCAPE '\\'
+            ORDER BY LENGTH(p.projectName) ASC, p.id DESC
+            """)
+    List<SearchHit> findProjects(@Param("search") String search, Pageable pageable);
+
+    /**
+     * Finds tasks whose title matches.
+     *
+     * @param search   Lower-cased LIKE pattern.
+     * @param pageable The row limit to apply.
+     * @return Matching tasks as search hits, shortest title first.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.search.SearchHit(
+                     org.tornotron.echno_backend.search.SearchHitType.TASK, t.id, t.title, p.id)
+            FROM Task t LEFT JOIN t.project p
+            WHERE LOWER(t.title) LIKE :search ESCAPE '\\'
+            ORDER BY LENGTH(t.title) ASC, t.id DESC
+            """)
+    List<SearchHit> findTasks(@Param("search") String search, Pageable pageable);
+
+    /**
+     * Finds issues whose title matches.
+     *
+     * @param search   Lower-cased LIKE pattern.
+     * @param pageable The row limit to apply.
+     * @return Matching issues as search hits, shortest title first.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.search.SearchHit(
+                     org.tornotron.echno_backend.search.SearchHitType.ISSUE, i.id, i.title, p.id)
+            FROM Issue i LEFT JOIN i.task t LEFT JOIN t.project p
+            WHERE LOWER(i.title) LIKE :search ESCAPE '\\'
+            ORDER BY LENGTH(i.title) ASC, i.id DESC
+            """)
+    List<SearchHit> findIssues(@Param("search") String search, Pageable pageable);
+}

--- a/src/main/java/org/tornotron/echno_backend/search/SearchService.java
+++ b/src/main/java/org/tornotron/echno_backend/search/SearchService.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.search;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quick search across the records the navigation palette can jump to.
+ *
+ * <p>Answers the question a search box actually asks, which is "what matches this", not "give me
+ * the first page of everything". The palette used to be fed by whole-collection reads that the
+ * browser then filtered, so it could only find what had already been downloaded and it downloaded
+ * the collections whether or not anyone opened it. Matching in the database instead makes the
+ * result independent of what the client happens to be holding, and makes the response a few tens
+ * of rows regardless of how much history the tenant has.
+ */
+@Service
+public class SearchService {
+
+    /**
+     * Shortest term worth running. A single character matches most of a tenant's records, which
+     * costs a full scan to produce a result nobody can use.
+     */
+    public static final int MIN_TERM_LENGTH = 2;
+
+    /** Default rows per kind when the caller does not ask for a specific limit. */
+    public static final int DEFAULT_LIMIT = 10;
+
+    /**
+     * Most rows per kind a caller may ask for. A palette shows a couple of screens at most, and the
+     * ceiling is what stops this endpoint being turned back into the bulk read it replaced.
+     */
+    public static final int MAX_LIMIT = 25;
+
+    private final SearchRepository searchRepository;
+
+    /**
+     * Constructs the service with its read model.
+     *
+     * @param searchRepository The cross-entity search queries.
+     */
+    public SearchService(SearchRepository searchRepository) {
+        this.searchRepository = searchRepository;
+    }
+
+    /**
+     * Finds projects, tasks and issues whose name matches the term.
+     *
+     * <p>Hits come back grouped by kind, projects first, and ranked shortest name first within each
+     * kind. A term shorter than {@link #MIN_TERM_LENGTH} returns nothing without touching the
+     * database, so an empty search box costs no query.
+     *
+     * @param term  The raw search term as the user typed it.
+     * @param limit Rows per kind, clamped to {@link #MAX_LIMIT}.
+     * @return Matching hits, at most {@code limit} of each kind.
+     */
+    @Transactional(readOnly = true)
+    public List<SearchHit> search(String term, Integer limit) {
+        String pattern = searchPattern(term);
+        if (pattern == null) {
+            return List.of();
+        }
+
+        Pageable rows = PageRequest.ofSize(
+                Math.clamp(limit == null ? DEFAULT_LIMIT : limit, 1, MAX_LIMIT));
+
+        List<SearchHit> hits = new ArrayList<>();
+        hits.addAll(searchRepository.findProjects(pattern, rows));
+        hits.addAll(searchRepository.findTasks(pattern, rows));
+        hits.addAll(searchRepository.findIssues(pattern, rows));
+        return hits;
+    }
+
+    /**
+     * Builds the lower-cased {@code %...%} LIKE pattern for a term, or null when the term is too
+     * short to run.
+     *
+     * <p>Wildcards the user typed are escaped, so searching for a per-cent sign finds records
+     * containing one rather than every record in the tenant.
+     *
+     * @param term The raw search term.
+     * @return The LIKE pattern, or null when there is nothing worth searching for.
+     */
+    private static String searchPattern(String term) {
+        if (term == null) {
+            return null;
+        }
+        String trimmed = term.trim();
+        if (trimmed.length() < MIN_TERM_LENGTH) {
+            return null;
+        }
+        String escaped = trimmed.toLowerCase()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return "%" + escaped + "%";
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/search/SearchRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/search/SearchRepositoryIT.java
@@ -1,0 +1,201 @@
+package org.tornotron.echno_backend.search;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.Issue;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.enums.TaskStatus;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The quick-search queries against a real CockroachDB (see {@link AbstractIntegrationTest}).
+ *
+ * <p>These are constructor-expression queries written as JPQL strings, so a wrong field name or a
+ * malformed constructor call is invisible until the query runs. A unit test with a mocked
+ * repository cannot catch that, which is what this covers: that each query parses, projects into
+ * {@link SearchHit}, honours its row limit, and reaches the ids a link needs.
+ *
+ * <p>Carries the same {@code @DataJpaTest} configuration as the other repository integration tests,
+ * so it reuses their context rather than contributing another distinct one to the run's cache.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SearchRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private SearchRepository searchRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void aProjectIsFoundByPartOfItsNameWhateverTheCase() {
+        Organization org = persistOrganization("Search Org A");
+        persistProject(org, "Riverside Tower A");
+        persistProject(org, "Hillside Block B");
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findProjects("%tower%", PageRequest.ofSize(10));
+
+        assertThat(hits).extracting(SearchHit::title).containsExactly("Riverside Tower A");
+        assertThat(hits).allSatisfy(hit -> {
+            assertThat(hit.type()).isEqualTo(SearchHitType.PROJECT);
+            assertThat(hit.projectId())
+                    .as("a project hit points at itself so the palette can link to it")
+                    .isEqualTo(hit.id());
+        });
+    }
+
+    @Test
+    void aTaskIsFoundByItsTitleAndCarriesTheProjectItBelongsTo() {
+        Organization org = persistOrganization("Search Org B");
+        Employee creator = persistEmployee(org, "Bee");
+        Project project = persistProject(org, "Riverside");
+        persistTask(org, project, creator, "Pour the raft slab");
+        persistTask(org, project, creator, "Erect scaffolding");
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findTasks("%slab%", PageRequest.ofSize(10));
+
+        assertThat(hits).extracting(SearchHit::title).containsExactly("Pour the raft slab");
+        assertThat(hits.getFirst().type()).isEqualTo(SearchHitType.TASK);
+        assertThat(hits.getFirst().projectId()).isEqualTo(project.getId());
+    }
+
+    @Test
+    void anIssueIsFoundByItsTitleAndCarriesTheProjectOfItsTask() {
+        Organization org = persistOrganization("Search Org C");
+        Employee creator = persistEmployee(org, "Cee");
+        Project project = persistProject(org, "Hillside");
+        Task task = persistTask(org, project, creator, "Inspect the beam");
+        persistIssue(org, task, creator, "Crack in the beam");
+        persistIssue(org, task, creator, "Missing handrail");
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findIssues("%crack%", PageRequest.ofSize(10));
+
+        assertThat(hits).extracting(SearchHit::title).containsExactly("Crack in the beam");
+        assertThat(hits.getFirst().type()).isEqualTo(SearchHitType.ISSUE);
+        assertThat(hits.getFirst().projectId()).isEqualTo(project.getId());
+    }
+
+    @Test
+    void anIssueWithNoTaskIsStillFound() {
+        Organization org = persistOrganization("Search Org D");
+        Employee creator = persistEmployee(org, "Dee");
+        persistIssue(org, null, creator, "Orphan drainage complaint");
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findIssues("%drainage%", PageRequest.ofSize(10));
+
+        assertThat(hits).extracting(SearchHit::title)
+                .as("an inner join on the task would drop this row silently")
+                .containsExactly("Orphan drainage complaint");
+        assertThat(hits.getFirst().projectId()).isNull();
+    }
+
+    @Test
+    void theRowLimitBoundsTheResultRatherThanTheMatchCount() {
+        Organization org = persistOrganization("Search Org E");
+        for (int i = 1; i <= 12; i++) {
+            persistProject(org, "Bounded project " + i);
+        }
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findProjects("%bounded%", PageRequest.ofSize(5));
+
+        assertThat(hits).hasSize(5);
+    }
+
+    @Test
+    void anEscapedWildcardMatchesItselfRatherThanEverything() {
+        Organization org = persistOrganization("Search Org F");
+        persistProject(org, "Phase 100% complete");
+        persistProject(org, "Phase two");
+        em.flush();
+        em.clear();
+
+        List<SearchHit> hits = searchRepository.findProjects("%100\\%%", PageRequest.ofSize(10));
+
+        assertThat(hits).extracting(SearchHit::title).containsExactly("Phase 100% complete");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Employee persistEmployee(Organization org, String name) {
+        User user = new User();
+        user.setKeycloakId("kc-search-" + name.toLowerCase());
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase() + "@search.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+        return employee;
+    }
+
+    private Project persistProject(Organization org, String name) {
+        Project project = new Project();
+        project.setProjectName(name);
+        project.setOrganization(org);
+        em.persist(project);
+        return project;
+    }
+
+    private Task persistTask(Organization org, Project project, Employee creator, String title) {
+        Task task = new Task();
+        task.setTitle(title);
+        task.setOrganization(org);
+        task.setCreator(creator);
+        task.setProject(project);
+        task.setStatus(TaskStatus.upcoming);
+        em.persist(task);
+        return task;
+    }
+
+    private void persistIssue(Organization org, Task task, Employee createdBy, String title) {
+        Issue issue = new Issue();
+        issue.setTitle(title);
+        issue.setDescription(title + " description");
+        issue.setType(IssueType.safety);
+        issue.setStatus(IssueStatus.open);
+        issue.setOrganization(org);
+        issue.setCreatedBy(createdBy);
+        issue.setTask(task);
+        em.persist(issue);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/search/SearchServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/search/SearchServiceTest.java
@@ -1,0 +1,139 @@
+package org.tornotron.echno_backend.search;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Term handling and bounding in {@link SearchService}.
+ *
+ * <p>This endpoint exists to replace whole-collection reads, so what matters is that it cannot be
+ * talked back into one: a term too short to be selective never reaches the database, and the row
+ * limit is the service's to decide rather than the caller's.
+ */
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @Mock
+    private SearchRepository searchRepository;
+
+    @InjectMocks
+    private SearchService service;
+
+    private void repositoryReturningNothing() {
+        when(searchRepository.findProjects(anyString(), any())).thenReturn(List.of());
+        when(searchRepository.findTasks(anyString(), any())).thenReturn(List.of());
+        when(searchRepository.findIssues(anyString(), any())).thenReturn(List.of());
+    }
+
+    private String capturedPattern() {
+        ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(searchRepository).findProjects(pattern.capture(), any());
+        return pattern.getValue();
+    }
+
+    private Pageable capturedRows() {
+        ArgumentCaptor<Pageable> rows = ArgumentCaptor.forClass(Pageable.class);
+        org.mockito.Mockito.verify(searchRepository).findProjects(anyString(), rows.capture());
+        return rows.getValue();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "   ", "a", " b "})
+    void aTermTooShortToBeSelectiveNeverReachesTheDatabase(String term) {
+        assertThat(service.search(term, null)).isEmpty();
+        verifyNoInteractions(searchRepository);
+    }
+
+    @Test
+    void aTermIsLowerCasedAndWrappedForALikeMatch() {
+        repositoryReturningNothing();
+
+        service.search("  Slab  ", null);
+
+        assertThat(capturedPattern()).isEqualTo("%slab%");
+    }
+
+    @Test
+    void aWildcardInTheTermIsEscapedSoItMatchesItself() {
+        repositoryReturningNothing();
+
+        service.search("100%", null);
+
+        assertThat(capturedPattern())
+                .as("an unescaped % would turn a search into a full listing")
+                .isEqualTo("%100\\%%");
+    }
+
+    @Test
+    void anUnderscoreInTheTermIsEscapedSoItIsNotASingleCharacterWildcard() {
+        repositoryReturningNothing();
+
+        service.search("block_a", null);
+
+        assertThat(capturedPattern()).isEqualTo("%block\\_a%");
+    }
+
+    @Test
+    void aMissingLimitFallsBackToTheDefault() {
+        repositoryReturningNothing();
+
+        service.search("slab", null);
+
+        assertThat(capturedRows().getPageSize()).isEqualTo(SearchService.DEFAULT_LIMIT);
+    }
+
+    @Test
+    void aLimitAboveTheCeilingIsClampedToIt() {
+        repositoryReturningNothing();
+
+        service.search("slab", 100_000);
+
+        assertThat(capturedRows().getPageSize())
+                .as("the caller must not be able to ask this endpoint for the whole tenant")
+                .isEqualTo(SearchService.MAX_LIMIT);
+    }
+
+    @Test
+    void aLimitOfZeroIsRaisedToOneRatherThanRejectedByPageRequest() {
+        repositoryReturningNothing();
+
+        service.search("slab", 0);
+
+        assertThat(capturedRows().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void hitsFromAllThreeKindsComeBackTogetherWithProjectsFirst() {
+        when(searchRepository.findProjects(anyString(), any()))
+                .thenReturn(List.of(new SearchHit(SearchHitType.PROJECT, 1L, "Tower A", 1L)));
+        when(searchRepository.findTasks(anyString(), any()))
+                .thenReturn(List.of(new SearchHit(SearchHitType.TASK, 8L, "Tower slab", 1L)));
+        when(searchRepository.findIssues(anyString(), any()))
+                .thenReturn(List.of(new SearchHit(SearchHitType.ISSUE, 4L, "Tower crack", 1L)));
+
+        List<SearchHit> hits = service.search("tower", null);
+
+        assertThat(hits).extracting(SearchHit::type).containsExactly(
+                SearchHitType.PROJECT, SearchHitType.TASK, SearchHitType.ISSUE);
+        assertThat(hits).extracting(SearchHit::projectId)
+                .as("a hit carries the project it hangs off so a link needs no second lookup")
+                .containsOnly(1L);
+    }
+}


### PR DESCRIPTION
Backend half of tornotron/echno-web#269. **Step 1 of 3** (backend → core release → web).

## Why a search endpoint rather than pagination

The web command palette is fed by whole-collection reads of projects, tasks and issues taken in the application shell, so they run on every route, and then filtered in the browser down to a few tens of rows.

I verified the consumer before designing against it. `command-palette.tsx` is not a count badge and not a paged list: it flattens all three collections plus the static nav routes into one `searchEntries` array, filters it by substring on a `keywords` field, ranks prefix matches above contains matches, and slices the ranked result to 50. It is a search box.

That settles the question the issue raised. Pagination does not serve it, because a palette wants whatever matches the query rather than an arbitrary first page. Two further findings from reading the consumer reinforce it:

- the shell pre-slices to 30 projects and 40 tasks/issues **before** the palette searches, so today it cannot find a project past the 30th or an issue past the 40th even when the data is loaded;
- tasks are capped at ten regardless, by echno-backend#478.

So the palette's search is already wrong, not merely expensive. Matching in the database fixes both.

## Design

**One endpoint, not one per kind.** `GET /api/v1/search/web?q=&limit=`. The consumer is a single search box showing a single ranked list, so per-kind endpoints would mean three requests per keystroke-debounce and three loading states to reconcile in the browser, and would push cross-kind ranking back into the client. The three kinds already share one read-authorization expression (`isMemberOfCurrentTenant() or hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')`, verified identical on `TaskControllerWeb`, `ProjectControllerWeb` and `IssueControllerWeb`), so serving them together gives up no authorization fidelity. The per-entity `/vendors/web/search` precedent stands where the consumer is a per-entity picker; this consumer is cross-entity.

**What it returns.** A flat array of `{type, id, title, projectId}`. That is exactly what the palette needs to pick an icon, show a label and build a link, and nothing more. Full DTOs would put back the transfer cost this exists to remove. `projectId` saves the client a second lookup to build a task's href.

**Bounding.** `limit` is per kind, defaults to 10, clamped to 25. A term under two characters returns empty without touching the database. LIKE wildcards in the term are escaped, so a bare `%` matches a per-cent sign rather than every row. No new unbounded read; the ArchUnit ratchet is untouched.

**Its own repository.** The three queries live in `SearchRepository` rather than being spread across the project, task and issue repositories. Search has one consumer and one shape, and keeping its queries together is what keeps them consistent. Every method carries an explicit `@Query`, so none is derived from the declared domain type.

## Verification

`SearchServiceTest` (plain Mockito): short-term short-circuit, wildcard and underscore escaping, limit default/clamp/floor, all three kinds returned together.

`SearchRepositoryIT` against a real CockroachDB, run on lab `.116` since these are constructor-expression JPQL strings that only fail when executed:

```
aProjectIsFoundByPartOfItsNameWhateverTheCase()        PASSED
aTaskIsFoundByItsTitleAndCarriesTheProjectItBelongsTo() PASSED
anIssueIsFoundByItsTitleAndCarriesTheProjectOfItsTask() PASSED
anIssueWithNoTaskIsStillFound()                        PASSED
theRowLimitBoundsTheResultRatherThanTheMatchCount()    PASSED
anEscapedWildcardMatchesItselfRatherThanEverything()   PASSED
BUILD SUCCESSFUL
```

`anIssueWithNoTaskIsStillFound` earns its place: an implicit `i.task.project.id` path join is an inner join and drops such rows silently, which is what the existing issue search does today.

## Not in this PR

The breadcrumb half of #269, and the web-side palette rewrite. The breadcrumb fix needs no backend work at all and ships now as a pure web change.