### PR TITLE
REVIEW ONLY, DO NOT MERGE: retro review of #479 (drop canned ACL from presigned uploads)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
@@ -104,6 +104,16 @@ public class FileStorageService {
      *
      * <p>The URL is write-only, limited to the single key it names, and expires.
      * The caller registers the object afterwards using the returned key.
+     *
+     * <p>No canned ACL is set here, deliberately. Every header on the request
+     * is folded into {@code X-Amz-SignedHeaders}, and SigV4 requires the client
+     * to send back each one byte-for-byte or the signature will not match. A
+     * browser PUT sends {@code Content-Type} and nothing else, so signing an
+     * {@code x-amz-acl} header made every direct upload fail on the signature.
+     * The bucket is private, so objects are private without the canned ACL; the
+     * server-side path in {@link #uploadFile} still sets it because it sends the
+     * header itself. Anything added to this request must be a header the client
+     * is known to send.
      */
     public PresignedUpload generateUploadUrl(String folder, String filename, String contentType, Duration expiry) {
         if (filename == null || filename.isBlank()) {
@@ -116,7 +126,6 @@ public class FileStorageService {
                 .bucket(bucketName)
                 .key(key)
                 .contentType(contentType)
-                .acl(ObjectCannedACL.PRIVATE)
                 .build();
 
         PresignedPutObjectRequest presignedRequest =

--- a/src/test/java/org/tornotron/echno_backend/common/service/FileStorageServicePresignTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/FileStorageServicePresignTest.java
@@ -1,0 +1,97 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Pins the header set a presigned upload URL commits the client to.
+ *
+ * <p>SigV4 folds every header on the signed request into
+ * {@code X-Amz-SignedHeaders}, and the client must reproduce each of them
+ * byte-for-byte or storage rejects the PUT as a signature mismatch. The browser
+ * uploads with {@code Content-Type} and nothing else, so a signed
+ * {@code x-amz-acl} broke every direct-to-storage attachment upload. These
+ * tests fail if a header the client does not send creeps back onto the request.
+ */
+class FileStorageServicePresignTest {
+
+    private S3Presigner presigner;
+    private FileStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        presigner = S3Presigner.builder()
+                .endpointOverride(URI.create("https://storage.example.test"))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("test-key-id", "test-secret-key")))
+                .build();
+
+        service = new FileStorageService(mock(S3Client.class), presigner);
+        ReflectionTestUtils.setField(service, "bucketName", "test-bucket");
+    }
+
+    @AfterEach
+    void tearDown() {
+        presigner.close();
+    }
+
+    @Test
+    void signsOnlyTheHeadersTheClientSends() {
+        PresignedUpload upload = service.generateUploadUrl(
+                "issue", "site-photo.png", "image/png", Duration.ofMinutes(15));
+
+        assertThat(signedHeadersOf(upload)).containsExactlyInAnyOrder("content-type", "host");
+    }
+
+    @Test
+    void doesNotSignACannedAcl() {
+        PresignedUpload upload = service.generateUploadUrl(
+                "issue", "site-photo.png", "image/png", Duration.ofMinutes(15));
+
+        assertThat(signedHeadersOf(upload)).doesNotContain("x-amz-acl");
+    }
+
+    @Test
+    void signsTheContentTypeItReportsBackToTheCaller() {
+        PresignedUpload upload = service.generateUploadUrl(
+                "issue", "drawing.pdf", "application/pdf", Duration.ofMinutes(15));
+
+        // The caller PUTs with exactly this value, so it has to be the signed one.
+        assertThat(upload.contentType()).isEqualTo("application/pdf");
+        assertThat(signedHeadersOf(upload)).contains("content-type");
+    }
+
+    /** Reads the lower-cased header names out of a presigned URL's query string. */
+    private static List<String> signedHeadersOf(PresignedUpload upload) {
+        Map<String, String> query = Arrays.stream(URI.create(upload.url()).getRawQuery().split("&"))
+                .map(pair -> pair.split("=", 2))
+                .collect(Collectors.toMap(
+                        pair -> URLDecoder.decode(pair[0], StandardCharsets.UTF_8),
+                        pair -> pair.length > 1 ? URLDecoder.decode(pair[1], StandardCharsets.UTF_8) : ""));
+
+        return Arrays.asList(query.getOrDefault("X-Amz-SignedHeaders", "").split(";"));
+    }
+}


### PR DESCRIPTION
Review-only replay of already merged PR #479. The tree is identical to merge commit 8cca566a69cc2c0c15fc13f26dff1043e174f079.

This exists solely so an automated review can run against the change, which was merged without one. It will never be merged and will be closed once the review lands.

Original PR: https://github.com/tornotron/echno-backend/pull/479