### PR TITLE
Run the constraints on the attendance check-in and clock-event payloads

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
+import jakarta.validation.Validator;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +35,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -63,6 +67,7 @@ public class AttendanceService {
     private final AttachmentService attachmentService;
     private final FileStorageService fileStorageService;
     private final UserContextService userContextService;
+    private final Validator validator;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              ShiftTimingRepository shiftTimingRepository,
@@ -75,7 +80,8 @@ public class AttendanceService {
                              AttendanceMapper attendanceMapper,
                              AttachmentService attachmentService,
                              FileStorageService fileStorageService,
-                             UserContextService userContextService) {
+                             UserContextService userContextService,
+                             Validator validator) {
         this.attendanceRepository = attendanceRepository;
         this.shiftTimingRepository = shiftTimingRepository;
         this.employeeRepository = employeeRepository;
@@ -88,6 +94,26 @@ public class AttendanceService {
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
         this.userContextService = userContextService;
+        this.validator = validator;
+    }
+
+    /**
+     * Runs bean validation over a payload the controller deserialized itself.
+     *
+     * <p>All four check-in and clock-event handlers take their payload as the JSON string part of
+     * a multipart request and read it by hand, so Spring never binds a bean and never validates
+     * one, and the constraints on these payloads would otherwise never fire. Doing it here covers
+     * the /web twin and the base controller at once, and any later caller by construction.
+     *
+     * @param payload The payload as deserialized from the request.
+     * @param <T> The payload type.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    private <T> void requireValid(T payload) {
+        Set<ConstraintViolation<T>> violations = validator.validate(payload);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
     /**
@@ -106,6 +132,7 @@ public class AttendanceService {
      */
     @Transactional
     public AttendanceResponseDto checkIn(AttendanceCheckInDto dto, MultipartFile photo) {
+        requireValid(dto);
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -243,6 +270,7 @@ public class AttendanceService {
      */
     @Transactional
     public AttendanceResponseDto recordClockEvent(AttendanceClockEventDto dto, MultipartFile photo) {
+        requireValid(dto);
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
@@ -1,0 +1,169 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.dto.AttendanceCheckInDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceClockEventDto;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * All four check-in and clock-event handlers take their payload as the JSON part of a multipart
+ * request and deserialize it by hand, so Spring never binds a bean and never validates one and
+ * the constraints on these payloads were decorative. These pin that the service runs them
+ * itself, and that a rejected payload never reaches the repository.
+ *
+ * <p>A real Hibernate Validator with mocked collaborators: whether the constraints fire needs a
+ * genuine validator, but no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendancePayloadValidationTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository,
+                employeeRepository, organizationRepository, projectRepository, settingsService,
+                calculationService, sequenceValidator, attendanceMapper, attachmentService,
+                fileStorageService, userContextService, validator);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private AttendanceCheckInDto checkInDto() {
+        AttendanceCheckInDto dto = new AttendanceCheckInDto();
+        dto.setEmployeeId(42L);
+        dto.setProjectId(12L);
+        dto.setEventTimestamp(LocalDateTime.of(2026, 1, 15, 9, 2));
+        return dto;
+    }
+
+    private AttendanceClockEventDto clockEventDto() {
+        AttendanceClockEventDto dto = new AttendanceClockEventDto();
+        dto.setAttendanceId(781L);
+        dto.setEventType(ClockEventType.LUNCH_BREAK_START);
+        dto.setEventTimestamp(LocalDateTime.of(2026, 1, 15, 13, 0));
+        return dto;
+    }
+
+    @Test
+    void checkIn_rejectsAMissingEmployeeId_beforeTouchingTheRepository() {
+        // A null id went into the lookup and came back as a 404 naming employee "null".
+        AttendanceCheckInDto dto = checkInDto();
+        dto.setEmployeeId(null);
+
+        assertThatThrownBy(() -> service.checkIn(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(attendanceRepository, never()).save(ArgumentMatchers.any());
+        verify(organizationRepository, never()).findById(ArgumentMatchers.any());
+    }
+
+    @Test
+    void checkIn_rejectsAMissingProjectId() {
+        AttendanceCheckInDto dto = checkInDto();
+        dto.setProjectId(null);
+
+        assertThatThrownBy(() -> service.checkIn(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void checkIn_rejectsAMissingEventTimestamp() {
+        AttendanceCheckInDto dto = checkInDto();
+        dto.setEventTimestamp(null);
+
+        assertThatThrownBy(() -> service.checkIn(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void recordClockEvent_rejectsAMissingAttendanceId_beforeTouchingTheRepository() {
+        AttendanceClockEventDto dto = clockEventDto();
+        dto.setAttendanceId(null);
+
+        assertThatThrownBy(() -> service.recordClockEvent(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        verify(attendanceRepository, never()).save(ArgumentMatchers.any());
+        verify(organizationRepository, never()).findById(ArgumentMatchers.any());
+    }
+
+    @Test
+    void recordClockEvent_rejectsAMissingEventType() {
+        AttendanceClockEventDto dto = clockEventDto();
+        dto.setEventType(null);
+
+        assertThatThrownBy(() -> service.recordClockEvent(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void recordClockEvent_rejectsAMissingEventTimestamp() {
+        AttendanceClockEventDto dto = clockEventDto();
+        dto.setEventTimestamp(null);
+
+        assertThatThrownBy(() -> service.recordClockEvent(dto, null))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void checkIn_leavesTheOptionalShiftAlone() {
+        // The shift is documented as optional: absent, the employee's assigned shift is used.
+        // Failing past validation means it reached the tenant lookup, which is mocked empty
+        // here; what matters is that it is not a constraint failure.
+        AttendanceCheckInDto dto = checkInDto();
+        dto.setShiftTimingId(null);
+
+        assertThatThrownBy(() -> service.checkIn(dto, null))
+                .isNotInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.attendance.service;
 
+import jakarta.validation.Validation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,7 @@ class AttendanceServiceApprovalTest {
         service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
                 organizationRepository, projectRepository, settingsService, calculationService,
                 sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
-                userContextService);
+                userContextService, Validation.buildDefaultValidatorFactory().getValidator());
     }
 
     @AfterEach


### PR DESCRIPTION
Part of #490, and an addition to it. #492 covers task and issue, #495 covers organization and chat; the three are independent and can land in any order.

## Four sites the issue's survey missed

The survey on #490 lists seven endpoints. There are eleven. `AttendanceController.checkIn`, `AttendanceControllerWeb.checkIn`, `AttendanceController.recordClockEvent` and `AttendanceControllerWeb.recordClockEvent` have exactly the same defect and are not on it, because they take the payload as a `@RequestParam` rather than a `@RequestPart`:

```java
public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data, …) {
    AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
```

Same shape, same consequence. The `@Valid` is on the `String`, which carries no constraints, so it does nothing, and the DTO that comes out of `readValue` is never validated at all. `AttendanceCheckInDto` and `AttendanceClockEventDto` carry three `@NotNull`s each, across a base controller and a `/web` twin, so six constraint declarations rather than the 26 the issue counts. Both endpoints document a 400 "or a field failed validation" that could not happen.

Worth noting for anyone auditing the rest of the codebase: `readValue` on a hand-read part is the pattern to grep for, not `@RequestPart`.

## The fix

The shape #488 used for projects: validate in the service, at the single shared caller, so the `/web` twin and the base controller are covered by one change rather than two that can drift. One generic `requireValid` serves both payloads since the two entry points sit on the same service.

The `ConstraintViolationException` to 400 mapping in `GlobalExceptionHandler` already exists (#488 added it), so nothing is added there.

## No constraint needed correcting

Unlike the other two PRs, all six are right as written. They are the ids and timestamps the service dereferences on its first line, and `shiftTimingId` is correctly left unconstrained: it is documented as optional, falling back to the employee's assigned shift.

## What newly returns 400

Nothing that succeeds today. A null `employeeId` already goes straight into `employeeRepository.findByIdAndOrganizationId(null, orgId)` and comes back as a 404 reading "Employee with ID null was not found in this organization"; a null `attendanceId` does the same on the clock-event path. The change is which 4xx it is and whether the message names the field. A caller that omits one of these has never had a working request.

## Verification

```
$ ./gradlew test --tests "*AttendancePayloadValidationTest*" --tests "*AttendanceServiceApprovalTest*"
AttendancePayloadValidationTest    7 PASSED
AttendanceServiceApprovalTest      2 PASSED
BUILD SUCCESSFUL in 1m 57s
```

Confirmed load bearing by commenting out the two `requireValid` calls and rerunning: all six rejection tests FAILED, the optional-shift guard still passed (it is there to catch the shift being made mandatory, not to prove enforcement). Restored, all seven pass.

`AttendanceServiceApprovalTest` takes the new constructor argument and is given a real validator rather than a mock.

Plain JUnit, Mockito and a real Hibernate `Validator` built in the test, no Spring context, following `ProjectCreationValidationTest`.
