### PR TITLE
fix: reject an offset on the date-only fields instead of moving the day

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import lombok.extern.slf4j.Slf4j;
+import org.tornotron.echno_backend.common.conversions.DateConversion;
 import org.tornotron.echno_backend.attendance.ShiftTiming;
 import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
@@ -29,7 +30,6 @@ import org.tornotron.echno_backend.user.UserRepository;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -332,7 +332,7 @@ public class EmployeeService {
                     employee.setDesignation((String) value);
                     break;
                 case "joiningDate":
-                    employee.setJoiningDate(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
+                    employee.setJoiningDate(DateConversion.parseLocalDateTime(value));
                     break;
                 case "phoneNumber":
                     employee.setPhoneNumber((String) value);
@@ -355,7 +355,7 @@ public class EmployeeService {
                     employee.setEmailAddress((String) value);
                     break;
                 case "dateOfBirth":
-                    employee.setDateOfBirth(LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME));
+                    employee.setDateOfBirth(DateConversion.parseLocalDateTime(value));
                     break;
                 case "managerId":
                     Long managerId = ((Number) value).longValue();

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -23,6 +25,7 @@ public class EmployeeCreationDto {
     private String department;
 
     @Schema(description = "Date the employee joined.", example = "2026-01-15T00:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime joiningDate;
 
     @Schema(description = "Organization-assigned employee code.", example = "EMP-0042")
@@ -73,6 +76,7 @@ public class EmployeeCreationDto {
 
     @Schema(description = "Date of birth of the employee.", example = "1994-03-22T00:00:00")
     @NotNull(message = "dateOfBirth is required")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime dateOfBirth;
 
     @Schema(description = "Name of the organization the employee belongs to.", example = "Asset Homes")

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeJoinOrgDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.employee.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -23,6 +25,7 @@ public class EmployeeJoinOrgDto {
     private String department;
 
     @Schema(description = "Date the employee joined.", example = "2026-01-15T00:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime joiningDate;
 
     @Schema(description = "Organization-assigned employee code.", example = "EMP-0042")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.project.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -83,8 +85,10 @@ public class ProjectCreationDto {
     private Float projectLongitude;
 
     @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime startDate;
 
     @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime endDate;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.task.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,9 +21,11 @@ public class TaskCreationDto {
     private String title;
 
     @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime startDate;
 
     @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime endDate;
 
     @Schema(description = "Longer description of the work to be done.",

--- a/src/main/java/org/tornotron/echno_backend/user/dto/UserCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/user/dto/UserCreationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
@@ -41,6 +43,7 @@ public class UserCreationDto {
 
     @Past(message = "dateOfBirth must be a past date")
     @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime dateOfBirth;
 
     @NotBlank(message = "qualification is required")

--- a/src/main/java/org/tornotron/echno_backend/user/dto/UserRegistrationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/user/dto/UserRegistrationDto.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 
@@ -23,6 +25,7 @@ public class UserRegistrationDto {
     private String gender;
 
     @NotNull(message = "dateOfBirth is required")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, lenient = OptBoolean.FALSE)
     private LocalDateTime dateOfBirth;
 
     private String role;

--- a/src/test/java/org/tornotron/echno_backend/common/DateOnlyContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/DateOnlyContractTest.java
@@ -1,0 +1,107 @@
+package org.tornotron.echno_backend.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
+import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.task.dto.TaskCreationDto;
+import org.tornotron.echno_backend.user.dto.UserRegistrationDto;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the wire contract for the date-only fields, the same way
+ * {@code AttendanceTimestampContractTest} does for a clock punch.
+ *
+ * <p>These fields are calendar dates held in a {@link LocalDateTime}: a task's start and end, a
+ * project's start and end, a date of birth, a joining date. Each is entered through an
+ * {@code <input type="date">} and carries no time of day, and the column has no offset. Jackson's
+ * default leniency accepted an offset-bearing value and discarded the offset, which for a date at
+ * local midnight moves it to the neighbouring day.
+ *
+ * <p>Plain Jackson, no Spring context: the behaviour under test comes from the field annotations,
+ * not the container.
+ */
+class DateOnlyContractTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("task create accepts local calendar dates verbatim")
+    void taskAcceptsLocalDates() throws Exception {
+        String json = """
+                {"title":"Column casting","startDate":"2026-08-27T00:00:00","endDate":"2026-09-30T00:00:00"}""";
+
+        TaskCreationDto dto = objectMapper.readValue(json, TaskCreationDto.class);
+
+        assertThat(dto.getStartDate()).isEqualTo(LocalDateTime.of(2026, 8, 27, 0, 0));
+        assertThat(dto.getEndDate()).isEqualTo(LocalDateTime.of(2026, 9, 30, 0, 0));
+    }
+
+    @Test
+    @DisplayName("task create rejects a UTC startDate rather than moving the day")
+    void taskRejectsUtcStartDate() {
+        String json = """
+                {"title":"Column casting","startDate":"2026-08-26T18:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, TaskCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("project create rejects a UTC startDate")
+    void projectRejectsUtcStartDate() {
+        String json = """
+                {"projectName":"Marina Towers","startDate":"2026-08-26T18:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, ProjectCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("employee create rejects a UTC dateOfBirth")
+    void employeeRejectsUtcDateOfBirth() {
+        String json = """
+                {"employeeName":"A Worker","dateOfBirth":"1990-08-21T18:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, EmployeeCreationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("registration rejects a UTC dateOfBirth")
+    void registrationRejectsUtcDateOfBirth() {
+        String json = """
+                {"userName":"aworker","dateOfBirth":"1990-08-21T18:30:00.000Z"}""";
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, UserRegistrationDto.class))
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("employee create keeps a date of birth on its own day")
+    void employeeKeepsTheDate() throws Exception {
+        String json = """
+                {"employeeName":"A Worker","dateOfBirth":"1990-08-22T00:00:00"}""";
+
+        EmployeeCreationDto dto = objectMapper.readValue(json, EmployeeCreationDto.class);
+
+        assertThat(dto.getDateOfBirth().toLocalDate()).isEqualTo(java.time.LocalDate.of(1990, 8, 22));
+    }
+}


### PR DESCRIPTION
**Last step of the date-only chain, and it must land last.** Hold until tornotron/echno-web#297 is merged and deployed.

## Why the order matters here

The attendance chain went backend-first: the strictness made an offset payload a hard 400, and that cost nothing against two seeded rows and no production.

Repeating that here would have 400'd **task, project and employee create**, which are in daily use. So core went first instead. A naive local string is accepted by the lenient backend and the strict one alike, since both `ISO_DATE_TIME` and lenient Jackson parse a value with no offset, which leaves **no window** where client and server disagree.

By the time this merges, nothing is sending UTC on these fields. The strictness is a regression guard rather than a change of behaviour, which is the whole point of putting it last.

1. tornotron/echno-backend#512 — merged
2. tornotron/echno-core#50 — merged, released `1.18.0`
3. tornotron/echno-web#297 — the bump, in review
4. **this PR**

## What it does

`@JsonFormat(shape = STRING, lenient = OptBoolean.FALSE)` on the date-only fields:

| DTO | Fields |
|---|---|
| `TaskCreationDto` | `startDate`, `endDate` |
| `ProjectCreationDto` | `startDate`, `endDate` |
| `EmployeeCreationDto` | `dateOfBirth`, `joiningDate` |
| `EmployeeJoinOrgDto` | `joiningDate` |
| `UserRegistrationDto` | `dateOfBirth` |
| `UserCreationDto` | `dateOfBirth` |

No pattern is supplied, on purpose. Without one the deserializer keeps `ISO_LOCAL_DATE_TIME`, so optional seconds and fractional seconds still parse; `lenient = FALSE` removes only the branch that discards a trailing `Z`.

These are calendar dates held in a `LocalDateTime`, each entered through an `<input type="date">` with no time of day. For a date at local midnight, discarding the offset moves it to the neighbouring day, which is how a date of birth ends up a day early.

## The last two hand-parses

`EmployeeService` had the remaining `ISO_DATE_TIME` parses, on `joiningDate` and `dateOfBirth`. They move to `DateConversion.parseLocalDateTime`, added in #512, so the partial-update route and the typed route now say the same thing about the same field.

**That leaves no `ISO_DATE_TIME` parse anywhere in the codebase.** It was the quiet one in this family: it looks deliberate, it parses an offset-bearing value without complaint, and then drops the offset on the way into a `LocalDateTime`.

Worth recording the counter-example again, because it is the one that was right all along: `UserService.parseDateOfBirth` uses a bare `LocalDateTime.parse`, which is `ISO_LOCAL_DATE_TIME` and already rejects an offset, and it is fed by `formatDateForBackend`, which emits a naive string. Both halves agreed, so it never broke.

## Verification

`DateOnlyContractTest` is plain JUnit and a Jackson `ObjectMapper`, no Spring context, so nothing is added to the cached-context heap.

Against `development`, all four rejection tests fail while the two acceptance tests pass:

```
task create rejects a UTC startDate rather than moving the day FAILED
project create rejects a UTC startDate                         FAILED
employee create rejects a UTC dateOfBirth                      FAILED
registration rejects a UTC dateOfBirth                         FAILED
task create accepts local calendar dates verbatim              PASSED
employee create keeps a date of birth on its own day           PASSED
8 tests completed, 4 failed
```

With the change, all pass alongside the parser and partial-update suites:

```
./gradlew test --tests "*DateOnlyContractTest" --tests "*DateConversionTest" \
               --tests "*PartialUpdateDateTest" --tests "*EmployeeService*"
BUILD SUCCESSFUL in 1m 6s
```

No timezone pinning in this class, and the reason is the same as `DateConversionTest`: Jackson turns a string into a `LocalDateTime` without consulting a clock or a zone, so a pinned zone would be ritual rather than coverage. The pinning belongs on the client, where the string is produced, and those tests have it.
