### PR TITLE
Give indent items and purchase order items a page to ask for

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -79,6 +80,35 @@ public class IndentItemController {
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
         return UnpagedResultCap.respond(
                 indentItemService.getAllIndentItems(UnpagedResultCap.firstPage()));
+    }
+
+    /**
+     * Retrieves a page of indent items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing above. That one answers with the first
+     * {@link UnpagedResultCap#MAX_ROWS} rows and marks itself when it left some out, but gives a
+     * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
+     * {@code totalElements}, {@code totalPages} and the page index travel with the content.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page, clamped to the result cap.
+     * @return A {@link ResponseEntity} containing the page of indent items.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("hasAuthority('indent-item:read') or hasAuthority('indent-item:admin')")
+    @Operation(
+            summary = "List indent items, paginated",
+            description = "Returns a single page of indent items with the paging metadata included. "
+                    + "pageSize is clamped to 500."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
+    })
+    public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageNo, pageSize));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -75,6 +76,35 @@ public class IndentItemControllerWeb {
     public ResponseEntity<List<IndentItemDto>> getAllIndentItems() {
         return UnpagedResultCap.respond(
                 indentItemService.getAllIndentItems(UnpagedResultCap.firstPage()));
+    }
+
+    /**
+     * Retrieves a page of indent items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing above. That one answers with the first
+     * {@link UnpagedResultCap#MAX_ROWS} rows and marks itself when it left some out, but gives a
+     * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
+     * {@code totalElements}, {@code totalPages} and the page index travel with the content.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page, clamped to the result cap.
+     * @return A {@link ResponseEntity} containing the page of indent items.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List indent items, paginated",
+            description = "Returns a single page of indent items with the paging metadata included. "
+                    + "pageSize is clamped to 500."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of indent items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageNo, pageSize));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
@@ -2,8 +2,11 @@ package org.tornotron.echno_backend.indentItem;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -81,6 +84,30 @@ public class IndentItemService {
     public Page<IndentItemDto> getAllIndentItems(Pageable pageable) {
         return indentItemRepository.findAll(pageable)
                 .map(indentItem -> indentItemMapper.toDto(indentItem));
+    }
+
+    /**
+     * Retrieves a page of indent items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing, which answers with the first page and says so in
+     * its headers but gives a caller no way to ask for the next one. Here the {@link Page} reaches
+     * the response, so the total row count and the page index survive with it.
+     *
+     * <p>Ordered by id ascending. The capped listing asks for no sort at all, which is tolerable
+     * when there is only ever one page but not here: paging over an unordered result lets rows
+     * repeat on one page and vanish from another, so an explicit order is what makes the pages
+     * add up.
+     *
+     * @param pageNo   Zero-based page index; a negative value is treated as zero.
+     * @param pageSize Rows per page, clamped to {@link UnpagedResultCap#MAX_ROWS} so one request
+     *                 cannot re-create the unbounded read the cap exists to prevent.
+     * @return A page of indent item DTOs.
+     */
+    @Transactional(readOnly = true)
+    public Page<IndentItemDto> getIndentItemsPaginated(int pageNo, int pageSize) {
+        int page = Math.max(pageNo, 0);
+        int size = Math.clamp(pageSize, 1, UnpagedResultCap.MAX_ROWS);
+        return getAllIndentItems(PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id")));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -82,6 +83,35 @@ public class PurchaseOrderItemController {
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
         return UnpagedResultCap.respond(
                 purchaseOrderItemService.getAllPurchaseOrderItems(UnpagedResultCap.firstPage()));
+    }
+
+    /**
+     * Retrieves a page of purchase order items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing above. That one answers with the first
+     * {@link UnpagedResultCap#MAX_ROWS} rows and marks itself when it left some out, but gives a
+     * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
+     * {@code totalElements}, {@code totalPages} and the page index travel with the content.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page, clamped to the result cap.
+     * @return A {@link ResponseEntity} containing the page of purchase order items.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase order items, paginated",
+            description = "Returns a single page of purchase order items with the paging metadata included. "
+                    + "pageSize is clamped to 500."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageNo, pageSize));
     }
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
@@ -78,6 +79,35 @@ public class PurchaseOrderItemControllerWeb {
     public ResponseEntity<List<PurchaseOrderItemResponseDto>> getAllPurchaseOrderItems() {
         return UnpagedResultCap.respond(
                 purchaseOrderItemService.getAllPurchaseOrderItems(UnpagedResultCap.firstPage()));
+    }
+
+    /**
+     * Retrieves a page of purchase order items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing above. That one answers with the first
+     * {@link UnpagedResultCap#MAX_ROWS} rows and marks itself when it left some out, but gives a
+     * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
+     * {@code totalElements}, {@code totalPages} and the page index travel with the content.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page, clamped to the result cap.
+     * @return A {@link ResponseEntity} containing the page of purchase order items.
+     */
+    @GetMapping("/paginated")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List purchase order items, paginated",
+            description = "Returns a single page of purchase order items with the paging metadata included. "
+                    + "pageSize is clamped to 500."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of purchase order items returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageNo, pageSize));
     }
 
     @GetMapping("/purchase-order/{purchaseOrderId}")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
@@ -2,8 +2,11 @@ package org.tornotron.echno_backend.purchaseOrderItem;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -109,6 +112,31 @@ public class PurchaseOrderItemService {
     public Page<PurchaseOrderItemResponseDto> getAllPurchaseOrderItems(Pageable pageable) {
         return purchaseOrderItemRepository.findAll(pageable)
                 .map(this::convertToResponseDto);
+    }
+
+    /**
+     * Retrieves a page of purchase order items, chosen by the caller.
+     *
+     * <p>The counterpart to the capped listing, which answers with the first page and says so in
+     * its headers but gives a caller no way to ask for the next one. Here the {@link Page} reaches
+     * the response, so the total row count and the page index survive with it.
+     *
+     * <p>Ordered by id ascending. The capped listing asks for no sort at all, which is tolerable
+     * when there is only ever one page but not here: paging over an unordered result lets rows
+     * repeat on one page and vanish from another, so an explicit order is what makes the pages
+     * add up.
+     *
+     * @param pageNo   Zero-based page index; a negative value is treated as zero.
+     * @param pageSize Rows per page, clamped to {@link UnpagedResultCap#MAX_ROWS} so one request
+     *                 cannot re-create the unbounded read the cap exists to prevent.
+     * @return A page of purchase order item DTOs.
+     */
+    @Transactional(readOnly = true)
+    public Page<PurchaseOrderItemResponseDto> getPurchaseOrderItemsPaginated(int pageNo, int pageSize) {
+        int page = Math.max(pageNo, 0);
+        int size = Math.clamp(pageSize, 1, UnpagedResultCap.MAX_ROWS);
+        return getAllPurchaseOrderItems(
+                PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id")));
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/org/tornotron/echno_backend/indentItem/IndentItemServicePaginationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/indentItem/IndentItemServicePaginationTest.java
@@ -1,0 +1,100 @@
+package org.tornotron.echno_backend.indentItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.indent.IndentRepository;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.material.MaterialRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Paging in {@link IndentItemService#getIndentItemsPaginated}.
+ *
+ * <p>This is the route out of the cap, so the thing worth pinning is that it cannot become a way
+ * back around it: a caller asking for an enormous page gets the cap, not the whole table. The sort
+ * matters too, because paging an unordered result is what makes rows repeat on one page and go
+ * missing from another.
+ */
+@ExtendWith(MockitoExtension.class)
+class IndentItemServicePaginationTest {
+
+    @Mock
+    private IndentItemRepository indentItemRepository;
+
+    @Mock
+    private IndentRepository indentRepository;
+
+    @Mock
+    private MaterialRepository materialRepository;
+
+    @Mock
+    private TenantEntityHelper tenantEntityHelper;
+
+    @Mock
+    private IndentItemMapper indentItemMapper;
+
+    @InjectMocks
+    private IndentItemService service;
+
+    private Pageable capturePageable() {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(indentItemRepository).findAll(pageable.capture());
+        return pageable.getValue();
+    }
+
+    private void stubEmptyPage() {
+        when(indentItemRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
+    }
+
+    @Test
+    void clampsAPageSizeAboveTheCap() {
+        stubEmptyPage();
+
+        service.getIndentItemsPaginated(0, 100_000);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void clampsAPageSizeOfZeroUpToOneRow() {
+        stubEmptyPage();
+
+        service.getIndentItemsPaginated(0, 0);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void treatsANegativePageNumberAsTheFirstPage() {
+        stubEmptyPage();
+
+        service.getIndentItemsPaginated(-5, 20);
+
+        assertThat(capturePageable().getPageNumber()).isZero();
+    }
+
+    @Test
+    void ordersByIdSoThePagesAddUp() {
+        stubEmptyPage();
+
+        service.getIndentItemsPaginated(2, 20);
+
+        Pageable pageable = capturePageable();
+        assertThat(pageable.getSort()).isEqualTo(Sort.by(Sort.Direction.ASC, "id"));
+        assertThat(pageable.getPageNumber()).isEqualTo(2);
+        assertThat(pageable.getPageSize()).isEqualTo(20);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemServicePaginationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemServicePaginationTest.java
@@ -1,0 +1,104 @@
+package org.tornotron.echno_backend.purchaseOrderItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Paging in {@link PurchaseOrderItemService#getPurchaseOrderItemsPaginated}.
+ *
+ * <p>This is the route out of the cap, so the thing worth pinning is that it cannot become a way
+ * back around it: a caller asking for an enormous page gets the cap, not the whole table. The sort
+ * matters too, because paging an unordered result is what makes rows repeat on one page and go
+ * missing from another.
+ */
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderItemServicePaginationTest {
+
+    @Mock
+    private PurchaseOrderItemRepository purchaseOrderItemRepository;
+
+    @Mock
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Mock
+    private MaterialRepository materialRepository;
+
+    @Mock
+    private IndentItemRepository indentItemRepository;
+
+    @Mock
+    private TenantEntityHelper tenantEntityHelper;
+
+    @Mock
+    private PurchaseOrderService purchaseOrderService;
+
+    @InjectMocks
+    private PurchaseOrderItemService service;
+
+    private Pageable capturePageable() {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(purchaseOrderItemRepository).findAll(pageable.capture());
+        return pageable.getValue();
+    }
+
+    private void stubEmptyPage() {
+        when(purchaseOrderItemRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
+    }
+
+    @Test
+    void clampsAPageSizeAboveTheCap() {
+        stubEmptyPage();
+
+        service.getPurchaseOrderItemsPaginated(0, 100_000);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void clampsAPageSizeOfZeroUpToOneRow() {
+        stubEmptyPage();
+
+        service.getPurchaseOrderItemsPaginated(0, 0);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void treatsANegativePageNumberAsTheFirstPage() {
+        stubEmptyPage();
+
+        service.getPurchaseOrderItemsPaginated(-5, 20);
+
+        assertThat(capturePageable().getPageNumber()).isZero();
+    }
+
+    @Test
+    void ordersByIdSoThePagesAddUp() {
+        stubEmptyPage();
+
+        service.getPurchaseOrderItemsPaginated(2, 20);
+
+        Pageable pageable = capturePageable();
+        assertThat(pageable.getSort()).isEqualTo(Sort.by(Sort.Direction.ASC, "id"));
+        assertThat(pageable.getPageNumber()).isEqualTo(2);
+        assertThat(pageable.getPageSize()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
Closes #511.

## The gap

#483 capped the unpaginated list reads at 500 rows. That was the right call, and for most of what it touched it was safe because nineteen of the twenty-six endpoints already had a paginated sibling on the same controller: a caller who needed more had somewhere to go.

Indent items and purchase order items did not. Their only other list routes filter by parent indent, purchase order or material, so for a tenant holding more than 500 rows the rest were unreachable through the API unless you already knew which parent to ask about. The cap had quietly become the ceiling on what these endpoints could ever return.

The capped listing was already honest about it. `X-Total-Count` carries the true figure and `X-Result-Capped` marks a response that left rows out, and the OpenAPI description has been telling callers to "use the paginated variant for a complete result" since #483. There was no paginated variant.

## The change

`GET /paginated` on all four controllers, mobile and web, taking `pageNo` and `pageSize` and returning the `Page` so `totalElements`, `totalPages` and the page index reach the response with the content. This is the same shape `TaskControllerWeb` and `ProjectControllerWeb` already use, so nothing new is being invented here.

The services already had the paginated read, added by #483, but it was only ever called with `UnpagedResultCap.firstPage()`. The capability existed and nothing exposed it.

Two decisions worth stating:

- **`pageSize` is clamped in the service, not the controller.** The route out of the cap must not become a route around it, so a caller asking for a hundred thousand rows gets 500. Clamping where the `Pageable` is built means a future caller of the service inherits it too.
- **Ordered by id ascending.** The capped listing asks for no sort at all. That is tolerable when there is only ever one page, and not tolerable once pages have to add up, because paging an unordered result lets rows repeat on one page and vanish from another.

## Nothing that reads these endpoints today changes

Checked before touching anything, since the response shape is the sensitive part.

`echno-core` publishes `indentItemsService.list()`, which calls `GET /indent-items/web`, along with a `useIndentItems` hook over it. No `echno-web` screen calls that hook, so there is no live consumer, but the shape does have a consumer in the published client library. Worth recording, because #483 described these as endpoints "neither echno-core nor echno-web reads today", and for indent items that was not quite right.

For purchase order items, core has no bare-list method at all, only by id, by purchase order and by material.

Either way the bare listings are untouched here. This PR only adds routes.

## Verification

Built and tested on the lab box, not the laptop.

- `./gradlew compileJava compileTestJava`: BUILD SUCCESSFUL
- The eight new tests pass. They pin the two things that make this safe: that an enormous `pageSize` comes back clamped to the cap, and that the sort is explicit.

```
IndentItemServicePaginationTest > clampsAPageSizeAboveTheCap() PASSED
IndentItemServicePaginationTest > clampsAPageSizeOfZeroUpToOneRow() PASSED
IndentItemServicePaginationTest > treatsANegativePageNumberAsTheFirstPage() PASSED
IndentItemServicePaginationTest > ordersByIdSoThePagesAddUp() PASSED
PurchaseOrderItemServicePaginationTest > clampsAPageSizeAboveTheCap() PASSED
PurchaseOrderItemServicePaginationTest > clampsAPageSizeOfZeroUpToOneRow() PASSED
PurchaseOrderItemServicePaginationTest > treatsANegativePageNumberAsTheFirstPage() PASSED
PurchaseOrderItemServicePaginationTest > ordersByIdSoThePagesAddUp() PASSED
```

Both are plain Mockito tests with no Spring context, so they add nothing to the shared test JVM's context cache.

Two existing ArchUnit guards also ran and passed, which is the useful part: `EndpointAuthorizationTest > everyControllerEndpointHasAnAuthorizationGuard` confirms all four new endpoints carry a guard, and `UnboundedRepositoryReadTest > noProductionClassReadsAWholeTable` confirms nothing here reintroduced a whole-table read. Each new route repeats the authorization its controller's existing listing uses: the org role for three of them, and the `indent-item:read` or `indent-item:admin` authority on the indent-item mobile controller.

## Note on review

CodeRabbit is rate limited, so expect no automated review on this one. The finding it is fixing came from a retrospective review of #483.
