### PR TITLE
fix(attendance): pin the movement start and end times to local wall-clock

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.attendance.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -32,11 +34,17 @@ public class MovementRecordCreationDto {
     @Schema(description = "Location the employee is travelling to.", example = "Tile Vendor Showroom, Guindy")
     private String toLocation;
 
-    @Schema(description = "Timestamp the movement started.", example = "2026-01-15T11:00:00")
+    @Schema(
+            description = "Site-local wall-clock time the movement started, with no timezone offset. A value carrying an offset or a trailing Z is rejected: the field has no offset to store it in, so accepting one would silently shift the recorded time.",
+            example = "2026-01-15T11:00:00")
     @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime startTime;
 
-    @Schema(description = "Timestamp the movement ended, once known.", example = "2026-01-15T12:30:00")
+    @Schema(
+            description = "Site-local wall-clock time the movement ended, once known, with no timezone offset. A value carrying an offset or a trailing Z is rejected: the field has no offset to store it in, so accepting one would silently shift the recorded time.",
+            example = "2026-01-15T12:30:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime endTime;
 
     @Schema(description = "Purpose of the movement.", example = "Vendor negotiation for tile supply")

--- a/src/test/java/org/tornotron/echno_backend/attendance/MovementTimestampContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/MovementTimestampContractTest.java
@@ -1,0 +1,87 @@
+package org.tornotron.echno_backend.attendance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.attendance.dto.MovementRecordCreationDto;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the wire contract for a movement record's start and end times, the same way
+ * {@link AttendanceTimestampContractTest} does for a clock punch.
+ *
+ * <p>Both fields are {@link LocalDateTime} and carry no offset, and the web form feeds
+ * them from a {@code datetime-local} input, which is a local wall clock by definition.
+ * Jackson's default leniency accepted an offset-bearing value and discarded the offset,
+ * shifting the recorded time. These tests assert it is rejected instead.
+ *
+ * <p>Plain Jackson, no Spring context: the behaviour under test comes from the field
+ * annotations, not the container.
+ */
+class MovementTimestampContractTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("accepts local wall-clock start and end times verbatim")
+    void acceptsLocalWallClock() throws Exception {
+        String json = """
+                {"attendanceId":5,"movementType":"SITE_TRAVEL","fromLocation":"Site","purpose":"Vendor",\
+                "startTime":"2026-08-27T11:00:00","endTime":"2026-08-27T12:30:00"}""";
+
+        MovementRecordCreationDto dto = objectMapper.readValue(json, MovementRecordCreationDto.class);
+
+        assertThat(dto.getStartTime()).isEqualTo(LocalDateTime.of(2026, 8, 27, 11, 0, 0));
+        assertThat(dto.getEndTime()).isEqualTo(LocalDateTime.of(2026, 8, 27, 12, 30, 0));
+    }
+
+    @Test
+    @DisplayName("rejects a UTC startTime instead of silently dropping the Z")
+    void rejectsOffsetBearingStartTime() {
+        String json = """
+                {"attendanceId":5,"movementType":"SITE_TRAVEL","fromLocation":"Site","purpose":"Vendor",\
+                "startTime":"2026-08-27T05:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, MovementRecordCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("rejects a UTC endTime instead of silently dropping the Z")
+    void rejectsOffsetBearingEndTime() {
+        String json = """
+                {"attendanceId":5,"movementType":"SITE_TRAVEL","fromLocation":"Site","purpose":"Vendor",\
+                "startTime":"2026-08-27T11:00:00","endTime":"2026-08-27T07:00:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, MovementRecordCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("a null endTime is still allowed, since a movement can be open")
+    void allowsNullEndTime() throws Exception {
+        String json = """
+                {"attendanceId":5,"movementType":"SITE_TRAVEL","fromLocation":"Site","purpose":"Vendor",\
+                "startTime":"2026-08-27T11:00:00"}""";
+
+        MovementRecordCreationDto dto = objectMapper.readValue(json, MovementRecordCreationDto.class);
+
+        assertThat(dto.getEndTime()).isNull();
+    }
+}


### PR DESCRIPTION
**Step 1 of 3**, same chain shape as the clock fix: this → tornotron/echno-core#45 + a release → an echno-web bump.
Follows tornotron/echno-backend#491. Sibling identified on tornotron/echno-core#41.

## What is wrong

`MovementRecordCreationDto` carries `startTime` and `endTime` into `java.time.LocalDateTime`, which has no offset. Jackson is lenient by default, so an offset-bearing value has its `Z` stripped and the UTC digits kept, and the recorded time is silently shifted by the caller's offset.

The frontend makes the intent unambiguous. `movement-log-form.tsx` binds both fields to a `datetime-local` input and passes `new Date(form.startTime)`, a local `Date`, which `createMovementToJson` then put through `.toISOString()`. So what the user typed was never what was stored.

## Severity, so this is sequenced honestly

Lower than the clock fields, and worth being explicit about rather than implying parity:

- `MovementRecordService:93` computes `durationMinutes` as `Duration.between(startTime, endTime)`. An offset cancels in a subtraction, so the duration was always right.
- Nothing derives a calendar date from either field the way `AttendanceService` derives `attendanceDate` from a punch, so no movement was ever filed on the wrong day.

What was wrong is the stored value itself and anything read from it. There is no corrupted derived flag here, which is why this was kept out of #491 rather than widening the fix for live corruption.

## The change

Same treatment as the clock fields, so the two read alike:

```java
@JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
private LocalDateTime startTime;
```

on both fields, with `@Schema` descriptions saying so, so the generated OpenAPI carries it. No pattern is supplied: without one the deserializer keeps `ISO_LOCAL_DATE_TIME`, so optional seconds and fractional seconds still parse, and `lenient = FALSE` only removes the branch that discards a trailing `Z`. `endTime` stays nullable, since a movement can be open.

## Verification

`MovementTimestampContractTest`, plain JUnit and a Jackson `ObjectMapper`, no Spring context, so nothing is added to the cached-context heap.

Against `development`, both rejection tests fail:

```
MovementTimestampContractTest > rejects a UTC startTime instead of silently dropping the Z FAILED
MovementTimestampContractTest > rejects a UTC endTime instead of silently dropping the Z FAILED
6 tests completed, 2 failed
```

With the change, all pass, and the wider attendance suite is unaffected:

```
./gradlew test --tests "*MovementTimestampContractTest" --tests "org.tornotron.echno_backend.attendance.*"
BUILD SUCCESSFUL in 1m 12s
```

## Compatibility

Same shape as #491: this rejects what the currently deployed frontend sends, so logging a movement returns 400 between deploying it and deploying the paired core release plus the web bump. Deploy the three together, as with the clock fix.