### PR TITLE
Take the compliance model call out of the transaction

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
@@ -4,22 +4,41 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
-import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
 import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
 
 /**
  * Runs AI compliance generation when a project is approved. It fires only AFTER the
  * approving transaction commits (so the project row is durable) and on a separate
  * async thread (so the slow AI call never blocks the approving request). That async
- * thread has no {@link TenantContext}, so the organization id is read from the event
- * and set on the thread for the duration of the tenant-scoped work, then cleared.
+ * thread has no tenant context, so the organization id is read from the event and
+ * established for the duration of the work by {@link TenantScopedJobRunner}.
+ *
+ * <h2>Why this listener owns no transaction</h2>
+ *
+ * <p>It used to be {@code @Transactional(REQUIRES_NEW)} and set the tenant context inside
+ * the method body. That was wrong in two ways.
+ *
+ * <p>The transaction interceptor is pinned at {@code HIGHEST_PRECEDENCE} and
+ * {@code HibernateFilterConfig} sits at {@code LOWEST_PRECEDENCE}, so the order on entry
+ * was: open the transaction, run the filter aspect, run the body. The aspect read the
+ * tenant context one step before the body set it, saw null, and never enabled
+ * {@code orgFilter} for that transaction. The filter came on later only as a side effect
+ * of the inner service call firing the same aspect on the already-open session, which is
+ * an ordering accident rather than a design, and one that both isolation mechanisms would
+ * have failed open on had it stopped holding.
+ *
+ * <p>The transaction also spanned the external model call, so the approval path pinned a
+ * pool connection for its full 34 to 47 seconds. Being {@code @Async} moved the wait off
+ * the request thread; it did nothing about the connection.
+ *
+ * <p>So the listener now does what a listener should: establish the tenant, delegate, and
+ * let {@link ComplianceGenerationService} own its own transaction boundaries.
  */
 @Slf4j
 @Component
@@ -27,9 +46,9 @@ import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
 public class ComplianceGenerationListener {
 
     private final ComplianceGenerationService complianceGenerationService;
+    private final TenantScopedJobRunner tenantScopedJobRunner;
 
     @Async
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onProjectApproved(ProjectApprovedEvent event) {
         Long projectId = event.getProjectId();
@@ -42,8 +61,8 @@ public class ComplianceGenerationListener {
 
         log.info("Project {} approved; generating compliance inspections for organization {}", projectId, orgId);
         try {
-            TenantContext.setCurrentOrgId(orgId);
-            complianceGenerationService.generateForProject(projectId, orgId);
+            tenantScopedJobRunner.runForTenant(orgId,
+                    () -> complianceGenerationService.generateForProject(projectId, orgId));
         } catch (InvalidRequestException | ResourceNotFoundException e) {
             // Expected on auto-approval: a project approved without a state in its address, or
             // before any rules exist for its jurisdiction, is normal. Log quietly and move on;
@@ -52,8 +71,6 @@ public class ComplianceGenerationListener {
         } catch (Exception e) {
             log.error("Compliance generation failed for project {} in organization {}: {}",
                     projectId, orgId, e.getMessage(), e);
-        } finally {
-            TenantContext.clear();
         }
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunner.java
@@ -1,0 +1,90 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
+
+import java.util.function.Supplier;
+
+/**
+ * Runs a block of work under an explicit tenant, and restores whatever tenant state was
+ * there before. This is the entry point for anything that executes outside a request:
+ * event listeners, scheduled tasks, queue workers.
+ *
+ * <p>It exists because both tenant-isolation mechanisms fail <em>open</em> on a missing
+ * tenant context, so forgetting to set one is silent rather than loud:
+ *
+ * <ul>
+ *   <li>{@link HibernateFilterConfig} enables the {@code orgFilter} only when
+ *       {@link TenantContext#getCurrentOrgId()} is non-null. With no org id it logs at
+ *       debug and lets the transaction run unfiltered.</li>
+ *   <li>{@link TenantIsolationLoadListener} returns early on the same condition, so the
+ *       load-boundary check that exists to catch what the filter misses shares the
+ *       filter's blind spot exactly.</li>
+ * </ul>
+ *
+ * <p>Background work that skipped the context would therefore read every organization's
+ * rows and look entirely healthy doing it. {@link #callForTenant} refuses a null org id
+ * instead, which turns that silent leak into a failure at the call site. The wider problem
+ * is tracked separately; this is the local answer for work we own.
+ *
+ * <p>{@link TenantContext} is backed by {@link ThreadLocal}s, so two further things matter
+ * on a pooled thread and both are handled here. The context is restored in a
+ * {@code finally}, so an org id cannot leak into whatever task the executor runs next on
+ * that thread. And the bypass flag is forced off for the duration, so a leaked bypass from
+ * an earlier task cannot silently widen this job's reach.
+ *
+ * <p>Set and restore rather than set and clear: this is safe to call on a request thread,
+ * where clearing would discard the context {@code TenantFilter} established for the
+ * request. Where there was no previous context, restoring removes the thread-locals
+ * entirely.
+ *
+ * @see org.tornotron.echno_backend.common.retry.TransactionalWorkRunner the
+ *      transaction-boundary counterpart, which is what keeps {@code orgFilter} enabled
+ *      once the context is in place
+ */
+@Slf4j
+@Component
+public class TenantScopedJobRunner {
+
+    /**
+     * Runs {@code work} with the tenant context pinned to {@code orgId} and returns its
+     * result.
+     *
+     * @param orgId the organization the work belongs to; read from durable state such as a
+     *              job row or an event payload, never inferred from the ambient thread
+     * @throws TenantIdMissingException if {@code orgId} is null, rather than running the
+     *                                  work unscoped
+     */
+    public <T> T callForTenant(Long orgId, Supplier<T> work) {
+        if (orgId == null) {
+            throw new TenantIdMissingException(
+                    "Background work requires an explicit organization id; refusing to run with no tenant context");
+        }
+
+        Long previousOrgId = TenantContext.getCurrentOrgId();
+        boolean previousBypass = TenantContext.isBypassed();
+
+        TenantContext.setCurrentOrgId(orgId);
+        TenantContext.setBypass(false);
+        try {
+            return work.get();
+        } finally {
+            TenantContext.clear();
+            if (previousOrgId != null) {
+                TenantContext.setCurrentOrgId(previousOrgId);
+            }
+            if (previousBypass) {
+                TenantContext.setBypass(true);
+            }
+        }
+    }
+
+    /** {@link #callForTenant} for work that returns nothing. */
+    public void runForTenant(Long orgId, Runnable work) {
+        callForTenant(orgId, () -> {
+            work.run();
+            return null;
+        });
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -3,11 +3,11 @@ package org.tornotron.echno_backend.compliance;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
@@ -43,6 +43,27 @@ import java.util.stream.Collectors;
  * is skipped, so a re-run (the manual regenerate endpoint, or a repeated approval)
  * only adds compliances that are missing. The document number series is shared with
  * manual inspections ({@code INSP}).
+ *
+ * <h2>Why this class owns no transaction of its own</h2>
+ *
+ * <p>The model call takes 34 to 47 seconds today and grows with the size of the curated
+ * rule set. Running it inside a transaction pinned one of twenty pool connections for
+ * that whole time while doing nothing but waiting on a third party, so a handful of
+ * concurrent users could exhaust the pool. {@link #generateForProject} is therefore
+ * three phases: read the inputs in one transaction, call the model with no transaction
+ * and no connection held, then persist in a second transaction.
+ *
+ * <p>Both transactions are opened by calling {@link TransactionalWorkRunner}, and that
+ * choice is load bearing rather than stylistic. {@code HibernateFilterConfig} advises
+ * {@code @Transactional} methods in this package tree to enable the {@code orgFilter}
+ * tenant filter on the session. A programmatic {@code TransactionTemplate} carries no
+ * such annotation, so splitting the boundary that way would have run both phases with
+ * tenant filtering off, and (because that filter fails open rather than closed) would
+ * have done so silently.
+ *
+ * <p>The corollary is that the caller must have a tenant context on the thread before
+ * calling in. Request threads get one from {@code TenantFilter}; background callers must
+ * go through {@code TenantScopedJobRunner}.
  */
 @Slf4j
 @Service
@@ -58,6 +79,18 @@ public class ComplianceGenerationService {
     private final EntryNumberGenerator numberGen;
     private final TenantEntityHelper tenantEntityHelper;
     private final InspectionMapper inspectionMapper;
+    private final TransactionalWorkRunner workRunner;
+
+    /**
+     * What the read phase hands to the phases after it. The entities are detached once the
+     * read transaction closes, which is safe here because every field the model call and
+     * the write phase go on to read is a basic column loaded eagerly with the row: the
+     * project's name, type and address, and each rule's code, name, phase, default risk,
+     * description, authority and resolution options. Nothing in here is dereferenced
+     * through a lazy association, and nothing may start being, or it will fail outside a
+     * session.
+     */
+    private record GenerationInputs(Project project, String state, List<ComplianceRule> candidateRules) {}
 
     /**
      * Generates the missing compliance inspections for a project. Returns the DTOs of
@@ -71,11 +104,39 @@ public class ComplianceGenerationService {
      * no recognisable state, no rules registered for that jurisdiction, or an
      * unconfigured AI service each raise {@link InvalidRequestException} (400).
      *
+     * <p>Runs in three phases so the model call holds no database connection; see the class
+     * javadoc for why the boundaries are drawn where they are.
+     *
      * @param projectId the project to generate for
      * @param orgId     the owning organization; must match the current tenant context
      */
-    @Transactional
     public List<InspectionDto> generateForProject(Long projectId, Long orgId) {
+        GenerationInputs inputs = workRunner.runInTransaction(() -> loadInputs(projectId, orgId));
+
+        // Outside any transaction: this is the 34 to 47 second call, and it must not be
+        // holding a pool connection while it waits.
+        List<ComplianceSuggestion> suggestions = complianceAiService.suggestCompliances(
+                inputs.project(), inputs.state(), inputs.candidateRules());
+
+        if (suggestions.isEmpty()) {
+            if (!complianceAiService.isConfigured()) {
+                throw new InvalidRequestException(
+                        "The compliance AI service is not configured, so suggestions cannot be "
+                                + "generated. Set the compliance AI key and try again.");
+            }
+            log.info("Compliance AI returned no suggestions for project {}", projectId);
+            return List.of();
+        }
+
+        return workRunner.runInTransaction(() -> persist(projectId, orgId, inputs, suggestions));
+    }
+
+    /**
+     * Read phase. Resolves the project, its jurisdiction and the candidate rules, and
+     * raises the precondition failures so the caller can tell the user what to fix before
+     * anything slow happens.
+     */
+    private GenerationInputs loadInputs(Long projectId, Long orgId) {
         Project project = projectRepository.findByIdAndOrganization_Id(projectId, orgId).orElse(null);
         if (project == null) {
             throw new ResourceNotFoundException(
@@ -111,19 +172,20 @@ public class ComplianceGenerationService {
                             + "are added, generation will produce results.");
         }
 
-        List<ComplianceSuggestion> suggestions =
-                complianceAiService.suggestCompliances(project, state, candidateRules);
-        if (suggestions.isEmpty()) {
-            if (!complianceAiService.isConfigured()) {
-                throw new InvalidRequestException(
-                        "The compliance AI service is not configured, so suggestions cannot be "
-                                + "generated. Set the compliance AI key and try again.");
-            }
-            log.info("Compliance AI returned no suggestions for project {}", projectId);
-            return List.of();
-        }
+        return new GenerationInputs(project, state, candidateRules);
+    }
 
-        Map<String, ComplianceRule> rulesByCode = candidateRules.stream()
+    /**
+     * Write phase. Materialises each "applies" decision that does not already have an
+     * inspection. The document-number sequence is locked here, inside the second
+     * transaction, so it is held for the length of a few inserts rather than the length of
+     * the model call.
+     */
+    private List<InspectionDto> persist(Long projectId,
+                                        Long orgId,
+                                        GenerationInputs inputs,
+                                        List<ComplianceSuggestion> suggestions) {
+        Map<String, ComplianceRule> rulesByCode = inputs.candidateRules().stream()
                 .collect(Collectors.toMap(ComplianceRule::getCode, Function.identity(), (a, b) -> a));
 
         Organization organization = tenantEntityHelper.resolveCurrentOrganization();
@@ -168,7 +230,7 @@ public class ComplianceGenerationService {
         }
 
         log.info("Generated {} compliance inspection(s) for project {} (state '{}', type {})",
-                created.size(), projectId, state, projectType);
+                created.size(), projectId, inputs.state(), inputs.project().getProjectType());
         return created;
     }
 

--- a/src/test/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListenerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListenerTest.java
@@ -1,0 +1,115 @@
+package org.tornotron.echno_backend.common.events.listeners;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The approval path runs on a pooled async thread with no request behind it, so what
+ * matters here is that the tenant is established from the event before any work happens,
+ * and that the listener owns no transaction of its own.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceGenerationListenerTest {
+
+    private static final Long PROJECT_ID = 42L;
+    private static final Long ORG_ID = 7L;
+
+    @Mock
+    private ComplianceGenerationService complianceGenerationService;
+    @Mock
+    private TenantScopedJobRunner tenantScopedJobRunner;
+
+    @InjectMocks
+    private ComplianceGenerationListener listener;
+
+    /** Makes the mocked runner behave like the real one for the duration of a call. */
+    private void runInline() {
+        doAnswer(invocation -> {
+            Long orgId = invocation.getArgument(0);
+            TenantContext.setCurrentOrgId(orgId);
+            try {
+                invocation.getArgument(1, Runnable.class).run();
+            } finally {
+                TenantContext.clear();
+            }
+            return null;
+        }).when(tenantScopedJobRunner).runForTenant(anyLong(), any(Runnable.class));
+    }
+
+    @Test
+    void establishesTheTenantFromTheEventBeforeGenerating() {
+        runInline();
+        AtomicReference<Long> tenantDuringWork = new AtomicReference<>();
+        when(complianceGenerationService.generateForProject(PROJECT_ID, ORG_ID))
+                .thenAnswer(invocation -> {
+                    tenantDuringWork.set(TenantContext.getCurrentOrgId());
+                    return java.util.List.of();
+                });
+
+        listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, ORG_ID));
+
+        verify(tenantScopedJobRunner).runForTenant(eq(ORG_ID), any(Runnable.class));
+        assertThat(tenantDuringWork.get())
+                .as("generation must run with the event's organization on the thread")
+                .isEqualTo(ORG_ID);
+    }
+
+    @Test
+    void eventWithNoOrganization_generatesNothing() {
+        listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, null));
+
+        verify(complianceGenerationService, never()).generateForProject(anyLong(), any());
+        verify(tenantScopedJobRunner, never()).runForTenant(any(), any(Runnable.class));
+    }
+
+    @Test
+    void unmetPrecondition_isSwallowedSoApprovalIsNotDisturbed() {
+        runInline();
+        when(complianceGenerationService.generateForProject(PROJECT_ID, ORG_ID))
+                .thenThrow(new InvalidRequestException("no rules for this jurisdiction yet"));
+
+        assertThatCode(() -> listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, ORG_ID)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void listenerOwnsNoTransaction() throws Exception {
+        Method method = ComplianceGenerationListener.class
+                .getMethod("onProjectApproved", ProjectApprovedEvent.class);
+
+        assertThat(method.getAnnotation(Transactional.class))
+                .as("""
+                        A @Transactional here re-creates the defect this listener was fixed for. \
+                        The transaction interceptor is pinned at HIGHEST_PRECEDENCE and \
+                        HibernateFilterConfig at LOWEST_PRECEDENCE, so the filter aspect reads the \
+                        tenant context before the body can set it, sees null, and never enables \
+                        orgFilter for the transaction. It would also hold a pool connection across \
+                        the whole external model call.""")
+                .isNull();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunnerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunnerTest.java
@@ -1,0 +1,92 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The behaviour these tests pin down is what stands between background work and a silent
+ * cross-tenant read. Both isolation mechanisms fail open on a missing tenant context, so
+ * the runner has to refuse a null org id loudly, and it has to put the thread back the way
+ * it found it whatever the work does, because the threads it runs on are pooled.
+ */
+class TenantScopedJobRunnerTest {
+
+    private static final Long ORG_ID = 7L;
+    private static final Long OTHER_ORG_ID = 9L;
+
+    private final TenantScopedJobRunner runner = new TenantScopedJobRunner();
+
+    @AfterEach
+    void clearContext() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void setsTheTenantForTheDurationOfTheWork() {
+        AtomicReference<Long> seen = new AtomicReference<>();
+
+        runner.runForTenant(ORG_ID, () -> seen.set(TenantContext.getCurrentOrgId()));
+
+        assertThat(seen.get()).isEqualTo(ORG_ID);
+    }
+
+    @Test
+    void returnsTheResultOfTheWork() {
+        assertThat(runner.callForTenant(ORG_ID, () -> "done")).isEqualTo("done");
+    }
+
+    @Test
+    void nullOrgId_refusesRatherThanRunningUnscoped() {
+        AtomicReference<Boolean> ran = new AtomicReference<>(false);
+
+        assertThatThrownBy(() -> runner.runForTenant(null, () -> ran.set(true)))
+                .isInstanceOf(TenantIdMissingException.class)
+                .hasMessageContaining("explicit organization id");
+
+        assertThat(ran.get()).isFalse();
+    }
+
+    @Test
+    void clearsTheContextAfterwardsSoItCannotLeakToTheNextTaskOnAPooledThread() {
+        runner.runForTenant(ORG_ID, () -> {});
+
+        assertThat(TenantContext.getCurrentOrgId()).isNull();
+        assertThat(TenantContext.isBypassed()).isFalse();
+    }
+
+    @Test
+    void clearsTheContextEvenWhenTheWorkThrows() {
+        assertThatThrownBy(() -> runner.runForTenant(ORG_ID, () -> {
+            throw new IllegalStateException("boom");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(TenantContext.getCurrentOrgId()).isNull();
+    }
+
+    @Test
+    void restoresAPreExistingContextRatherThanClearingIt() {
+        TenantContext.setCurrentOrgId(OTHER_ORG_ID);
+
+        runner.runForTenant(ORG_ID, () ->
+                assertThat(TenantContext.getCurrentOrgId()).isEqualTo(ORG_ID));
+
+        assertThat(TenantContext.getCurrentOrgId()).isEqualTo(OTHER_ORG_ID);
+    }
+
+    @Test
+    void forcesBypassOffForTheWorkAndRestoresIt() {
+        TenantContext.setBypass(true);
+        AtomicReference<Boolean> bypassedDuringWork = new AtomicReference<>();
+
+        runner.runForTenant(ORG_ID, () -> bypassedDuringWork.set(TenantContext.isBypassed()));
+
+        assertThat(bypassedDuringWork.get()).isFalse();
+        assertThat(TenantContext.isBypassed()).isTrue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.when;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ComplianceGenerationService.class, InspectionMapperImpl.class,
-        TenantEntityHelper.class, EntryNumberGenerator.class})
+        TenantEntityHelper.class, EntryNumberGenerator.class, TransactionalWorkRunner.class})
 class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
 
     private static final String RULE_PRE = "TN-BPA";        // pre-construction

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
@@ -1,7 +1,10 @@
 package org.tornotron.echno_backend.compliance;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -9,6 +12,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
@@ -16,9 +20,12 @@ import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.project.enums.ProjectType;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,9 +59,22 @@ class ComplianceGenerationServiceTest {
     private TenantEntityHelper tenantEntityHelper;
     @Mock
     private InspectionMapper inspectionMapper;
+    @Mock
+    private TransactionalWorkRunner workRunner;
 
     @InjectMocks
     private ComplianceGenerationService service;
+
+    /**
+     * The runner is the transaction boundary in production; here it only has to run the
+     * block it is handed, so the phase split is exercised without a database. Every test
+     * reaches at least the read phase, so this stub is always used.
+     */
+    @BeforeEach
+    void runWorkInline() {
+        when(workRunner.runInTransaction(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+    }
 
     private Project project(ProjectType type, String address) {
         Project project = new Project();
@@ -151,6 +171,22 @@ class ComplianceGenerationServiceTest {
         assertThatThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
                 .isInstanceOf(InvalidRequestException.class)
                 .hasMessageContaining("AI service is not configured");
+    }
+
+    /**
+     * The orchestrator must hold no transaction of its own, because its middle phase is an
+     * external model call measured at 34 to 47 seconds. A {@code @Transactional} here would
+     * put that call back inside a transaction and pin one of twenty pool connections for
+     * its duration. The two transactions belong to the read and write phases, which reach
+     * them through {@code TransactionalWorkRunner}.
+     */
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void orchestratorOwnsNoTransaction() throws Exception {
+        Method method = ComplianceGenerationService.class
+                .getMethod("generateForProject", Long.class, Long.class);
+
+        assertThat(method.getAnnotation(Transactional.class)).isNull();
     }
 
     @Test


### PR DESCRIPTION
Stage 1 of the #482 plan. Fixes #508, and adds the local containment for #507.

## The problem

`ComplianceGenerationService.generateForProject` was `@Transactional` across the whole external model call. That call is 34 to 47 seconds today and grows at roughly 2.5 s per curated rule, so every click pinned one of twenty pool connections for its duration while doing nothing but waiting on a third party. A handful of concurrent users would exhaust the pool.

Moving that boundary is not a free refactor. `HibernateFilterConfig` advises `@Transactional` methods in this package tree to enable the `orgFilter` tenant filter on the session, so the transaction annotation and the tenant filter are the same annotation. Splitting the boundary carelessly runs the work with tenant filtering off, and because that filter fails open rather than closed, it does so silently.

## What changed

**The service is three phases.** Read the inputs in one transaction, call the model with no transaction and no connection held, persist in a second. Both transactions are opened by calling `TransactionalWorkRunner`, which is declarative and inside the advised package, so the aspect fires on each phase. A programmatic `TransactionTemplate` would have split the boundary correctly and run both phases unfiltered.

The read phase hands the later phases detached entities. Every field they touch is a basic column loaded with the row, and the record carrying them says so explicitly, because that is the invariant an edit could break without a test noticing.

**The listener owns no transaction.** `ComplianceGenerationListener` had the same connection pin plus one of its own. It was `@Transactional(REQUIRES_NEW)` and set the tenant context inside the method body, but the transaction interceptor is pinned at `HIGHEST_PRECEDENCE` and `HibernateFilterConfig` sits at `LOWEST_PRECEDENCE`, so the filter aspect read the context one step before the body set it, saw null, and never enabled `orgFilter` for that transaction. The filter came on later only as a side effect of the inner service call firing the same aspect on the already-open session. It worked by ordering accident, and the phase split above is exactly the kind of change that would have stopped the accident holding.

Being `@Async` was not protection: it moved the wait off the request thread and did nothing about the connection.

**New `TenantScopedJobRunner`.** Both isolation mechanisms fail open on a missing tenant context: `HibernateFilterConfig` logs at debug and skips, and `TenantIsolationLoadListener` returns early on the same condition. So background work that forgets to establish the tenant reads every organization's rows and looks healthy doing it. The runner refuses a null organization id instead, forces the bypass flag off for the duration, and restores the previous context rather than blind-clearing, so it is safe on a request thread as well as a pooled one. On a pooled thread restoring is clearing, which is what stops an org id leaking into the executor's next task.

That is the containment for the work we own. The wider property is #507 and is not addressed here.

## What this does not do

**The endpoint still blocks, and still fails at the 60 second edge timeout.** Nothing here changes what the caller experiences. "Compliance transaction boundary fixed" could reasonably be read as the timeout going with it, and it did not: the model call is still synchronous inside the request, and it still crosses `proxy_read_timeout` at roughly 20 to 25 rules for one jurisdiction. That ceiling is #482, and the job table, dispatcher and polling endpoint that answer it are deliberately not in this PR.

No API change, no schema change, no `echno-core` or `echno-web` change, so this ships on its own.

## Tests

- `TenantScopedJobRunnerTest`, 7 cases: null refusal, tenant visible during the work, context cleared afterwards, cleared on throw, a pre-existing context restored rather than discarded, bypass forced off and restored.
- `ComplianceGenerationListenerTest`, 4 cases, including a reflection guard asserting `onProjectApproved` carries no `@Transactional` with the reason in the failure message. Same guard on `generateForProject`. Reintroducing either annotation now fails a test rather than quietly restoring the accident.
- `ComplianceGenerationServiceIT` is unchanged and passes against a real CockroachDB, which is the check that mattered: the phase split still produces the same rows in the same lifecycle order and is still idempotent on a second run.

Full affected scope green on the lab build box after rebasing onto current `development`: compliance, multitenancy, events and retry, including `TenantIsolationIT` and `TransactionRetryTemplateIT`.

## Related

- #482 the design this is Stage 1 of, and where the remaining stages are set out
- #507 tenant isolation failing open, which this contains locally but does not fix
- #508 the ordering accident, fixed here
- #509 the token ceiling, which asynchrony does not fix and this does not touch
- #510 the duplicate-inspection race, untouched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compliance generation reliability during project approval.
  * Prevented tenant context from leaking between background tasks.
  * Invalid compliance-generation requests no longer interrupt the approval process.
  * Improved handling of projects missing required tenant information.

* **Performance**
  * Compliance generation now avoids holding database resources during AI processing, improving scalability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->