### PR TITLE
Stop the web project listing at ten rows without saying so

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -17,6 +17,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
@@ -80,28 +81,72 @@ public class ProjectControllerWeb {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addProject(dto, attachments));
     }
     /**
-     * Retrieves a paginated list of all projects.
+     * Lists the current tenant's projects as a bare array, capped rather than paged.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of projects per page (default is 10).
-     * @return A {@link ResponseEntity} containing the list of project DTOs and HTTP status 200 (OK).
+     * <p>This used to accept {@code pageNo} and {@code pageSize} defaulting to the first ten rows
+     * and then answer with {@code page.getContent()}, so a caller that passed no parameters, which
+     * is every caller the web client has, received ten projects and no indication that more
+     * existed. Most of those callers are project pickers in forms, so the effect was that a user
+     * could not select their own project unless it happened to hold one of the ten lowest ids, and
+     * the dropdown looked complete while doing it.
+     *
+     * <p>The parameters are gone rather than re-tuned: keeping them on an endpoint that discards
+     * the page envelope is what made the truncation silent. The read is bounded by
+     * {@link UnpagedResultCap} instead and never silently truncated. Every response carries the
+     * true row count in {@code X-Total-Count}, and one that did not fit also carries
+     * {@code X-Result-Capped}. A caller that needs to walk past the cap has
+     * {@link #readAllProjectsPaginated} for it.
+     *
+     * @return A {@link ResponseEntity} containing the project DTOs and the count headers.
      */
     @GetMapping()
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List projects",
-            description = "Returns a single page of projects. The pageNo and pageSize parameters "
-                    + "control paging; only the page content is returned, without paging metadata."
+            description = "Returns the current tenant's projects as a bare array, capped at 500 "
+                    + "rows. The response always carries the true total in X-Total-Count, and "
+                    + "carries X-Result-Capped when rows were left out, so a caller can tell a "
+                    + "complete result from a capped one. Use /paginated to page beyond the cap."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Projects returned, capped at 500 rows"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<List<ProjectDto>> readAllProjects() {
+        logger.info("All Projects Retrieved Successfully");
+        return UnpagedResultCap.respond(service.getAllProjects(0, UnpagedResultCap.MAX_ROWS));
+    }
+
+    /**
+     * Lists projects as a real {@link Page}, with the paging metadata intact.
+     *
+     * <p>The honest counterpart to {@link #readAllProjects}: a caller gets {@code totalElements},
+     * {@code totalPages} and the page index alongside the content, so a truncated result describes
+     * itself. Deliberately the same shape as {@code GET /tasks/web/paginated}; consistency between
+     * the two listings matters more than either choice would in isolation.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page, clamped to the result cap.
+     * @param search   Optional case-insensitive match on the project name.
+     * @return A {@link ResponseEntity} containing the page of project DTOs.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List projects, paginated and filtered",
+            description = "Returns a single page of projects with the paging metadata included, "
+                    + "optionally filtered by a free-text search on the project name. pageSize is "
+                    + "clamped to 500."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of projects returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<ProjectDto>> readAllProjects(@RequestParam(defaultValue = "0") int pageNo,
-                                                            @RequestParam(defaultValue = "10") int pageSize) {
-        Page<ProjectDto> projects = service.getAllProjects(pageNo,pageSize);
-        logger.info("All Projects Retrieved Successfully");
-        return new ResponseEntity<>(projects.getContent(),HttpStatus.OK);
+    public ResponseEntity<Page<ProjectDto>> readAllProjectsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(required = false) String search) {
+        return ResponseEntity.ok(service.getProjectsPaginated(pageNo, pageSize, search));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
@@ -2,7 +2,11 @@ package org.tornotron.echno_backend.project;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,4 +33,24 @@ public interface ProjectRepository extends JpaRepository<Project,Long> {
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 
     List<Project> findByEmployees_IdAndOrganization_Id(Long employeeId, Long organizationId);
+
+    /**
+     * Finds projects under an optional free-text filter, one page at a time.
+     *
+     * <p>A null search drops the clause, so the query serves the unfiltered listing as well as a
+     * searched one. The pattern is a pre-lowercased {@code %...%} LIKE built by the service, which
+     * escapes any wildcard the user typed; {@code ESCAPE '\'} is what makes that escaping take
+     * effect.
+     *
+     * <p>The tenant filter applies to this query exactly as it does to a derived finder.
+     *
+     * @param search   Optional lower-cased LIKE pattern for the project name.
+     * @param pageable The page to return.
+     * @return A page of matching projects.
+     */
+    @Query("""
+            SELECT p FROM Project p
+            WHERE :search IS NULL OR LOWER(p.projectName) LIKE :search ESCAPE '\\'
+            """)
+    Page<Project> search(@Param("search") String search, Pageable pageable);
 }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.compliance.IndianStateResolver;
@@ -146,6 +147,47 @@ public class ProjectService {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC,"id"));
         return repository.findAll(pageable)
                 .map(project -> projectMapper.toDto(project));
+    }
+
+    /**
+     * Retrieves a page of projects under an optional free-text filter.
+     *
+     * <p>Unlike {@link #getAllProjects(int, int)} the caller keeps the {@link Page}, so the total
+     * row count and the page index survive to the response and a truncated result says so. Newest
+     * first, because a project list is read from the recent end.
+     *
+     * @param pageNo   Zero-based page index; a negative value is treated as zero.
+     * @param pageSize Rows per page, clamped to {@link UnpagedResultCap#MAX_ROWS} so one request
+     *                 cannot re-create the unbounded read this endpoint exists to replace.
+     * @param search   Optional case-insensitive match on the project name; blank means none.
+     * @return A {@link Page} of project DTOs.
+     */
+    @Transactional(readOnly = true)
+    public Page<ProjectDto> getProjectsPaginated(int pageNo, int pageSize, String search) {
+        int page = Math.max(pageNo, 0);
+        int size = Math.clamp(pageSize, 1, UnpagedResultCap.MAX_ROWS);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        return repository.search(searchPattern(search), pageable)
+                .map(project -> projectMapper.toDto(project));
+    }
+
+    /**
+     * Builds a lower-cased {@code %...%} LIKE pattern for a search term, or null when there is no
+     * term to match on. Wildcards the user typed are escaped so a bare {@code %} matches a literal
+     * percent sign rather than every row.
+     *
+     * @param value The raw search term.
+     * @return The LIKE pattern, or null when the term is absent or blank.
+     */
+    private static String searchPattern(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String escaped = value.trim().toLowerCase()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return "%" + escaped + "%";
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
@@ -1,0 +1,169 @@
+package org.tornotron.echno_backend.project;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.project.dto.ProjectDto;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The listing behaviour of {@code GET /api/v1/project/web} and its paginated counterpart.
+ *
+ * <p>Guards the defect these tests were written for: the bare listing took a {@code pageSize} that
+ * defaulted to ten and then answered with {@code page.getContent()}, so a caller that passed no
+ * parameters received the ten lowest-id projects in the tenant. Every web caller passed no
+ * parameters, and most of them are project pickers in forms, so the effect was that a user could
+ * not select their own project unless it held one of those ten ids.
+ *
+ * <p>Deliberately the same tests as {@code TaskControllerWebListingTest}: the two listings share a
+ * fix, and they should fail the same way if either regresses.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectControllerWebListingTest {
+
+    @Mock
+    private ProjectService service;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ProjectControllerWeb controller;
+
+    private static List<ProjectDto> projects(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> {
+                    ProjectDto dto = new ProjectDto();
+                    dto.setId((long) i);
+                    dto.setProjectName("Project " + i);
+                    return dto;
+                })
+                .toList();
+    }
+
+    /**
+     * Stubs the service so it honours the page it was asked for, the way the repository does.
+     *
+     * <p>A stub that returns the whole list whatever page is requested would pass against the
+     * truncating controller too, which is exactly the blind spot that let the defect ship: the
+     * behaviour under test is the size of the page the handler asks for, so the stub has to be
+     * sensitive to it.
+     */
+    private void serviceHolding(int projectCount) {
+        List<ProjectDto> all = projects(projectCount);
+        when(service.getAllProjects(anyInt(), anyInt())).thenAnswer(invocation -> {
+            int pageNo = invocation.getArgument(0);
+            int pageSize = invocation.getArgument(1);
+            int from = Math.min(pageNo * pageSize, all.size());
+            int to = Math.min(from + pageSize, all.size());
+            return new PageImpl<>(all.subList(from, to), PageRequest.of(pageNo, pageSize), all.size());
+        });
+    }
+
+    @Test
+    void theBareListingDoesNotStopAtTheFirstTenProjects() {
+        serviceHolding(12);
+
+        ResponseEntity<List<ProjectDto>> response = controller.readAllProjects();
+
+        assertThat(response.getBody())
+                .as("a tenant with twelve projects must see twelve, not the first ten")
+                .hasSize(12);
+    }
+
+    @Test
+    void theBareListingReachesTheProjectsAPickerWouldOtherwiseNeverOffer() {
+        serviceHolding(400);
+
+        ResponseEntity<List<ProjectDto>> response = controller.readAllProjects();
+
+        assertThat(response.getBody())
+                .as("a form's project dropdown has to contain the project the user actually works on")
+                .hasSize(400)
+                .last()
+                .extracting(ProjectDto::getId)
+                .isEqualTo(400L);
+    }
+
+    @Test
+    void theBareListingAsksForTheResultCapRatherThanAPageOfTen() {
+        when(service.getAllProjects(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        controller.readAllProjects();
+
+        ArgumentCaptor<Integer> pageNo = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> pageSize = ArgumentCaptor.forClass(Integer.class);
+        verify(service).getAllProjects(pageNo.capture(), pageSize.capture());
+
+        assertThat(pageNo.getValue()).isZero();
+        assertThat(pageSize.getValue())
+                .as("the ten-row default is what made the truncation silent")
+                .isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void theBareListingReportsTheTrueTotalOnEveryResponse() {
+        serviceHolding(12);
+
+        ResponseEntity<List<ProjectDto>> response = controller.readAllProjects();
+
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("12");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER))
+                .as("a complete result must not claim to be capped")
+                .isNull();
+    }
+
+    @Test
+    void theBareListingSaysSoWhenRowsWereLeftOut() {
+        List<ProjectDto> capped = projects(UnpagedResultCap.MAX_ROWS);
+        when(service.getAllProjects(anyInt(), anyInt()))
+                .thenReturn(new PageImpl<>(capped, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), 900));
+
+        ResponseEntity<List<ProjectDto>> response = controller.readAllProjects();
+
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER))
+                .as("a truncated result must describe itself rather than look complete")
+                .isEqualTo("true");
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER)).isEqualTo("900");
+    }
+
+    @Test
+    void thePaginatedListingKeepsThePageEnvelope() {
+        Page<ProjectDto> page = new PageImpl<>(projects(20), PageRequest.of(1, 20), 137);
+        when(service.getProjectsPaginated(eq(1), eq(20), isNull())).thenReturn(page);
+
+        ResponseEntity<Page<ProjectDto>> response = controller.readAllProjectsPaginated(1, 20, null);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTotalElements()).isEqualTo(137);
+        assertThat(response.getBody().getNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void thePaginatedListingPassesTheSearchFilterThrough() {
+        when(service.getProjectsPaginated(anyInt(), anyInt(), any())).thenReturn(Page.empty());
+
+        controller.readAllProjectsPaginated(0, 20, "riverside");
+
+        verify(service).getProjectsPaginated(0, 20, "riverside");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectRepositoryIT.java
@@ -1,0 +1,107 @@
+package org.tornotron.echno_backend.project;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The paginated project search against a real CockroachDB (see {@link AbstractIntegrationTest}).
+ *
+ * <p>{@link ProjectServicePaginationTest} covers the clamping and the pattern building with a
+ * mocked repository, and by construction cannot catch anything about the query itself. This is
+ * written as JPQL, so a wrong field name or a mishandled {@code ESCAPE} clause is invisible until
+ * it runs against a database.
+ *
+ * <p>Carries the same {@code @DataJpaTest} configuration as the other repository integration tests,
+ * so it reuses their context rather than contributing another distinct one to the run's cache.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ProjectRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private static final PageRequest TEN = PageRequest.ofSize(10);
+
+    @Test
+    void aNullSearchReturnsEveryProjectAndAPatternNarrowsIt() {
+        Organization org = persistOrganization("Project Repo Org A");
+        persistProject(org, "Riverside Tower");
+        persistProject(org, "Hillside Block");
+        em.flush();
+        em.clear();
+
+        Page<Project> everything = projectRepository.search(null, TEN);
+        Page<Project> matching = projectRepository.search("%tower%", TEN);
+
+        assertThat(everything.getContent())
+                .as("a null search must drop its clause rather than match nothing")
+                .extracting(Project::getProjectName)
+                .contains("Riverside Tower", "Hillside Block");
+        assertThat(matching.getContent())
+                .extracting(Project::getProjectName)
+                .containsExactly("Riverside Tower");
+    }
+
+    @Test
+    void theResultIsBoundedByTheLimitAndTheTotalStillReportsEveryMatch() {
+        Organization org = persistOrganization("Project Repo Org B");
+        for (int i = 1; i <= 12; i++) {
+            persistProject(org, "Bounded project " + i);
+        }
+        em.flush();
+        em.clear();
+
+        Page<Project> page = projectRepository.search("%bounded%", PageRequest.ofSize(5));
+
+        assertThat(page.getContent()).hasSize(5);
+        assertThat(page.getTotalElements())
+                .as("the page envelope is the whole point: a short page must still say how many exist")
+                .isEqualTo(12);
+    }
+
+    @Test
+    void anEscapedWildcardMatchesItselfRatherThanEverything() {
+        Organization org = persistOrganization("Project Repo Org C");
+        persistProject(org, "Phase 100% complete");
+        persistProject(org, "Phase two");
+        em.flush();
+        em.clear();
+
+        Page<Project> page = projectRepository.search("%100\\%%", TEN);
+
+        assertThat(page.getContent())
+                .as("an unescaped per-cent sign would match every project")
+                .extracting(Project::getProjectName)
+                .containsExactly("Phase 100% complete");
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private void persistProject(Organization org, String name) {
+        Project project = new Project();
+        project.setProjectName(name);
+        project.setOrganization(org);
+        em.persist(project);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectServicePaginationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectServicePaginationTest.java
@@ -1,0 +1,133 @@
+package org.tornotron.echno_backend.project;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Paging and filter handling in {@link ProjectService#getProjectsPaginated}.
+ *
+ * <p>The endpoint this backs replaces a listing that silently truncated, so the two things worth
+ * pinning are that it cannot be talked into an unbounded read by a large {@code pageSize}, and that
+ * a wildcard in the search term matches a literal character rather than every row.
+ *
+ * <p>Only the collaborators this path touches are mocked. Mockito passes null for the rest of the
+ * constructor, which is accurate: nothing else is reachable from the method under test.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectServicePaginationTest {
+
+    @Mock
+    private ProjectRepository repository;
+
+    @Mock
+    private ProjectMapper projectMapper;
+
+    @InjectMocks
+    private ProjectService service;
+
+    private Pageable capturePageable() {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(repository).search(any(), pageable.capture());
+        return pageable.getValue();
+    }
+
+    private String captureSearchPattern() {
+        ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
+        verify(repository).search(pattern.capture(), any());
+        return pattern.getValue();
+    }
+
+    @Test
+    void aPageSizeAboveTheCapIsClampedToIt() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 100_000, null);
+
+        assertThat(capturePageable().getPageSize())
+                .as("one request must not be able to re-create the unbounded read")
+                .isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void aPageSizeOfZeroIsRaisedToOneRatherThanRejectedByPageRequest() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 0, null);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void aNegativePageIndexIsTreatedAsTheFirstPage() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(-3, 20, null);
+
+        assertThat(capturePageable().getPageNumber()).isZero();
+    }
+
+    @Test
+    void theListingIsOrderedNewestFirst() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 20, null);
+
+        assertThat(capturePageable().getSort().getOrderFor("id"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.DESC);
+    }
+
+    @Test
+    void aBlankSearchTermDropsTheSearchClauseRatherThanMatchingNothing() {
+        when(repository.search(isNull(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 20, "   ");
+
+        assertThat(captureSearchPattern()).isNull();
+    }
+
+    @Test
+    void aSearchTermIsLowerCasedAndWrappedForALikeMatch() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 20, "  Riverside  ");
+
+        assertThat(captureSearchPattern()).isEqualTo("%riverside%");
+    }
+
+    @Test
+    void aWildcardInTheSearchTermIsEscapedSoItMatchesItself() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 20, "100%");
+
+        assertThat(captureSearchPattern())
+                .as("an unescaped % would turn a search into a full listing")
+                .isEqualTo("%100\\%%");
+    }
+
+    @Test
+    void anUnderscoreInTheSearchTermIsEscapedSoItIsNotASingleCharacterWildcard() {
+        when(repository.search(any(), any())).thenReturn(Page.empty());
+
+        service.getProjectsPaginated(0, 20, "block_a");
+
+        assertThat(captureSearchPattern()).isEqualTo("%block\\_a%");
+    }
+}


### PR DESCRIPTION
Closes #503. Backend-only, no core or web change needed.

## The defect

`GET /api/v1/project/web` took `pageNo`/`pageSize` defaulting to ten, then answered with `page.getContent()`. Bare array, no total, no way to tell a complete result from a truncated one. echno-core's `projectService.getAll()` passes no parameters, so it always took the defaults.

Same defect as #478 on `/tasks/web`, found while fixing that one, and it lands worse. Most of the 20-odd `useProjects()` callers are **project pickers in forms**, not list pages: site transfers, purchase orders, material consumption, goods receipts, indents, materials, storage locations, labour, inspections, marking attendance, chat room creation, finance payments. A user whose project was not among the ten lowest ids could not select it, and the dropdown looked complete while doing it, so the failure read as the project not existing rather than as a bug.

It also compounds with tornotron/echno-web#269: a truncated project list caps what the command palette can find by name, on top of the palette's own client-side slice.

## What changed

Deliberately **the same shape #494 used on tasks**, because consistency between the two listings matters more than either choice would in isolation:

- the paging parameters are gone from the bare listing rather than re-tuned, since keeping them on an endpoint that discards the envelope is what made the truncation silent;
- the read is bounded by `UnpagedResultCap`, so the response stays a bare array and carries `X-Total-Count` always plus `X-Result-Capped` when rows were left out;
- `GET /project/web/paginated` is new and returns a real `Page<ProjectDto>`, optionally filtered by a free-text search on the name, with page size clamped to the same cap and LIKE wildcards escaped.

Because the bare array shape is unchanged, **every picker is fixed by this PR alone** with no core release and no web change.

No new unbounded read: the added repository query takes a `Pageable`, and the ArchUnit ratchet is untouched.

## Verification

Run on lab `.116` (Testcontainers needs Docker):

```
ProjectControllerWebListingTest    7 PASSED
ProjectServicePaginationTest       8 PASSED
ProjectRepositoryIT                3 PASSED
ProjectControllerWebAuthzTest      3 PASSED  (existing, unaffected)
ProjectCreationValidationTest      5 PASSED  (existing, unaffected)
EndpointAuthorizationTest          PASSED
UnboundedRepositoryReadTest        3 PASSED
BUILD SUCCESSFUL
```

Against the pre-fix controller body, five of the seven listing tests fail:

```
theBareListingDoesNotStopAtTheFirstTenProjects()            FAILED
theBareListingReachesTheProjectsAPickerWouldOtherwiseNeverOffer() FAILED
theBareListingAsksForTheResultCapRatherThanAPageOfTen()     FAILED
theBareListingReportsTheTrueTotalOnEveryResponse()          FAILED
theBareListingSaysSoWhenRowsWereLeftOut()                   FAILED
```

The two `/paginated` tests pass in that run only because the endpoint they exercise is still present; without this change it does not exist.

The stub honours the requested page size on purpose. A stub that ignores it passes against the truncating controller too, which is precisely the blind spot that let the original defect ship with a green suite.

`ProjectRepositoryIT` is new; there was none before. The paginated query is JPQL, so a wrong field name or a mishandled `ESCAPE` clause is invisible until it runs against a real database, which the mocked service test cannot catch by construction.