### PR TITLE
Keep the subscription writes off the instance the cache is holding

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/components/SubscriptionCache.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/components/SubscriptionCache.java
@@ -7,6 +7,8 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.tornotron.echno_backend.billing.Subscription;
 
 import java.time.Duration;
@@ -35,6 +37,36 @@ public class SubscriptionCache {
 
     public void evict(Long userId) {
         cache.invalidate(userId);
+    }
+
+    /**
+     * Evicts a user's entry for a write that is still in flight, both now and once the
+     * surrounding transaction has finished.
+     *
+     * <p>Evicting only at the point of the write leaves a window: the entry is gone but the
+     * change is not committed yet, so a concurrent read misses the cache, re-reads the
+     * pre-change row and caches it for the rest of the TTL. A user who had just changed plan
+     * would keep the old entitlement for up to five minutes. The second eviction runs on
+     * completion rather than on commit, so a rolled-back write clears anything a concurrent
+     * read parked in the cache as well.
+     *
+     * <p>Falls back to the immediate eviction alone when no transaction is active.
+     *
+     * @param userId The ID of the user whose entry the in-flight write invalidates.
+     */
+    public void evictOnWrite(Long userId) {
+        evict(userId);
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                evict(userId);
+            }
+        });
     }
 
     public void evictAll() {

--- a/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
@@ -78,9 +78,16 @@ public class SubscriptionService {
     /**
      * Loads the user's active subscription entity, serving it from the cache when present.
      *
-     * <p>On a cache miss it queries the repository and, if found, populates the cache. The
-     * query fetch-joins the plan, its plan features and each feature, so a cached instance
-     * carries them initialized and stays mappable after its session closes; keep it that way.
+     * <p>On a cache miss it queries the repository and, if found, populates the cache.
+     *
+     * <p>A cached instance is detached, so anything it left uninitialized throws
+     * {@code LazyInitializationException} on the next hit, in a later transaction that cannot
+     * reattach it. What keeps that from happening is that the graph is always initialized before
+     * the session that loaded it closes: {@code findActiveSubscriptionByUserId} fetch-joins the
+     * plan, its plan features and each feature, and every caller below then maps or walks the
+     * whole graph inside its own transaction anyway. Either alone would do; do not remove both.
+     * A new caller that caches a subscription without touching its plan would be relying on the
+     * fetch joins by itself.
      *
      * @param userId The ID of the user whose subscription to resolve.
      * @return The active subscription, or empty if the user has none.
@@ -98,6 +105,29 @@ public class SubscriptionService {
         subscription.ifPresent(sub -> subscriptionCache.put(userId, sub));
 
         return subscription;
+    }
+
+    /**
+     * Loads the user's active subscription entity for a caller that is about to change it,
+     * always from the database and never from the cache.
+     *
+     * <p>{@link #loadActiveSubscription(Long)} hands back the very instance the cache holds,
+     * which every concurrent reader of this user shares and which is detached from any
+     * persistence context. A write path must not touch that instance: mutating it publishes a
+     * half-finished change to every reader at once, and leaves the cache holding state that
+     * never reached the database if the write then fails. Reading fresh gives the caller a
+     * managed entity of its own, so the change is confined to its transaction and reaches
+     * other callers only through the eviction on
+     * {@link SubscriptionCache#evictOnWrite(Long)}.
+     *
+     * <p>The read deliberately does not populate the cache either. The row is about to change,
+     * so caching what it looks like now would only have to be undone.
+     *
+     * @param userId The ID of the user whose subscription is about to be changed.
+     * @return The active subscription as a managed entity, or empty if the user has none.
+     */
+    private Optional<Subscription> loadActiveSubscriptionForWrite(Long userId) {
+        return subscriptionRepository.findActiveSubscriptionByUserId(userId);
     }
 
     /**
@@ -281,7 +311,7 @@ public class SubscriptionService {
      */
     @Transactional
     public SubscriptionDto createSubscription(Long userId, String planCode, BillingPeriod billingPeriod) {
-        if (loadActiveSubscription(userId).isPresent()) {
+        if (loadActiveSubscriptionForWrite(userId).isPresent()) {
             throw new DuplicateResourceException(
                     "User " + userId + " already has an active subscription; use change-plan to switch plans instead");
         }
@@ -309,7 +339,7 @@ public class SubscriptionService {
 
         subscription = subscriptionRepository.save(subscription);
 
-        subscriptionCache.evict(userId);
+        subscriptionCache.evictOnWrite(userId);
 
         log.info("Created subscription {} for user {} on plan {} ({})", 
                 subscription.getId(), userId, planCode, billingPeriod);
@@ -331,7 +361,7 @@ public class SubscriptionService {
      */
     @Transactional
     public SubscriptionDto changeSubscription(Long userId,String newPlanCode) {
-        Subscription currentSubscription = loadActiveSubscription(userId)
+        Subscription currentSubscription = loadActiveSubscriptionForWrite(userId)
                 .orElseThrow(() -> new NoActiveSubscriptionException("User " + userId + " has no active subscription"));
 
         Plan newPlan = planRepository.findByCodeAndIsActiveTrue(newPlanCode)
@@ -340,7 +370,7 @@ public class SubscriptionService {
         currentSubscription.setPlan(newPlan);
         currentSubscription = subscriptionRepository.save(currentSubscription);
 
-        subscriptionCache.evict(userId);
+        subscriptionCache.evictOnWrite(userId);
 
         log.info("Changed subscription {} for user {} to plan {}",
                 currentSubscription.getId(), userId, newPlanCode);
@@ -363,7 +393,7 @@ public class SubscriptionService {
     @Transactional
     public void cancelSubscription(Long userId, boolean immediate) {
 
-       Subscription subscription = loadActiveSubscription(userId)
+       Subscription subscription = loadActiveSubscriptionForWrite(userId)
                .orElseThrow(() -> new NoActiveSubscriptionException("User " + userId + " has no active subscription"));
 
        if(immediate) {
@@ -374,7 +404,7 @@ public class SubscriptionService {
        }
 
        subscriptionRepository.save(subscription);
-       subscriptionCache.evict(userId);
+       subscriptionCache.evictOnWrite(userId);
 
        log.info("Canceled subscription {} for user {} (immediate: {})",
                subscription.getId(), userId, immediate);

--- a/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.billing.components.SubscriptionCache;
 import org.tornotron.echno_backend.billing.dto.BillingMapper;
@@ -179,6 +181,109 @@ class BillingMappingIT extends AbstractIntegrationTest {
         SubscriptionDto dto = subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);
 
         assertFullyMapped(dto, TARGET_PLAN);
+    }
+
+    /**
+     * The counterpart to the test above, and the reason the cache may hold entities at all.
+     * {@code findActiveSubscriptionByUserId} fetch-joins the plan, its plan features and each
+     * feature, so what it returns is still mappable once its session has closed, which is the
+     * state every cache hit sees. Weaken those fetch joins and this fails where the query above
+     * already fails.
+     *
+     * <p>Nothing in the type system says the query has to keep them, and the cache is what makes
+     * it matter: an ordinary caller would notice a missing fetch join as extra queries, a caller
+     * served from the cache would notice it as a 500.
+     */
+    @Test
+    void theQueryBehindTheCacheReturnsAGraphThatOutlivesItsSession() {
+        Subscription subscription = inCommittedTx(() ->
+                subscriptionRepository.findActiveSubscriptionByUserId(SUBSCRIBED_USER).orElseThrow());
+
+        assertFullyMapped(BillingMapper.toSubscriptionDto(subscription), CURRENT_PLAN);
+    }
+
+    /**
+     * The invariant the one above is only half of. What has to hold is that whatever reaches the
+     * cache is fully initialized by the time its session closes, which the fetch joins secure at
+     * the query and every current caller secures again by mapping or walking the graph inside its
+     * own transaction. This asserts it end to end, on the instance the cache is actually holding.
+     */
+    @Test
+    void whatTheCacheHoldsIsStillMappableOnceItsSessionHasClosed() {
+        subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
+
+        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
+        assertThat(cached).as("the read should have populated the cache").isNotNull();
+
+        assertFullyMapped(BillingMapper.toSubscriptionDto(cached), CURRENT_PLAN);
+    }
+
+    /**
+     * The cached instance is shared by every concurrent reader of this user, so a write path
+     * must not change it in place. changeSubscription used to resolve its subscription through
+     * the cache and call setPlan on whatever came back, which published the new plan to every
+     * reader before the transaction had committed, and left the cache holding it if the
+     * transaction then rolled back.
+     */
+    @Test
+    void changeSubscription_leavesTheCachedInstanceAlone() {
+        subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
+        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
+        assertThat(cached.getPlan().getCode()).isEqualTo(CURRENT_PLAN);
+
+        subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);
+
+        assertThat(cached.getPlan().getCode())
+                .as("the write must not have mutated the shared cached instance")
+                .isEqualTo(CURRENT_PLAN);
+    }
+
+    /**
+     * The same hazard on the cancellation path, which used to set the status and the
+     * cancellation timestamp straight onto the cached instance.
+     */
+    @Test
+    void cancelSubscription_leavesTheCachedInstanceAlone() {
+        subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
+        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
+        assertThat(cached.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+
+        subscriptionService.cancelSubscription(SUBSCRIBED_USER, true);
+
+        assertThat(cached.getStatus())
+                .as("the write must not have mutated the shared cached instance")
+                .isEqualTo(SubscriptionStatus.ACTIVE);
+        assertThat(cached.getCanceledAt()).isNull();
+    }
+
+    /**
+     * Evicting at the point of the write is not enough on its own: between that eviction and
+     * the commit, a concurrent read still sees the old row and caches it for the rest of the
+     * TTL, so a user who has just changed plan keeps the old entitlement for five minutes.
+     *
+     * <p>A race is not reproducible, so the concurrent read is stood in for by a
+     * synchronization that repopulates the cache during the same commit, which puts the entry
+     * back at precisely the point the real race would. Nothing may survive completion.
+     */
+    @Test
+    void changeSubscription_evictsAgainOnceItsTransactionHasCompleted() {
+        Subscription concurrentlyCachedRow = inCommittedTx(() ->
+                subscriptionRepository.findActiveSubscriptionByUserId(SUBSCRIBED_USER).orElseThrow());
+
+        inCommittedTx(() -> {
+            subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void beforeCommit(boolean readOnly) {
+                    subscriptionCache.put(SUBSCRIBED_USER, concurrentlyCachedRow);
+                }
+            });
+        });
+
+        assertThat(subscriptionCache.get(SUBSCRIBED_USER))
+                .as("a read that landed mid-write must not leave a stale entry behind")
+                .isNull();
     }
 
     /**


### PR DESCRIPTION
Closes the part of #485 that is a defect rather than a design question, and answers the design question rather than acting on it unilaterally.

## What was wrong

`changeSubscription` and `cancelSubscription` resolved their subscription through `loadActiveSubscription`, which returns the very instance the cache is holding, and then mutated it. That instance is detached and shared by every concurrent reader of the user, so:

- the change was visible to every reader the moment it was made, before the transaction committed;
- if the write then failed, the eviction after it never ran and the cache went on serving state that had never reached the database.

`createSubscription` decided whether a user already had a subscription from the same shared instance, so a stale entry could refuse a legitimate subscribe.

All three now read the row for themselves through `loadActiveSubscriptionForWrite`. Each gets a managed entity of its own, the change stays inside its transaction, and it reaches other callers only through the eviction.

## The eviction had the same shape of hole

Evicting at the point of the write leaves a window: the entry is gone but the change has not committed, so a read landing in that window misses the cache, re-reads the pre-change row and caches it for the rest of the five minute TTL. A user who had just paid to change plan would keep the old entitlement for five minutes. `evictOnWrite` evicts immediately and again on transaction completion, which also clears whatever a read parked there if the write rolled back.

## The fetch-join dependency, and a correction to the issue

The issue and the loader's Javadoc both said the entity cache is safe today because `findActiveSubscriptionByUserId` fetch-joins the whole graph. That is only half of it, and the half that is not load-bearing on its own. `theQueryBehindTheCacheReturnsAGraphThatOutlivesItsSession` was written to fail if the fetch joins were weakened; with them stripped out, the rest of the suite went on passing, because every current caller of the loader also maps or walks the whole graph inside its own transaction. So the query alone can be weakened today without anything breaking.

Both halves are now pinned, and the Javadoc says which is which rather than crediting the fetch joins with all of it.

## Recommendation on caching DTOs

Leave the cache holding entities.

- `SubscriptionDto.expired` and `inTrial` derive from `Instant.now()` over immutable timestamps, so the entity cache evaluates them correctly at read time and a DTO cache would pin them for the TTL. Those are the entitlement fields the paywall reads. Caching the public DTO makes them wrong.
- The issue lists `active` with those two. It is not time-derived at all: `Subscription.isActive()` reads only `status`, which the entity cache already freezes. So `active` is equally stale either way, bounded by eviction on write and the TTL. Nothing in the codebase changes a subscription's status outside `SubscriptionService`, so the bound holds (`findExpiredSubscriptions` has no callers).
- The feature-id problem is real but not the constraint the issue takes it for. It only forces a change to `PlanFeatureDto` if the cache has to hold the public DTO, which is the response contract and not the cache's business. An internal projection carrying the feature id would need no contract change and no core release.
- That projection is the honest alternative, and its only payoff is removing a hazard the new tests now catch. The payment gateway work will change what the cache must hold anyway (external subscription ids, provider status, grace periods), so building it now means building it twice.

Cost of leaving it: the query must keep its fetch joins, which is now enforced by a test rather than a comment.

## Verification

Every new test confirmed failing without its fix, on `lab-node-116-f`.

With `SubscriptionService` and `SubscriptionCache` reverted to `development`:

```
changeSubscription_leavesTheCachedInstanceAlone()            FAILED
cancelSubscription_leavesTheCachedInstanceAlone()            FAILED
changeSubscription_evictsAgainOnceItsTransactionHasCompleted() FAILED
```

With the fetch joins stripped from `findActiveSubscriptionByUserId`:

```
theQueryBehindTheCacheReturnsAGraphThatOutlivesItsSession()  FAILED
    org.hibernate.LazyInitializationException
```

Full `./gradlew build`: BUILD SUCCESSFUL.

No new Spring context: the four tests reuse `BillingMappingIT`, which already runs `@Transactional(propagation = NOT_SUPPORTED)` so the mapping happens with the persistence context closed, which is the point. No entities added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cache invalidation during subscription creation, plan changes, and cancellations.
  * Prevented stale subscription data from being retained after transactions complete.
  * Ensured subscription updates and cancellations do not unexpectedly mutate cached data.

* **Tests**
  * Added coverage for cache consistency, session-independent subscription mapping, and post-transaction eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->