### PR TITLE
Split the inspection module's authority along the jobs that do the work

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
+++ b/src/main/java/org/tornotron/echno_backend/common/enums/OrgRole.java
@@ -15,12 +15,27 @@ import java.util.Set;
  *   @PreAuthorize("@orgSecurity.hasOrgRole(#orgId, 'system-admin')")
  *
  * The groupName field is the actual Keycloak subgroup name (kebab-case).
+ *
+ * <p>Adding a constant here adds the subgroup to every organization created from
+ * then on. Organizations that already exist get theirs the first time the role is
+ * assigned: {@code KeycloakGroupService.assignOrgRole} creates a missing subgroup
+ * rather than refusing, so no backfill over existing tenants is needed.
  */
 public enum OrgRole {
     SYSTEM_ADMIN("system-admin"),
     ORG_MANAGER("org-manager"),
     HR_ADMIN("hr-admin"),
-    PROJECT_MANAGER("project-manager");
+    PROJECT_MANAGER("project-manager"),
+    // The three inspection roles. They are org-scoped rather than realm occupation
+    // roles because this is the layer @PreAuthorize actually checks: the realm has a
+    // 'site-engineer' and a 'safety-officer' occupation role already, but occupation
+    // roles gate nothing in application code and are a catalogue for assignment, not
+    // an authority. They are deliberately not manager roles: a QA engineer signs off
+    // quality, not headcount, and getManagerRoles decides who may be named the
+    // manager on a project invite code.
+    QA_ENGINEER("qa-engineer"),
+    SAFETY_OFFICER("safety-officer"),
+    SITE_ENGINEER("site-engineer");
 
     private final String groupName;
 

--- a/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
@@ -176,8 +176,15 @@ public class KeycloakGroupService {
      * groups claim, which JwtAuthConverter converts to authority "ORG_5_ROLE_system-admin".
      *
      * NOTE: The user must ALSO be a member of the org (via addUserToOrganization).
-     * Role assignment and membership are separate — a user can be a member without
+     * Role assignment and membership are separate: a user can be a member without
      * any role, but should not have a role without being a member.
+     *
+     * A subgroup that does not exist yet is created here rather than refused. The
+     * subgroups are created from OrgRole when an organization is created, so an
+     * organization created before a role was added to the enum has no subgroup for
+     * it, and every existing tenant is in that position the moment a role is added.
+     * Creating it on first assignment keeps that a non-event instead of a migration
+     * over every tenant, and it can only ever create a name the enum already names.
      */
     public void assignOrgRole(String userId, String organizationId, OrgRole role) {
         Keycloak keycloak = getKeycloakAdminClient();
@@ -189,12 +196,7 @@ public class KeycloakGroupService {
                         "Cannot assign role: group 'org-" + organizationId + "' was not found in Keycloak");
             }
 
-            String subgroupId = findRoleSubgroupId(keycloak, orgGroupId, role.getGroupName());
-            if (subgroupId == null) {
-                throw new RuntimeException(
-                        "Cannot assign role: subgroup '" + role.getGroupName() + "' was not found under 'org-"
-                                + organizationId + "'");
-            }
+            String subgroupId = ensureRoleSubgroup(keycloak, orgGroupId, organizationId, role);
 
             keycloak.realm(realm).users().get(userId).joinGroup(subgroupId);
             log.info("Assigned role '{}' to user {} in organization {}", role.getGroupName(), userId, organizationId);
@@ -280,23 +282,67 @@ public class KeycloakGroupService {
      */
     private void createDefaultRoleSubgroups(Keycloak keycloak, String orgGroupId, String organizationId) {
         for (OrgRole role : OrgRole.values()) {
-            GroupRepresentation subgroup = new GroupRepresentation();
-            subgroup.setName(role.getGroupName());
-
-            Response response = keycloak.realm(realm).groups().group(orgGroupId).subGroup(subgroup);
-
-            if (response.getStatus() != 201) {
-                String error = response.readEntity(String.class);
-                response.close();
-                throw new RuntimeException(
-                        "Failed to create role subgroup '" + role.getGroupName() + "' under 'org-" + organizationId
-                                + "' in Keycloak (status " + response.getStatus() + "): " + error);
-            }
-
-            response.close();
-
-            log.debug("Created role subgroup '{}' under org-{}", role.getGroupName(), organizationId);
+            createRoleSubgroup(keycloak, orgGroupId, organizationId, role);
         }
+    }
+
+    /**
+     * The id of a role subgroup, creating it if this organization does not have one.
+     *
+     * Organizations get their subgroups from OrgRole at creation, so one created
+     * before a role was added to the enum is missing that subgroup. Rather than
+     * refuse the assignment and leave an operator to create groups by hand in
+     * Keycloak for every existing tenant, the subgroup is created on demand. The
+     * name always comes from the enum, so this cannot invent an authority.
+     */
+    private String ensureRoleSubgroup(Keycloak keycloak, String orgGroupId,
+                                      String organizationId, OrgRole role) {
+        String subgroupId = findRoleSubgroupId(keycloak, orgGroupId, role.getGroupName());
+        if (subgroupId != null) {
+            return subgroupId;
+        }
+        log.info("Role subgroup '{}' is missing under org-{}; creating it",
+                role.getGroupName(), organizationId);
+        try {
+            createRoleSubgroup(keycloak, orgGroupId, organizationId, role);
+        } catch (RuntimeException e) {
+            // Two assignments of the same new role can race here and the loser is told
+            // the group already exists. That is the outcome it wanted, so it is only an
+            // error if the subgroup still is not there when it looks again.
+            if (findRoleSubgroupId(keycloak, orgGroupId, role.getGroupName()) == null) {
+                throw e;
+            }
+            log.debug("Role subgroup '{}' under org-{} was created concurrently",
+                    role.getGroupName(), organizationId);
+        }
+
+        String created = findRoleSubgroupId(keycloak, orgGroupId, role.getGroupName());
+        if (created == null) {
+            throw new RuntimeException(
+                    "Cannot assign role: subgroup '" + role.getGroupName()
+                            + "' was created under 'org-" + organizationId + "' but cannot be read back");
+        }
+        return created;
+    }
+
+    private void createRoleSubgroup(Keycloak keycloak, String orgGroupId,
+                                    String organizationId, OrgRole role) {
+        GroupRepresentation subgroup = new GroupRepresentation();
+        subgroup.setName(role.getGroupName());
+
+        Response response = keycloak.realm(realm).groups().group(orgGroupId).subGroup(subgroup);
+
+        if (response.getStatus() != 201) {
+            String error = response.readEntity(String.class);
+            response.close();
+            throw new RuntimeException(
+                    "Failed to create role subgroup '" + role.getGroupName() + "' under 'org-" + organizationId
+                            + "' in Keycloak (status " + response.getStatus() + "): " + error);
+        }
+
+        response.close();
+
+        log.debug("Created role subgroup '{}' under org-{}", role.getGroupName(), organizationId);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionSecurityService.java
@@ -1,0 +1,154 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inspection.NcrType;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+import org.tornotron.echno_backend.inspection.repositories.NcrRepository;
+
+import java.util.UUID;
+
+/**
+ * Inspection authorization policy, kept in one place so the role model can be
+ * retuned without touching the controllers, following the
+ * {@code attendanceSecurity} precedent. Controllers reference this bean from
+ * {@code @PreAuthorize} (for example
+ * {@code @inspectionSecurity.canSignOffNcr(#id)}).
+ *
+ * <p>The module used to admit only {@code system-admin} and
+ * {@code project-manager} on every endpoint, which collapsed four jobs into one
+ * and made the closure trail on an NCR meaningless: whoever could raise it could
+ * also close it. The defaults below give each job the authority the functional
+ * spec assigns it:
+ *
+ * <ul>
+ *   <li>{@code echno.security.inspection.read-roles} (default
+ *       {@code system-admin,project-manager,qa-engineer,safety-officer,site-engineer})
+ *       reads inspections, checklists and NCRs. The project manager's full read and
+ *       the site engineer's view of the NCRs assigned to them are both here.</li>
+ *   <li>{@code echno.security.inspection.manage-roles} (default
+ *       {@code system-admin,project-manager,qa-engineer,safety-officer}) schedules
+ *       and records inspections. Not the site engineer: they act on the
+ *       non-conformances an inspection raises, they do not carry it out.</li>
+ *   <li>{@code echno.security.inspection.checklist-roles} (default
+ *       {@code system-admin,qa-engineer}) defines the criteria work is judged
+ *       against. Deliberately narrow: this is the QA engineer's job, and setting a
+ *       tolerance is a bigger authority than recording a measurement against one.
+ *       The safety officer is not here yet because a checklist template is keyed by
+ *       trade, which is the QA/QC axis; safety criteria arrive with the safety
+ *       phase and this default moves with them.</li>
+ *   <li>{@code echno.security.inspection.ncr-raise-roles} (default
+ *       {@code system-admin,qa-engineer,safety-officer}) raises and assigns
+ *       non-conformances. The project manager reads them and does not assign them,
+ *       which is what the spec's approval-visibility line means.</li>
+ *   <li>{@code echno.security.inspection.corrective-action-roles} (default
+ *       {@code system-admin,site-engineer}) reports the corrective work done. This
+ *       is as far as the assignee takes it.</li>
+ *   <li>{@code echno.security.inspection.quality-signoff-roles} (default
+ *       {@code system-admin,qa-engineer}) and
+ *       {@code echno.security.inspection.safety-signoff-roles} (default
+ *       {@code system-admin,safety-officer}) verify, reject, reopen and close, each
+ *       only for their own discipline. See {@link #canSignOffNcr}.</li>
+ * </ul>
+ *
+ * <p>Override any of them per environment as a comma-separated list of org-role
+ * tokens, no code change needed.
+ */
+@Service("inspectionSecurity")
+public class InspectionSecurityService {
+
+    private final OrganizationSecurityService orgSecurity;
+    private final NcrRepository ncrRepo;
+    private final String[] readRoles;
+    private final String[] manageRoles;
+    private final String[] checklistRoles;
+    private final String[] ncrRaiseRoles;
+    private final String[] correctiveActionRoles;
+    private final String[] qualitySignOffRoles;
+    private final String[] safetySignOffRoles;
+
+    public InspectionSecurityService(
+            OrganizationSecurityService orgSecurity,
+            NcrRepository ncrRepo,
+            @Value("${echno.security.inspection.read-roles:"
+                    + "system-admin,project-manager,qa-engineer,safety-officer,site-engineer}")
+            String[] readRoles,
+            @Value("${echno.security.inspection.manage-roles:"
+                    + "system-admin,project-manager,qa-engineer,safety-officer}")
+            String[] manageRoles,
+            @Value("${echno.security.inspection.checklist-roles:system-admin,qa-engineer}")
+            String[] checklistRoles,
+            @Value("${echno.security.inspection.ncr-raise-roles:"
+                    + "system-admin,qa-engineer,safety-officer}")
+            String[] ncrRaiseRoles,
+            @Value("${echno.security.inspection.corrective-action-roles:system-admin,site-engineer}")
+            String[] correctiveActionRoles,
+            @Value("${echno.security.inspection.quality-signoff-roles:system-admin,qa-engineer}")
+            String[] qualitySignOffRoles,
+            @Value("${echno.security.inspection.safety-signoff-roles:system-admin,safety-officer}")
+            String[] safetySignOffRoles) {
+        this.orgSecurity = orgSecurity;
+        this.ncrRepo = ncrRepo;
+        this.readRoles = readRoles;
+        this.manageRoles = manageRoles;
+        this.checklistRoles = checklistRoles;
+        this.ncrRaiseRoles = ncrRaiseRoles;
+        this.correctiveActionRoles = correctiveActionRoles;
+        this.qualitySignOffRoles = qualitySignOffRoles;
+        this.safetySignOffRoles = safetySignOffRoles;
+    }
+
+    /** Read inspections, checklist templates and non-conformance reports. */
+    public boolean canRead() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(readRoles);
+    }
+
+    /** Schedule an inspection and record what it found. */
+    public boolean canManageInspections() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(manageRoles);
+    }
+
+    /** Define the criteria work is judged against. */
+    public boolean canDefineChecklists() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(checklistRoles);
+    }
+
+    /** Raise a non-conformance and hand it to a site engineer. */
+    public boolean canRaiseNcrs() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(ncrRaiseRoles);
+    }
+
+    /** Report the corrective work done and the non-conformance ready for re-inspection. */
+    public boolean canReportCorrectiveAction() {
+        return orgSecurity.hasAnyOrgRoleForCurrentTenant(correctiveActionRoles);
+    }
+
+    /**
+     * Whether the caller may verify, reject, reopen or close this particular
+     * non-conformance.
+     *
+     * <p>The discipline has to match: a safety officer cannot close a quality
+     * non-conformance and a QA engineer cannot close a safety one. Both are
+     * sign-offs on work outside the signer's competence, and the report is the
+     * record that somebody qualified accepted it. The check is per-report rather
+     * than per-endpoint because the discipline is a property of the report, not of
+     * the request.
+     *
+     * <p>A report that does not exist in this tenant is allowed through, so the
+     * caller gets the service's 404 rather than a 403 that would read as "it exists
+     * and you may not touch it".
+     *
+     * @param ncrId Id of the report being signed off.
+     * @return true when the caller holds the sign-off role for that report's discipline.
+     */
+    @Transactional(readOnly = true)
+    public boolean canSignOffNcr(UUID ncrId) {
+        return ncrRepo.findByIdScoped(ncrId)
+                .map(Ncr::getType)
+                .map(type -> orgSecurity.hasAnyOrgRoleForCurrentTenant(
+                        type == NcrType.SAFETY ? safetySignOffRoles : qualitySignOffRoles))
+                .orElse(true);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/ChecklistTemplateControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/ChecklistTemplateControllerWeb.java
@@ -30,14 +30,17 @@ import java.util.UUID;
                 + "inspection created for a trade starts from a copy of that trade's active "
                 + "template, so later edits never rewrite a checklist already signed off. The "
                 + "starter endpoints expose the product-supplied defaults an organization adopts "
-                + "as its own editable templates. All endpoints are tenant scoped."
+                + "as its own editable templates. All endpoints are tenant scoped. Defining a "
+                + "template is the QA engineer's authority: setting the tolerance work is judged "
+                + "against is a bigger act than recording a measurement against one. Everyone with "
+                + "inspection read access can see the templates."
 )
 public class ChecklistTemplateControllerWeb {
 
     private final ChecklistTemplateService service;
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canDefineChecklists()")
     @Operation(
             summary = "Define a checklist template",
             description = "Creates the organization's checklist for a trade, with its check points. "
@@ -54,7 +57,7 @@ public class ChecklistTemplateControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "Get a checklist template by id",
             description = "Returns a single template including its check points in line order."
@@ -69,7 +72,7 @@ public class ChecklistTemplateControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "List checklist templates",
             description = "Returns a page of the organization's templates. The trade and active "
@@ -87,7 +90,7 @@ public class ChecklistTemplateControllerWeb {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canDefineChecklists()")
     @Operation(
             summary = "Replace a checklist template",
             description = "Replaces the name, description, active flag and check points of an "
@@ -108,7 +111,7 @@ public class ChecklistTemplateControllerWeb {
     }
 
     @GetMapping("/starters")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "List the starter checklists on offer",
             description = "Returns the product-supplied default checklists, one per trade at most. "
@@ -124,7 +127,7 @@ public class ChecklistTemplateControllerWeb {
     }
 
     @PostMapping("/starters/{trade}/adopt")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canDefineChecklists()")
     @Operation(
             summary = "Adopt a starter checklist",
             description = "Copies the shipped starter for a trade into this organization as its own "

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -31,15 +31,17 @@ import java.util.UUID;
         name = "Inspections",
         description = "Site inspections carried out against a project, covering routine, safety and "
                 + "compliance types. An inspection tracks its checklist items, defects, result and status. "
-                + "All endpoints are tenant scoped and limited to system administrators and project "
-                + "managers."
+                + "All endpoints are tenant scoped. Reading is open to the project manager, QA engineer, "
+                + "safety officer and site engineer; scheduling and recording an inspection is not open "
+                + "to the site engineer, who acts on the non-conformances an inspection raises rather "
+                + "than carrying it out."
 )
 public class InspectionControllerWeb {
 
     private final InspectionService service;
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
     @Operation(
             summary = "Create an inspection",
             description = "Creates a new inspection for a project, including its checklist items."
@@ -55,7 +57,7 @@ public class InspectionControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "Get an inspection by id",
             description = "Returns a single inspection including its checklist items and any recorded "
@@ -71,7 +73,7 @@ public class InspectionControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "List inspections",
             description = "Returns a page of inspections in the current tenant. The projectId, status, "
@@ -93,7 +95,7 @@ public class InspectionControllerWeb {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
     @Operation(
             summary = "Update an inspection",
             description = "Updates the status, result, checklist items and defects of an existing "

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
@@ -31,14 +31,19 @@ import java.util.UUID;
                 + "non-conformance, which site engineer owns it, who re-inspected it and who closed "
                 + "it. The lifecycle runs open, assigned, corrective action complete, verified, "
                 + "closed, with reject and reopen as the ways off that line; a step that is not part "
-                + "of it is refused rather than recorded. All endpoints are tenant scoped."
+                + "of it is refused rather than recorded. All endpoints are tenant scoped, and the "
+                + "authority is split along the same line as the lifecycle: the QA engineer and the "
+                + "safety officer raise and assign, the site engineer reports the corrective work "
+                + "done, and verifying, rejecting, reopening and closing need the sign-off role for "
+                + "that report's own discipline, so a safety officer cannot close a quality report or "
+                + "the other way round."
 )
 public class NcrControllerWeb {
 
     private final NcrService service;
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRaiseNcrs()")
     @Operation(
             summary = "Raise a non-conformance report",
             description = "Raises an NCR against an inspection, and against one of its defects when "
@@ -58,7 +63,7 @@ public class NcrControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(summary = "Get a non-conformance report by id")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "NCR found"),
@@ -70,7 +75,7 @@ public class NcrControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRead()")
     @Operation(
             summary = "List non-conformance reports",
             description = "Returns a page of NCRs in the current tenant. Every parameter is an "
@@ -91,7 +96,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/assign")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canRaiseNcrs()")
     @Operation(
             summary = "Assign a non-conformance report",
             description = "Hands the corrective work to a site engineer, or moves it to a different "
@@ -108,7 +113,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/corrective-action-complete")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canReportCorrectiveAction()")
     @Operation(
             summary = "Report the corrective action complete",
             description = "The site engineer reports the work done and the NCR ready for "
@@ -127,7 +132,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/verify")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canSignOffNcr(#id)")
     @Operation(
             summary = "Verify the corrective action",
             description = "Records that the corrective work was re-inspected and accepted."
@@ -144,7 +149,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/reject")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canSignOffNcr(#id)")
     @Operation(
             summary = "Reject the corrective action",
             description = "Records that the corrective work was re-inspected and not accepted. The "
@@ -162,7 +167,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/reopen")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canSignOffNcr(#id)")
     @Operation(
             summary = "Reopen a non-conformance report",
             description = "Records that the same non-conformance has come back after it was verified "
@@ -181,7 +186,7 @@ public class NcrControllerWeb {
     }
 
     @PostMapping("/{id}/close")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @PreAuthorize("@inspectionSecurity.canSignOffNcr(#id)")
     @Operation(
             summary = "Close a non-conformance report",
             description = "Closes a verified NCR and records who closed it."

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionSecurityServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionSecurityServiceTest.java
@@ -1,0 +1,127 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inspection.domain.Ncr;
+import org.tornotron.echno_backend.inspection.repositories.NcrRepository;
+import org.tornotron.echno_backend.inspection.service.InspectionSecurityService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The discipline boundary on an NCR sign-off: a safety officer cannot close a
+ * quality non-conformance and a QA engineer cannot close a safety one. Both would
+ * be a sign-off on work outside the signer's competence, and the closed report is
+ * the record that somebody qualified accepted it.
+ *
+ * <p>Plain Mockito, no Spring context: the rule is which role list gets checked
+ * for which report, and the test JVM caches every context it loads for the whole
+ * run.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InspectionSecurityServiceTest {
+
+    private static final UUID NCR_ID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+    private static final String[] READ = {"system-admin"};
+    private static final String[] MANAGE = {"system-admin"};
+    private static final String[] CHECKLIST = {"system-admin", "qa-engineer"};
+    private static final String[] RAISE = {"system-admin"};
+    private static final String[] CORRECTIVE = {"system-admin", "site-engineer"};
+    private static final String[] QUALITY_SIGN_OFF = {"system-admin", "qa-engineer"};
+    private static final String[] SAFETY_SIGN_OFF = {"system-admin", "safety-officer"};
+
+    @Mock
+    private OrganizationSecurityService orgSecurity;
+    @Mock
+    private NcrRepository ncrRepo;
+
+    private InspectionSecurityService security() {
+        return new InspectionSecurityService(orgSecurity, ncrRepo, READ, MANAGE, CHECKLIST,
+                RAISE, CORRECTIVE, QUALITY_SIGN_OFF, SAFETY_SIGN_OFF);
+    }
+
+    @Test
+    void aQualityReportIsCheckedAgainstTheQualitySignOffRoles() {
+        when(ncrRepo.findByIdScoped(NCR_ID)).thenReturn(Optional.of(ncrOfType(NcrType.QUALITY)));
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(QUALITY_SIGN_OFF)).thenReturn(true);
+
+        assertThat(security().canSignOffNcr(NCR_ID)).isTrue();
+
+        verify(orgSecurity).hasAnyOrgRoleForCurrentTenant(QUALITY_SIGN_OFF);
+        verify(orgSecurity, never()).hasAnyOrgRoleForCurrentTenant(SAFETY_SIGN_OFF);
+    }
+
+    @Test
+    void aSafetyReportIsCheckedAgainstTheSafetySignOffRoles() {
+        when(ncrRepo.findByIdScoped(NCR_ID)).thenReturn(Optional.of(ncrOfType(NcrType.SAFETY)));
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SAFETY_SIGN_OFF)).thenReturn(true);
+
+        assertThat(security().canSignOffNcr(NCR_ID)).isTrue();
+
+        verify(orgSecurity).hasAnyOrgRoleForCurrentTenant(SAFETY_SIGN_OFF);
+        verify(orgSecurity, never()).hasAnyOrgRoleForCurrentTenant(QUALITY_SIGN_OFF);
+    }
+
+    @Test
+    void aSafetyOfficerCannotSignOffAQualityReport() {
+        when(ncrRepo.findByIdScoped(NCR_ID)).thenReturn(Optional.of(ncrOfType(NcrType.QUALITY)));
+        // holds the safety role and not the quality one
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(QUALITY_SIGN_OFF)).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SAFETY_SIGN_OFF)).thenReturn(true);
+
+        assertThat(security().canSignOffNcr(NCR_ID)).isFalse();
+    }
+
+    @Test
+    void aQaEngineerCannotSignOffASafetyReport() {
+        when(ncrRepo.findByIdScoped(NCR_ID)).thenReturn(Optional.of(ncrOfType(NcrType.SAFETY)));
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SAFETY_SIGN_OFF)).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(QUALITY_SIGN_OFF)).thenReturn(true);
+
+        assertThat(security().canSignOffNcr(NCR_ID)).isFalse();
+    }
+
+    @Test
+    void aReportThatIsNotInThisTenantIsLeftToTheServiceToReportMissing() {
+        // a 403 here would read as "it exists and you may not touch it", which is both
+        // wrong and a worse answer than the 404 the service already gives
+        when(ncrRepo.findByIdScoped(NCR_ID)).thenReturn(Optional.empty());
+
+        assertThat(security().canSignOffNcr(NCR_ID)).isTrue();
+        verify(orgSecurity, never()).hasAnyOrgRoleForCurrentTenant(any(String[].class));
+    }
+
+    @Test
+    void theOtherActsCheckTheirOwnRoleList() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(CHECKLIST)).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(CORRECTIVE)).thenReturn(false);
+
+        InspectionSecurityService security = security();
+        assertThat(security.canDefineChecklists()).isTrue();
+        assertThat(security.canReportCorrectiveAction()).isFalse();
+
+        verify(orgSecurity).hasAnyOrgRoleForCurrentTenant(CHECKLIST);
+        verify(orgSecurity).hasAnyOrgRoleForCurrentTenant(CORRECTIVE);
+    }
+
+    private static Ncr ncrOfType(NcrType type) {
+        Ncr ncr = new Ncr();
+        ncr.setNcrNumber("NCR-2027-000001");
+        ncr.setType(type);
+        return ncr;
+    }
+}


### PR DESCRIPTION
Phase 1 of the inspection module, part 3 of 3. Implements section 3.5 of
`docs/specs/2026-08-26-inspection-module.md`.

**Merges last, after #498.**

## What this changes

Every endpoint in the module admitted `system-admin` and `project-manager` and nobody
else. On the NCR that made part 2's closure trail meaningless: whoever could raise a
non-conformance could also close it.

The policy now lives in one `inspectionSecurity` bean, following the existing
`attendanceSecurity` precedent, with each role set overridable per environment:

| Act | Default roles |
|---|---|
| Read inspections, checklists, NCRs | `system-admin, project-manager, qa-engineer, safety-officer, site-engineer` |
| Schedule and record an inspection | `system-admin, project-manager, qa-engineer, safety-officer` |
| Define a checklist template | `system-admin, qa-engineer` |
| Raise and assign an NCR | `system-admin, qa-engineer, safety-officer` |
| Report the corrective action done | `system-admin, site-engineer` |
| Verify / reject / reopen / close a **quality** NCR | `system-admin, qa-engineer` |
| Verify / reject / reopen / close a **safety** NCR | `system-admin, safety-officer` |

## Decisions where the spec was silent

- **The three new roles are org-scoped `OrgRole` constants, not realm occupation roles.**
  The realm already carries `site-engineer` and `safety-officer` as occupation roles, but
  as `docs/specs/2026-08-25-rbac-composite-job-roles.md` records, occupation roles gate
  nothing in application code: `@PreAuthorize` checks the `/org-{id}/{role}` subgroup
  layer. Putting the FRS roles anywhere else would not enforce anything. There is no
  `qa-engineer` in either layer today, so it is new.
- **Existing organizations need no backfill.** Subgroups are created from `OrgRole` when
  an organization is created, so every existing tenant lacks the three new ones.
  `assignOrgRole` now creates a missing subgroup instead of refusing, so the first
  assignment provisions it. The name can only come from the enum, so this cannot invent
  an authority. Without it, adding a role would need a Keycloak migration over every
  tenant before the module could be used.
- **They are not manager roles.** `OrgRole.getManagerRoles()` decides who may be named
  the manager on a project invite code; a QA engineer signs off quality, not headcount.
- **The project manager reads NCRs but does not raise or assign them.** This is a
  deliberate reading of the spec's "full read and approval visibility" line, not an
  omission, and it is the reversible direction. If a PM turns out to need to raise or
  assign, that is one config token; the opposite mistake leaves someone with broad
  authority quietly closing quality reports the spec means a QA engineer to own.
- **The safety officer is not on the checklist-write list.** A template is keyed by
  `InspectionTrade`, which is the QA/QC axis; safety criteria genuinely have no home
  until Phase 2, and granting authority over something that does not exist is not a
  grant. Confirmed as the intended reading rather than left open.
- **The site engineer cannot schedule or record an inspection.** The spec gives them
  NCRs; they act on what an inspection raises rather than carrying it out.
- **The sign-off check is per report, not per endpoint**, because the discipline is a
  property of the report rather than of the request. A report that is not in the tenant is
  allowed through the guard so the caller gets the service's 404 rather than a 403 that
  would read as "it exists and you may not touch it".

## Activation

Nothing blocks the merge. The roles are inert until someone holds them and `system-admin`
covers every act meanwhile, so no tenant is locked out the moment this deploys. To put
the split live on `echno.in`, assign `qa-engineer` / `safety-officer` / `site-engineer`
to the relevant employees through the existing org-role endpoint; the subgroups appear on
first assignment.

## No bot review ran on this one

CodeRabbit's check is green, but its description reads `Review rate limited`, which means
no review happened rather than that it found nothing. I re-requested once and got the
same answer. Worth knowing before reading the green tick as a second opinion: #497 was
never reviewed either, and #498 is the only one of the three that got a real pass.

In its place, the guard rewiring was audited by pairing every request mapping in the
three controllers against the expression that guards it, since that edit was applied
mechanically and a read guard landing on a write endpoint is exactly the mistake it could
have made. All 19 endpoints carry the intended guard: reads on `canRead()`, each write on
the act it belongs to, and the four sign-off actions on the per-report check. Two things
deliberately left alone and confirmed still alone: `removeOrgRole` looks the subgroup up
and fails rather than creating one, because removing a role from a group that does not
exist is a real error, and `OrgRole.MANAGER_ROLES` is unchanged, so project invite codes
and the employee hierarchy do not start seeing the three new roles as manager roles.

## Verification

Full suite on `lab-node-116-f` at the tip of the stack, against a pristine
`origin/development` baseline on the same box:

| | result | time |
|---|---|---|
| pristine `origin/development` | BUILD SUCCESSFUL, 104 test classes | 7m31s |
| this branch, rebased on the merged #497 | BUILD SUCCESSFUL, 673 passed, 0 failures, 0 OOM | 7m41s |

- `InspectionSecurityServiceTest`: plain Mockito, no context. Covers both discipline
  directions and the missing-report case.
- The `EndpointAuthorizationTest` ratchet still passes: every endpoint carries a guard.
- The Keycloak subgroup path has no automated cover: it drives the Keycloak admin client
  and there is no Keycloak in the suite. Read it as read, and it only ever creates a name
  that comes from the `OrgRole` enum.

> Based on `feat/inspection-ncr-workflow` (#498), rebased onto the merged #497. Retarget
> to `development` once #498 lands and CI and CodeRabbit will run on it. Reports
> (spec 3.6) are the remaining Phase 1 item and are filed as #502.
