### PR TITLE
fix(task,project): save the dates the partial-update endpoints were ignoring

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/conversions/DateConversion.java
+++ b/src/main/java/org/tornotron/echno_backend/common/conversions/DateConversion.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Component
 public class DateConversion {
@@ -14,5 +15,46 @@ public class DateConversion {
         }
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm");
         return javaDate.format(formatter);
+    }
+
+    /**
+     * Reads a value from a partial-update map into a {@link LocalDateTime}.
+     *
+     * <p>The partial-update endpoints take a {@code Map<String, Object>} rather than a typed DTO,
+     * so the field annotations that pin the wire contract elsewhere do not apply and the parsing
+     * has to be done here. This keeps the two routes saying the same thing: the value is a local
+     * wall-clock time with no offset, and a value carrying one is rejected rather than truncated.
+     *
+     * <p>The truncation is the reason this exists. {@code DateTimeFormatter.ISO_DATE_TIME}, which
+     * these switches used, happily parses {@code "2026-08-27T03:30:00Z"} and then discards the
+     * offset on the way into a {@code LocalDateTime}, so the stored time is silently shifted by
+     * the caller's offset. {@code ISO_LOCAL_DATE_TIME} rejects it instead, while still accepting
+     * optional seconds and fractional seconds.
+     *
+     * @param value The raw map value: an ISO local date-time string, an already-typed
+     *              {@link LocalDateTime}, or null.
+     * @return The parsed value, or null when the caller is clearing the field.
+     * @throws IllegalArgumentException if the value is not a string, or carries a timezone offset,
+     *                                  or is not a valid ISO local date-time.
+     */
+    public static LocalDateTime parseLocalDateTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime;
+        }
+        if (!(value instanceof String text)) {
+            throw new IllegalArgumentException(
+                    "Expected a date-time string but got " + value.getClass().getSimpleName());
+        }
+        try {
+            return LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    "Expected a local date-time with no timezone offset, for example "
+                            + "2026-08-27T09:00:00, but got \"" + text + "\". A value carrying an "
+                            + "offset cannot be stored here without silently shifting the time.", e);
+        }
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -11,6 +11,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.conversions.DateConversion;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
 import org.tornotron.echno_backend.common.entity.Attachment;
@@ -263,6 +264,12 @@ public class ProjectService {
                                 ? project.getOrganization().getId() : null;
                         eventPublisher.publishEvent(new ProjectApprovedEvent(this, project.getId(), orgId));
                     }
+                    break;
+                case "startDate":
+                    project.setStartDate(DateConversion.parseLocalDateTime(value));
+                    break;
+                case "endDate":
+                    project.setEndDate(DateConversion.parseLocalDateTime(value));
                     break;
                 case "projectType":
                     project.setProjectType(value != null ? ProjectType.valueOf((String) value) : null);

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.task.mapper.TaskMapper;
 import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.conversions.DateConversion;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
@@ -32,7 +33,6 @@ import org.tornotron.echno_backend.task.dto.TaskSimpleDto;
 import org.tornotron.echno_backend.task.enums.TaskStatus;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -321,8 +321,11 @@ public class TaskService {
                 case "description":
                     task.setDescription((String) value);
                     break;
+                case "startDate":
+                    task.setStartDate(DateConversion.parseLocalDateTime(value));
+                    break;
                 case "endDate":
-                    task.setEndDate(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
+                    task.setEndDate(DateConversion.parseLocalDateTime(value));
                     break;
                 case "progress":
                     if (value == null) {

--- a/src/test/java/org/tornotron/echno_backend/common/conversions/DateConversionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/conversions/DateConversionTest.java
@@ -1,0 +1,75 @@
+package org.tornotron.echno_backend.common.conversions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link DateConversion#parseLocalDateTime} is the partial-update route's equivalent of the
+ * {@code @JsonFormat(lenient = FALSE)} that pins the typed DTOs. A partial update arrives as a
+ * {@code Map<String, Object>}, so no field annotation applies and the strictness has to live here.
+ *
+ * <p>No timezone pinning in this class, deliberately. The method converts a string to a
+ * {@link LocalDateTime} without consulting a clock or a zone, so there is nothing for a zone to
+ * change and pinning one would be ritual rather than coverage. The zone matters on the client,
+ * where the string is produced, and those tests pin it.
+ */
+class DateConversionTest {
+
+    @Test
+    @DisplayName("parses a local date-time")
+    void parsesLocalDateTime() {
+        assertThat(DateConversion.parseLocalDateTime("2026-08-27T09:00:00"))
+                .isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0, 0));
+    }
+
+    @Test
+    @DisplayName("accepts optional seconds and fractional seconds")
+    void acceptsOptionalPrecision() {
+        assertThat(DateConversion.parseLocalDateTime("2026-08-27T09:00"))
+                .isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0));
+        assertThat(DateConversion.parseLocalDateTime("2026-08-27T09:00:00.123"))
+                .isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0, 0, 123_000_000));
+    }
+
+    @Test
+    @DisplayName("rejects a UTC value rather than discarding the offset")
+    void rejectsUtcValue() {
+        assertThatThrownBy(() -> DateConversion.parseLocalDateTime("2026-08-27T03:30:00.000Z"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no timezone offset");
+    }
+
+    @Test
+    @DisplayName("rejects an explicit offset rather than discarding it")
+    void rejectsExplicitOffset() {
+        assertThatThrownBy(() -> DateConversion.parseLocalDateTime("2026-08-27T09:00:00+05:30"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no timezone offset");
+    }
+
+    @Test
+    @DisplayName("passes a null through so a field can be cleared")
+    void passesNullThrough() {
+        assertThat(DateConversion.parseLocalDateTime(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("passes an already-typed value through")
+    void passesTypedValueThrough() {
+        LocalDateTime value = LocalDateTime.of(2026, 8, 27, 9, 0);
+        assertThat(DateConversion.parseLocalDateTime(value)).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("rejects a value that is not a date-time string")
+    void rejectsNonString() {
+        assertThatThrownBy(() -> DateConversion.parseLocalDateTime(42))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected a date-time string");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectPartialUpdateDateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectPartialUpdateDateTest.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.project;
+
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Date handling in the project partial-update switch.
+ *
+ * <p>The switch handled ten keys and no dates at all, so a user editing a project's start or end
+ * date got a 200 and no change. The entity has had both columns throughout and the client has been
+ * sending them, which is the part that makes this a bug rather than a missing feature.
+ *
+ * <p>Plain Mockito, no Spring context, so this adds nothing to the cached-context heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectPartialUpdateDateTest {
+
+    @Mock private ProjectRepository repository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private ProjectMapper projectMapper;
+    @Mock private EmployeeMapper employeeMapper;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private Validator validator;
+
+    @InjectMocks private ProjectService service;
+
+    private Project updateWith(Map<String, Object> updates) {
+        Project project = new Project();
+        TenantContext.setCurrentOrgId(1L);
+        try {
+            when(repository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(project));
+            when(repository.save(any(Project.class))).thenAnswer(i -> i.getArgument(0));
+            service.partialUpdateAProject(updates, 12L, null, "PROJECT");
+        } finally {
+            TenantContext.clear();
+        }
+        return project;
+    }
+
+    @Test
+    @DisplayName("applies startDate, which the switch used to ignore entirely")
+    void appliesStartDate() {
+        Project project = updateWith(Map.of("startDate", "2026-08-27T09:00:00"));
+
+        assertThat(project.getStartDate()).isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0));
+    }
+
+    @Test
+    @DisplayName("applies endDate, which the switch used to ignore entirely")
+    void appliesEndDate() {
+        Project project = updateWith(Map.of("endDate", "2027-03-31T18:00:00"));
+
+        assertThat(project.getEndDate()).isEqualTo(LocalDateTime.of(2027, 3, 31, 18, 0));
+    }
+
+    @Test
+    @DisplayName("leaves the other fields it already handled alone")
+    void stillAppliesTheExistingFields() {
+        Project project = updateWith(Map.of(
+                "projectName", "Marina Towers",
+                "startDate", "2026-08-27T09:00:00"));
+
+        assertThat(project.getProjectName()).isEqualTo("Marina Towers");
+        assertThat(project.getStartDate()).isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0));
+    }
+
+    @Test
+    @DisplayName("rejects a UTC startDate rather than storing a shifted time")
+    void rejectsUtcStartDate() {
+        assertThatThrownBy(() -> updateWith(Map.of("startDate", "2026-08-27T03:30:00.000Z")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no timezone offset");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/task/TaskPartialUpdateDateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskPartialUpdateDateTest.java
@@ -1,0 +1,113 @@
+package org.tornotron.echno_backend.task;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Date handling in the task partial-update switch.
+ *
+ * <p>Two things are pinned. {@code startDate} is applied at all: the client has always sent it and
+ * the entity has always had the column, but the switch had no case for it, so a user setting a
+ * task's start date got a 200 and no change. And both dates reject an offset-bearing value rather
+ * than truncating it, which is what {@code ISO_DATE_TIME} was doing here.
+ *
+ * <p>Plain Mockito, no Spring context, so this adds nothing to the cached-context heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TaskPartialUpdateDateTest {
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private TaskMapper taskMapper;
+
+    @InjectMocks private TaskService service;
+
+    private Task updateWith(Map<String, Object> updates) {
+        // The task needs a project only because saving rolls task progress up to it; the
+        // roll-up is not what this class is about.
+        Project project = new Project();
+        project.setId(3L);
+        Task task = new Task();
+        task.setProject(project);
+
+        TenantContext.setCurrentOrgId(1L);
+        try {
+            when(taskRepository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(task));
+            when(taskRepository.save(any(Task.class))).thenAnswer(i -> i.getArgument(0));
+            when(taskRepository.findByProject_Id(any())).thenReturn(java.util.List.of());
+            service.partialUpdateATask(updates, 7L, null, "TASK");
+        } finally {
+            TenantContext.clear();
+        }
+        return task;
+    }
+
+    @Test
+    @DisplayName("applies startDate, which the switch used to ignore entirely")
+    void appliesStartDate() {
+        Task task = updateWith(Map.of("startDate", "2026-08-27T09:00:00"));
+
+        assertThat(task.getStartDate()).isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0));
+    }
+
+    @Test
+    @DisplayName("applies endDate")
+    void appliesEndDate() {
+        Task task = updateWith(Map.of("endDate", "2026-09-30T18:00:00"));
+
+        assertThat(task.getEndDate()).isEqualTo(LocalDateTime.of(2026, 9, 30, 18, 0));
+    }
+
+    @Test
+    @DisplayName("applies both dates together")
+    void appliesBothDates() {
+        Task task = updateWith(Map.of(
+                "startDate", "2026-08-27T09:00:00",
+                "endDate", "2026-09-30T18:00:00"));
+
+        assertThat(task.getStartDate()).isEqualTo(LocalDateTime.of(2026, 8, 27, 9, 0));
+        assertThat(task.getEndDate()).isEqualTo(LocalDateTime.of(2026, 9, 30, 18, 0));
+    }
+
+    @Test
+    @DisplayName("rejects a UTC startDate rather than storing a shifted time")
+    void rejectsUtcStartDate() {
+        assertThatThrownBy(() -> updateWith(Map.of("startDate", "2026-08-27T03:30:00.000Z")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no timezone offset");
+    }
+
+    @Test
+    @DisplayName("rejects a UTC endDate rather than storing a shifted time")
+    void rejectsUtcEndDate() {
+        assertThatThrownBy(() -> updateWith(Map.of("endDate", "2026-09-30T12:30:00.000Z")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no timezone offset");
+    }
+}


### PR DESCRIPTION
From the sibling table on tornotron/echno-core#46, filed there under "fields sent that no endpoint reads". **Backend only, no core release involved.**

## What is wrong

Two partial-update switches quietly drop dates the client sends:

- `TaskService.partialUpdateATask` handles `title`, `description`, `endDate`, `progress`, `status`, `tags`. There is **no case for `startDate`**.
- `ProjectService.partialUpdateAProject` handles ten keys and **no dates at all**.

Both entities have had `startDate` and `endDate` as `LocalDateTime` throughout, both appear on the create DTOs, and `updateTaskToJson` and `updateProjectToJson` have been sending them. So a user editing a task's start date or either of a project's dates gets a 200 and no change. A `switch` with no `default` is a silent sink for any key it does not name.

## Why fix rather than stop sending

This is the same shape as the attendance regularization bug: an input offered to the user, accepted by the API, then never applied. That was fixed by applying the value, not by removing the input, and the same reasoning holds. Deleting the fields from the serializers instead would leave the UI unable to set a column the entity has and the create path already populates.

It is a behaviour change, which is why it is on its own branch rather than folded into the DTO work. But it is a change in the direction of doing what both sides already believe is happening.

## The parsing had to move with it

A partial update arrives as a `Map<String, Object>`, so the `@JsonFormat(lenient = FALSE)` that pins the typed DTOs does not apply here and the strictness has to live in the switch.

The existing `endDate` case used `DateTimeFormatter.ISO_DATE_TIME`, which parses `"2026-08-27T03:30:00Z"` quite happily and then discards the offset on the way into a `LocalDateTime`. That is the same truncation as lenient Jackson, in code where it is easier to miss because it looks deliberate.

`DateConversion.parseLocalDateTime` replaces it, on `ISO_LOCAL_DATE_TIME`: optional seconds and fractional seconds still parse, an offset is rejected with a message saying why, null passes through so a field can still be cleared.

**One deviation from the agreed split, flagged rather than done quietly.** The plan put this hand-parse in the paired `@JsonFormat` PR. It is on the exact lines this PR edits, and adding `startDate` beside an `endDate` that still truncated would have left two conventions inside one switch. So it is fixed here. The other PR keeps only the DTO annotations.

## Verification

Both new test classes are plain Mockito with no Spring context, so nothing is added to the cached-context heap.

Against `development`, the task tests fail **4 of 5**, with `applies endDate` passing because that case always worked:

```
applies startDate, which the switch used to ignore entirely FAILED
applies both dates together                                 FAILED
rejects a UTC startDate rather than storing a shifted time  FAILED
rejects a UTC endDate rather than storing a shifted time    FAILED
applies endDate                                             PASSED
```

The project tests fail **4 of 4**, since no date case existed at all. With the change, all pass, alongside the existing pagination tests for both services:

```
./gradlew test --tests "*TaskPartialUpdateDateTest" --tests "*ProjectPartialUpdateDateTest" \
               --tests "*DateConversionTest" --tests "*TaskServicePaginationTest" \
               --tests "*ProjectServicePaginationTest"
BUILD SUCCESSFUL in 47s
```

The Testcontainers ITs were not run locally: there is no Docker daemon on this machine, so they fail on `DockerClientProviderStrategy` regardless of the change. CI covers them.

`DateConversionTest` deliberately does **not** pin a timezone, and says so in the class comment. The method turns a string into a `LocalDateTime` without consulting a clock or a zone, so there is nothing for a zone to change and pinning one would be ritual rather than coverage. The pinning belongs on the client, where the string is produced, and those tests have it.

## Related

Two more hand-parse sites of the same kind are left for the DTO PR, since they are not on lines this one touches: `EmployeeService:335` and `:358`, both on `ISO_DATE_TIME`.

Worth recording the counter-example: `UserService.parseDateOfBirth` uses a bare `LocalDateTime.parse`, which is `ISO_LOCAL_DATE_TIME` and already rejects an offset. It is fed by `formatDateForBackend`, which emits a naive string, so that path has been correct all along. It is the one place in this family that got it right, and it got it right by having both halves agree.
