### PR TITLE
Give each trade a checklist an org owns, and copy it onto the inspection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,16 @@ tasks.named('test') {
     // and the OOM killer then takes the database, failing the rest of the suite.
     maxHeapSize = '1024m'
     jvmArgs '-XX:MaxMetaspaceSize=512m'
+    // Bound how many Spring test contexts the run keeps alive at once. There is no
+    // forkEvery, so one JVM serves the whole suite and the default cache of 32 means
+    // every distinct test configuration's context, each with its own Hibernate
+    // SessionFactory, is held to the last test. That total only grows as the schema
+    // does, and it is what leaves nothing for the ArchUnit import that runs late in
+    // the run and needs the class graph of the whole application in memory at once.
+    // Capping the cache makes Spring close the least recently used context instead of
+    // holding all of them; a context is rebuilt if a later class needs it again,
+    // which costs seconds where the alternative costs the build.
+    systemProperty 'spring.test.context.cache.maxSize', '8'
     // Print each test as it starts and finishes so a CI log always shows which test
     // is running; without this, a hung test leaves no trace of which one stalled.
     testLogging {

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplate.java
@@ -1,0 +1,94 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A reusable checklist an organization's QA engineer defines once for a trade and
+ * an inspection of that trade is then created from. Tenant-scoped through the
+ * Hibernate {@code orgFilter} exactly as {@link Inspection} is: the criteria a
+ * client accepts work against are their own, so a template belongs to one org and
+ * is invisible to every other.
+ *
+ * <p>One template per trade per org, enforced by the unique constraint on
+ * ({@code organization_id}, {@code trade}). {@code version} is therefore a
+ * revision counter on that one row rather than a key: it starts at 1 and the
+ * service bumps it on every edit, so an inspection's copied items can be traced
+ * back to the revision they came from. {@code active} decides whether the
+ * template is instantiated into new inspections; deactivating it retires the
+ * checklist without deleting the definition or the history that references it.
+ *
+ * <p>The starter content each org begins from is {@link StarterChecklistTemplate},
+ * which is global reference data. Adopting a starter copies it into a row of this
+ * table, after which the two are independent.
+ */
+@Entity
+@Table(name = "checklist_templates",
+        uniqueConstraints = @UniqueConstraint(name = "uk_checklist_template_trade",
+                columnNames = {"organization_id", "trade"}),
+        indexes = {
+                @Index(name = "idx_checklist_template_trade", columnList = "trade"),
+                @Index(name = "idx_checklist_template_active", columnList = "active")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter @Setter
+@NoArgsConstructor
+public class ChecklistTemplate implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade", nullable = false, length = 50)
+    private InspectionTrade trade;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    /** Revision counter, bumped by the service on every edit. Never a key. */
+    @Column(name = "version", nullable = false)
+    private int version = 1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @OrderBy("lineOrder ASC")
+    private List<ChecklistTemplateItem> items = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void addItem(ChecklistTemplateItem item) {
+        item.setTemplate(this);
+        item.setLineOrder(this.items.size());
+        this.items.add(item);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplateItem.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/ChecklistTemplateItem.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * One check point in a {@link ChecklistTemplate}. Owned by the template through
+ * the {@code template_id} FK; the parent cascades persist and removal. Tenant
+ * scoping is inherited from the owning template, which carries the org filter,
+ * the same way {@link InspectionCheckItem} inherits it from its inspection.
+ *
+ * <p>{@code acceptanceCriterion} and {@code tolerance} are the measurable form of
+ * a criterion: the criterion states what makes the check point pass ("rebar
+ * spacing matches the bar bending schedule"), {@code expectedValue} is the target
+ * ("150 mm"), and {@code tolerance} is the band around it ("+/- 10 mm"). They are
+ * copied onto the inspection's check items unchanged, where the recorded
+ * measurement is judged against them.
+ */
+@Entity
+@Table(name = "checklist_template_items",
+        indexes = @Index(name = "idx_checklist_template_item_template", columnList = "template_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChecklistTemplateItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "template_id", nullable = false)
+    private ChecklistTemplate template;
+
+    @Column(nullable = false, length = 200)
+    private String category;
+
+    @Column(name = "check_point", nullable = false, length = 500)
+    private String checkPoint;
+
+    @Column(length = 1000)
+    private String specification;
+
+    @Column(name = "expected_value", length = 200)
+    private String expectedValue;
+
+    @Column(name = "acceptance_criterion", length = 1000)
+    private String acceptanceCriterion;
+
+    @Column(name = "tolerance", length = 100)
+    private String tolerance;
+
+    @Column(name = "photos_required", nullable = false)
+    private boolean photosRequired;
+
+    // Free-form priority, matching the same field on InspectionCheckItem so
+    // instantiation is a straight copy. That means the same three tokens and no
+    // others: 'high' | 'medium' | 'low' is what the web contract renders, so a
+    // fourth value here would reach the UI as an unrecognised label. How serious a
+    // failure of the check point is belongs in the acceptance criterion, not here.
+    @Column(length = 20)
+    private String priority = "medium";
+
+    @Column(name = "line_order", nullable = false)
+    private int lineOrder;
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionCheckItem.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/InspectionCheckItem.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.tornotron.echno_backend.inspection.CheckItemStatus;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -61,6 +62,26 @@ public class InspectionCheckItem {
 
     @Column(name = "expected_value", length = 200)
     private String expectedValue;
+
+    // The measurable criterion copied from the checklist template this check point
+    // came from: what makes it pass, and the band around the expected value.
+    @Column(name = "acceptance_criterion", length = 1000)
+    private String acceptanceCriterion;
+
+    @Column(name = "tolerance", length = 100)
+    private String tolerance;
+
+    // measurement minus expectedValue, computed server-side by MeasurementDeviation
+    // whenever both are numeric and carry the same unit. Null when either is absent
+    // or non-numeric, which is the normal case for a qualitative check point.
+    @Column(name = "deviation", precision = 19, scale = 4)
+    private BigDecimal deviation;
+
+    // IFC GlobalId of the BIM element this check point was carried out against.
+    // Nullable and unused until the BIM phase; the column exists now so the link is
+    // already in place when the viewer lands and needs no migration of live rows.
+    @Column(name = "bim_element_guid", length = 100)
+    private String bimElementGuid;
 
     // Free-form priority ('high' | 'medium' | 'low'), kept as text to match the
     // web contract's inline string union.

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/StarterChecklistTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/StarterChecklistTemplate.java
@@ -1,0 +1,57 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The default per-trade checklist a new organization starts from. This is GLOBAL
+ * reference data shipped with the product and is deliberately NOT tenant-scoped
+ * (no organization_id, no {@code orgFilter}), following the
+ * {@code ComplianceRule} precedent: the check points for a rebar or waterproofing
+ * inspection are the same trade practice whichever org is building.
+ *
+ * <p>It is a starting point, never the live definition. An org adopts a starter,
+ * which copies it into a tenant-scoped {@link ChecklistTemplate} the org's QA
+ * engineer then edits. The two are independent from that moment: a later revision
+ * of the starter does not reach into any org's template, and an org's edits are
+ * never pushed back here.
+ *
+ * <p>One starter per trade, enforced by the unique constraint on {@code trade}.
+ */
+@Entity
+@Table(name = "starter_checklist_templates",
+        uniqueConstraints = @UniqueConstraint(name = "uk_starter_checklist_template_trade",
+                columnNames = {"trade"}),
+        indexes = @Index(name = "idx_starter_checklist_template_active", columnList = "active"))
+@Getter @Setter
+@NoArgsConstructor
+public class StarterChecklistTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade", nullable = false, length = 50)
+    private InspectionTrade trade;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @OneToMany(mappedBy = "template", fetch = FetchType.LAZY)
+    @OrderBy("lineOrder ASC")
+    private List<StarterChecklistTemplateItem> items = new ArrayList<>();
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/StarterChecklistTemplateItem.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/StarterChecklistTemplateItem.java
@@ -1,0 +1,58 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * One check point in a {@link StarterChecklistTemplate}. Global reference data,
+ * read-only to the application: the rows are shipped by a Liquibase seed, exactly
+ * as the curated compliance rules are, and no endpoint writes them. The parent
+ * therefore declares no cascade, and this side carries no tenancy of its own.
+ */
+@Entity
+@Table(name = "starter_checklist_template_items",
+        indexes = @Index(name = "idx_starter_checklist_item_template", columnList = "template_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class StarterChecklistTemplateItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "template_id", nullable = false)
+    private StarterChecklistTemplate template;
+
+    @Column(nullable = false, length = 200)
+    private String category;
+
+    @Column(name = "check_point", nullable = false, length = 500)
+    private String checkPoint;
+
+    @Column(length = 1000)
+    private String specification;
+
+    @Column(name = "expected_value", length = 200)
+    private String expectedValue;
+
+    @Column(name = "acceptance_criterion", length = 1000)
+    private String acceptanceCriterion;
+
+    @Column(name = "tolerance", length = 100)
+    private String tolerance;
+
+    @Column(name = "photos_required", nullable = false)
+    private boolean photosRequired;
+
+    @Column(length = 20)
+    private String priority = "medium";
+
+    @Column(name = "line_order", nullable = false)
+    private int lineOrder;
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateDto.java
@@ -1,0 +1,21 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "An organization's checklist template for one trade, with its check points.")
+public record ChecklistTemplateDto(
+        UUID id,
+        InspectionTrade trade,
+        String name,
+        String description,
+        boolean active,
+        int version,
+        List<ChecklistTemplateItemDto> items,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemDto.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "A check point within a checklist template, as returned by the API.")
+public record ChecklistTemplateItemDto(
+        UUID id,
+        String category,
+        String checkPoint,
+        String specification,
+        String expectedValue,
+        String acceptanceCriterion,
+        String tolerance,
+        boolean photosRequired,
+        String priority,
+        int lineOrder
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateItemRequest.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Check-point payload shared by the create and update template requests. The line
+ * order is the position in the submitted list and is not accepted from the client.
+ */
+@Schema(description = "A single check point within a checklist template.")
+public record ChecklistTemplateItemRequest(
+        @Schema(description = "Grouping the check point belongs to.", example = "Reinforcement")
+        @NotBlank @Size(max = 200) String category,
+        @Schema(description = "What is being checked.", example = "Main bar spacing matches the bar bending schedule")
+        @NotBlank @Size(max = 500) String checkPoint,
+        @Schema(description = "Reference specification or code clause for the check point.", example = "IS 456:2000 cl. 26.3")
+        @Size(max = 1000) String specification,
+        @Schema(description = "Value expected per specification.", example = "150 mm")
+        @Size(max = 200) String expectedValue,
+        @Schema(description = "What makes this check point pass.", example = "Spacing measured at three locations per bay")
+        @Size(max = 1000) String acceptanceCriterion,
+        @Schema(description = "Permitted band around the expected value.", example = "+/- 10 mm")
+        @Size(max = 100) String tolerance,
+        @Schema(description = "Whether supporting photos are required for this check point.", example = "true")
+        boolean photosRequired,
+        @Schema(description = "Priority of this check point. Defaults to medium when omitted.", example = "high")
+        @Size(max = 20) String priority
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/ChecklistTemplateRequest.java
@@ -1,0 +1,34 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+
+import java.util.List;
+
+/**
+ * Creates or fully replaces an organization's checklist template for a trade. The
+ * check points are rebuilt from the payload on every save, so a replacement carries
+ * the whole list rather than a delta. The version is a server-side revision counter
+ * and is not accepted here.
+ */
+@Schema(description = "Payload to define or replace a checklist template for one trade.")
+public record ChecklistTemplateRequest(
+        @Schema(description = "Trade the checklist covers. One template per trade per organization.",
+                example = "reinforcement")
+        @NotNull InspectionTrade trade,
+        @Schema(description = "Name of the checklist.", example = "Reinforcement inspection checklist")
+        @NotBlank @Size(max = 200) String name,
+        @Schema(description = "What the checklist covers and when it is used.",
+                example = "Pre-pour reinforcement check for slabs, beams and columns")
+        String description,
+        @Schema(description = "Whether new inspections of this trade are created from this template. "
+                + "Defaults to true when omitted.", example = "true")
+        Boolean active,
+        @Schema(description = "Check points, in the order they are carried out.")
+        @NotEmpty @Valid List<ChecklistTemplateItemRequest> items
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemDto.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.inspection.dtos;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.inspection.CheckItemStatus;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -18,5 +19,9 @@ public record InspectionCheckItemDto(
         List<String> photos,
         String measurement,
         String expectedValue,
+        String acceptanceCriterion,
+        String tolerance,
+        BigDecimal deviation,
+        String bimElementGuid,
         String priority
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/InspectionCheckItemRequest.java
@@ -11,7 +11,8 @@ import java.util.List;
 /**
  * Check-point payload shared by the create and update requests. The inspection's
  * passed, failed and total counts are derived server-side from the supplied
- * check items; the client does not set them.
+ * check items; the client does not set them, and neither is the deviation, which
+ * the server computes from the measurement and the expected value.
  */
 @Schema(description = "A single checklist item within an inspection.")
 public record InspectionCheckItemRequest(
@@ -33,6 +34,14 @@ public record InspectionCheckItemRequest(
         @Size(max = 200) String measurement,
         @Schema(description = "Value expected per specification.", example = "150mm")
         @Size(max = 200) String expectedValue,
+        @Schema(description = "What makes this check point pass, copied from the checklist template.",
+                example = "Spacing measured at three locations per bay")
+        @Size(max = 1000) String acceptanceCriterion,
+        @Schema(description = "Permitted band around the expected value.", example = "+/- 10 mm")
+        @Size(max = 100) String tolerance,
+        @Schema(description = "IFC GlobalId of the BIM element this check point covers, when the "
+                + "inspection was carried out against a model.", example = "1kTvXnbbzCWw8lcMd1dR4o")
+        @Size(max = 100) String bimElementGuid,
         @Schema(description = "Priority of this check point.", example = "high")
         @Size(max = 20) String priority
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/StarterChecklistTemplateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/StarterChecklistTemplateDto.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "A product-supplied starter checklist for one trade, which an organization "
+        + "adopts to create its own editable template.")
+public record StarterChecklistTemplateDto(
+        UUID id,
+        InspectionTrade trade,
+        String name,
+        String description,
+        List<ChecklistTemplateItemDto> items
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/mapper/ChecklistTemplateMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/mapper/ChecklistTemplateMapper.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.inspection.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplate;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplateItem;
+import org.tornotron.echno_backend.inspection.domain.StarterChecklistTemplate;
+import org.tornotron.echno_backend.inspection.domain.StarterChecklistTemplateItem;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateItemDto;
+import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
+
+@Mapper(componentModel = "spring")
+public interface ChecklistTemplateMapper {
+
+    ChecklistTemplateDto toDto(ChecklistTemplate template);
+
+    ChecklistTemplateItemDto toItemDto(ChecklistTemplateItem item);
+
+    StarterChecklistTemplateDto toStarterDto(StarterChecklistTemplate template);
+
+    ChecklistTemplateItemDto toStarterItemDto(StarterChecklistTemplateItem item);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/ChecklistTemplateRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/ChecklistTemplateRepository.java
@@ -1,0 +1,37 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplate;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ChecklistTemplateRepository
+        extends JpaRepository<ChecklistTemplate, UUID>, JpaSpecificationExecutor<ChecklistTemplate> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads. The
+     * items load lazily while the transaction is still open.
+     */
+    @Query("SELECT t FROM ChecklistTemplate t WHERE t.id = :id")
+    Optional<ChecklistTemplate> findByIdScoped(@Param("id") UUID id);
+
+    /**
+     * The template an inspection of this trade is created from. Only an active
+     * template is instantiated: deactivating one retires the checklist for new
+     * inspections without touching the ones already carried out against it. The
+     * {@code orgFilter} restricts this to the calling tenant, and the unique
+     * constraint on (organization, trade) makes at most one row match.
+     */
+    Optional<ChecklistTemplate> findByTradeAndActiveTrue(InspectionTrade trade);
+
+    /** Guard for the one-template-per-trade rule, checked before an insert. */
+    boolean existsByTrade(InspectionTrade trade);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/ChecklistTemplateSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/ChecklistTemplateSpecifications.java
@@ -1,0 +1,33 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the optional list filters as a JPA {@link Specification}. Only non-null
+ * arguments become predicates, which avoids binding null-typed parameters on the
+ * Postgres wire protocol. Organization scoping is handled separately by the
+ * Hibernate {@code orgFilter} enabled per request.
+ */
+public final class ChecklistTemplateSpecifications {
+
+    private ChecklistTemplateSpecifications() {}
+
+    public static Specification<ChecklistTemplate> withFilters(InspectionTrade trade, Boolean active) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (trade != null) {
+                predicates.add(cb.equal(root.get("trade"), trade));
+            }
+            if (active != null) {
+                predicates.add(cb.equal(root.get("active"), active));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/StarterChecklistTemplateRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/StarterChecklistTemplateRepository.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.inspection.domain.StarterChecklistTemplate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface StarterChecklistTemplateRepository
+        extends JpaRepository<StarterChecklistTemplate, UUID> {
+
+    /**
+     * Every starter on offer. Bounded by what the table is rather than by how much
+     * data a tenant has accumulated: there is at most one starter per
+     * {@link InspectionTrade}, and the enum has sixteen members. It is global
+     * reference data shipped by a Liquibase seed, so no tenant can grow it.
+     */
+    List<StarterChecklistTemplate> findByActiveTrueOrderByTradeAsc();
+
+    Optional<StarterChecklistTemplate> findByTradeAndActiveTrue(InspectionTrade trade);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/ChecklistTemplateService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/ChecklistTemplateService.java
@@ -1,0 +1,238 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inspection.CheckItemStatus;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplate;
+import org.tornotron.echno_backend.inspection.domain.ChecklistTemplateItem;
+import org.tornotron.echno_backend.inspection.domain.InspectionCheckItem;
+import org.tornotron.echno_backend.inspection.domain.StarterChecklistTemplate;
+import org.tornotron.echno_backend.inspection.domain.StarterChecklistTemplateItem;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateItemRequest;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateRequest;
+import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapper;
+import org.tornotron.echno_backend.inspection.repositories.ChecklistTemplateRepository;
+import org.tornotron.echno_backend.inspection.repositories.ChecklistTemplateSpecifications;
+import org.tornotron.echno_backend.inspection.repositories.StarterChecklistTemplateRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The per-trade checklist library an organization inspects against.
+ *
+ * <p>Two populations sit behind this service and they must not be confused. The
+ * {@code starter_checklist_templates} are global reference data shipped with the
+ * product, read-only, and shared by every tenant. The {@code checklist_templates}
+ * are an org's own, tenant-scoped and editable. {@link #adoptStarter} is the only
+ * bridge: it copies a starter into the calling tenant, after which the two are
+ * independent, so a later revision of the shipped starter never rewrites criteria
+ * a client has tailored and signed work off against.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChecklistTemplateService {
+
+    private final ChecklistTemplateRepository templateRepo;
+    private final StarterChecklistTemplateRepository starterRepo;
+    private final ChecklistTemplateMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public ChecklistTemplateDto findById(UUID id) {
+        return mapper.toDto(require(id));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChecklistTemplateDto> findAll(InspectionTrade trade, Boolean active, Pageable pageable) {
+        return templateRepo.findAll(ChecklistTemplateSpecifications.withFilters(trade, active), pageable)
+                .map(mapper::toDto);
+    }
+
+    /**
+     * Defines the organization's checklist for a trade.
+     *
+     * @throws DuplicateResourceException if the tenant already has one for that trade.
+     *                                    There is exactly one template per trade per
+     *                                    org, so a second definition is an edit of the
+     *                                    first, not a new row.
+     */
+    @Transactional
+    public ChecklistTemplateDto create(ChecklistTemplateRequest req) {
+        requireTradeIsFree(req.trade());
+
+        ChecklistTemplate template = new ChecklistTemplate();
+        template.setTrade(req.trade());
+        template.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        apply(template, req);
+
+        ChecklistTemplate saved = templateRepo.saveAndFlush(template);
+        log.info("Created checklist template {} for trade {}", saved.getId(), saved.getTrade());
+        return mapper.toDto(saved);
+    }
+
+    /**
+     * Replaces a checklist template's name, description, active flag and check
+     * points, and bumps its revision counter.
+     *
+     * <p>The trade is fixed when the template is created: it is the key the
+     * template is found by when an inspection is instantiated, and moving one to
+     * another trade would silently repoint every future inspection of two trades at
+     * once. Retire the template and define one for the other trade instead.
+     *
+     * @throws ResourceNotFoundException if no such template exists in this tenant.
+     * @throws InvalidRequestException   if the payload names a different trade.
+     */
+    @Transactional
+    public ChecklistTemplateDto update(UUID id, ChecklistTemplateRequest req) {
+        ChecklistTemplate template = require(id);
+        if (req.trade() != null && req.trade() != template.getTrade()) {
+            throw new InvalidRequestException(
+                    "Checklist template " + id + " covers trade " + template.getTrade().getValue()
+                            + " and cannot be moved to " + req.trade().getValue()
+                            + ". The trade is fixed when the template is created.");
+        }
+
+        template.getItems().clear();
+        apply(template, req);
+        template.setVersion(template.getVersion() + 1);
+
+        ChecklistTemplate saved = templateRepo.saveAndFlush(template);
+        log.info("Updated checklist template {} to version {}", saved.getId(), saved.getVersion());
+        return mapper.toDto(saved);
+    }
+
+    /**
+     * The starter checklists on offer, one per trade at most. Global reference data,
+     * identical for every tenant.
+     */
+    @Transactional(readOnly = true)
+    public List<StarterChecklistTemplateDto> findStarters() {
+        return starterRepo.findByActiveTrueOrderByTradeAsc().stream()
+                .map(mapper::toStarterDto)
+                .toList();
+    }
+
+    /**
+     * Copies the shipped starter for a trade into the calling tenant as its own
+     * editable template. The copy is a snapshot: nothing links the two afterwards.
+     *
+     * @throws ResourceNotFoundException  if no active starter exists for the trade.
+     * @throws DuplicateResourceException if the tenant already has a template for it.
+     */
+    @Transactional
+    public ChecklistTemplateDto adoptStarter(InspectionTrade trade) {
+        requireTradeIsFree(trade);
+
+        StarterChecklistTemplate starter = starterRepo.findByTradeAndActiveTrue(trade)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No starter checklist is available for trade " + trade.getValue()));
+
+        ChecklistTemplate template = new ChecklistTemplate();
+        template.setTrade(starter.getTrade());
+        template.setName(starter.getName());
+        template.setDescription(starter.getDescription());
+        template.setActive(true);
+        template.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        for (StarterChecklistTemplateItem source : starter.getItems()) {
+            ChecklistTemplateItem item = new ChecklistTemplateItem();
+            item.setCategory(source.getCategory());
+            item.setCheckPoint(source.getCheckPoint());
+            item.setSpecification(source.getSpecification());
+            item.setExpectedValue(source.getExpectedValue());
+            item.setAcceptanceCriterion(source.getAcceptanceCriterion());
+            item.setTolerance(source.getTolerance());
+            item.setPhotosRequired(source.isPhotosRequired());
+            item.setPriority(source.getPriority() != null ? source.getPriority() : "medium");
+            template.addItem(item);
+        }
+
+        ChecklistTemplate saved = templateRepo.saveAndFlush(template);
+        log.info("Adopted starter checklist for trade {} as template {}", trade, saved.getId());
+        return mapper.toDto(saved);
+    }
+
+    /**
+     * The check items a new inspection of this trade starts with, copied from the
+     * tenant's active template for it.
+     *
+     * <p>A copy, not a reference: an inspection carried out in March records the
+     * criteria that were in force in March, and a QA engineer tightening a tolerance
+     * in April must not rewrite what was signed off. The copied items start
+     * {@code PENDING} with no measurement, which is what an inspector fills in.
+     *
+     * @param trade The inspection's trade, may be null.
+     * @return The instantiated check items, or an empty list when the trade is null,
+     *         or the tenant has no active template for it. An empty list is a normal
+     *         outcome, not an error: an inspection may be run without a template.
+     */
+    @Transactional(readOnly = true)
+    public List<InspectionCheckItem> instantiateFor(InspectionTrade trade) {
+        if (trade == null) {
+            return List.of();
+        }
+        return templateRepo.findByTradeAndActiveTrue(trade)
+                .map(template -> template.getItems().stream()
+                        .map(ChecklistTemplateService::toCheckItem)
+                        .toList())
+                .orElseGet(List::of);
+    }
+
+    private static InspectionCheckItem toCheckItem(ChecklistTemplateItem source) {
+        InspectionCheckItem item = new InspectionCheckItem();
+        item.setCategory(source.getCategory());
+        item.setCheckPoint(source.getCheckPoint());
+        item.setSpecification(source.getSpecification());
+        item.setExpectedValue(source.getExpectedValue());
+        item.setAcceptanceCriterion(source.getAcceptanceCriterion());
+        item.setTolerance(source.getTolerance());
+        item.setPhotosRequired(source.isPhotosRequired());
+        item.setPriority(source.getPriority() != null ? source.getPriority() : "medium");
+        item.setStatus(CheckItemStatus.PENDING);
+        return item;
+    }
+
+    private ChecklistTemplate require(UUID id) {
+        return templateRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Checklist template with ID " + id + " was not found"));
+    }
+
+    private void requireTradeIsFree(InspectionTrade trade) {
+        if (templateRepo.existsByTrade(trade)) {
+            throw new DuplicateResourceException(
+                    "This organization already has a checklist template for trade "
+                            + trade.getValue() + ". Edit that template instead of defining a second one.");
+        }
+    }
+
+    private void apply(ChecklistTemplate template, ChecklistTemplateRequest req) {
+        template.setName(req.name());
+        template.setDescription(req.description());
+        template.setActive(req.active() == null || req.active());
+        for (ChecklistTemplateItemRequest source : req.items()) {
+            ChecklistTemplateItem item = new ChecklistTemplateItem();
+            item.setCategory(source.category());
+            item.setCheckPoint(source.checkPoint());
+            item.setSpecification(source.specification());
+            item.setExpectedValue(source.expectedValue());
+            item.setAcceptanceCriterion(source.acceptanceCriterion());
+            item.setTolerance(source.tolerance());
+            item.setPhotosRequired(source.photosRequired());
+            item.setPriority(source.priority() != null ? source.priority() : "medium");
+            template.addItem(item);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
@@ -37,6 +37,11 @@ import java.util.UUID;
  * status field: status and result are set directly from the request, and the
  * summary counts (total, passed, failed check points and defects found) are
  * recomputed from the supplied check items and defects on every save.
+ *
+ * <p>Creating an inspection for a trade the organization has an active checklist
+ * template for starts it from a copy of that template's check points, so an
+ * inspector opens a ready checklist instead of an empty one. See
+ * {@link #applyChildrenAndCounts} for when the template is consulted.
  */
 @Slf4j
 @Service
@@ -49,6 +54,7 @@ public class InspectionService {
     private final EntryNumberGenerator numberGen;
     private final InspectionMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
+    private final ChecklistTemplateService checklistTemplateService;
 
     @Transactional(readOnly = true)
     public InspectionDto findById(UUID id) {
@@ -99,6 +105,7 @@ public class InspectionService {
         inspection.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         applyChildrenAndCounts(inspection, req.checkItems(), req.defects());
+        instantiateTemplateIfEmpty(inspection);
 
         Inspection saved = inspectionRepo.saveAndFlush(inspection);
         log.info("Created inspection {}", saved.getInspectionNumber());
@@ -203,6 +210,10 @@ public class InspectionService {
                 replaceAll(item.getPhotos(), cr.photos());
                 item.setMeasurement(cr.measurement());
                 item.setExpectedValue(cr.expectedValue());
+                item.setAcceptanceCriterion(cr.acceptanceCriterion());
+                item.setTolerance(cr.tolerance());
+                item.setDeviation(MeasurementDeviation.of(cr.measurement(), cr.expectedValue()));
+                item.setBimElementGuid(cr.bimElementGuid());
                 item.setPriority(cr.priority() != null ? cr.priority() : "medium");
                 inspection.addCheckItem(item);
 
@@ -247,6 +258,37 @@ public class InspectionService {
      */
     private static InspectionCategory categoryFor(InspectionCategory requested, InspectionType type) {
         return requested != null ? requested : InspectionCategory.defaultFor(type);
+    }
+
+    /**
+     * Starts a new inspection from the organization's checklist for its trade, when
+     * the caller supplied no check points of their own.
+     *
+     * <p>An explicit list always wins. A client that sends its own check points has
+     * said what this inspection covers, and a template is a default, not an override:
+     * silently appending template rows to a hand-built checklist would double up every
+     * check point on the re-inspection of a failed item. The template is therefore
+     * consulted only for an inspection that would otherwise start empty, which is the
+     * normal case for one scheduled against a trade.
+     *
+     * <p>The counts are recomputed here rather than left to
+     * {@link #applyChildrenAndCounts}, because the instantiated items are only known
+     * after it has run. Instantiated items are all {@code PENDING}, so only the total
+     * moves; passed and failed stay at zero until the inspection is carried out.
+     */
+    private void instantiateTemplateIfEmpty(Inspection inspection) {
+        if (!inspection.getCheckItems().isEmpty()) {
+            return;
+        }
+        List<InspectionCheckItem> instantiated =
+                checklistTemplateService.instantiateFor(inspection.getTrade());
+        if (instantiated.isEmpty()) {
+            return;
+        }
+        instantiated.forEach(inspection::addCheckItem);
+        inspection.setTotalCheckPoints(instantiated.size());
+        log.info("Instantiated {} check points from the {} checklist template",
+                instantiated.size(), inspection.getTrade().getValue());
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/MeasurementDeviation.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/MeasurementDeviation.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Derives a check point's deviation, the measured value minus the expected one.
+ *
+ * <p>Both values are free text on site ("148 mm", "40mm", "1:1.5"), because a
+ * check point may be dimensional, qualitative or a ratio, and the inspector types
+ * whatever the drawing uses. So the deviation is computed only where it is
+ * meaningful and left null everywhere else, rather than guessed:
+ *
+ * <ul>
+ *   <li>Both values must parse as a leading decimal number, optionally signed.</li>
+ *   <li>Whatever follows the number is the unit. The two units must match, ignoring
+ *       case and surrounding spaces. "148 mm" against "150mm" is a deviation of
+ *       -2; "15 cm" against "150 mm" is not, because subtracting them would produce
+ *       a number in no unit at all and a reader would take it for millimetres.</li>
+ *   <li>Anything else, including a missing value, yields null: not recorded, rather
+ *       than zero, which would read as "measured exactly on target".</li>
+ * </ul>
+ *
+ * <p>The result is rounded to the four decimal places the {@code deviation} column
+ * holds, so a value written with more precision than the column can store is
+ * rounded here rather than rejected by the database on insert.
+ */
+public final class MeasurementDeviation {
+
+    /** Decimal places the {@code inspection_check_items.deviation} column holds. */
+    private static final int SCALE = 4;
+
+    /** Leading optional sign and decimal number, then everything else as the unit. */
+    private static final Pattern VALUE = Pattern.compile("^([+-]?\\d+(?:\\.\\d+)?)\\s*(.*)$");
+
+    private MeasurementDeviation() {
+    }
+
+    /**
+     * The deviation of a measurement from its expected value.
+     *
+     * @param measurement   What was recorded on site, may be null or blank.
+     * @param expectedValue What the specification asks for, may be null or blank.
+     * @return measurement minus expectedValue, or null when the pair is not a
+     *         comparable numeric quantity in one unit.
+     */
+    public static BigDecimal of(String measurement, String expectedValue) {
+        Matcher measured = match(measurement);
+        Matcher expected = match(expectedValue);
+        if (measured == null || expected == null) {
+            return null;
+        }
+        if (!measured.group(2).trim().equalsIgnoreCase(expected.group(2).trim())) {
+            return null;
+        }
+        return new BigDecimal(measured.group(1))
+                .subtract(new BigDecimal(expected.group(1)))
+                .setScale(SCALE, RoundingMode.HALF_UP);
+    }
+
+    private static Matcher match(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        Matcher matcher = VALUE.matcher(value.trim());
+        return matcher.matches() ? matcher : null;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/ChecklistTemplateControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/ChecklistTemplateControllerWeb.java
@@ -1,0 +1,143 @@
+package org.tornotron.echno_backend.inspection.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.inspection.InspectionTrade;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateRequest;
+import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/checklist-templates/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Checklist templates",
+        description = "The reusable per-trade checklists an organization inspects against. An "
+                + "inspection created for a trade starts from a copy of that trade's active "
+                + "template, so later edits never rewrite a checklist already signed off. The "
+                + "starter endpoints expose the product-supplied defaults an organization adopts "
+                + "as its own editable templates. All endpoints are tenant scoped."
+)
+public class ChecklistTemplateControllerWeb {
+
+    private final ChecklistTemplateService service;
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Define a checklist template",
+            description = "Creates the organization's checklist for a trade, with its check points. "
+                    + "There is one template per trade per organization."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Template created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "409", description = "The tenant already has a template for that trade")
+    })
+    public ResponseEntity<ChecklistTemplateDto> create(@Valid @RequestBody ChecklistTemplateRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Get a checklist template by id",
+            description = "Returns a single template including its check points in line order."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Template found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No template with the given id in the current tenant")
+    })
+    public ChecklistTemplateDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List checklist templates",
+            description = "Returns a page of the organization's templates. The trade and active "
+                    + "parameters are optional filters; omitting both returns every template, "
+                    + "subject to paging."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching templates"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public Page<ChecklistTemplateDto> list(@RequestParam(required = false) InspectionTrade trade,
+                                           @RequestParam(required = false) Boolean active,
+                                           Pageable pageable) {
+        return service.findAll(trade, active, pageable);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Replace a checklist template",
+            description = "Replaces the name, description, active flag and check points of an "
+                    + "existing template and bumps its version. The trade is fixed when the "
+                    + "template is created and cannot be changed here. Inspections already created "
+                    + "from this template are unaffected: they hold their own copy of the criteria."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Template updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body, or the "
+                    + "payload names a different trade"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No template with the given id in the current tenant")
+    })
+    public ChecklistTemplateDto update(@PathVariable UUID id,
+                                       @Valid @RequestBody ChecklistTemplateRequest req) {
+        return service.update(id, req);
+    }
+
+    @GetMapping("/starters")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List the starter checklists on offer",
+            description = "Returns the product-supplied default checklists, one per trade at most. "
+                    + "These are global reference data and identical for every organization; adopt "
+                    + "one to get an editable copy of your own."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The available starter checklists"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public List<StarterChecklistTemplateDto> listStarters() {
+        return service.findStarters();
+    }
+
+    @PostMapping("/starters/{trade}/adopt")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Adopt a starter checklist",
+            description = "Copies the shipped starter for a trade into this organization as its own "
+                    + "editable template. The copy is a snapshot: later revisions of the starter do "
+                    + "not reach into it."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Template created from the starter"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No starter checklist is available for that trade"),
+            @ApiResponse(responseCode = "409", description = "The tenant already has a template for that trade")
+    })
+    public ResponseEntity<ChecklistTemplateDto> adoptStarter(@PathVariable InspectionTrade trade) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.adoptStarter(trade));
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -304,4 +304,10 @@
     <!-- v4.0 - Project site address as fields: city, state and postal code -->
     <include file="db/changelog/v4.0/056-add-project-structured-location.xml"/>
 
+    <!-- v4.0 - Inspection QA/QC: per-trade checklist templates, tenant-owned, plus the shipped starter seed -->
+    <include file="db/changelog/v4.0/057-create-and-seed-checklist-templates.xml"/>
+
+    <!-- v4.0 - Inspection QA/QC: acceptance criterion, tolerance, computed deviation and the BIM element link -->
+    <include file="db/changelog/v4.0/058-extend-inspection-check-items.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/057-create-and-seed-checklist-templates.xml
+++ b/src/main/resources/db/changelog/v4.0/057-create-and-seed-checklist-templates.xml
@@ -1,0 +1,1459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="057-01-create-checklist-templates" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="checklist_templates"/>
+            </not>
+            <not>
+                <tableExists tableName="checklist_template_items"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The per-trade checklist library an organization inspects against. Tenant-scoped
+            like inspections: the criteria a client accepts work against are their own, so
+            organization_id is mandatory and the Hibernate orgFilter applies. One template
+            per trade per org, enforced by uk_checklist_template_trade; version is a
+            revision counter on that one row, not part of the key. Items inherit tenancy
+            from the parent, exactly as inspection check items do.
+
+            No separate index on organization_id: uk_checklist_template_trade leads with it,
+            so the org-scoped reads are already served and a second index would only cost
+            writes.
+
+            Both tables are guarded above. A precondition naming only the first would mark
+            the changeset as run on a database that already had it, silently skipping the
+            second.
+        </comment>
+
+        <createTable tableName="checklist_templates">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="trade" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="INT" defaultValueNumeric="1">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="checklist_templates"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_checklist_template_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="checklist_templates"
+                             columnNames="organization_id, trade"
+                             constraintName="uk_checklist_template_trade"/>
+
+        <createIndex tableName="checklist_templates" indexName="idx_checklist_template_trade">
+            <column name="trade"/>
+        </createIndex>
+        <createIndex tableName="checklist_templates" indexName="idx_checklist_template_active">
+            <column name="active"/>
+        </createIndex>
+
+        <createTable tableName="checklist_template_items">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="template_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="check_point" type="VARCHAR(500)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="specification" type="VARCHAR(1000)"/>
+            <column name="expected_value" type="VARCHAR(200)"/>
+            <column name="acceptance_criterion" type="VARCHAR(1000)"/>
+            <column name="tolerance" type="VARCHAR(100)"/>
+            <column name="photos_required" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="priority" type="VARCHAR(20)" defaultValue="medium"/>
+            <column name="line_order" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="checklist_template_items"
+                                 baseColumnNames="template_id"
+                                 constraintName="fk_checklist_template_item_template"
+                                 referencedTableName="checklist_templates"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="checklist_template_items" indexName="idx_checklist_template_item_template">
+            <column name="template_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="057-02-create-starter-checklist-templates" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="starter_checklist_templates"/>
+            </not>
+            <not>
+                <tableExists tableName="starter_checklist_template_items"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The default per-trade checklists shipped with the product. GLOBAL reference data
+            following the compliance_rules precedent: no organization_id and no org filter,
+            because the check points for a rebar or waterproofing inspection are the same
+            trade practice whichever org is building. An org adopts one, which copies it into
+            checklist_templates; nothing links the two afterwards, so a later revision here
+            never rewrites criteria a client has tailored and signed work off against.
+
+            Both tables are guarded above, for the reason given on the previous changeset.
+        </comment>
+
+        <createTable tableName="starter_checklist_templates">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="trade" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="starter_checklist_templates"
+                             columnNames="trade"
+                             constraintName="uk_starter_checklist_template_trade"/>
+
+        <createIndex tableName="starter_checklist_templates" indexName="idx_starter_checklist_template_active">
+            <column name="active"/>
+        </createIndex>
+
+        <createTable tableName="starter_checklist_template_items">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="template_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="check_point" type="VARCHAR(500)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="specification" type="VARCHAR(1000)"/>
+            <column name="expected_value" type="VARCHAR(200)"/>
+            <column name="acceptance_criterion" type="VARCHAR(1000)"/>
+            <column name="tolerance" type="VARCHAR(100)"/>
+            <column name="photos_required" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="priority" type="VARCHAR(20)" defaultValue="medium"/>
+            <column name="line_order" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="starter_checklist_template_items"
+                                 baseColumnNames="template_id"
+                                 constraintName="fk_starter_checklist_item_template"
+                                 referencedTableName="starter_checklist_templates"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"/>
+
+        <createIndex tableName="starter_checklist_template_items" indexName="idx_starter_checklist_item_template">
+            <column name="template_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="057-03-seed-starter-checklist-templates" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM starter_checklist_templates</sqlCheck>
+        </preConditions>
+
+        <comment>
+            One starter checklist for each of the sixteen InspectionTrade members, five or six
+            check points each, drawn from ordinary Indian construction QA practice and the IS
+            codes each trade is inspected against. The template ids are fixed literals rather
+            than generated, so the item rows can name their parent in the same changeset and
+            so a later revision of a starter can be written against a known id.
+
+            trade is stored as the enum constant name, matching @Enumerated(STRING). priority
+            carries the same 'high' | 'medium' | 'low' free text as the inspection check item
+            it is copied onto. A null tolerance is expressed by leaving the column out of the
+            insert: the criterion is qualitative and has no measurable band.
+        </comment>
+
+        <!-- ===================== PRE_CONSTRUCTION_DOCUMENTATION ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="trade" value="PRE_CONSTRUCTION_DOCUMENTATION"/>
+            <column name="name" value="Pre-construction documentation checklist"/>
+            <column name="description" value="Drawings, approvals and method statements that must be in place and current before work starts on the activity."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="category" value="Drawings"/>
+            <column name="check_point" value="Latest approved good-for-construction drawing is available at the work front"/>
+            <column name="specification" value="Drawing register, current revision"/>
+            <column name="expected_value" value="Current revision"/>
+            <column name="acceptance_criterion" value="Revision on site matches the revision in the drawing register, and superseded prints have been withdrawn"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="category" value="Approvals"/>
+            <column name="check_point" value="Statutory approval covering this activity is in force and unexpired"/>
+            <column name="specification" value="Approval certificate"/>
+            <column name="expected_value" value="Valid on the day of work"/>
+            <column name="acceptance_criterion" value="Certificate produced, within its validity period, and covering the scope being built"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="category" value="Method statement"/>
+            <column name="check_point" value="Approved method statement and sequence of work issued to the site team"/>
+            <column name="specification" value="Method statement, approved revision"/>
+            <column name="expected_value" value="Issued and acknowledged"/>
+            <column name="acceptance_criterion" value="Signed by the site engineer and the contractor's supervisor before work starts"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="category" value="Materials"/>
+            <column name="check_point" value="Material test certificates for the batch to be used are on file"/>
+            <column name="specification" value="Mill or batch certificate per consignment"/>
+            <column name="expected_value" value="One per consignment"/>
+            <column name="acceptance_criterion" value="Certificate traceable to the delivery challan for the material actually on site"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="deaebfc8-ef7c-5c0f-859d-b97b3df93bc4"/>
+            <column name="category" value="Setting out"/>
+            <column name="check_point" value="Setting-out drawing, grid lines and benchmark levels confirmed against the survey record"/>
+            <column name="specification" value="Survey record, established benchmark"/>
+            <column name="expected_value" value="Matches the survey record"/>
+            <column name="acceptance_criterion" value="Grid and level confirmed by the surveyor and countersigned by the site engineer"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+
+        <!-- ===================== SHUTTERING_FORMWORK ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="trade" value="SHUTTERING_FORMWORK"/>
+            <column name="name" value="Shuttering and formwork checklist"/>
+            <column name="description" value="Pre-pour check on formwork alignment, tightness, props and release agent, carried out before reinforcement is closed up."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Alignment"/>
+            <column name="check_point" value="Formwork line and level checked against the setting-out drawing"/>
+            <column name="specification" value="IS 14687, setting-out drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Line and level measured at each face and at both ends of the member"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Plumb"/>
+            <column name="check_point" value="Vertical faces are plumb over the full height of the member"/>
+            <column name="specification" value="IS 14687"/>
+            <column name="expected_value" value="Vertical"/>
+            <column name="acceptance_criterion" value="Plumb bob or spirit level reading taken at three points along the face"/>
+            <column name="tolerance" value="+/- 3 mm per 1 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Joints"/>
+            <column name="check_point" value="Panel joints are tight and sealed against grout leakage"/>
+            <column name="specification" value="IS 14687"/>
+            <column name="expected_value" value="No visible gap"/>
+            <column name="acceptance_criterion" value="No gap admits a 2 mm feeler; joints taped or sealed"/>
+            <column name="tolerance" value="2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Props"/>
+            <column name="check_point" value="Props and bracing are vertical, on a firm base, and spaced per the design"/>
+            <column name="specification" value="Formwork design drawing"/>
+            <column name="expected_value" value="As per design"/>
+            <column name="acceptance_criterion" value="Spacing measured in both directions; sole plates bear on a firm surface, not on loose fill"/>
+            <column name="tolerance" value="+/- 50 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Surface"/>
+            <column name="check_point" value="Release agent applied uniformly and the shutter face is clean of debris and old concrete"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="Uniform coat"/>
+            <column name="acceptance_criterion" value="No bare patches, no ponding, and no release agent on the reinforcement"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="55cdb0c2-f5f9-5fcd-a2c8-5b3d972333dc"/>
+            <column name="category" value="Cover blocks"/>
+            <column name="check_point" value="Cover blocks are in place, of the specified thickness and of the same grade as the concrete"/>
+            <column name="specification" value="IS 456:2000 cl. 26.4"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Blocks at the specified spacing and secured so they cannot displace during the pour"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== REINFORCEMENT ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="trade" value="REINFORCEMENT"/>
+            <column name="name" value="Reinforcement checklist"/>
+            <column name="description" value="Pre-pour check on bar size, spacing, cover, laps and binding against the bar bending schedule."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Bar size"/>
+            <column name="check_point" value="Bar diameter matches the bar bending schedule for every layer"/>
+            <column name="specification" value="IS 456:2000, bar bending schedule"/>
+            <column name="expected_value" value="As per schedule"/>
+            <column name="acceptance_criterion" value="Diameter verified with a vernier on a sample from each bundle"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Spacing"/>
+            <column name="check_point" value="Main bar spacing measured against the schedule"/>
+            <column name="specification" value="IS 456:2000 cl. 26.3"/>
+            <column name="expected_value" value="As per schedule"/>
+            <column name="acceptance_criterion" value="Spacing measured at three locations per bay and averaged"/>
+            <column name="tolerance" value="+/- 10 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Cover"/>
+            <column name="check_point" value="Clear cover to the outermost bar measured at the soffit and both faces"/>
+            <column name="specification" value="IS 456:2000 cl. 26.4"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Measured at not fewer than five points per member with a cover meter or a gauge"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Laps"/>
+            <column name="check_point" value="Lap length and stagger comply with the drawing"/>
+            <column name="specification" value="IS 456:2000 cl. 26.2.5"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Lap length measured on each lapped bar; laps staggered so no more than half fall in one section"/>
+            <column name="tolerance" value="+/- 25 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Binding"/>
+            <column name="check_point" value="Binding wire is tied at every intersection required and the ends are turned inwards"/>
+            <column name="specification" value="IS 2502"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="No loose intersection; no wire end projects into the cover zone"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="dab3b565-b360-5e4b-ac8f-241506758bef"/>
+            <column name="category" value="Cleanliness"/>
+            <column name="check_point" value="Bars are free of loose rust, oil, mud and formwork release agent"/>
+            <column name="specification" value="IS 456:2000 cl. 5.6"/>
+            <column name="expected_value" value="Clean"/>
+            <column name="acceptance_criterion" value="Surface wire-brushed where needed; no oil film or mud coating remains"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== RCC ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="trade" value="RCC"/>
+            <column name="name" value="RCC pour and curing checklist"/>
+            <column name="description" value="Concrete grade, slump, cube sampling, placing, compaction and curing for a reinforced concrete pour."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Mix"/>
+            <column name="check_point" value="Concrete grade at the pour matches the drawing and the delivery challan"/>
+            <column name="specification" value="IS 456:2000, mix design"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Grade on the challan matches the drawing for the member being poured"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Workability"/>
+            <column name="check_point" value="Slump measured at the point of placing, not at the batching plant"/>
+            <column name="specification" value="IS 1199"/>
+            <column name="expected_value" value="As per mix design"/>
+            <column name="acceptance_criterion" value="One slump test per truck, recorded before discharge"/>
+            <column name="tolerance" value="+/- 25 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Sampling"/>
+            <column name="check_point" value="Cube samples taken at the specified frequency and marked with the pour reference"/>
+            <column name="specification" value="IS 456:2000 cl. 15.2"/>
+            <column name="expected_value" value="As per code frequency"/>
+            <column name="acceptance_criterion" value="Cubes cast, identified, and kept in the curing tank; sampling register signed"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Placing"/>
+            <column name="check_point" value="Free fall of concrete kept within limits and layers placed before the previous one sets"/>
+            <column name="specification" value="IS 456:2000 cl. 13.2"/>
+            <column name="expected_value" value="1.5 m maximum free fall"/>
+            <column name="acceptance_criterion" value="Chute or pump line used where the drop exceeds the limit; no cold joint formed"/>
+            <column name="tolerance" value="1.5 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Compaction"/>
+            <column name="check_point" value="Concrete compacted with a vibrator without segregation or over-vibration"/>
+            <column name="specification" value="IS 456:2000 cl. 13.3"/>
+            <column name="expected_value" value="Full compaction"/>
+            <column name="acceptance_criterion" value="Vibrator immersed vertically and withdrawn slowly; no honeycombing on stripping"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="28f3acb4-a45b-53d3-860a-7f5981cf96fa"/>
+            <column name="category" value="Curing"/>
+            <column name="check_point" value="Curing started within the specified time and maintained for the full period"/>
+            <column name="specification" value="IS 456:2000 cl. 13.5"/>
+            <column name="expected_value" value="7 days minimum"/>
+            <column name="acceptance_criterion" value="Curing log records the start time and daily wetting for the full period"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== MASONRY ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="trade" value="MASONRY"/>
+            <column name="name" value="Masonry checklist"/>
+            <column name="description" value="Block or brick work: coursing, plumb, joint thickness, bonding and reinforcement at junctions."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Materials"/>
+            <column name="check_point" value="Units are of the specified class and free of visible cracks and chips"/>
+            <column name="specification" value="IS 1077 / IS 2185"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="Sample checked from each stack; broken or under-burnt units rejected"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Coursing"/>
+            <column name="check_point" value="Course height uniform and level over the length of the wall"/>
+            <column name="specification" value="IS 2212"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Level taken at both ends and mid-length of each wall"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Plumb"/>
+            <column name="check_point" value="Wall face plumb over the storey height"/>
+            <column name="specification" value="IS 2212"/>
+            <column name="expected_value" value="Vertical"/>
+            <column name="acceptance_criterion" value="Plumb reading taken at each end and at every 3 m of length"/>
+            <column name="tolerance" value="+/- 5 mm per 3 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Joints"/>
+            <column name="check_point" value="Mortar joint thickness uniform and joints fully filled"/>
+            <column name="specification" value="IS 2212"/>
+            <column name="expected_value" value="10 mm"/>
+            <column name="acceptance_criterion" value="Joint thickness measured at five points; no unfilled vertical joint"/>
+            <column name="tolerance" value="+/- 2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Bonding"/>
+            <column name="check_point" value="Bond pattern and junction ties are as detailed, with no continuous vertical joint"/>
+            <column name="specification" value="IS 2212"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="No straight joint runs more than one course; junction ties present at the specified spacing"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="68a8e7de-52a9-5b4b-97ce-52b77738cd35"/>
+            <column name="category" value="Soaking"/>
+            <column name="check_point" value="Units wetted before laying and the wall protected from drying too fast"/>
+            <column name="specification" value="IS 2212"/>
+            <column name="expected_value" value="Soaked, surface dry"/>
+            <column name="acceptance_criterion" value="Units soaked as specified; no dry unit laid into fresh mortar"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== PLASTERING ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="trade" value="PLASTERING"/>
+            <column name="name" value="Plastering checklist"/>
+            <column name="description" value="Surface preparation, thickness, plumb, finish and curing for internal and external plaster."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Preparation"/>
+            <column name="check_point" value="Surface raked, cleaned and wetted, and services chases filled before plastering"/>
+            <column name="specification" value="IS 1661"/>
+            <column name="expected_value" value="Clean and damp"/>
+            <column name="acceptance_criterion" value="Joints raked to the specified depth, dust removed, and the surface damp but not running"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Thickness"/>
+            <column name="check_point" value="Plaster thickness measured against the specification"/>
+            <column name="specification" value="IS 1661"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="Thickness checked at gauge dots at every 2 m in both directions"/>
+            <column name="tolerance" value="+/- 3 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Plumb"/>
+            <column name="check_point" value="Plastered face plumb and true over the storey height"/>
+            <column name="specification" value="IS 1661"/>
+            <column name="expected_value" value="Vertical"/>
+            <column name="acceptance_criterion" value="Straight edge and plumb applied at every 2 m of wall length"/>
+            <column name="tolerance" value="+/- 4 mm per 2 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Finish"/>
+            <column name="check_point" value="Surface free of cracks, blisters, hollow patches and trowel marks"/>
+            <column name="specification" value="IS 1661"/>
+            <column name="expected_value" value="No defect"/>
+            <column name="acceptance_criterion" value="Tapped over the full area; no hollow sound and no crack visible at arm's length"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Corners"/>
+            <column name="check_point" value="Arrises, grooves and drip moulds are straight and to the detail"/>
+            <column name="specification" value="Architectural drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Corners checked with a straight edge over their full length"/>
+            <column name="tolerance" value="+/- 2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4f2702a8-a465-5159-af37-297386c24076"/>
+            <column name="category" value="Curing"/>
+            <column name="check_point" value="Plaster cured for the specified period without drying out"/>
+            <column name="specification" value="IS 1661"/>
+            <column name="expected_value" value="7 days minimum"/>
+            <column name="acceptance_criterion" value="Curing log records daily wetting for the full period"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== WATERPROOFING ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="trade" value="WATERPROOFING"/>
+            <column name="name" value="Waterproofing checklist"/>
+            <column name="description" value="Substrate preparation, membrane application, laps, upturns and the ponding test that proves the work."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Substrate"/>
+            <column name="check_point" value="Substrate is sound, dry, free of laitance and to the specified fall"/>
+            <column name="specification" value="Manufacturer's specification"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="No loose material; falls checked with a level to the outlet"/>
+            <column name="tolerance" value="+/- 3 mm per 1 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Priming"/>
+            <column name="check_point" value="Primer applied at the specified coverage and allowed to cure before the membrane"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="As per data sheet"/>
+            <column name="acceptance_criterion" value="Coverage recorded against the area treated; no unprimed patch"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Membrane"/>
+            <column name="check_point" value="Membrane applied to the specified thickness or number of coats"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="As per data sheet"/>
+            <column name="acceptance_criterion" value="Wet-film thickness measured during application, or coats counted and recorded"/>
+            <column name="tolerance" value="+/- 10 percent"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Laps"/>
+            <column name="check_point" value="Overlaps at joints are of the specified width and fully bonded"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="100 mm"/>
+            <column name="acceptance_criterion" value="Lap width measured at every joint; edge probed for a fully bonded seam"/>
+            <column name="tolerance" value="+/- 10 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Upturns"/>
+            <column name="check_point" value="Membrane turned up at walls, kerbs and around penetrations to the specified height"/>
+            <column name="specification" value="Manufacturer's specification"/>
+            <column name="expected_value" value="150 mm above finished level"/>
+            <column name="acceptance_criterion" value="Upturn height measured at every wall junction and pipe penetration"/>
+            <column name="tolerance" value="+/- 10 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8729afe8-5c5b-5316-9726-fcc4caf1905d"/>
+            <column name="category" value="Ponding test"/>
+            <column name="check_point" value="Area ponded for the specified duration with no leakage or drop in level"/>
+            <column name="specification" value="IS 3067"/>
+            <column name="expected_value" value="48 hours minimum"/>
+            <column name="acceptance_criterion" value="Water level marked at the start and at the end; soffit inspected for damp patches"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== FLOORING ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="trade" value="FLOORING"/>
+            <column name="name" value="Flooring checklist"/>
+            <column name="description" value="Bedding, level, slope, joint width and finish for tiled, stone and screeded floors."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Base"/>
+            <column name="check_point" value="Base is clean, sound and to the correct level before bedding"/>
+            <column name="specification" value="IS 1443"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Base level surveyed and recorded before laying starts"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Level"/>
+            <column name="check_point" value="Finished floor level measured against the drawing datum"/>
+            <column name="specification" value="IS 1443"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Level taken on a grid at every 2 m across the area"/>
+            <column name="tolerance" value="+/- 3 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Slope"/>
+            <column name="check_point" value="Wet-area floors fall to the drain with no ponding"/>
+            <column name="specification" value="IS 1443"/>
+            <column name="expected_value" value="1 in 100"/>
+            <column name="acceptance_criterion" value="Water poured on the finished surface drains fully within five minutes"/>
+            <column name="tolerance" value="+/- 0.2 percent"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Joints"/>
+            <column name="check_point" value="Joint width uniform and the joint lines are straight and aligned across the room"/>
+            <column name="specification" value="Architectural drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Joint width measured at ten points; joint lines checked with a string line"/>
+            <column name="tolerance" value="+/- 1 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Hollowness"/>
+            <column name="check_point" value="No hollow tiles: bedding is full under every unit"/>
+            <column name="specification" value="IS 1443"/>
+            <column name="expected_value" value="No hollow"/>
+            <column name="acceptance_criterion" value="Every tile tapped; any hollow sound recorded and the tile relaid"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6dcf409f-e5f0-5ef0-b022-d3e5ed81b010"/>
+            <column name="category" value="Finish"/>
+            <column name="check_point" value="Surface free of chips, scratches, stains and lippage between adjacent units"/>
+            <column name="specification" value="Architectural specification"/>
+            <column name="expected_value" value="No defect"/>
+            <column name="acceptance_criterion" value="Lippage measured at random joints with a straight edge"/>
+            <column name="tolerance" value="1 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== FABRICATION ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="trade" value="FABRICATION"/>
+            <column name="name" value="Structural steel fabrication checklist"/>
+            <column name="description" value="Material identification, cutting, fit-up, welding and protective coating for fabricated steelwork."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Material"/>
+            <column name="check_point" value="Steel section and grade match the fabrication drawing and carry mill certificates"/>
+            <column name="specification" value="IS 2062, fabrication drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Section and grade traced from the mill certificate to the member mark"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Cutting"/>
+            <column name="check_point" value="Cut lengths and hole positions measured against the drawing"/>
+            <column name="specification" value="Fabrication drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Length and hole centres measured on each fabricated member"/>
+            <column name="tolerance" value="+/- 2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Fit-up"/>
+            <column name="check_point" value="Root gap and edge preparation at the joint are as specified before welding"/>
+            <column name="specification" value="IS 9595"/>
+            <column name="expected_value" value="As per WPS"/>
+            <column name="acceptance_criterion" value="Root gap measured at three points along each joint"/>
+            <column name="tolerance" value="+/- 1 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Welding"/>
+            <column name="check_point" value="Welds are of the specified size and free of undercut, porosity and slag inclusion"/>
+            <column name="specification" value="IS 814, IS 9595"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Fillet size measured with a weld gauge; visual inspection over the full weld length"/>
+            <column name="tolerance" value="+/- 1 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Straightness"/>
+            <column name="check_point" value="Member is straight and free of distortion after welding"/>
+            <column name="specification" value="IS 800"/>
+            <column name="expected_value" value="Straight"/>
+            <column name="acceptance_criterion" value="Straight edge or string line applied over the full member length"/>
+            <column name="tolerance" value="L/1000"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="8b21e166-182a-50a3-b826-32510b0cb6b1"/>
+            <column name="category" value="Coating"/>
+            <column name="check_point" value="Surface prepared and the protective coating applied to the specified dry-film thickness"/>
+            <column name="specification" value="IS 1477"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="Dry-film thickness measured at five points per member with a gauge"/>
+            <column name="tolerance" value="+/- 10 percent"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== ALUMINIUM_UPVC ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="trade" value="ALUMINIUM_UPVC"/>
+            <column name="name" value="Aluminium and UPVC joinery checklist"/>
+            <column name="description" value="Frame fixing, plumb, glazing, sealing and operation for aluminium and UPVC doors and windows."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Opening"/>
+            <column name="check_point" value="Structural opening size checked against the frame before fixing"/>
+            <column name="specification" value="Shop drawing"/>
+            <column name="expected_value" value="As per shop drawing"/>
+            <column name="acceptance_criterion" value="Opening measured at head, mid-height and sill, and at both jambs"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Plumb and level"/>
+            <column name="check_point" value="Frame is plumb, level and square after fixing"/>
+            <column name="specification" value="IS 1948 / IS 12933"/>
+            <column name="expected_value" value="Plumb and square"/>
+            <column name="acceptance_criterion" value="Plumb, level and both diagonals measured after the fixings are made"/>
+            <column name="tolerance" value="+/- 2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Fixings"/>
+            <column name="check_point" value="Anchor type and spacing are as specified and the packers are permanent"/>
+            <column name="specification" value="Shop drawing"/>
+            <column name="expected_value" value="As per shop drawing"/>
+            <column name="acceptance_criterion" value="Fixing spacing measured on every jamb; no timber or compressible packer left in place"/>
+            <column name="tolerance" value="+/- 25 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Glazing"/>
+            <column name="check_point" value="Glass type, thickness and gasket match the specification and the unit is unbroken"/>
+            <column name="specification" value="IS 2553, specification"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="Thickness measured with a glass gauge; unit checked for edge chips and seal failure"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Sealing"/>
+            <column name="check_point" value="Perimeter joint fully sealed with the specified sealant and backer rod"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="Continuous seal"/>
+            <column name="acceptance_criterion" value="Seal continuous with no void; joint width and depth within the sealant's working range"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="bf31f53b-2929-5380-a2a7-a9d3014a637d"/>
+            <column name="category" value="Operation"/>
+            <column name="check_point" value="Every leaf opens, closes, locks and stays shut without binding"/>
+            <column name="specification" value="Manufacturer's specification"/>
+            <column name="expected_value" value="Smooth operation"/>
+            <column name="acceptance_criterion" value="Each leaf operated through its full travel and locked; no binding or self-opening"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== ELECTRICAL_FIXTURES ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="trade" value="ELECTRICAL_FIXTURES"/>
+            <column name="name" value="Electrical fixtures checklist"/>
+            <column name="description" value="Fixture mounting, circuit identification, earthing, insulation resistance and functional test."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Mounting"/>
+            <column name="check_point" value="Fixture mounted at the specified height, level and securely fixed"/>
+            <column name="specification" value="Electrical layout drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Height measured from finished floor level; fixture does not move under hand pressure"/>
+            <column name="tolerance" value="+/- 10 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Identification"/>
+            <column name="check_point" value="Circuit is identified at the fixture and matches the distribution board schedule"/>
+            <column name="specification" value="DB schedule"/>
+            <column name="expected_value" value="Matches schedule"/>
+            <column name="acceptance_criterion" value="Circuit traced from the fixture to the labelled way on the board"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Earthing"/>
+            <column name="check_point" value="Earth continuity confirmed from the fixture body back to the earth bar"/>
+            <column name="specification" value="IS 732"/>
+            <column name="expected_value" value="Continuous"/>
+            <column name="acceptance_criterion" value="Continuity measured with a low-resistance ohmmeter"/>
+            <column name="tolerance" value="1 ohm maximum"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Insulation"/>
+            <column name="check_point" value="Insulation resistance measured on the circuit before energising"/>
+            <column name="specification" value="IS 732"/>
+            <column name="expected_value" value="1 megohm minimum"/>
+            <column name="acceptance_criterion" value="Measured at 500 V DC between conductors and to earth, with the fixture connected"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Polarity"/>
+            <column name="check_point" value="Live, neutral and earth are correctly connected at every point on the circuit"/>
+            <column name="specification" value="IS 732"/>
+            <column name="expected_value" value="Correct polarity"/>
+            <column name="acceptance_criterion" value="Polarity confirmed at the fixture and at every socket outlet on the circuit"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="2264c3b1-a624-5870-9dab-4a2996bb4533"/>
+            <column name="category" value="Function"/>
+            <column name="check_point" value="Fixture switches, dims and operates from every control point"/>
+            <column name="specification" value="Electrical layout drawing"/>
+            <column name="expected_value" value="Operates correctly"/>
+            <column name="acceptance_criterion" value="Operated from each switch and two-way point serving it"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== PLUMBING_FIXTURES ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="trade" value="PLUMBING_FIXTURES"/>
+            <column name="name" value="Plumbing pipework and fixtures checklist"/>
+            <column name="description" value="Pipe material, supports, slope, pressure test and the fixing of water supply fittings."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Material"/>
+            <column name="check_point" value="Pipe and fitting material, class and diameter match the drawing"/>
+            <column name="specification" value="IS 15778 / IS 4985, drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Marking on the pipe traced to the specification for each run"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Supports"/>
+            <column name="check_point" value="Clamps and supports are at the specified spacing and the run is not sagging"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="As per data sheet"/>
+            <column name="acceptance_criterion" value="Support spacing measured on every run; no visible sag between supports"/>
+            <column name="tolerance" value="+/- 50 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Slope"/>
+            <column name="check_point" value="Drainage runs fall continuously towards the discharge point"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="1 in 60"/>
+            <column name="acceptance_criterion" value="Fall measured with a level at both ends of each run"/>
+            <column name="tolerance" value="+/- 10 percent"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Pressure test"/>
+            <column name="check_point" value="Supply line held at the test pressure for the specified duration without loss"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="1.5 times working pressure, 24 hours"/>
+            <column name="acceptance_criterion" value="Gauge reading recorded at the start and end of the hold; no drop and no visible leak"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Concealment"/>
+            <column name="check_point" value="No joint is buried in a wall or floor without being tested and recorded first"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="Tested before concealment"/>
+            <column name="acceptance_criterion" value="Test record and photographs taken before the chase is closed"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="6b10be2b-1464-5d26-b568-2da4583f8b22"/>
+            <column name="category" value="Fixtures"/>
+            <column name="check_point" value="Taps, mixers and stop valves fixed level, secure and operating without leaks"/>
+            <column name="specification" value="Manufacturer's specification"/>
+            <column name="expected_value" value="No leak"/>
+            <column name="acceptance_criterion" value="Each fitting operated through its full travel and inspected under pressure"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== SANITARY_FIXTURES ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="trade" value="SANITARY_FIXTURES"/>
+            <column name="name" value="Sanitary fixtures checklist"/>
+            <column name="description" value="Setting out, fixing, trap seal, connection to the waste and the water test on installed sanitaryware."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Position"/>
+            <column name="check_point" value="Fixture set out at the position and height shown on the drawing"/>
+            <column name="specification" value="Sanitary layout drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Centre line and rim height measured from the finished floor and the adjacent wall"/>
+            <column name="tolerance" value="+/- 10 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Fixing"/>
+            <column name="check_point" value="Fixture is level, rigidly fixed and bears evenly on its support"/>
+            <column name="specification" value="Manufacturer's specification"/>
+            <column name="expected_value" value="Level and rigid"/>
+            <column name="acceptance_criterion" value="Level checked in both directions; no rocking under hand pressure"/>
+            <column name="tolerance" value="+/- 2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Trap seal"/>
+            <column name="check_point" value="Every fixture discharges through a trap with the specified seal depth"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="50 mm minimum"/>
+            <column name="acceptance_criterion" value="Seal depth measured on each trap before the fixture is connected"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Connection"/>
+            <column name="check_point" value="Waste connection is watertight and the joint is accessible for maintenance"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="No leak"/>
+            <column name="acceptance_criterion" value="Joint run under full flow and inspected; access retained without cutting finishes"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Water test"/>
+            <column name="check_point" value="Fixture filled and discharged with no leak at the trap, the waste or the wall face"/>
+            <column name="specification" value="IS 5329"/>
+            <column name="expected_value" value="No leak"/>
+            <column name="acceptance_criterion" value="Filled to the overflow, discharged, and the surrounding surfaces inspected dry"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="4b6e7b50-a4f8-54e4-ba31-ddb834abb963"/>
+            <column name="category" value="Finish"/>
+            <column name="check_point" value="Sealant at the wall and floor junction is continuous and the fixture is undamaged"/>
+            <column name="specification" value="Architectural specification"/>
+            <column name="expected_value" value="No defect"/>
+            <column name="acceptance_criterion" value="Silicone bead continuous with no gap; no chip, crack or stain on the glazed surface"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== FINISHING ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="trade" value="FINISHING"/>
+            <column name="name" value="Finishing checklist"/>
+            <column name="description" value="Painting, polishing, joinery and the final make-good inspection before handover of a space."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Preparation"/>
+            <column name="check_point" value="Surface filled, rubbed down and primed before the finish coat"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="As per data sheet"/>
+            <column name="acceptance_criterion" value="No visible fill mark, no sanding scratch and no unprimed patch under a raking light"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Coats"/>
+            <column name="check_point" value="The specified number of coats applied and each allowed to dry before the next"/>
+            <column name="specification" value="Manufacturer's data sheet"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="Coat count recorded per surface; drying interval respected between coats"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Coverage"/>
+            <column name="check_point" value="Finish is uniform in colour and sheen with no brush marks, runs or missed area"/>
+            <column name="specification" value="Architectural specification"/>
+            <column name="expected_value" value="Uniform"/>
+            <column name="acceptance_criterion" value="Surface viewed under a raking light from 1 m; no defect visible"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Edges"/>
+            <column name="check_point" value="Cut lines at ceilings, skirtings, frames and switch plates are straight and clean"/>
+            <column name="specification" value="Architectural specification"/>
+            <column name="expected_value" value="Straight and clean"/>
+            <column name="acceptance_criterion" value="Cut line checked over its full length; no overrun onto the adjacent finish"/>
+            <column name="tolerance" value="2 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Hardware"/>
+            <column name="check_point" value="Ironmongery fitted, aligned and operating, with no paint on the hardware"/>
+            <column name="specification" value="Architectural specification"/>
+            <column name="expected_value" value="Operates correctly"/>
+            <column name="acceptance_criterion" value="Each item operated through its full travel; fixings tight and finish undamaged"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="a923e73f-6375-512e-8df6-1a6beaaf3a00"/>
+            <column name="category" value="Make good"/>
+            <column name="check_point" value="Snags from earlier trades are closed out and the space is clean and undamaged"/>
+            <column name="specification" value="Snag list"/>
+            <column name="expected_value" value="All closed"/>
+            <column name="acceptance_criterion" value="Every open snag against this space verified closed and signed off"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== DIMENSIONAL_CHECK ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="trade" value="DIMENSIONAL_CHECK"/>
+            <column name="name" value="Dimensional and alignment checklist"/>
+            <column name="description" value="As-built dimensions, levels, plumb, squareness and floor flatness measured against the drawing."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="Setting out"/>
+            <column name="check_point" value="Grid lines transferred to the floor and checked against the survey control"/>
+            <column name="specification" value="Setting-out drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Grid measured from two independent control points and the results agree"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="Level"/>
+            <column name="check_point" value="Finished level surveyed on a grid across the area"/>
+            <column name="specification" value="Structural drawing"/>
+            <column name="expected_value" value="As per drawing"/>
+            <column name="acceptance_criterion" value="Levels taken at every 3 m and at all corners, and recorded on a marked-up plan"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="Plumb"/>
+            <column name="check_point" value="Vertical elements are plumb over the storey height"/>
+            <column name="specification" value="IS 456:2000 cl. 6"/>
+            <column name="expected_value" value="Vertical"/>
+            <column name="acceptance_criterion" value="Plumb measured on two adjacent faces of each element"/>
+            <column name="tolerance" value="+/- 5 mm per storey"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="Squareness"/>
+            <column name="check_point" value="Room and opening diagonals are equal"/>
+            <column name="specification" value="Architectural drawing"/>
+            <column name="expected_value" value="Equal diagonals"/>
+            <column name="acceptance_criterion" value="Both diagonals measured and compared for every room and opening"/>
+            <column name="tolerance" value="+/- 5 mm"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="Flatness"/>
+            <column name="check_point" value="Floor and wall flatness measured with a straight edge"/>
+            <column name="specification" value="IS 1443"/>
+            <column name="expected_value" value="As per specification"/>
+            <column name="acceptance_criterion" value="3 m straight edge laid in two directions at five locations per room"/>
+            <column name="tolerance" value="3 mm per 3 m"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="d596fd51-d689-5fa5-989f-bff23500358a"/>
+            <column name="category" value="As-built record"/>
+            <column name="check_point" value="Measured deviations recorded against the drawing reference and the grid"/>
+            <column name="specification" value="Quality plan"/>
+            <column name="expected_value" value="Recorded"/>
+            <column name="acceptance_criterion" value="Every measurement traceable to a grid reference and a drawing revision"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+        <!-- ===================== PROGRESS_CHECK ===================== -->
+        <insert tableName="starter_checklist_templates">
+            <column name="id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="trade" value="PROGRESS_CHECK"/>
+            <column name="name" value="Progress verification checklist"/>
+            <column name="description" value="Quantities in place, sequence, quality of completed work and readiness for the next activity, for a progress claim."/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Quantity"/>
+            <column name="check_point" value="Quantity in place measured and agreed against the claim"/>
+            <column name="specification" value="Bill of quantities"/>
+            <column name="expected_value" value="As claimed"/>
+            <column name="acceptance_criterion" value="Measured jointly on site and the measurement sheet signed by both parties"/>
+            <column name="tolerance" value="+/- 2 percent"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="0"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Sequence"/>
+            <column name="check_point" value="Preceding activities are complete and signed off before this one is claimed"/>
+            <column name="specification" value="Programme, quality plan"/>
+            <column name="expected_value" value="Complete"/>
+            <column name="acceptance_criterion" value="Every preceding inspection for the same area is closed"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="1"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Quality"/>
+            <column name="check_point" value="Completed work has passed its own trade inspection with no open defect"/>
+            <column name="specification" value="Quality plan"/>
+            <column name="expected_value" value="No open defect"/>
+            <column name="acceptance_criterion" value="No defect against this area is open or awaiting verification"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="high"/>
+            <column name="line_order" valueNumeric="2"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Photographs"/>
+            <column name="check_point" value="Dated photographs taken of the work claimed, showing the location reference"/>
+            <column name="specification" value="Quality plan"/>
+            <column name="expected_value" value="Per claim"/>
+            <column name="acceptance_criterion" value="Photographs cover every area claimed and carry the date and the grid reference"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="3"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Materials on site"/>
+            <column name="check_point" value="Materials claimed as delivered but not yet built in are on site and protected"/>
+            <column name="specification" value="Delivery challans"/>
+            <column name="expected_value" value="As claimed"/>
+            <column name="acceptance_criterion" value="Physically counted on site and reconciled to the delivery challans"/>
+            <column name="photos_required" valueBoolean="true"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="4"/>
+        </insert>
+        <insert tableName="starter_checklist_template_items">
+            <column name="template_id" value="74f5cd73-f329-5b69-adb2-d6a8388f1125"/>
+            <column name="category" value="Readiness"/>
+            <column name="check_point" value="Work front is ready for the next activity with access, services and protection in place"/>
+            <column name="specification" value="Programme"/>
+            <column name="expected_value" value="Ready"/>
+            <column name="acceptance_criterion" value="Next trade's supervisor has accepted the work front in writing"/>
+            <column name="photos_required" valueBoolean="false"/>
+            <column name="priority" value="medium"/>
+            <column name="line_order" valueNumeric="5"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/058-extend-inspection-check-items.xml
+++ b/src/main/resources/db/changelog/v4.0/058-extend-inspection-check-items.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="058-01-add-check-item-criteria-and-bim-link" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="inspection_check_items" columnName="acceptance_criterion"/>
+            </not>
+            <not>
+                <columnExists tableName="inspection_check_items" columnName="tolerance"/>
+            </not>
+            <not>
+                <columnExists tableName="inspection_check_items" columnName="deviation"/>
+            </not>
+            <not>
+                <columnExists tableName="inspection_check_items" columnName="bim_element_guid"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The measurable form of a check point, carried onto the inspection when a checklist
+            template is instantiated. acceptance_criterion states what makes the check point
+            pass and tolerance is the band around expected_value; deviation is the measured
+            value minus the expected one, computed server-side and left NULL where the pair is
+            not a comparable numeric quantity in one unit, which is the normal case for a
+            qualitative check point.
+
+            bim_element_guid holds the IFC GlobalId of the element the check point was carried
+            out against. It is unused until the BIM phase; the column is added now so the link
+            is already in place when the viewer lands and no live table has to be migrated then.
+
+            All four columns are guarded above. A precondition naming only the first would mark
+            the changeset as run on a database that already had it and silently skip the rest.
+        </comment>
+
+        <addColumn tableName="inspection_check_items">
+            <column name="acceptance_criterion" type="VARCHAR(1000)"/>
+            <column name="tolerance" type="VARCHAR(100)"/>
+            <column name="deviation" type="DECIMAL(19,4)"/>
+            <column name="bim_element_guid" type="VARCHAR(100)"/>
+        </addColumn>
+
+        <createIndex tableName="inspection_check_items" indexName="idx_insp_check_item_bim_guid">
+            <column name="bim_element_guid"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inspection/ChecklistTemplateServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/ChecklistTemplateServiceIT.java
@@ -1,0 +1,331 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.domain.InspectionCheckItem;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateItemRequest;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateRequest;
+import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The checklist library against a real CockroachDB: an org defines its own template
+ * per trade, edits it, adopts a shipped starter as a copy, and cannot see another
+ * org's. It also proves the Liquibase starter seed actually loaded, which no unit
+ * test can.
+ *
+ * <p>The annotations and the {@code @Import} list repeat {@link InspectionServiceIT}
+ * to the letter on purpose, so Spring's context cache serves both classes from one
+ * context. See that class for why that matters in a 1 GB test JVM. Keep the two in
+ * step when either changes.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class ChecklistTemplateServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ChecklistTemplateService service;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long orgBId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("Template Org A");
+            Organization orgB = persistOrganization("Template Org B");
+            entityManager.flush();
+            orgAId = orgA.getId();
+            orgBId = orgB.getId();
+        });
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    /**
+     * Resets the per-test session state while the test transaction is still open.
+     * The database rows are removed separately by {@link #removeCommittedRows()},
+     * once that transaction has gone.
+     */
+    @AfterEach
+    void clearTenantState() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+    }
+
+    /**
+     * Removes the rows the seed committed, after the test transaction has rolled
+     * back rather than while it is still open.
+     *
+     * <p>{@code @AfterEach} runs inside the test transaction, so a delete issued
+     * from there runs in a second, committed transaction while the first still
+     * holds write intents on the same tables. CockroachDB may resolve that by
+     * aborting the writer, or it may make the deleter wait for a transaction that
+     * cannot commit until the delete returns. When it waits, the statement timeout
+     * fires 30 seconds later and the test fails on cleanup with a query timeout and
+     * no failed assertion, which is exactly the kind of failure that gets blamed on
+     * an unrelated test. {@code @AfterTransaction} runs after the rollback, so
+     * there are no intents left to contend with.
+     */
+    @AfterTransaction
+    void removeCommittedRows() {
+        if (orgAId == null && orgBId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            deleteForOrgs("DELETE FROM checklist_template_items WHERE template_id IN "
+                    + "(SELECT id FROM checklist_templates WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM checklist_templates WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
+        });
+    }
+
+    @Test
+    void create_storesTheCheckPointsInTheSubmittedOrderAtVersionOne() {
+        ChecklistTemplateDto created = service.create(request(
+                new ChecklistTemplateItemRequest("Cover", "Clear cover to the outermost bar",
+                        "IS 456:2000 cl. 26.4", "40 mm", "Measured at five points", "+/- 5 mm",
+                        true, "high"),
+                new ChecklistTemplateItemRequest("Spacing", "Main bar spacing",
+                        "IS 456:2000 cl. 26.3", "150 mm", "Measured at three locations", "+/- 10 mm",
+                        true, null)));
+
+        assertThat(created.trade()).isEqualTo(InspectionTrade.REINFORCEMENT);
+        assertThat(created.version()).isEqualTo(1);
+        // active is omitted on the request and defaults to true, so the template is
+        // instantiated into new inspections straight away
+        assertThat(created.active()).isTrue();
+        assertThat(created.items()).extracting(item -> item.checkPoint())
+                .containsExactly("Clear cover to the outermost bar", "Main bar spacing");
+        assertThat(created.items().getFirst().lineOrder()).isZero();
+        assertThat(created.items().get(1).lineOrder()).isEqualTo(1);
+        assertThat(created.items().getFirst().tolerance()).isEqualTo("+/- 5 mm");
+        // priority omitted, so it takes the same default the inspection check item uses
+        assertThat(created.items().get(1).priority()).isEqualTo("medium");
+    }
+
+    @Test
+    void create_refusesASecondTemplateForTheSameTrade() {
+        service.create(request(anItem()));
+
+        assertThatThrownBy(() -> service.create(request(anItem())))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessageContaining("reinforcement");
+    }
+
+    @Test
+    void update_replacesTheCheckPointsAndBumpsTheVersion() {
+        UUID id = service.create(request(anItem())).id();
+
+        ChecklistTemplateDto updated = service.update(id, new ChecklistTemplateRequest(
+                InspectionTrade.REINFORCEMENT,
+                "Reinforcement checklist, revision 2",
+                "Tightened after the audit",
+                false,
+                List.of(new ChecklistTemplateItemRequest("Laps", "Lap length and stagger",
+                        "IS 456:2000 cl. 26.2.5", "50d", "Measured on each lapped bar", "+/- 25 mm",
+                        true, "high"))));
+
+        assertThat(updated.version()).isEqualTo(2);
+        assertThat(updated.name()).isEqualTo("Reinforcement checklist, revision 2");
+        assertThat(updated.active()).isFalse();
+        assertThat(updated.items()).extracting(item -> item.checkPoint())
+                .containsExactly("Lap length and stagger");
+    }
+
+    @Test
+    void update_refusesToMoveATemplateToAnotherTrade() {
+        UUID id = service.create(request(anItem())).id();
+
+        assertThatThrownBy(() -> service.update(id, new ChecklistTemplateRequest(
+                InspectionTrade.MASONRY, "Moved", null, null, List.of(anItem()))))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be moved");
+    }
+
+    @Test
+    void findStarters_returnsTheShippedSeedForEveryTrade() {
+        List<StarterChecklistTemplateDto> starters = service.findStarters();
+
+        assertThat(starters).hasSize(InspectionTrade.values().length);
+        assertThat(starters).extracting(StarterChecklistTemplateDto::trade)
+                .containsExactlyInAnyOrder(InspectionTrade.values());
+        assertThat(starters).allSatisfy(starter -> assertThat(starter.items()).isNotEmpty());
+    }
+
+    @Test
+    void adoptStarter_copiesTheShippedChecklistIntoTheTenant() {
+        ChecklistTemplateDto adopted = service.adoptStarter(InspectionTrade.WATERPROOFING);
+
+        StarterChecklistTemplateDto starter = service.findStarters().stream()
+                .filter(candidate -> candidate.trade() == InspectionTrade.WATERPROOFING)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(adopted.trade()).isEqualTo(InspectionTrade.WATERPROOFING);
+        assertThat(adopted.version()).isEqualTo(1);
+        assertThat(adopted.active()).isTrue();
+        assertThat(adopted.items()).hasSameSizeAs(starter.items());
+        assertThat(adopted.items()).extracting(item -> item.checkPoint())
+                .isEqualTo(starter.items().stream().map(item -> item.checkPoint()).toList());
+        // the copy is independent: it has its own row ids, not the starter's
+        assertThat(adopted.items().getFirst().id())
+                .isNotEqualTo(starter.items().getFirst().id());
+    }
+
+    @Test
+    void adoptStarter_refusesWhenTheTenantAlreadyHasATemplateForTheTrade() {
+        service.create(request(anItem()));
+
+        assertThatThrownBy(() -> service.adoptStarter(InspectionTrade.REINFORCEMENT))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void findById_isScopedToTheOwningTenant() {
+        UUID id = service.create(request(anItem())).id();
+        entityManager.flush();
+        entityManager.clear();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        enableOrgFilter(orgBId);
+        assertThatThrownBy(() -> service.findById(id)).isInstanceOf(ResourceNotFoundException.class);
+        assertThat(service.findAll(null, null, pageable).getTotalElements()).isZero();
+        // and an inspection in the other tenant gets no check points from it
+        assertThat(service.instantiateFor(InspectionTrade.REINFORCEMENT)).isEmpty();
+        disableOrgFilter();
+
+        enableOrgFilter(orgAId);
+        assertThat(service.findById(id).id()).isEqualTo(id);
+        assertThat(service.findAll(InspectionTrade.REINFORCEMENT, true, pageable).getTotalElements())
+                .isEqualTo(1);
+        assertThat(service.findAll(InspectionTrade.MASONRY, null, pageable).getTotalElements())
+                .isZero();
+        disableOrgFilter();
+    }
+
+    @Test
+    void instantiateFor_skipsARetiredTemplateAndAnUnknownTrade() {
+        UUID id = service.create(request(anItem())).id();
+        assertThat(service.instantiateFor(InspectionTrade.REINFORCEMENT)).hasSize(1);
+
+        // no template at all for this trade
+        assertThat(service.instantiateFor(InspectionTrade.FLOORING)).isEmpty();
+        // and no trade at all, which is every safety and compliance inspection
+        assertThat(service.instantiateFor(null)).isEmpty();
+
+        service.update(id, new ChecklistTemplateRequest(InspectionTrade.REINFORCEMENT,
+                "Retired", null, false, List.of(anItem())));
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(service.instantiateFor(InspectionTrade.REINFORCEMENT)).isEmpty();
+    }
+
+    @Test
+    void instantiateFor_copiesTheCriteriaOntoUnansweredCheckItems() {
+        service.create(request(new ChecklistTemplateItemRequest("Cover",
+                "Clear cover to the outermost bar", "IS 456:2000 cl. 26.4", "40 mm",
+                "Measured at five points", "+/- 5 mm", true, "high")));
+
+        List<InspectionCheckItem> items = service.instantiateFor(InspectionTrade.REINFORCEMENT);
+
+        assertThat(items).hasSize(1);
+        InspectionCheckItem item = items.getFirst();
+        assertThat(item.getCheckPoint()).isEqualTo("Clear cover to the outermost bar");
+        assertThat(item.getAcceptanceCriterion()).isEqualTo("Measured at five points");
+        assertThat(item.getTolerance()).isEqualTo("+/- 5 mm");
+        assertThat(item.getExpectedValue()).isEqualTo("40 mm");
+        assertThat(item.getPriority()).isEqualTo("high");
+        assertThat(item.isPhotosRequired()).isTrue();
+        assertThat(item.getStatus()).isEqualTo(CheckItemStatus.PENDING);
+        assertThat(item.getMeasurement()).isNull();
+        // not attached to an inspection yet: the caller does that
+        assertThat(item.getInspection()).isNull();
+    }
+
+    private static ChecklistTemplateRequest request(ChecklistTemplateItemRequest... items) {
+        return new ChecklistTemplateRequest(InspectionTrade.REINFORCEMENT,
+                "Reinforcement checklist", "Pre-pour check", null, List.of(items));
+    }
+
+    private static ChecklistTemplateItemRequest anItem() {
+        return new ChecklistTemplateItemRequest("Spacing", "Main bar spacing",
+                null, "150 mm", null, "+/- 10 mm", false, null);
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    private void deleteForOrgs(String sql) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("a", orgAId)
+                .setParameter("b", orgBId)
+                .executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
@@ -14,17 +14,23 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateItemRequest;
+import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateRequest;
 import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemDto;
 import org.tornotron.echno_backend.inspection.dtos.InspectionCheckItemRequest;
 import org.tornotron.echno_backend.inspection.dtos.InspectionDefectRequest;
 import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
 import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
 import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
@@ -46,10 +52,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>No {@code JpaAuditingConfig} import is needed: the created and updated
  * timestamps are populated by Hibernate's {@code @CreationTimestamp}/{@code
  * @UpdateTimestamp} at persist time, not by Spring Data auditing.
+ *
+ * <p>{@link ChecklistTemplateServiceIT} and {@link InspectionTaxonomyMigrationIT}
+ * declare the same annotations and the same {@code @Import} list, deliberately and
+ * to the letter, so Spring's context cache hands all of them one context instead of
+ * building three. The test JVM is capped at 1 GB with no fork between classes, so
+ * every distinct test configuration is a Spring context that stays cached for the
+ * whole run. Keep the lists identical when any one changes.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class})
 class InspectionServiceIT extends AbstractIntegrationTest {
 
@@ -58,6 +72,9 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
     @Autowired
     private InspectionRepository inspectionRepo;
+
+    @Autowired
+    private ChecklistTemplateService templateService;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -94,10 +111,33 @@ class InspectionServiceIT extends AbstractIntegrationTest {
         TenantContext.setCurrentOrgId(orgAId);
     }
 
+    /**
+     * Resets the per-test session state while the test transaction is still open.
+     * The database rows are removed separately by {@link #removeCommittedRows()},
+     * once that transaction has gone.
+     */
     @AfterEach
-    void cleanup() {
+    void clearTenantState() {
         entityManager.unwrap(Session.class).disableFilter("orgFilter");
         TenantContext.clear();
+    }
+
+    /**
+     * Removes the rows the seed committed, after the test transaction has rolled
+     * back rather than while it is still open.
+     *
+     * <p>{@code @AfterEach} runs inside the test transaction, so a delete issued
+     * from there runs in a second, committed transaction while the first still
+     * holds write intents on the same tables. CockroachDB may resolve that by
+     * aborting the writer, or it may make the deleter wait for a transaction that
+     * cannot commit until the delete returns. When it waits, the statement timeout
+     * fires 30 seconds later and the test fails on cleanup with a query timeout and
+     * no failed assertion, which is exactly the kind of failure that gets blamed on
+     * an unrelated test. {@code @AfterTransaction} runs after the rollback, so
+     * there are no intents left to contend with.
+     */
+    @AfterTransaction
+    void removeCommittedRows() {
         if (orgAId == null && orgBId == null) {
             return;
         }
@@ -117,6 +157,9 @@ class InspectionServiceIT extends AbstractIntegrationTest {
             deleteForOrgs("DELETE FROM inspection_check_items WHERE inspection_id IN "
                     + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
             deleteForOrgs("DELETE FROM inspections WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM checklist_template_items WHERE template_id IN "
+                    + "(SELECT id FROM checklist_templates WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM checklist_templates WHERE organization_id IN (:a,:b)");
             deleteForOrgs("DELETE FROM document_sequence WHERE organization_id IN (:a,:b)");
             deleteForOrgs("DELETE FROM project WHERE organization_id IN (:a,:b)");
             deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
@@ -159,13 +202,13 @@ class InspectionServiceIT extends AbstractIntegrationTest {
                 List.of(
                         new InspectionCheckItemRequest("Structural", "Column alignment",
                                 "Within 5mm", CheckItemStatus.PASSED, null, false, null,
-                                "3mm", "5mm", "high"),
+                                "3mm", "5mm", null, null, null, "high"),
                         new InspectionCheckItemRequest("Structural", "Rebar spacing",
                                 "150mm c/c", CheckItemStatus.PASSED, null, false, null,
-                                null, null, "medium"),
+                                null, null, null, null, null, "medium"),
                         new InspectionCheckItemRequest("Finishing", "Surface level",
                                 "Level within tolerance", CheckItemStatus.FAILED, "Uneven patch",
-                                true, List.of("photo-1.jpg"), null, null, "low")
+                                true, List.of("photo-1.jpg"), null, null, null, null, null, "low")
                 ),
                 List.of(
                         new InspectionDefectRequest("Finishing", "Uneven surface near grid B2",
@@ -189,6 +232,10 @@ class InspectionServiceIT extends AbstractIntegrationTest {
         // status omitted on the request, so it takes the OPEN default
         assertThat(created.defects().getFirst().status()).isEqualTo(DefectStatus.OPEN);
         assertThat(created.attendees()).containsExactly("Site Engineer", "Safety Officer");
+        // measurement 3mm against an expected 5mm, in the same unit, so the deviation is -2
+        assertThat(created.checkItems().getFirst().deviation()).isEqualByComparingTo("-2");
+        // no measurement recorded, so there is nothing to deviate from
+        assertThat(created.checkItems().get(1).deviation()).isNull();
         assertThat(created.totalCheckPoints()).isEqualTo(3);
         assertThat(created.passedCheckPoints()).isEqualTo(2);
         assertThat(created.failedCheckPoints()).isEqualTo(1);
@@ -253,7 +300,7 @@ class InspectionServiceIT extends AbstractIntegrationTest {
                 List.of(
                         new InspectionCheckItemRequest("Structural", "Column alignment",
                                 "Within 5mm", CheckItemStatus.PASSED, null, false, null,
-                                null, null, "high")
+                                null, null, null, null, null, "high")
                 ),
                 List.of()
         );
@@ -269,6 +316,78 @@ class InspectionServiceIT extends AbstractIntegrationTest {
         assertThat(updated.passedCheckPoints()).isEqualTo(1);
         assertThat(updated.failedCheckPoints()).isZero();
         assertThat(updated.defectsFound()).isZero();
+    }
+
+    @Test
+    void create_startsFromTheTradeChecklistTemplateWhenNoCheckItemsAreSupplied() {
+        templateService.create(new ChecklistTemplateRequest(
+                InspectionTrade.MASONRY,
+                "Masonry checklist",
+                "Block work",
+                null,
+                List.of(
+                        new ChecklistTemplateItemRequest("Coursing", "Course height uniform",
+                                "IS 2212", "200 mm", "Level taken at both ends", "+/- 5 mm",
+                                true, "high"),
+                        new ChecklistTemplateItemRequest("Joints", "Mortar joints fully filled",
+                                "IS 2212", "10 mm", "No unfilled vertical joint", "+/- 2 mm",
+                                false, "medium"))));
+
+        InspectionDto created = service.create(scheduleFor(InspectionTrade.MASONRY, null));
+
+        assertThat(created.checkItems()).hasSize(2);
+        assertThat(created.totalCheckPoints()).isEqualTo(2);
+        assertThat(created.passedCheckPoints()).isZero();
+        assertThat(created.failedCheckPoints()).isZero();
+
+        InspectionCheckItemDto first = created.checkItems().getFirst();
+        assertThat(first.checkPoint()).isEqualTo("Course height uniform");
+        assertThat(first.acceptanceCriterion()).isEqualTo("Level taken at both ends");
+        assertThat(first.tolerance()).isEqualTo("+/- 5 mm");
+        assertThat(first.expectedValue()).isEqualTo("200 mm");
+        assertThat(first.photosRequired()).isTrue();
+        // instantiated items are unanswered: an inspector fills these in on site
+        assertThat(first.status()).isEqualTo(CheckItemStatus.PENDING);
+        assertThat(first.measurement()).isNull();
+        assertThat(first.deviation()).isNull();
+        assertThat(created.checkItems().get(1).checkPoint()).isEqualTo("Mortar joints fully filled");
+    }
+
+    @Test
+    void create_keepsTheSuppliedCheckItemsInsteadOfAppendingTheTemplate() {
+        templateService.create(new ChecklistTemplateRequest(
+                InspectionTrade.MASONRY,
+                "Masonry checklist",
+                null,
+                null,
+                List.of(new ChecklistTemplateItemRequest("Coursing", "Course height uniform",
+                        null, null, null, null, false, null))));
+
+        InspectionDto created = service.create(scheduleFor(InspectionTrade.MASONRY,
+                List.of(new InspectionCheckItemRequest("Joints", "Re-check the failed joint",
+                        null, CheckItemStatus.PENDING, null, false, null,
+                        null, null, null, null, null, "high"))));
+
+        assertThat(created.checkItems()).hasSize(1);
+        assertThat(created.checkItems().getFirst().checkPoint()).isEqualTo("Re-check the failed joint");
+        assertThat(created.totalCheckPoints()).isEqualTo(1);
+    }
+
+    @Test
+    void create_leavesTheChecklistEmptyWhenTheTradeHasNoActiveTemplate() {
+        InspectionDto created = service.create(scheduleFor(InspectionTrade.PLASTERING, null));
+
+        assertThat(created.checkItems()).isEmpty();
+        assertThat(created.totalCheckPoints()).isZero();
+    }
+
+    private CreateInspectionRequest scheduleFor(InspectionTrade trade,
+                                                List<InspectionCheckItemRequest> checkItems) {
+        return new CreateInspectionRequest(
+                "Wall check", InspectionType.QUALITY, null, trade, projectId,
+                "Block A", null, null, LocalDate.of(2026, 8, 20), null,
+                null, null, null, 100L, null, null, null, null, null,
+                checkItems, null);
     }
 
     private void enableOrgFilter(Long orgId) {

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
@@ -10,7 +10,9 @@ import org.springframework.context.annotation.Import;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import org.w3c.dom.Document;
@@ -45,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class})
 class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
 

--- a/src/test/java/org/tornotron/echno_backend/inspection/MeasurementDeviationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/MeasurementDeviationTest.java
@@ -1,0 +1,75 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.tornotron.echno_backend.inspection.service.MeasurementDeviation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The deviation a check point records is the measured value minus the expected
+ * one, and both arrive as free text an inspector typed. These cases pin down where
+ * that subtraction is meaningful and where the answer has to be "not recorded",
+ * which is the distinction that matters: a wrong number here reads as a real
+ * measurement on a QA report and a null reads as an unanswered check point.
+ *
+ * <p>Plain JUnit with no Spring context: the rule is arithmetic and string parsing,
+ * and the test JVM is capped at 1 GB with every cached context living for the whole
+ * run, so a context this needs nothing from is a context it must not start.
+ */
+class MeasurementDeviationTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            // same unit, spacing and case are irrelevant
+            "148mm,     150mm,     -2",
+            "'148 mm',  150mm,     -2",
+            "150MM,     '150 mm',   0",
+            "'40 mm',   '35 mm',    5",
+            // decimals keep their precision
+            "148.25mm,  150mm,     -1.75",
+            // an explicit sign parses
+            "+2.5mm,    -2.5mm,     5",
+            // a bare number has an empty unit on both sides, which still matches
+            "12,        10,         2",
+    })
+    void computesTheDifferenceWhenBothValuesAreNumericAndInOneUnit(String measurement,
+                                                                   String expected,
+                                                                   String deviation) {
+        assertThat(MeasurementDeviation.of(measurement, expected)).isEqualByComparingTo(deviation);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // differing units: subtracting them would produce a number in no unit at all,
+            // and a reader would take the answer for millimetres
+            "'15 cm',   '150 mm'",
+            "150mm,     150",
+            // qualitative check points, which is most of a finishing or documentation checklist
+            "Level,     Level",
+            "'No leak', 'No leak'",
+            // a ratio is not a quantity this can subtract
+            "1:1.5,     1:2",
+            // the number has to lead: a value that starts with text is not measured
+            "'approx 150mm', 150mm",
+    })
+    void returnsNullWhenThePairIsNotAComparableQuantity(String measurement, String expected) {
+        assertThat(MeasurementDeviation.of(measurement, expected)).isNull();
+    }
+
+    @Test
+    void returnsNullWhenEitherValueIsMissing() {
+        assertThat(MeasurementDeviation.of(null, "150mm")).isNull();
+        assertThat(MeasurementDeviation.of("150mm", null)).isNull();
+        assertThat(MeasurementDeviation.of("  ", "150mm")).isNull();
+        assertThat(MeasurementDeviation.of(null, null)).isNull();
+    }
+
+    @Test
+    void roundsToTheScaleTheColumnHolds() {
+        // five decimal places in, four out, so the insert cannot be rejected for precision
+        assertThat(MeasurementDeviation.of("150.00005mm", "150mm").scale()).isEqualTo(4);
+        assertThat(MeasurementDeviation.of("150.00005mm", "150mm")).isEqualByComparingTo("0.0001");
+    }
+}


### PR DESCRIPTION
Phase 1 of the inspection module, part 1 of 3. Implements section 3.1 of
`docs/specs/2026-08-26-inspection-module.md`. Phase 0 (PR #469) is the base.

**Merge order: this PR, then the NCR workflow, then the RBAC split.** They stack in
that order; the second and third are branched off this one.

## What this adds

**A checklist library keyed by trade, in two populations that must not be confused.**

- `StarterChecklistTemplate` / `StarterChecklistTemplateItem` are global reference
  data shipped with the product, seeded by Liquibase for all sixteen
  `InspectionTrade` members (16 checklists, 95 check points), following the
  `ComplianceRule` precedent exactly: no `organization_id`, no org filter, read-only
  to the application. They give a new client a working system on day one.
- `ChecklistTemplate` / `ChecklistTemplateItem` are the org's own: `TenantScopedEntity`
  with the `orgFilter` and a `@ManyToOne Organization`, editable, one per trade per org.
- `POST /starters/{trade}/adopt` is the only bridge. It copies a starter into the
  tenant and cuts the link, so a later revision of a shipped checklist never rewrites
  criteria a client has tailored and signed work off against.

**Instantiation onto the inspection.** Creating an inspection for a trade starts it
from a copy of that trade's active template. A copy rather than a reference: an
inspection carried out in March records the criteria that were in force in March, and
a QA engineer tightening a tolerance in April must not rewrite what was signed off.

**Check-item extension.** `acceptanceCriterion`, `tolerance`, a server-computed
`deviation`, and a nullable `bimElementGuid` (unused, indexed, so the BIM phase finds
its link column already in place rather than migrating a live table).

## Decisions where the spec was silent

- **Template ownership** is tenant-owned with a global starter seed, as you decided.
  The seed could not live in `checklist_templates` itself: a row with a null
  `organization_id` would be invisible through the `orgFilter`, which is fail-closed by
  design. Hence the separate global pair of tables.
- **`version` is a revision counter, not a key.** The spec says "one template per trade
  per org, versioned by an integer", which are only consistent if the integer counts
  revisions of the single row. Unique constraint on (`organization_id`, `trade`);
  `update` bumps the counter. `active` then means "instantiated into new inspections",
  so deactivating retires a checklist without deleting a definition history references.
- **The trade is fixed at creation**, mirroring the existing project-immutability rule
  on `Inspection`. It is the key the template is found by, so moving one would silently
  repoint every future inspection of two trades at once.
- **No DELETE endpoint.** `active = false` retires a template; deleting one that
  historical inspections were created from destroys the definition without destroying
  the references to it.
- **`priority` on the template item**, which the spec does not list. Without it a
  template cannot fully instantiate an `InspectionCheckItem`, which already has the
  field. Same `'high' | 'medium' | 'low'` free text, same `medium` default.
- **Deviation is computed only where the subtraction means something.** Both values are
  free text an inspector typed, so the rule is: both must parse as a leading decimal,
  and the trailing unit must match case-insensitively. `15 cm` against `150 mm` yields
  null, not `-135`, because the answer would be in no unit at all and a reader would
  take it for millimetres. Null everywhere else, which is most of a finishing or
  documentation checklist. Rounded to the four decimals the column holds so a
  high-precision input is rounded here rather than rejected on insert.
- **An explicit check-item list on the create request always wins.** A template is a
  default, not an override; appending template rows to a hand-built list would double
  up every check point on the re-inspection of a failed item.
- **`bimElementGuid` on the check item only**, not on `InspectionDefect`. Section 6.3
  wants both eventually; only the check item is in this phase's scope.

## Two test-infrastructure fixes this needed

**Cleanup moved to `@AfterTransaction`.** `@AfterEach` runs inside the test
transaction, so deleting rows that transaction still holds write intents on made
CockroachDB wait for a transaction that could not commit until the delete returned. The
30s statement timeout then failed the test on cleanup with a query timeout and no failed
assertion, which is the shape of failure that gets blamed on an unrelated test. Seen on
CI and on `.116` before the fix; green on both after.

**The Spring test-context cache is now capped at 8** (`build.gradle`). This addresses
**#481** and it does so without touching `maxHeapSize`, which is deliberately sized
against the 2 vCPU / 7 GB CI runner and should stay where it is.

#481 names the mechanism exactly: no `forkEvery`, so one JVM serves the whole suite and
Spring keeps a context per distinct test configuration, each with its own Hibernate
`SessionFactory`, alive to the last test. The default cache of 32 means every one of
them is permanent. Four more entities was enough to tip it: the run finished all 646 of
its tests and then died with `OutOfMemoryError` inside ArchUnit's
`ClassFileImportRecord`, which needs the whole application's class graph in memory at
once and runs late, when there is least of it left. That is #481's "it fails somewhere
else" symptom with a new face.

Capping the cache makes Spring close the least recently used context rather than holding
all of them, so the ceiling stops moving with the schema. A context is rebuilt if a
later class needs it again, which is the only cost, and it does not show: measured on
`.116`, 7m18s with the cap against a 7m31s pristine baseline.

## Verification

Full suite on `lab-node-116-f`, against a pristine `origin/development` baseline run on
the same box:

| | result | time |
|---|---|---|
| pristine `origin/development` | BUILD SUCCESSFUL, 104 test classes | 7m31s |
| this branch | BUILD SUCCESSFUL, 538 passed, 0 failures, 0 OOM | 7m18s |

CI on this branch is green as well, including the JaCoCo floor.

- `MeasurementDeviationTest`: plain JUnit, no context.
- `ChecklistTemplateServiceIT`: real CockroachDB. Also proves the Liquibase starter seed
  loaded, which no unit test can.
- **No new Spring context.** `ChecklistTemplateServiceIT`, `InspectionServiceIT` and
  `InspectionTaxonomyMigrationIT` carry the same annotations and the same `@Import` list
  to the letter, so the cache serves all three from one.

## Liquibase

`057-create-and-seed-checklist-templates.xml` (four tables plus the seed) and
`058-extend-inspection-check-items.xml` (four columns plus an index). Both registered in
`db.changelog-master.xml`. 056 went to the project-location work while this was in
flight, hence 057. Every precondition names **every** object its changeset creates: the
four-column `addColumn` is guarded on all four, not just the first.
