### PR TITLE
Make a non-conformance carry its own trail, and stop status jumping

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionStatus.java
@@ -3,10 +3,26 @@ package org.tornotron.echno_backend.inspection;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Lifecycle state of an inspection. The wire value is the hyphenated form from
  * {@link #getValue()}; the constant name is the database representation stored
  * by {@code @Enumerated(STRING)}.
+ *
+ * <p>{@link #canTransitionTo} states which moves are real. The update endpoint
+ * used to take whatever status the payload carried, so an inspection could go
+ * from cancelled back to passed, or from passed to scheduled, and the record
+ * would show a conclusion that was never reached. The graph is deliberately
+ * permissive about how an inspection is concluded, because it is: work is often
+ * carried out and recorded afterwards, so scheduled straight to passed is a
+ * normal day and not an error. What it refuses is going backwards out of a
+ * conclusion, with one exception that is not backwards at all: a failed
+ * inspection returning to in-progress is the re-inspection of the failed items.
  */
 public enum InspectionStatus {
     SCHEDULED("scheduled"),
@@ -37,5 +53,55 @@ public enum InspectionStatus {
             }
         }
         throw new IllegalArgumentException("Unknown inspection status: " + value);
+    }
+
+    private static final Map<InspectionStatus, Set<InspectionStatus>> NEXT;
+
+    static {
+        Set<InspectionStatus> conclusions =
+                EnumSet.of(COMPLETED, PASSED, PASSED_WITH_REMARKS, FAILED);
+        Map<InspectionStatus, Set<InspectionStatus>> next = new EnumMap<>(InspectionStatus.class);
+        // An AI-generated compliance suggestion is taken up, dismissed, or recorded as
+        // already satisfied. The last one is why the conclusions are here: a client who
+        // already holds the fire NOC the model suggested marks it obtained, and making
+        // them schedule an inspection they will never carry out to say so is theatre.
+        next.put(SUGGESTED, plus(conclusions, SCHEDULED, IN_PROGRESS, CANCELLED));
+        // Scheduled work may be started, cancelled, or simply recorded once done.
+        next.put(SCHEDULED, plus(conclusions, IN_PROGRESS, CANCELLED));
+        next.put(IN_PROGRESS, plus(conclusions, CANCELLED));
+        // Carried out but not yet judged: only the verdict is left.
+        next.put(COMPLETED, EnumSet.of(PASSED, PASSED_WITH_REMARKS, FAILED));
+        // A failed inspection is re-inspected. That is forwards, not backwards.
+        next.put(FAILED, EnumSet.of(IN_PROGRESS));
+        // Terminal. Passed work that turns out to be defective is a new inspection
+        // and an NCR against this one, not a rewrite of the verdict already given.
+        next.put(PASSED, EnumSet.noneOf(InspectionStatus.class));
+        next.put(PASSED_WITH_REMARKS, EnumSet.noneOf(InspectionStatus.class));
+        next.put(CANCELLED, EnumSet.noneOf(InspectionStatus.class));
+        NEXT = Collections.unmodifiableMap(next);
+    }
+
+    private static Set<InspectionStatus> plus(Set<InspectionStatus> base,
+                                              InspectionStatus... extra) {
+        Set<InspectionStatus> combined = EnumSet.copyOf(base);
+        Collections.addAll(combined, extra);
+        return combined;
+    }
+
+    /**
+     * Whether an inspection in this state may move to {@code target}. Staying put
+     * is always allowed: the web client sends the whole record back on every save,
+     * so an unchanged status is the normal case, not an attempted transition.
+     *
+     * @param target The state being moved to.
+     * @return true when the move is part of the lifecycle, or is no move at all.
+     */
+    public boolean canTransitionTo(InspectionStatus target) {
+        return this == target || NEXT.get(this).contains(target);
+    }
+
+    /** The states this one may move to, for an error message that says what is allowed. */
+    public Set<InspectionStatus> allowedNext() {
+        return Collections.unmodifiableSet(NEXT.get(this));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/inspection/NcrStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/NcrStatus.java
@@ -1,0 +1,97 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where a non-conformance report has reached in its lifecycle.
+ *
+ * <p>The path an NCR normally walks is
+ * {@code OPEN -> ASSIGNED -> CORRECTIVE_ACTION_COMPLETE -> VERIFIED -> CLOSED},
+ * with two ways out of the straight line. {@link #REJECTED} is where a verifier
+ * puts work that was declared complete but is not acceptable, and it goes back to
+ * the site engineer. {@link #REOPENED} is where an NCR goes when the same
+ * non-conformance is found again after it was verified or closed, which is a real
+ * outcome on site and must not be recorded by raising a second NCR: the history of
+ * the first one is the evidence that it recurred.
+ *
+ * <p>{@link #canTransitionTo} is the whole of that rule and the only place it is
+ * written down. Staying put is always allowed, because the web client sends a
+ * record back unchanged on every save and an unchanged status must not be an error.
+ *
+ * <p>The wire value is the hyphenated lowercase form from {@link #getValue()}; the
+ * constant name is the database representation stored by
+ * {@code @Enumerated(STRING)}.
+ */
+public enum NcrStatus {
+    OPEN("open"),
+    ASSIGNED("assigned"),
+    CORRECTIVE_ACTION_COMPLETE("corrective-action-complete"),
+    VERIFIED("verified"),
+    CLOSED("closed"),
+    REJECTED("rejected"),
+    REOPENED("reopened");
+
+    private final String value;
+
+    NcrStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static NcrStatus fromValue(String value) {
+        for (NcrStatus status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown NCR status: " + value);
+    }
+
+    private static final Map<NcrStatus, Set<NcrStatus>> NEXT;
+
+    static {
+        Map<NcrStatus, Set<NcrStatus>> next = new EnumMap<>(NcrStatus.class);
+        // Raised but not yet given to anyone.
+        next.put(OPEN, EnumSet.of(ASSIGNED));
+        // With a site engineer, who reports the corrective work done.
+        next.put(ASSIGNED, EnumSet.of(CORRECTIVE_ACTION_COMPLETE));
+        // Declared done, awaiting re-inspection: accepted, or sent back.
+        next.put(CORRECTIVE_ACTION_COMPLETE, EnumSet.of(VERIFIED, REJECTED));
+        // Re-inspected and accepted. Closure is a separate, role-gated act.
+        next.put(VERIFIED, EnumSet.of(CLOSED, REOPENED));
+        // Closed, and reopened only if the same non-conformance comes back.
+        next.put(CLOSED, EnumSet.of(REOPENED));
+        // Sent back, so it returns to the assignee rather than to the raiser.
+        next.put(REJECTED, EnumSet.of(ASSIGNED));
+        // Reopened work is reassigned before it can be worked on again.
+        next.put(REOPENED, EnumSet.of(ASSIGNED));
+        NEXT = Collections.unmodifiableMap(next);
+    }
+
+    /**
+     * Whether an NCR in this state may move to {@code target}.
+     *
+     * @param target The state being moved to.
+     * @return true when the move is part of the lifecycle, or is no move at all.
+     */
+    public boolean canTransitionTo(NcrStatus target) {
+        return this == target || NEXT.get(this).contains(target);
+    }
+
+    /** The states this one may move to, for an error message that says what is allowed. */
+    public Set<NcrStatus> allowedNext() {
+        return Collections.unmodifiableSet(NEXT.get(this));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/NcrType.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/NcrType.java
@@ -1,0 +1,50 @@
+package org.tornotron.echno_backend.inspection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Whether a non-conformance is a quality or a safety matter. This is not a label:
+ * it decides who may close the NCR. A quality NCR is closed by a QA engineer and a
+ * safety one by a safety officer, and neither may close the other's, which is the
+ * separation the functional spec asks for and the reason the type is fixed when
+ * the NCR is raised.
+ *
+ * <p>The wire value is the lowercase form from {@link #getValue()}; the constant
+ * name is the database representation stored by {@code @Enumerated(STRING)}.
+ */
+public enum NcrType {
+    QUALITY("quality"),
+    SAFETY("safety");
+
+    private final String value;
+
+    NcrType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static NcrType fromValue(String value) {
+        for (NcrType type : values()) {
+            if (type.value.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown NCR type: " + value);
+    }
+
+    /**
+     * The category of inspection an NCR of this type is raised from. A quality
+     * non-conformance belongs to a QA/QC inspection and a safety one to a safety
+     * inspection, so an NCR raised against an inspection of another category has
+     * the wrong type on it.
+     */
+    public static NcrType forCategory(InspectionCategory category) {
+        return category == InspectionCategory.SAFETY ? SAFETY : QUALITY;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToNcrStatusConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToNcrStatusConverter.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+
+/**
+ * Binds the hyphenated wire value of {@link NcrStatus} (e.g. {@code open},
+ * {@code corrective-action-complete}) when it arrives as a query parameter on the
+ * list endpoint. Spring's default enum binding matches the constant name, not the
+ * wire value, so an explicit converter is registered.
+ */
+@Component
+public class StringToNcrStatusConverter implements Converter<String, NcrStatus> {
+
+    @Override
+    public NcrStatus convert(String source) {
+        return NcrStatus.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToNcrTypeConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/converter/StringToNcrTypeConverter.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.inspection.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.inspection.NcrType;
+
+/**
+ * Binds the lowercase wire value of {@link NcrType} ({@code quality},
+ * {@code safety}) when it arrives as a query parameter on the list endpoint.
+ * Spring's default enum binding matches the constant name, not the wire value, so
+ * an explicit converter is registered.
+ */
+@Component
+public class StringToNcrTypeConverter implements Converter<String, NcrType> {
+
+    @Override
+    public NcrType convert(String source) {
+        return NcrType.fromValue(source);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
@@ -1,0 +1,130 @@
+package org.tornotron.echno_backend.inspection.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+import org.tornotron.echno_backend.inspection.NcrType;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * A non-conformance report: the accountability wrapper over work that failed an
+ * inspection. Tenant-scoped through the Hibernate {@code orgFilter}, with its own
+ * {@code NCR} document series.
+ *
+ * <p>The corrective action itself stays on {@link InspectionDefect}, which already
+ * records what has to be done, by whom and by when. What a defect cannot carry is
+ * the chain of custody the functional spec asks for: who raised the
+ * non-conformance, which site engineer owns it, who re-inspected it and who
+ * finally closed it, with a status that cannot jump. That chain is this entity,
+ * and it is why an NCR is a separate record rather than four more columns on the
+ * defect: one defect may be raised, rejected and reopened more than once, and each
+ * pass needs its own owner and its own dates.
+ *
+ * <p>The links to the inspection and the defect are plain scalar ids with no FK,
+ * matching the way {@link Inspection} refers to its project. This keeps the module
+ * additive and lets an NCR outlive the defect row it started from.
+ */
+@Entity
+@Table(name = "ncrs",
+        uniqueConstraints = @UniqueConstraint(name = "uk_ncr_number",
+                columnNames = {"organization_id", "ncr_number"}),
+        indexes = {
+                @Index(name = "idx_ncr_inspection", columnList = "inspection_id"),
+                @Index(name = "idx_ncr_defect", columnList = "defect_id"),
+                @Index(name = "idx_ncr_status", columnList = "status"),
+                @Index(name = "idx_ncr_type", columnList = "type"),
+                @Index(name = "idx_ncr_site_engineer", columnList = "site_engineer_id")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter @Setter
+@NoArgsConstructor
+public class Ncr implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "ncr_number", nullable = false, length = 30)
+    private String ncrNumber;
+
+    // Fixed when the NCR is raised: it decides who may close it.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private NcrType type;
+
+    @Column(name = "inspection_id", nullable = false)
+    private UUID inspectionId;
+
+    // The specific defect this NCR is about, when it is about one. An NCR may also
+    // be raised against the inspection as a whole.
+    @Column(name = "defect_id")
+    private UUID defectId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 2000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", length = 20)
+    private DefectSeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private NcrStatus status = NcrStatus.OPEN;
+
+    // Scalar employee references, as elsewhere in this module.
+    @Column(name = "site_engineer_id")
+    private Long siteEngineerId;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(name = "raised_by_id")
+    private Long raisedById;
+
+    @Column(name = "closed_by_id")
+    private Long closedById;
+
+    // What the site engineer reports on marking the corrective work complete, and
+    // what a verifier writes when sending it back or reopening it. Both are part of
+    // the record a client reads on a closed NCR, so neither is a transient note.
+    @Column(name = "corrective_action_remarks", length = 2000)
+    private String correctiveActionRemarks;
+
+    @Column(name = "verification_remarks", length = 2000)
+    private String verificationRemarks;
+
+    @Column(name = "corrective_action_completed_at")
+    private LocalDateTime correctiveActionCompletedAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "closed_at")
+    private LocalDateTime closedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/AssignNcrRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/AssignNcrRequest.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+@Schema(description = "Payload to assign a non-conformance report to a site engineer.")
+public record AssignNcrRequest(
+        @Schema(description = "Id of the site engineer who owns the corrective work.", example = "8")
+        @NotNull Long siteEngineerId,
+        @Schema(description = "Date the corrective work is due.", example = "2026-09-10")
+        LocalDate targetDate
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateNcrRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/CreateNcrRequest.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Raises a non-conformance report against an inspection. The NCR number, the type
+ * and the raiser are all set server-side: the number from the {@code NCR} series,
+ * the type from the originating inspection's category (so a safety inspection
+ * cannot produce a quality NCR), and the raiser from the authenticated caller. The
+ * status starts at {@code OPEN}, or {@code ASSIGNED} when a site engineer is named
+ * here, which is the usual case.
+ */
+@Schema(description = "Payload to raise a non-conformance report against an inspection.")
+public record CreateNcrRequest(
+        @Schema(description = "Id of the inspection the non-conformance was found on.",
+                example = "0f8b0a4c-9c2e-4f5b-b0a1-5b7e2d3c4a10")
+        @NotNull UUID inspectionId,
+        @Schema(description = "Id of the specific defect this NCR is about, when it is about one. "
+                + "Omit to raise it against the inspection as a whole.",
+                example = "3a1c5e77-2b44-4d90-9f11-8c6d0e2b7a55")
+        UUID defectId,
+        @Schema(description = "Short title of the non-conformance.",
+                example = "Cover to slab reinforcement below specification")
+        @NotBlank @Size(max = 200) String title,
+        @Schema(description = "What does not conform, and against what requirement.",
+                example = "Clear cover measured at 25 mm against a specified 40 mm at grid C3 to C6.")
+        @NotBlank @Size(max = 2000) String description,
+        @Schema(description = "Severity of the non-conformance.", example = "major")
+        DefectSeverity severity,
+        @Schema(description = "Id of the site engineer the corrective work is assigned to. Naming "
+                + "one here moves the NCR straight to assigned.", example = "8")
+        Long siteEngineerId,
+        @Schema(description = "Date the corrective work is due.", example = "2026-09-10")
+        LocalDate targetDate
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrDto.java
@@ -1,0 +1,35 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.tornotron.echno_backend.inspection.DefectSeverity;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+import org.tornotron.echno_backend.inspection.NcrType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "A non-conformance report as returned by the API, with its assignment and "
+        + "closure trail.")
+public record NcrDto(
+        UUID id,
+        String ncrNumber,
+        NcrType type,
+        UUID inspectionId,
+        UUID defectId,
+        String title,
+        String description,
+        DefectSeverity severity,
+        NcrStatus status,
+        Long siteEngineerId,
+        LocalDate targetDate,
+        Long raisedById,
+        Long closedById,
+        String correctiveActionRemarks,
+        String verificationRemarks,
+        LocalDateTime correctiveActionCompletedAt,
+        LocalDateTime verifiedAt,
+        LocalDateTime closedAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrRemarksRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/dtos/NcrRemarksRequest.java
@@ -1,0 +1,17 @@
+package org.tornotron.echno_backend.inspection.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+/**
+ * The note that accompanies a step in the NCR lifecycle: what the site engineer
+ * did, or why a verifier sent the work back or reopened the report. Shared by
+ * those actions because the payload is the same in each case and the meaning of
+ * the note is given by the endpoint it is sent to.
+ */
+@Schema(description = "A note recorded against a step in the NCR lifecycle.")
+public record NcrRemarksRequest(
+        @Schema(description = "What was done, or why the work was not accepted.",
+                example = "Section chipped out and re-poured on 5 September; cover re-measured at 42 mm.")
+        @Size(max = 2000) String remarks
+) {}

--- a/src/main/java/org/tornotron/echno_backend/inspection/mapper/NcrMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/mapper/NcrMapper.java
@@ -1,0 +1,11 @@
+package org.tornotron.echno_backend.inspection.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+import org.tornotron.echno_backend.inspection.dtos.NcrDto;
+
+@Mapper(componentModel = "spring")
+public interface NcrMapper {
+
+    NcrDto toDto(Ncr ncr);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrRepository.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface NcrRepository extends JpaRepository<Ncr, UUID>, JpaSpecificationExecutor<Ncr> {
+
+    /**
+     * Org-scoped lookup by id. Uses JPQL (not {@code find()} by primary key) so the
+     * Hibernate {@code orgFilter} is applied, preventing cross-tenant reads.
+     */
+    @Query("SELECT n FROM Ncr n WHERE n.id = :id")
+    Optional<Ncr> findByIdScoped(@Param("id") UUID id);
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrSpecifications.java
@@ -1,0 +1,52 @@
+package org.tornotron.echno_backend.inspection.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+import org.tornotron.echno_backend.inspection.NcrType;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Builds the optional list filters as a JPA {@link Specification}. Only non-null
+ * arguments become predicates, which avoids binding null-typed parameters on the
+ * Postgres wire protocol. Organization scoping is handled separately by the
+ * Hibernate {@code orgFilter} enabled per request.
+ */
+public final class NcrSpecifications {
+
+    private NcrSpecifications() {}
+
+    public static Specification<Ncr> withFilters(UUID inspectionId,
+                                                 NcrType type,
+                                                 NcrStatus status,
+                                                 Long siteEngineerId,
+                                                 Boolean open) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (inspectionId != null) {
+                predicates.add(cb.equal(root.get("inspectionId"), inspectionId));
+            }
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (siteEngineerId != null) {
+                predicates.add(cb.equal(root.get("siteEngineerId"), siteEngineerId));
+            }
+            if (open != null) {
+                // The punch list: everything still outstanding, which is every NCR that
+                // has not been closed. Expressed as one flag rather than making a client
+                // enumerate six statuses and get it wrong when a seventh is added.
+                Predicate notClosed = cb.notEqual(root.get("status"), NcrStatus.CLOSED);
+                predicates.add(open ? notClosed : cb.equal(root.get("status"), NcrStatus.CLOSED));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionService.java
@@ -139,7 +139,7 @@ public class InspectionService {
         inspection.setType(req.type());
         inspection.setCategory(categoryFor(req.category(), req.type()));
         inspection.setTrade(req.trade());
-        inspection.setStatus(req.status());
+        transitionTo(inspection, req.status());
         inspection.setResult(req.result());
         inspection.setLocation(req.location());
         inspection.setAreaInspected(req.areaInspected());
@@ -163,6 +163,43 @@ public class InspectionService {
         Inspection saved = inspectionRepo.saveAndFlush(inspection);
         log.info("Updated inspection {}", saved.getInspectionNumber());
         return mapper.toDto(saved);
+    }
+
+    /**
+     * Moves an inspection along its lifecycle, or refuses the move.
+     *
+     * <p>This is the only place the status is written after creation. It used to be
+     * taken from the payload as given, so an inspection could go from cancelled back
+     * to passed, or from passed to scheduled, and the record would then show a
+     * conclusion that was never reached. The graph in
+     * {@link InspectionStatus#canTransitionTo} is deliberately permissive about how
+     * an inspection is concluded, because work is often carried out and recorded
+     * afterwards; what it refuses is coming back out of a conclusion.
+     *
+     * <p>A payload that repeats the stored status passes, which is the normal case:
+     * the web client sends the whole record back on every save.
+     *
+     * @param inspection The inspection being updated.
+     * @param target     The status the request asks for.
+     * @throws InvalidRequestException if the move is not part of the lifecycle.
+     */
+    private static void transitionTo(Inspection inspection, InspectionStatus target) {
+        InspectionStatus current = inspection.getStatus();
+        if (!current.canTransitionTo(target)) {
+            throw new InvalidRequestException(
+                    "Inspection " + inspection.getInspectionNumber() + " is " + current.getValue()
+                            + " and cannot move to " + target.getValue() + ". From "
+                            + current.getValue() + " it may move to " + allowedFrom(current) + ".");
+        }
+        inspection.setStatus(target);
+    }
+
+    private static String allowedFrom(InspectionStatus current) {
+        if (current.allowedNext().isEmpty()) {
+            return "nothing: this is where the inspection ends";
+        }
+        return String.join(", ",
+                current.allowedNext().stream().map(InspectionStatus::getValue).toList());
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/NcrService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/NcrService.java
@@ -1,0 +1,296 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+import org.tornotron.echno_backend.inspection.NcrType;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+import org.tornotron.echno_backend.inspection.dtos.AssignNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.CreateNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.NcrDto;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.repositories.NcrRepository;
+import org.tornotron.echno_backend.inspection.repositories.NcrSpecifications;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * The non-conformance workflow: raise, assign, report complete, verify, close,
+ * with reject and reopen as the ways off the straight line.
+ *
+ * <p>Every state change goes through {@link #transition}, which asks
+ * {@link NcrStatus#canTransitionTo} first. Nothing here sets the status directly,
+ * which is the point: an NCR that could be closed straight from open would make
+ * the closure trail a record of nothing.
+ *
+ * <p>The type is taken from the originating inspection's category rather than the
+ * request, so a quality NCR cannot be raised from a safety inspection by sending
+ * the wrong value. That matters because the type is what decides who may close
+ * the NCR.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NcrService {
+
+    private static final String DOC_TYPE = "NCR";
+
+    private final NcrRepository ncrRepo;
+    private final InspectionRepository inspectionRepo;
+    private final EmployeeRepository employeeRepository;
+    private final UserContextService userContextService;
+    private final EntryNumberGenerator numberGen;
+    private final NcrMapper mapper;
+    private final TenantEntityHelper tenantEntityHelper;
+
+    @Transactional(readOnly = true)
+    public NcrDto findById(UUID id) {
+        return mapper.toDto(require(id));
+    }
+
+    /**
+     * The NCR register, and with {@code open} the punch list the functional spec
+     * asks for: every non-conformance still outstanding, across inspections.
+     */
+    @Transactional(readOnly = true)
+    public Page<NcrDto> findAll(UUID inspectionId,
+                                NcrType type,
+                                NcrStatus status,
+                                Long siteEngineerId,
+                                Boolean open,
+                                Pageable pageable) {
+        return ncrRepo.findAll(
+                        NcrSpecifications.withFilters(inspectionId, type, status, siteEngineerId, open),
+                        pageable)
+                .map(mapper::toDto);
+    }
+
+    /**
+     * Raises a non-conformance against an inspection, and assigns it in the same
+     * step when a site engineer is named.
+     *
+     * @throws ResourceNotFoundException if the inspection is not in this tenant, or
+     *                                   the named defect does not belong to it.
+     */
+    @Transactional
+    public NcrDto create(CreateNcrRequest req) {
+        Inspection inspection = inspectionRepo.findByIdScoped(req.inspectionId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Inspection with ID " + req.inspectionId() + " was not found"));
+        requireDefectBelongsToInspection(inspection, req.defectId());
+
+        Ncr ncr = new Ncr();
+        ncr.setNcrNumber(numberGen.next(DOC_TYPE));
+        ncr.setType(NcrType.forCategory(inspection.getCategory()));
+        ncr.setInspectionId(inspection.getId());
+        ncr.setDefectId(req.defectId());
+        ncr.setTitle(req.title());
+        ncr.setDescription(req.description());
+        ncr.setSeverity(req.severity());
+        ncr.setTargetDate(req.targetDate());
+        ncr.setRaisedById(currentEmployeeId());
+        ncr.setStatus(NcrStatus.OPEN);
+        ncr.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+
+        if (req.siteEngineerId() != null) {
+            requireEmployeeInTenant(req.siteEngineerId());
+            transition(ncr, NcrStatus.ASSIGNED);
+            ncr.setSiteEngineerId(req.siteEngineerId());
+        }
+
+        Ncr saved = ncrRepo.saveAndFlush(ncr);
+        log.info("Raised {} NCR {} against inspection {}",
+                saved.getType().getValue(), saved.getNcrNumber(), inspection.getInspectionNumber());
+        return mapper.toDto(saved);
+    }
+
+    /** Hands the corrective work to a site engineer, or moves it to a different one. */
+    @Transactional
+    public NcrDto assign(UUID id, AssignNcrRequest req) {
+        Ncr ncr = require(id);
+        requireEmployeeInTenant(req.siteEngineerId());
+        transition(ncr, NcrStatus.ASSIGNED);
+        ncr.setSiteEngineerId(req.siteEngineerId());
+        if (req.targetDate() != null) {
+            ncr.setTargetDate(req.targetDate());
+        }
+        return save(ncr, "assigned to employee " + req.siteEngineerId());
+    }
+
+    /**
+     * The site engineer reports the corrective work done and the NCR ready for
+     * re-inspection. This is as far as the assignee can take it: accepting the work
+     * is somebody else's decision.
+     */
+    @Transactional
+    public NcrDto markCorrectiveActionComplete(UUID id, String remarks) {
+        Ncr ncr = require(id);
+        transition(ncr, NcrStatus.CORRECTIVE_ACTION_COMPLETE);
+        ncr.setCorrectiveActionRemarks(remarks);
+        ncr.setCorrectiveActionCompletedAt(LocalDateTime.now());
+        return save(ncr, "corrective action reported complete");
+    }
+
+    /** Re-inspected and accepted. Closing it is a separate, role-gated step. */
+    @Transactional
+    public NcrDto verify(UUID id, String remarks) {
+        Ncr ncr = require(id);
+        transition(ncr, NcrStatus.VERIFIED);
+        ncr.setVerificationRemarks(remarks);
+        ncr.setVerifiedAt(LocalDateTime.now());
+        return save(ncr, "verified");
+    }
+
+    /** Re-inspected and not accepted: it goes back to the site engineer. */
+    @Transactional
+    public NcrDto reject(UUID id, String remarks) {
+        Ncr ncr = require(id);
+        transition(ncr, NcrStatus.REJECTED);
+        ncr.setVerificationRemarks(remarks);
+        return save(ncr, "rejected on re-inspection");
+    }
+
+    /**
+     * The same non-conformance has come back. It is recorded on the original NCR
+     * rather than as a new one, because the first report's history is the evidence
+     * that it recurred.
+     */
+    @Transactional
+    public NcrDto reopen(UUID id, String remarks) {
+        Ncr ncr = require(id);
+        transition(ncr, NcrStatus.REOPENED);
+        ncr.setVerificationRemarks(remarks);
+        ncr.setClosedById(null);
+        ncr.setClosedAt(null);
+        return save(ncr, "reopened");
+    }
+
+    /** Closes a verified NCR and records who closed it. */
+    @Transactional
+    public NcrDto close(UUID id) {
+        Ncr ncr = require(id);
+        transition(ncr, NcrStatus.CLOSED);
+        ncr.setClosedById(currentEmployeeId());
+        ncr.setClosedAt(LocalDateTime.now());
+        return save(ncr, "closed");
+    }
+
+    /**
+     * Moves an NCR along its lifecycle, or refuses the move.
+     *
+     * <p>This is the only place the status is written. Every action calls it before
+     * it writes anything else, because a refusal has to leave the report untouched:
+     * a rejected close that had already stamped closedAt would leave an open report
+     * carrying a closure date, and the caller reads that back inside the same
+     * transaction whether or not it is ever committed.
+     *
+     * <p>A refusal names both ends and what would have been allowed, because the
+     * caller is a person deciding what to do next, not a machine retrying.
+     *
+     * @throws InvalidRequestException if the move is not part of the lifecycle.
+     */
+    private void transition(Ncr ncr, NcrStatus target) {
+        NcrStatus current = ncr.getStatus();
+        if (!current.canTransitionTo(target)) {
+            throw new InvalidRequestException(
+                    "NCR " + ncr.getNcrNumber() + " is " + current.getValue()
+                            + " and cannot move to " + target.getValue() + ". From "
+                            + current.getValue() + " it may move to " + allowedFrom(current) + ".");
+        }
+        ncr.setStatus(target);
+    }
+
+    private static String allowedFrom(NcrStatus current) {
+        if (current.allowedNext().isEmpty()) {
+            return "nothing: this is where the report ends";
+        }
+        return String.join(", ", current.allowedNext().stream().map(NcrStatus::getValue).toList());
+    }
+
+    /**
+     * Refuses an NCR that names a defect belonging to a different inspection. The
+     * two ids arrive independently, so without this an NCR could point at an
+     * inspection and a defect that have nothing to do with each other, and the
+     * corrective action on the record would be somebody else's.
+     */
+    private static void requireDefectBelongsToInspection(Inspection inspection, UUID defectId) {
+        if (defectId == null) {
+            return;
+        }
+        boolean found = inspection.getDefects().stream()
+                .map(InspectionDefect::getId)
+                .anyMatch(defectId::equals);
+        if (!found) {
+            throw new ResourceNotFoundException("Defect with ID " + defectId
+                    + " was not found on inspection " + inspection.getInspectionNumber());
+        }
+    }
+
+    /**
+     * Refuses an assignment to an employee this organization does not have.
+     *
+     * <p>Employee references elsewhere in this module are unchecked scalar ids, and
+     * on an inspection that is defensible: the inspector is a label on a record of
+     * what happened. On an NCR it is not. The site engineer is the owner of
+     * outstanding corrective work, and the whole reason this entity exists is to say
+     * who that is. An id belonging to nobody, or to somebody in another
+     * organization, produces a report that is open against a person who will never
+     * see it, and a punch list that cannot be worked.
+     *
+     * @param siteEngineerId Id of the employee the work is being assigned to.
+     * @throws ResourceNotFoundException if no such employee exists in this tenant.
+     */
+    private void requireEmployeeInTenant(Long siteEngineerId) {
+        if (employeeRepository.existsByIdAndOrganization_Id(
+                siteEngineerId, TenantContext.getCurrentOrgId())) {
+            return;
+        }
+        throw new ResourceNotFoundException("Employee with ID " + siteEngineerId
+                + " was not found in this organization and cannot be assigned a non-conformance");
+    }
+
+    /**
+     * The authenticated caller as an employee of the current tenant, or null when
+     * they have no employee record. Null rather than a refusal: an organization's
+     * bootstrap administrator has no employee profile, and refusing to let them
+     * raise or close an NCR would leave a new tenant unable to use the module at
+     * all. The trail records who it can.
+     */
+    private Long currentEmployeeId() {
+        Long userId = userContextService.getCurrentUserId();
+        if (userId == null) {
+            return null;
+        }
+        return employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
+                .map(Employee::getId)
+                .orElse(null);
+    }
+
+    private Ncr require(UUID id) {
+        return ncrRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "NCR with ID " + id + " was not found"));
+    }
+
+    private NcrDto save(Ncr ncr, String what) {
+        Ncr saved = ncrRepo.saveAndFlush(ncr);
+        log.info("NCR {} {}", saved.getNcrNumber(), what);
+        return mapper.toDto(saved);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
@@ -1,0 +1,203 @@
+package org.tornotron.echno_backend.inspection.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.inspection.NcrStatus;
+import org.tornotron.echno_backend.inspection.NcrType;
+import org.tornotron.echno_backend.inspection.dtos.AssignNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.CreateNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.NcrDto;
+import org.tornotron.echno_backend.inspection.dtos.NcrRemarksRequest;
+import org.tornotron.echno_backend.inspection.service.NcrService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/ncrs/web")
+@RequiredArgsConstructor
+@Tag(
+        name = "Non-conformance reports",
+        description = "The accountability trail over work that failed an inspection: who raised the "
+                + "non-conformance, which site engineer owns it, who re-inspected it and who closed "
+                + "it. The lifecycle runs open, assigned, corrective action complete, verified, "
+                + "closed, with reject and reopen as the ways off that line; a step that is not part "
+                + "of it is refused rather than recorded. All endpoints are tenant scoped."
+)
+public class NcrControllerWeb {
+
+    private final NcrService service;
+
+    @PostMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Raise a non-conformance report",
+            description = "Raises an NCR against an inspection, and against one of its defects when "
+                    + "one is named. The NCR number, the type (from the inspection's category) and "
+                    + "the raiser are all set server-side. Naming a site engineer assigns it in the "
+                    + "same step."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "NCR raised"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No such inspection in the current tenant, or the "
+                    + "named defect does not belong to it")
+    })
+    public ResponseEntity<NcrDto> create(@Valid @RequestBody CreateNcrRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(summary = "Get a non-conformance report by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR found"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto get(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List non-conformance reports",
+            description = "Returns a page of NCRs in the current tenant. Every parameter is an "
+                    + "optional filter. Setting open=true returns the punch list: every NCR that has "
+                    + "not been closed, whatever stage it has reached."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching NCRs"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public Page<NcrDto> list(@RequestParam(required = false) UUID inspectionId,
+                             @RequestParam(required = false) NcrType type,
+                             @RequestParam(required = false) NcrStatus status,
+                             @RequestParam(required = false) Long siteEngineerId,
+                             @RequestParam(required = false) Boolean open,
+                             Pageable pageable) {
+        return service.findAll(inspectionId, type, status, siteEngineerId, open, pageable);
+    }
+
+    @PostMapping("/{id}/assign")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Assign a non-conformance report",
+            description = "Hands the corrective work to a site engineer, or moves it to a different "
+                    + "one. Allowed from open, rejected and reopened."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR assigned"),
+            @ApiResponse(responseCode = "400", description = "The NCR is at a stage it cannot be assigned from"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto assign(@PathVariable UUID id, @Valid @RequestBody AssignNcrRequest req) {
+        return service.assign(id, req);
+    }
+
+    @PostMapping("/{id}/corrective-action-complete")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Report the corrective action complete",
+            description = "The site engineer reports the work done and the NCR ready for "
+                    + "re-inspection. This is as far as the assignee takes it: accepting the work "
+                    + "and closing the report are separate steps."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Corrective action recorded"),
+            @ApiResponse(responseCode = "400", description = "The NCR is not assigned, so there is no work to report"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto markCorrectiveActionComplete(@PathVariable UUID id,
+                                               @Valid @RequestBody(required = false) NcrRemarksRequest req) {
+        return service.markCorrectiveActionComplete(id, remarksOf(req));
+    }
+
+    @PostMapping("/{id}/verify")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Verify the corrective action",
+            description = "Records that the corrective work was re-inspected and accepted."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR verified"),
+            @ApiResponse(responseCode = "400", description = "The corrective action has not been reported complete"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto verify(@PathVariable UUID id,
+                         @Valid @RequestBody(required = false) NcrRemarksRequest req) {
+        return service.verify(id, remarksOf(req));
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Reject the corrective action",
+            description = "Records that the corrective work was re-inspected and not accepted. The "
+                    + "NCR goes back to the site engineer."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR rejected"),
+            @ApiResponse(responseCode = "400", description = "The corrective action has not been reported complete"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto reject(@PathVariable UUID id,
+                         @Valid @RequestBody(required = false) NcrRemarksRequest req) {
+        return service.reject(id, remarksOf(req));
+    }
+
+    @PostMapping("/{id}/reopen")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Reopen a non-conformance report",
+            description = "Records that the same non-conformance has come back after it was verified "
+                    + "or closed. It is recorded on the original report, because that report's "
+                    + "history is the evidence that it recurred."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR reopened"),
+            @ApiResponse(responseCode = "400", description = "The NCR has not been verified or closed"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto reopen(@PathVariable UUID id,
+                         @Valid @RequestBody(required = false) NcrRemarksRequest req) {
+        return service.reopen(id, remarksOf(req));
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Close a non-conformance report",
+            description = "Closes a verified NCR and records who closed it."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NCR closed"),
+            @ApiResponse(responseCode = "400", description = "The NCR has not been verified"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No NCR with the given id in the current tenant")
+    })
+    public NcrDto close(@PathVariable UUID id) {
+        return service.close(id);
+    }
+
+    /** The remark, when a body was sent at all. Every note on the lifecycle is optional. */
+    private static String remarksOf(NcrRemarksRequest req) {
+        return req == null ? null : req.remarks();
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -310,4 +310,7 @@
     <!-- v4.0 - Inspection QA/QC: acceptance criterion, tolerance, computed deviation and the BIM element link -->
     <include file="db/changelog/v4.0/058-extend-inspection-check-items.xml"/>
 
+    <!-- v4.0 - Inspection QA/QC: non-conformance reports and their assignment and closure trail -->
+    <include file="db/changelog/v4.0/059-create-ncrs.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/059-create-ncrs.xml
+++ b/src/main/resources/db/changelog/v4.0/059-create-ncrs.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="059-01-create-ncrs" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="ncrs"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Non-conformance reports: the accountability trail over work that failed an
+            inspection. Tenant-scoped like inspections, with its own NCR document series
+            unique per organization.
+
+            inspection_id and defect_id are plain scalar UUIDs with no foreign key, matching
+            the way inspections refer to their project. That is deliberate: it keeps the
+            module additive, and it lets an NCR outlive the defect row it started from, since
+            an inspection's defects are rebuilt wholesale on every save.
+
+            type is fixed when the report is raised and is derived from the originating
+            inspection's category, because it decides who may close the report. status is
+            written only through the guarded transition in NcrService; the column carries no
+            database-level constraint on the lifecycle because the graph has branches
+            (reject, reopen) that a check constraint cannot express without duplicating the
+            rule in a second place that would then drift.
+        </comment>
+
+        <createTable tableName="ncrs">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="ncr_number" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="inspection_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="defect_id" type="UUID"/>
+            <column name="title" type="VARCHAR(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(2000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="severity" type="VARCHAR(20)"/>
+            <column name="status" type="VARCHAR(40)" defaultValue="OPEN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="site_engineer_id" type="BIGINT"/>
+            <column name="target_date" type="DATE"/>
+            <column name="raised_by_id" type="BIGINT"/>
+            <column name="closed_by_id" type="BIGINT"/>
+            <column name="corrective_action_remarks" type="VARCHAR(2000)"/>
+            <column name="verification_remarks" type="VARCHAR(2000)"/>
+            <column name="corrective_action_completed_at" type="TIMESTAMP"/>
+            <column name="verified_at" type="TIMESTAMP"/>
+            <column name="closed_at" type="TIMESTAMP"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="ncrs"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_ncr_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="ncrs"
+                             columnNames="organization_id, ncr_number"
+                             constraintName="uk_ncr_number"/>
+
+        <createIndex tableName="ncrs" indexName="idx_ncr_inspection">
+            <column name="inspection_id"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_defect">
+            <column name="defect_id"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_type">
+            <column name="type"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_site_engineer">
+            <column name="site_engineer_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inspection/ChecklistTemplateServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/ChecklistTemplateServiceIT.java
@@ -29,10 +29,13 @@ import org.tornotron.echno_backend.inspection.dtos.ChecklistTemplateRequest;
 import org.tornotron.echno_backend.inspection.dtos.StarterChecklistTemplateDto;
 import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
 import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.util.List;
 import java.util.UUID;
@@ -47,14 +50,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * test can.
  *
  * <p>The annotations and the {@code @Import} list repeat {@link InspectionServiceIT}
- * to the letter on purpose, so Spring's context cache serves both classes from one
- * context. See that class for why that matters in a 1 GB test JVM. Keep the two in
- * step when either changes.
+ * to the letter on purpose, so Spring's context cache serves all three inspection
+ * test classes from one context. See that class for why that matters in a 1 GB test
+ * JVM. Keep them in step when any one changes.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InspectionService.class, InspectionMapperImpl.class,
         ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class, UserContextService.class,
         TenantEntityHelper.class, EntryNumberGenerator.class})
 class ChecklistTemplateServiceIT extends AbstractIntegrationTest {
 

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionProjectImmutabilityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionProjectImmutabilityTest.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.inspection.domain.Inspection;
 import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
 import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
 
 import java.time.LocalDate;
@@ -51,6 +52,8 @@ class InspectionProjectImmutabilityTest {
     private InspectionMapper mapper;
     @Mock
     private TenantEntityHelper tenantEntityHelper;
+    @Mock
+    private ChecklistTemplateService checklistTemplateService;
 
     @InjectMocks
     private InspectionService service;

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -29,18 +30,22 @@ import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
 import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
 import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
 import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
 import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * End-to-end exercise of the inspection CRUD path against a real CockroachDB:
@@ -53,17 +58,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * timestamps are populated by Hibernate's {@code @CreationTimestamp}/{@code
  * @UpdateTimestamp} at persist time, not by Spring Data auditing.
  *
- * <p>{@link ChecklistTemplateServiceIT} and {@link InspectionTaxonomyMigrationIT}
- * declare the same annotations and the same {@code @Import} list, deliberately and
- * to the letter, so Spring's context cache hands all of them one context instead of
- * building three. The test JVM is capped at 1 GB with no fork between classes, so
- * every distinct test configuration is a Spring context that stays cached for the
- * whole run. Keep the lists identical when any one changes.
+ * <p>{@link ChecklistTemplateServiceIT}, {@link NcrServiceIT} and
+ * {@link InspectionTaxonomyMigrationIT} declare the same annotations and the same
+ * {@code @Import} list, deliberately and to the letter, so Spring's context cache
+ * hands all four classes one context instead of building four. The test JVM is
+ * capped at 1 GB with no fork between classes, so every distinct test configuration
+ * is a Spring context that stays cached for the whole run. Keep the lists identical
+ * when any one changes.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InspectionService.class, InspectionMapperImpl.class,
         ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class, UserContextService.class,
         TenantEntityHelper.class, EntryNumberGenerator.class})
 class InspectionServiceIT extends AbstractIntegrationTest {
 
@@ -379,6 +386,44 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
         assertThat(created.checkItems()).isEmpty();
         assertThat(created.totalCheckPoints()).isZero();
+    }
+
+    @Test
+    void update_refusesAStatusMoveThatIsNotPartOfTheLifecycle() {
+        InspectionDto created = service.create(scheduleFor(InspectionTrade.PLASTERING, null));
+        UUID id = created.id();
+
+        // scheduled straight to passed is legal: work is often carried out and recorded
+        // afterwards, so this is a normal day rather than a skipped step
+        assertThat(service.update(id, concludeAs(InspectionStatus.PASSED)).status())
+                .isEqualTo(InspectionStatus.PASSED);
+
+        // coming back out of that verdict is not
+        assertThatThrownBy(() -> service.update(id, concludeAs(InspectionStatus.SCHEDULED)))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("is passed and cannot move to scheduled")
+                .hasMessageContaining("this is where the inspection ends");
+
+        // and the refusal leaves the stored record untouched
+        assertThat(service.findById(id).status()).isEqualTo(InspectionStatus.PASSED);
+    }
+
+    @Test
+    void update_acceptsAPayloadThatRepeatsTheStoredStatus() {
+        // the web client sends the whole record back on every save, so an unchanged
+        // status must not be read as an attempted transition
+        UUID id = service.create(scheduleFor(InspectionTrade.PLASTERING, null)).id();
+
+        assertThat(service.update(id, concludeAs(InspectionStatus.SCHEDULED)).status())
+                .isEqualTo(InspectionStatus.SCHEDULED);
+    }
+
+    private UpdateInspectionRequest concludeAs(InspectionStatus status) {
+        return new UpdateInspectionRequest(
+                "Wall check", InspectionType.QUALITY, null, InspectionTrade.PLASTERING,
+                status, null, projectId, "Block A", null, null,
+                LocalDate.of(2026, 8, 20), null, null, null, null, 100L, null, null,
+                null, null, null, null, null);
     }
 
     private CreateInspectionRequest scheduleFor(InspectionTrade trade,

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionStatusTransitionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionStatusTransitionTest.java
@@ -1,0 +1,87 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The inspection lifecycle graph. Before this existed the update endpoint wrote
+ * whatever status the payload carried, so a cancelled inspection could come back
+ * as passed and the record would show a conclusion that was never reached.
+ *
+ * <p>Plain JUnit: the graph is a lookup and needs no Spring context, and every
+ * distinct context this suite loads stays cached for the life of a 1 GB JVM.
+ */
+class InspectionStatusTransitionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            // a suggestion is taken up, dismissed, or recorded as already satisfied
+            "SUGGESTED,           SCHEDULED",
+            "SUGGESTED,           CANCELLED",
+            "SUGGESTED,           PASSED",
+            // scheduled work is started, cancelled, or simply recorded once carried out
+            "SCHEDULED,           IN_PROGRESS",
+            "SCHEDULED,           COMPLETED",
+            "SCHEDULED,           PASSED_WITH_REMARKS",
+            "SCHEDULED,           CANCELLED",
+            "IN_PROGRESS,         FAILED",
+            // carried out but not yet judged, so only the verdict is left
+            "COMPLETED,           PASSED",
+            "COMPLETED,           FAILED",
+            // re-inspection of a failed inspection, which is forwards and not backwards
+            "FAILED,              IN_PROGRESS",
+    })
+    void allowsTheMovesTheLifecycleIsMadeOf(InspectionStatus from, InspectionStatus to) {
+        assertThat(from.canTransitionTo(to)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // out of a verdict already given: a passed inspection later found defective
+            // is a new inspection and an NCR, not a rewrite of the verdict
+            "PASSED,              IN_PROGRESS",
+            "PASSED,              FAILED",
+            "PASSED_WITH_REMARKS, SCHEDULED",
+            "CANCELLED,           SCHEDULED",
+            "CANCELLED,           PASSED",
+            // backwards out of a completed inspection
+            "COMPLETED,           SCHEDULED",
+            "COMPLETED,           IN_PROGRESS",
+            "COMPLETED,           CANCELLED",
+            // a failed inspection is re-inspected, not re-judged on the spot
+            "FAILED,              PASSED",
+            // and nothing goes back to being a suggestion
+            "SCHEDULED,           SUGGESTED",
+            "PASSED,              SUGGESTED",
+    })
+    void refusesTheMovesThatWouldRewriteAConclusion(InspectionStatus from, InspectionStatus to) {
+        assertThat(from.canTransitionTo(to)).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(InspectionStatus.class)
+    void alwaysAllowsStayingPut(InspectionStatus status) {
+        // the web client sends the whole record back on every save, so an unchanged
+        // status is the normal edit and must never be read as an attempted transition
+        assertThat(status.canTransitionTo(status)).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(InspectionStatus.class)
+    void everyStatusHasAnEntryInTheGraph(InspectionStatus status) {
+        // allowedNext() would throw on a member the graph forgot, which is how a new
+        // enum constant added without a rule gets caught here rather than in production
+        assertThat(status.allowedNext()).isNotNull();
+    }
+
+    @Test
+    void namesWhereTheInspectionEnds() {
+        assertThat(InspectionStatus.PASSED.allowedNext()).isEmpty();
+        assertThat(InspectionStatus.PASSED_WITH_REMARKS.allowedNext()).isEmpty();
+        assertThat(InspectionStatus.CANCELLED.allowedNext()).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionTaxonomyMigrationIT.java
@@ -12,9 +12,12 @@ import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.inspection.domain.InspectionDefect;
 import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
 import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -42,12 +45,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * rows for it to touch.
  *
  * <p>The Spring configuration is deliberately identical to {@link InspectionServiceIT}
- * so both classes share one cached application context rather than starting a second.
+ * so every inspection test class shares one cached application context rather than
+ * starting a second. Keep it in step when that list changes.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({InspectionService.class, InspectionMapperImpl.class,
         ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class, UserContextService.class,
         TenantEntityHelper.class, EntryNumberGenerator.class})
 class InspectionTaxonomyMigrationIT extends AbstractIntegrationTest {
 

--- a/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
@@ -1,0 +1,446 @@
+package org.tornotron.echno_backend.inspection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.inspection.dtos.AssignNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.CreateInspectionRequest;
+import org.tornotron.echno_backend.inspection.dtos.CreateNcrRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDefectRequest;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.dtos.NcrDto;
+import org.tornotron.echno_backend.inspection.mapper.ChecklistTemplateMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapperImpl;
+import org.tornotron.echno_backend.inspection.mapper.NcrMapperImpl;
+import org.tornotron.echno_backend.inspection.service.ChecklistTemplateService;
+import org.tornotron.echno_backend.inspection.service.InspectionService;
+import org.tornotron.echno_backend.inspection.service.NcrService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The non-conformance workflow against a real CockroachDB: the trail an NCR leaves
+ * as it is raised, assigned, reported complete, re-inspected and closed, and the
+ * moves it refuses. The refusals are the point of the entity: an NCR that could be
+ * closed straight from open would make the closure trail a record of nothing.
+ *
+ * <p>The annotations and the {@code @Import} list repeat {@link InspectionServiceIT}
+ * to the letter on purpose, so Spring's context cache serves all three inspection
+ * test classes from one context. See that class for why that matters in a 1 GB test
+ * JVM. Keep them in step when any one changes.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({InspectionService.class, InspectionMapperImpl.class,
+        ChecklistTemplateService.class, ChecklistTemplateMapperImpl.class,
+        NcrService.class, NcrMapperImpl.class, UserContextService.class,
+        TenantEntityHelper.class, EntryNumberGenerator.class})
+class NcrServiceIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private NcrService service;
+
+    @Autowired
+    private InspectionService inspectionService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    private Long orgAId;
+    private Long orgBId;
+    private Long projectId;
+    private Long siteEngineerId;
+    private Long foreignSiteEngineerId;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        inCommittedTx(() -> {
+            Organization orgA = persistOrganization("NCR Org A");
+            Organization orgB = persistOrganization("NCR Org B");
+
+            Project project = new Project();
+            project.setProjectName("Tower B");
+            project.setOrganization(orgA);
+            entityManager.persist(project);
+
+            Employee siteEngineer = persistEmployee(orgA, "kc-ncr-a", "Site Engineer A");
+            Employee otherOrgEngineer = persistEmployee(orgB, "kc-ncr-b", "Site Engineer B");
+
+            entityManager.flush();
+            orgAId = orgA.getId();
+            orgBId = orgB.getId();
+            projectId = project.getId();
+            siteEngineerId = siteEngineer.getId();
+            foreignSiteEngineerId = otherOrgEngineer.getId();
+        });
+        TenantContext.setCurrentOrgId(orgAId);
+    }
+
+    /**
+     * Resets the per-test session state while the test transaction is still open.
+     * The database rows are removed separately by {@link #removeCommittedRows()},
+     * once that transaction has gone.
+     */
+    @AfterEach
+    void clearTenantState() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+        TenantContext.clear();
+    }
+
+    /**
+     * Removes the rows the seed committed, after the test transaction has rolled
+     * back rather than while it is still open.
+     *
+     * <p>{@code @AfterEach} runs inside the test transaction, so a delete issued
+     * from there runs in a second, committed transaction while the first still
+     * holds write intents on the same tables. CockroachDB may resolve that by
+     * aborting the writer, or it may make the deleter wait for a transaction that
+     * cannot commit until the delete returns. When it waits, the statement timeout
+     * fires 30 seconds later and the test fails on cleanup with a query timeout and
+     * no failed assertion, which is exactly the kind of failure that gets blamed on
+     * an unrelated test. {@code @AfterTransaction} runs after the rollback, so
+     * there are no intents left to contend with.
+     */
+    @AfterTransaction
+    void removeCommittedRows() {
+        if (orgAId == null && orgBId == null) {
+            return;
+        }
+        inCommittedTx(() -> {
+            deleteForOrgs("DELETE FROM ncrs WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM inspection_defects WHERE inspection_id IN "
+                    + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspection_check_items WHERE inspection_id IN "
+                    + "(SELECT id FROM inspections WHERE organization_id IN (:a,:b))");
+            deleteForOrgs("DELETE FROM inspections WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM document_sequence WHERE organization_id IN (:a,:b)");
+            deleteForOrgs("DELETE FROM project WHERE organization_id IN (:a,:b)");
+            // Employees before their users, and users last: the FK runs that way and
+            // the users are not org-scoped, so they are named by the ids seeded above.
+            deleteForOrgs("DELETE FROM employee WHERE organization_id IN (:a,:b)");
+            entityManager.createNativeQuery(
+                            "DELETE FROM users_table WHERE keycloak_id IN ('kc-ncr-a','kc-ncr-b')")
+                    .executeUpdate();
+            deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
+        });
+    }
+
+    @Test
+    void create_takesItsTypeAndNumberFromTheInspectionItWasRaisedFrom() {
+        InspectionDto inspection = qualityInspection();
+
+        NcrDto raised = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm against a specified 40 mm",
+                DefectSeverity.MAJOR, null, LocalDate.of(2026, 9, 10)));
+
+        assertThat(raised.ncrNumber()).startsWith("NCR-");
+        // the type comes from the inspection's category, never from the request
+        assertThat(raised.type()).isEqualTo(NcrType.QUALITY);
+        assertThat(raised.status()).isEqualTo(NcrStatus.OPEN);
+        assertThat(raised.inspectionId()).isEqualTo(inspection.id());
+        assertThat(raised.siteEngineerId()).isNull();
+        assertThat(raised.closedAt()).isNull();
+    }
+
+    @Test
+    void create_raisesASafetyNcrFromASafetyInspection() {
+        InspectionDto inspection = inspectionOf(InspectionType.SAFETY);
+
+        NcrDto raised = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Edge protection missing", "Open edge on level 4 with no barrier",
+                DefectSeverity.CRITICAL, null, null));
+
+        assertThat(raised.type()).isEqualTo(NcrType.SAFETY);
+    }
+
+    @Test
+    void create_assignsInTheSameStepWhenASiteEngineerIsNamed() {
+        InspectionDto inspection = qualityInspection();
+
+        NcrDto raised = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm", DefectSeverity.MAJOR,
+                siteEngineerId, LocalDate.of(2026, 9, 10)));
+
+        assertThat(raised.status()).isEqualTo(NcrStatus.ASSIGNED);
+        assertThat(raised.siteEngineerId()).isEqualTo(siteEngineerId);
+        assertThat(raised.targetDate()).isEqualTo(LocalDate.of(2026, 9, 10));
+    }
+
+    @Test
+    void create_refusesADefectThatBelongsToAnotherInspection() {
+        InspectionDto withDefect = qualityInspection();
+        UUID foreignDefectId = withDefect.defects().getFirst().id();
+        InspectionDto other = inspectionOf(InspectionType.QUALITY);
+
+        assertThatThrownBy(() -> service.create(new CreateNcrRequest(other.id(), foreignDefectId,
+                "Wrong defect", "Points at another inspection's defect", null, null, null)))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("was not found on inspection");
+    }
+
+    @Test
+    void create_refusesAnInspectionThatIsNotInThisTenant() {
+        UUID unknown = UUID.fromString("00000000-0000-0000-0000-0000000000ff");
+
+        assertThatThrownBy(() -> service.create(new CreateNcrRequest(unknown, null,
+                "No inspection", "Nothing to raise this against", null, null, null)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void create_refusesAnAssigneeThisOrganizationDoesNotHave() {
+        InspectionDto inspection = qualityInspection();
+
+        // nobody at all
+        assertThatThrownBy(() -> service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm", null, 999_999L, null)))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("cannot be assigned a non-conformance");
+
+        // and somebody real, in another tenant: an NCR owned by them would be open
+        // against a person who will never see it
+        assertThatThrownBy(() -> service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm", null, foreignSiteEngineerId, null)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void assign_refusesAnAssigneeThisOrganizationDoesNotHave() {
+        InspectionDto inspection = qualityInspection();
+        UUID id = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm", null, null, null)).id();
+
+        assertThatThrownBy(() -> service.assign(id, new AssignNcrRequest(foreignSiteEngineerId, null)))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        // and the refusal leaves the report where it was, unowned
+        assertThat(service.findById(id).status()).isEqualTo(NcrStatus.OPEN);
+        assertThat(service.findById(id).siteEngineerId()).isNull();
+    }
+
+    @Test
+    void theWholeTrailFromRaisedToClosed() {
+        InspectionDto inspection = qualityInspection();
+        UUID id = service.create(new CreateNcrRequest(inspection.id(),
+                inspection.defects().getFirst().id(),
+                "Honeycombing on column C4", "Chip out and re-pour", DefectSeverity.MAJOR,
+                null, null)).id();
+
+        NcrDto assigned = service.assign(id,
+                new AssignNcrRequest(siteEngineerId, LocalDate.of(2026, 9, 5)));
+        assertThat(assigned.status()).isEqualTo(NcrStatus.ASSIGNED);
+        assertThat(assigned.siteEngineerId()).isEqualTo(siteEngineerId);
+
+        NcrDto reported = service.markCorrectiveActionComplete(id, "Re-poured on 5 September");
+        assertThat(reported.status()).isEqualTo(NcrStatus.CORRECTIVE_ACTION_COMPLETE);
+        assertThat(reported.correctiveActionRemarks()).isEqualTo("Re-poured on 5 September");
+        assertThat(reported.correctiveActionCompletedAt()).isNotNull();
+        // reporting the work done is not accepting it
+        assertThat(reported.closedAt()).isNull();
+
+        NcrDto verified = service.verify(id, "Re-inspected, cover now 42 mm");
+        assertThat(verified.status()).isEqualTo(NcrStatus.VERIFIED);
+        assertThat(verified.verifiedAt()).isNotNull();
+        assertThat(verified.closedAt()).isNull();
+
+        NcrDto closed = service.close(id);
+        assertThat(closed.status()).isEqualTo(NcrStatus.CLOSED);
+        assertThat(closed.closedAt()).isNotNull();
+    }
+
+    @Test
+    void rejectedWorkGoesBackToTheSiteEngineer() {
+        UUID id = assignedNcr();
+
+        service.markCorrectiveActionComplete(id, "Done");
+        NcrDto rejected = service.reject(id, "Cover still short at grid C5");
+        assertThat(rejected.status()).isEqualTo(NcrStatus.REJECTED);
+        assertThat(rejected.verificationRemarks()).isEqualTo("Cover still short at grid C5");
+
+        NcrDto reassigned = service.assign(id, new AssignNcrRequest(siteEngineerId, null));
+        assertThat(reassigned.status()).isEqualTo(NcrStatus.ASSIGNED);
+        assertThat(reassigned.siteEngineerId()).isEqualTo(siteEngineerId);
+    }
+
+    @Test
+    void reopeningAClosedReportClearsItsClosure() {
+        UUID id = assignedNcr();
+        service.markCorrectiveActionComplete(id, "Done");
+        service.verify(id, "Accepted");
+        NcrDto closed = service.close(id);
+        assertThat(closed.status()).isEqualTo(NcrStatus.CLOSED);
+
+        NcrDto reopened = service.reopen(id, "Same honeycombing found again on 20 September");
+        assertThat(reopened.status()).isEqualTo(NcrStatus.REOPENED);
+        // the closure is undone rather than left standing next to an open report
+        assertThat(reopened.closedAt()).isNull();
+        assertThat(reopened.closedById()).isNull();
+    }
+
+    @Test
+    void refusesToCloseAReportThatWasNeverWorkedOn() {
+        InspectionDto inspection = qualityInspection();
+        UUID id = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Cover below specification", "Measured 25 mm", null, null, null)).id();
+
+        assertThatThrownBy(() -> service.close(id))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("is open and cannot move to closed")
+                .hasMessageContaining("it may move to assigned");
+
+        assertThat(service.findById(id).status()).isEqualTo(NcrStatus.OPEN);
+        assertThat(service.findById(id).closedAt()).isNull();
+    }
+
+    @Test
+    void refusesToVerifyWorkThatWasNeverReportedComplete() {
+        UUID id = assignedNcr();
+
+        assertThatThrownBy(() -> service.verify(id, "Looks fine"))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("is assigned and cannot move to verified");
+    }
+
+    @Test
+    void listsThePunchListAndScopesEverythingToTheTenant() {
+        InspectionDto inspection = qualityInspection();
+        UUID open = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Still outstanding", "Not done", null, siteEngineerId, null)).id();
+        UUID done = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Settled", "Sorted", null, siteEngineerId, null)).id();
+        service.markCorrectiveActionComplete(done, "Done");
+        service.verify(done, "Accepted");
+        service.close(done);
+
+        entityManager.flush();
+        entityManager.clear();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        assertThat(service.findAll(null, null, null, null, true, pageable).getContent())
+                .extracting(NcrDto::id).containsExactly(open);
+        assertThat(service.findAll(null, null, null, null, false, pageable).getContent())
+                .extracting(NcrDto::id).containsExactly(done);
+        assertThat(service.findAll(null, NcrType.QUALITY, null, siteEngineerId, null, pageable)
+                .getTotalElements()).isEqualTo(2);
+        assertThat(service.findAll(null, NcrType.SAFETY, null, null, null, pageable)
+                .getTotalElements()).isZero();
+
+        enableOrgFilter(orgBId);
+        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements())
+                .isZero();
+        assertThatThrownBy(() -> service.findById(open))
+                .isInstanceOf(ResourceNotFoundException.class);
+        disableOrgFilter();
+    }
+
+    private UUID assignedNcr() {
+        InspectionDto inspection = qualityInspection();
+        return service.create(new CreateNcrRequest(inspection.id(), null,
+                "Honeycombing on column C4", "Chip out and re-pour", DefectSeverity.MAJOR,
+                siteEngineerId, null)).id();
+    }
+
+    private InspectionDto qualityInspection() {
+        return inspectionService.create(new CreateInspectionRequest(
+                "Slab check", InspectionType.QUALITY, null, null, projectId,
+                "Block A", null, null, LocalDate.of(2026, 8, 20), null,
+                null, null, null, 100L, null, null, null, null, null,
+                null,
+                List.of(new InspectionDefectRequest("Structural", "Honeycombing on column C4",
+                        DefectSeverity.MAJOR, "Grid C4", null, "Chip out and re-pour",
+                        "Contractor", LocalDate.of(2026, 9, 1), null, null))));
+    }
+
+    private InspectionDto inspectionOf(InspectionType type) {
+        return inspectionService.create(new CreateInspectionRequest(
+                "Site check", type, null, null, projectId,
+                "Block A", null, null, LocalDate.of(2026, 8, 20), null,
+                null, null, null, 100L, null, null, null, null, null,
+                null, null));
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    private void deleteForOrgs(String sql) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("a", orgAId)
+                .setParameter("b", orgBId)
+                .executeUpdate();
+    }
+
+    private void inCommittedTx(Runnable work) {
+        TransactionTemplate tt = new TransactionTemplate(txManager);
+        tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        tt.executeWithoutResult(status -> work.run());
+    }
+
+    private Employee persistEmployee(Organization org, String keycloakId, String name) {
+        User user = new User();
+        user.setKeycloakId(keycloakId);
+        user.setName(name);
+        entityManager.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(keycloakId + "@example.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        entityManager.persist(employee);
+        return employee;
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/NcrStatusTransitionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/NcrStatusTransitionTest.java
@@ -1,0 +1,86 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The NCR lifecycle graph. It is what stops a non-conformance being closed
+ * straight from open, which would make the closure trail a record of nothing.
+ *
+ * <p>Plain JUnit, for the same reason as {@link InspectionStatusTransitionTest}.
+ */
+class NcrStatusTransitionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "OPEN,                       ASSIGNED",
+            "ASSIGNED,                   CORRECTIVE_ACTION_COMPLETE",
+            "CORRECTIVE_ACTION_COMPLETE, VERIFIED",
+            "CORRECTIVE_ACTION_COMPLETE, REJECTED",
+            "VERIFIED,                   CLOSED",
+            "VERIFIED,                   REOPENED",
+            "CLOSED,                     REOPENED",
+            // rejected work goes back to the assignee, not to the raiser
+            "REJECTED,                   ASSIGNED",
+            // and a recurrence is reassigned before it can be worked on again
+            "REOPENED,                   ASSIGNED",
+    })
+    void allowsTheMovesTheLifecycleIsMadeOf(NcrStatus from, NcrStatus to) {
+        assertThat(from.canTransitionTo(to)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // closing without an owner, without corrective work and without verification
+            // is the whole reason this graph exists
+            "OPEN,                       CLOSED",
+            "OPEN,                       VERIFIED",
+            "OPEN,                       CORRECTIVE_ACTION_COMPLETE",
+            "ASSIGNED,                   CLOSED",
+            "ASSIGNED,                   VERIFIED",
+            "CORRECTIVE_ACTION_COMPLETE, CLOSED",
+            // and verification is not something the site engineer can undo
+            "VERIFIED,                   CORRECTIVE_ACTION_COMPLETE",
+            "VERIFIED,                   REJECTED",
+            "CLOSED,                     ASSIGNED",
+            "CLOSED,                     VERIFIED",
+            // nothing goes back to unassigned: the trail keeps its owner
+            "ASSIGNED,                   OPEN",
+            "REJECTED,                   OPEN",
+    })
+    void refusesTheMovesThatWouldSkipOrUndoAStep(NcrStatus from, NcrStatus to) {
+        assertThat(from.canTransitionTo(to)).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(NcrStatus.class)
+    void alwaysAllowsStayingPut(NcrStatus status) {
+        assertThat(status.canTransitionTo(status)).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(NcrStatus.class)
+    void everyStatusHasAnEntryInTheGraph(NcrStatus status) {
+        assertThat(status.allowedNext()).isNotNull();
+    }
+
+    @Test
+    void aReportCanAlwaysComeBack() {
+        // no state is terminal: a non-conformance that recurs is recorded on the report
+        // that already carries its history, so even a closed one has somewhere to go
+        assertThat(NcrStatus.CLOSED.allowedNext()).containsExactly(NcrStatus.REOPENED);
+    }
+
+    @Test
+    void theTypeFollowsTheInspectionItWasRaisedFrom() {
+        assertThat(NcrType.forCategory(InspectionCategory.SAFETY)).isEqualTo(NcrType.SAFETY);
+        assertThat(NcrType.forCategory(InspectionCategory.QA_QC)).isEqualTo(NcrType.QUALITY);
+        assertThat(NcrType.forCategory(InspectionCategory.COMPLIANCE)).isEqualTo(NcrType.QUALITY);
+        assertThat(NcrType.forCategory(InspectionCategory.OTHER)).isEqualTo(NcrType.QUALITY);
+        assertThat(NcrType.forCategory(null)).isEqualTo(NcrType.QUALITY);
+    }
+}


### PR DESCRIPTION
Phase 1 of the inspection module, part 2 of 3. Implements sections 3.3 and 3.4 of
`docs/specs/2026-08-26-inspection-module.md`.

**Merges before the RBAC PR (#499), which is branched from this one.**

## What this adds

**`Ncr`**, tenant-scoped, with its own `NCR` document series. `NcrType`
(quality/safety), `NcrStatus` (`OPEN -> ASSIGNED -> CORRECTIVE_ACTION_COMPLETE ->
VERIFIED -> CLOSED`, with `REJECTED` and `REOPENED` off the straight line), scalar links
to the originating inspection and optional defect, severity, assigned site engineer,
target date, raised-by and closed-by.

**One guarded transition method.** Nothing writes the status directly. A report that
could be closed straight from open would make the closure trail a record of nothing.

**The same treatment for the inspection's own status** (section 3.4). It was taken from
the payload as given, so a cancelled inspection could come back as passed.

## Decisions where the spec was silent

- **Why an entity rather than columns on the defect.** The defect already records what
  has to be done, by whom and by when. What it cannot carry is the chain of custody, and
  one defect can be raised, rejected and reopened more than once, each pass with its own
  owner and dates.
- **`type` is derived from the originating inspection's category, not from the request.**
  It decides who may close the report (part 3), so accepting it from the caller would let
  a safety inspection produce a quality NCR by sending the wrong value. `COMPLIANCE` and
  `OTHER` map to `QUALITY`.
- **Four fields the spec does not list, because the lifecycle is unusable without them:**
  `title` (an NCR register needs a line to read), `correctiveActionRemarks` (what the
  site engineer reports on marking complete), `verificationRemarks` (why a verifier sent
  it back or reopened it), and `correctiveActionCompletedAt` / `verifiedAt` / `closedAt`.
  All are part of the record a client reads on a closed NCR, so none is a transient note.
- **`REJECTED` goes back to `ASSIGNED`, not to `OPEN`.** The trail keeps its owner.
- **`REOPENED` is recorded on the original report**, not as a second one: that report's
  history is the evidence the same non-conformance came back, which a new report loses.
  Reopening clears `closedAt`/`closedById` rather than leaving a closure standing next to
  an open report.
- **`raisedById`/`closedById` are null when the caller has no employee record**, rather
  than a refusal. An org's bootstrap administrator has no employee profile, and refusing
  would leave a new tenant unable to use the module at all.
- **The defect id is checked against the inspection.** The two arrive independently, so
  without it an NCR could name an inspection and a defect that have nothing to do with
  each other, and the corrective action on the record would be somebody else's.
- **The punch list (FR-REP-08) is `?open=true` on the list endpoint**, one flag rather
  than making a client enumerate six statuses and get it wrong when a seventh is added.
- **No database check constraint on the lifecycle.** The graph has branches a check
  constraint cannot express without duplicating the rule in a second place that would
  then drift. The service is the single place it is written.

### The inspection graph is deliberately permissive about concluding

Work is often carried out and recorded afterwards, so scheduled straight to passed is a
normal day, not a skipped step. What it refuses is coming back out of a conclusion.
`FAILED -> IN_PROGRESS` is the one move that looks backwards and is not: that is the
re-inspection. `SUGGESTED` reaches the conclusions too, because a client who already
holds the fire NOC an AI compliance suggestion named marks it obtained, and making them
schedule an inspection they will never carry out to say so is theatre.

**This is a behaviour change on `PUT /api/v1/inspections/web/{id}`**: a payload asking
for an illegal move now gets a 400 naming both ends and what is allowed, where it used
to be applied. Staying put is always legal, since the web client sends the whole record
back on every save.

## From review

CodeRabbit raised the assignee not being validated. Fixed: `create` and `assign` now
refuse a `siteEngineerId` this organization does not have, before the transition, so a
refused assignment leaves the report where it was. Employee references elsewhere in the
module are unchecked scalar ids and on an inspection that is defensible, but the NCR's
owner is the point of the entity, and an id belonging to nobody or to another tenant
produces a report open against somebody who will never see it. Covered for both a
nonexistent id and a real employee in the other tenant.

Its other finding, that closing is not gated by discipline, is right about this PR alone
and is #499's subject. Nothing is loosened by merging this first: the close endpoint is
new here, and none of the three job roles exists until #499 creates them, so until then
only a system administrator can reach it.

## A defect the tests caught, worth naming

`close` stamped `closedById` and `closedAt` before asking whether the move was legal, so
a refused close left an open report carrying a closure date, which the caller read back
inside the same transaction whether or not it was ever committed. Every action now
transitions first and writes second, and the guard's javadoc says why. This mirrors the
rule the project-immutability test already pins on the inspection: the refusal has to
happen before anything is written.

## Verification

Full suite on `lab-node-116-f`, against a pristine `origin/development` baseline on the
same box. CI on this branch is green as well, including the JaCoCo floor.

| | result | time |
|---|---|---|
| pristine `origin/development` | BUILD SUCCESSFUL, 104 test classes | 7m31s |
| this branch, rebased on the merged #497 | BUILD SUCCESSFUL, 667 passed, 0 failures, 0 OOM | 7m36s |
| tip of the stack (with #499) | BUILD SUCCESSFUL, 671 passed, 0 failures, 0 OOM | 7m12s |

- `InspectionStatusTransitionTest`, `NcrStatusTransitionTest`: plain JUnit, no context.
- `NcrServiceIT`: real CockroachDB, and **no new Spring context** (same annotations and
  `@Import` list as the other three inspection ITs, to the letter).

## Liquibase

`059-create-ncrs.xml`, registered in `db.changelog-master.xml`.

> #497 is merged, so this is rebased onto `development` and its diff is this increment
> alone. Reports (spec 3.6) are the remaining Phase 1 item and are filed as #502 rather
> than left to the phase plan.
