### PR TITLE
Refuse to approve a project whose state nothing can determine

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -92,9 +92,10 @@ public class ComplianceGenerationService {
         // A project that states its own state is taken at its word; scanning the free-text
         // address is only the fallback for projects that predate the field, and it cannot find
         // what the address does not say (an address of "Chennai" names no state at all).
-        String state = project.getProjectState() != null
-                ? project.getProjectState()
-                : IndianStateResolver.resolve(project.getProjectAddress());
+        // Approval refuses a project this returns null for, so reaching the throw below means
+        // the state was cleared between approval and generation.
+        String state = IndianStateResolver.forProject(
+                project.getProjectState(), project.getProjectAddress());
         if (state == null) {
             throw new InvalidRequestException(
                     "This project has no state set, and its address does not name one, so the "

--- a/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/IndianStateResolver.java
@@ -55,6 +55,26 @@ public final class IndianStateResolver {
                 "'" + trimmed + "' is not an Indian state or union territory");
     }
 
+    /**
+     * The state a project's compliance rules are keyed by: its own state field where it has one,
+     * and otherwise whatever its free-text address happens to name.
+     *
+     * <p>Both the approval gate that refuses a project with no determinable state and the
+     * generation that runs straight afterwards resolve it through here, so the gate cannot admit
+     * a project that generation would then turn away, and cannot refuse one that generation
+     * would have handled.
+     *
+     * @param projectState The project's own state field, canonical or blank.
+     * @param projectAddress The project's free-text address, scanned only when the field is blank.
+     * @return The canonical state name, or null when neither route yields one.
+     */
+    public static String forProject(String projectState, String projectAddress) {
+        if (projectState != null && !projectState.isBlank()) {
+            return projectState;
+        }
+        return resolve(projectAddress);
+    }
+
     /** The canonical state name found in the address, or null if none matches. */
     static String resolve(String address) {
         if (address == null || address.isBlank()) {

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -233,6 +233,8 @@ public class ProjectService {
     }
 
     private void partialUpdateAProject(Map<String, Object> updates, Project project) {
+        ProjectCreationStatus previousStatus = project.getStatus();
+
         updates.forEach((key,value) -> {
             switch (key) {
                 case "projectName":
@@ -251,18 +253,7 @@ public class ProjectService {
                     project.setProjectPostalCode(trimToNull((String) value));
                     break;
                 case "status":
-                    ProjectCreationStatus previousStatus = project.getStatus();
-                    ProjectCreationStatus newStatus = ProjectCreationStatus.valueOf((String) value);
-                    project.setStatus(newStatus);
-                    // Fire a compliance-generation event only on the transition INTO
-                    // approved, never on a save that leaves it approved. The listener runs
-                    // AFTER_COMMIT, so the row is durable before the AI flow reads it.
-                    if (newStatus == ProjectCreationStatus.approved
-                            && previousStatus != ProjectCreationStatus.approved) {
-                        Long orgId = project.getOrganization() != null
-                                ? project.getOrganization().getId() : null;
-                        eventPublisher.publishEvent(new ProjectApprovedEvent(this, project.getId(), orgId));
-                    }
+                    project.setStatus(ProjectCreationStatus.valueOf((String) value));
                     break;
                 case "projectType":
                     project.setProjectType(value != null ? ProjectType.valueOf((String) value) : null);
@@ -292,6 +283,61 @@ public class ProjectService {
                     break;
             }
         });
+
+        onApproval(project, previousStatus);
+    }
+
+    /**
+     * Runs the approval transition, once the whole patch has been applied.
+     *
+     * <p>Approval is what publishes {@link ProjectApprovedEvent}, and only on the transition INTO
+     * approved, never on a save that leaves a project already approved. Because it runs after the
+     * loop rather than inside it, a single patch that sets the state and the status together is
+     * judged on the state it is setting, whichever order the two arrive in.
+     *
+     * @param project The project the patch has been applied to.
+     * @param previousStatus The status it held before the patch.
+     */
+    private void onApproval(Project project, ProjectCreationStatus previousStatus) {
+        if (project.getStatus() != ProjectCreationStatus.approved
+                || previousStatus == ProjectCreationStatus.approved) {
+            return;
+        }
+
+        requireStateForApproval(project);
+
+        Long orgId = project.getOrganization() != null ? project.getOrganization().getId() : null;
+        // The listener runs AFTER_COMMIT, so the row is durable before the AI flow reads it.
+        eventPublisher.publishEvent(new ProjectApprovedEvent(this, project.getId(), orgId));
+    }
+
+    /**
+     * Refuses an approval the compliance generation behind it could not act on.
+     *
+     * <p>The state is optional while a project is being drafted, because site paperwork is often
+     * settled after the project record exists. Approval is where it stops being optional: it is
+     * the moment that generates the project's compliance inspections, and those are keyed by the
+     * state's regulations. Left unchecked, the project is approved, the generation fails out of
+     * sight in an AFTER_COMMIT listener, and the missing field surfaces as an absence of
+     * inspections rather than as a message.
+     *
+     * <p>The address scan still counts, so a project that predates the state field but names its
+     * state in its address line approves exactly as it did before.
+     *
+     * @param project The project being approved.
+     * @throws InvalidRequestException if neither the state field nor the address yields a state.
+     */
+    private void requireStateForApproval(Project project) {
+        String state = IndianStateResolver.forProject(
+                project.getProjectState(), project.getProjectAddress());
+        if (state == null) {
+            throw new InvalidRequestException(
+                    "This project cannot be approved without a state. Approval draws up the "
+                            + "project's compliance inspections from the regulations of the state it "
+                            + "is built in, and neither the project's state nor its address names "
+                            + "one. Set the project's state (for example Tamil Nadu) and approve it "
+                            + "again.");
+        }
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectApprovalStateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectApprovalStateTest.java
@@ -1,0 +1,204 @@
+package org.tornotron.echno_backend.project;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The state a project is built in is optional while it is being drafted and required at the
+ * moment it is approved.
+ *
+ * <p>Approval is what publishes {@link ProjectApprovedEvent}, and the compliance inspections that
+ * event generates are keyed by the state's regulations. A project approved without one is
+ * approved successfully and then fails generation out of sight in an AFTER_COMMIT listener, so
+ * the user meets the missing field as an absence of inspections rather than as a message. These
+ * pin the gate that moves that failure forward to the request that can still fix it, and pin the
+ * two things the gate must not break: the address fallback that carries the projects predating
+ * the field, and every transition that is not an approval.
+ *
+ * <p>Only the collaborators this path touches are mocked. Mockito passes null for the rest of the
+ * constructor, which is accurate: nothing else is reachable from the method under test.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectApprovalStateTest {
+
+    private static final Long ORG_ID = 42L;
+    private static final Long PROJECT_ID = 7L;
+
+    @Mock
+    private ProjectRepository repository;
+
+    @Mock
+    private ProjectMapper projectMapper;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private ProjectService service;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    /**
+     * The ordinary case once the field is being filled in: the project says which state it is in,
+     * so approval goes through and generation has what it needs.
+     */
+    @Test
+    void approvingAProjectThatNamesItsState_publishesTheEvent() {
+        Project project = draftProject("Anywhere at all");
+        project.setProjectState("Tamil Nadu");
+
+        approve(project);
+
+        verify(eventPublisher).publishEvent(any(ProjectApprovedEvent.class));
+    }
+
+    /**
+     * The projects that predate the field. Their state is recoverable from the address line, and
+     * generation reads it the same way, so requiring the column alone would refuse projects the
+     * generation behind the gate would have handled perfectly well.
+     */
+    @Test
+    void approvingAProjectWhoseAddressNamesItsState_stillPublishesTheEvent() {
+        Project project = draftProject("No 32 college road, Chennai, Tamil Nadu");
+
+        approve(project);
+
+        verify(eventPublisher).publishEvent(any(ProjectApprovedEvent.class));
+    }
+
+    /**
+     * Neither route yields a state, so the approval is refused rather than accepted into a
+     * generation that cannot run. An address of "Chennai" names a city and no state at all,
+     * which is the exact case the state field was added for.
+     */
+    @Test
+    void approvingAProjectWithNoStateAnywhere_isRefusedAndPublishesNothing() {
+        Project project = draftProject("Chennai");
+
+        assertThatThrownBy(() -> approve(project))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be approved without a state");
+
+        verify(eventPublisher, never()).publishEvent(any(ProjectApprovedEvent.class));
+        verify(repository, never()).save(any(Project.class));
+    }
+
+    /**
+     * A user who fills the state in on the same screen that approves sends both fields in one
+     * patch, and JSON preserves the order they were written in. The gate therefore has to read
+     * the state the patch is setting rather than the one the project arrived with, whichever of
+     * the two the payload happens to list first.
+     */
+    @Test
+    void aPatchThatSetsTheStateAndApprovesInOneCall_isJudgedOnTheStateItSets() {
+        Project project = draftProject("Chennai");
+
+        Map<String, Object> updates = new LinkedHashMap<>();
+        updates.put("status", ProjectCreationStatus.approved.name());
+        updates.put("projectState", "Tamil Nadu");
+
+        patch(project, updates);
+
+        verify(eventPublisher).publishEvent(any(ProjectApprovedEvent.class));
+        assertThat(project.getProjectState()).isEqualTo("Tamil Nadu");
+    }
+
+    /**
+     * The gate is on the transition, not on the row. A project already approved before the field
+     * existed still has to be editable, and a save that leaves it approved must neither be
+     * refused nor generate its compliance a second time.
+     */
+    @Test
+    void patchingAnAlreadyApprovedProjectWithNoState_isNeitherRefusedNorRepublished() {
+        Project project = draftProject("Chennai");
+        project.setStatus(ProjectCreationStatus.approved);
+
+        patch(project, Map.of("projectName", "Renamed"));
+
+        verify(eventPublisher, never()).publishEvent(any(ProjectApprovedEvent.class));
+        assertThat(project.getProjectName()).isEqualTo("Renamed");
+    }
+
+    /**
+     * Every other transition is untouched. A project with no state can still be moved through
+     * the rest of its lifecycle, which is the point of the field being optional at creation.
+     */
+    @Test
+    void movingAProjectWithNoStateToAnyOtherStatus_isNotGated() {
+        Project project = draftProject("Chennai");
+
+        patch(project, Map.of("status", ProjectCreationStatus.onHold.name()));
+
+        verify(eventPublisher, never()).publishEvent(any(ProjectApprovedEvent.class));
+        assertThat(project.getStatus()).isEqualTo(ProjectCreationStatus.onHold);
+    }
+
+    /**
+     * The refusal has to be a 400 rather than a 500, because it is the user's missing field and
+     * the message tells them which one. {@link InvalidRequestException} is what the global
+     * handler maps to 400, and is the same type generation itself raises for this case.
+     */
+    @Test
+    void theRefusalNamesTheFieldAndAnExampleOfWhatToPutInIt() {
+        Project project = draftProject(null);
+
+        assertThatThrownBy(() -> approve(project))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("state")
+                .hasMessageContaining("Tamil Nadu");
+    }
+
+    private void approve(Project project) {
+        patch(project, Map.of("status", ProjectCreationStatus.approved.name()));
+    }
+
+    private void patch(Project project, Map<String, Object> updates) {
+        when(repository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(Optional.of(project));
+
+        service.partialUpdateAProject(updates, PROJECT_ID, null, "PROJECT");
+    }
+
+    private Project draftProject(String address) {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setProjectName("Draft");
+        project.setProjectAddress(address);
+        project.setStatus(ProjectCreationStatus.upcoming);
+        project.setOrganization(organization);
+        return project;
+    }
+}


### PR DESCRIPTION
Closes #493.

Optional at creation, required at approval, as decided on the issue.

## Why approval

Compliance generation is keyed by `(state, projectType)`. #488 made the state an explicit field but left it optional, so a project could reach approval without one. Approval publishes `ProjectApprovedEvent`, the listener runs `AFTER_COMMIT`, and generation then failed there with "This project has no state set". The approval itself succeeded, so the user met the missing field as an absence of inspections, on a screen they had already left.

Requiring it at creation would block the ordinary case of a project drafted before its site paperwork is settled. Approval is the first moment the state is genuinely needed and the last moment the user is still somewhere it can be typed in.

## The address fallback still counts

Projects that predate the field often name their state in the address line, and `ComplianceGenerationService` already reads it that way. Requiring the column alone would refuse projects the generation behind the gate would have handled.

Both sides now resolve through one method, `IndianStateResolver.forProject(state, address)`. The gate cannot admit a project generation would turn away, and cannot turn away one generation would have handled. A gate that disagreed with the generator would be worse than no gate.

## The transition moved out of the patch loop

The event used to fire from inside the `updates.forEach` switch, on the `status` key. A user filling the state in on the same screen that approves sends both fields in one patch, and JSON preserves the order they were written in, so a gate in that position would have judged the patch on whichever field the payload listed first. The transition and the gate now run once, after the whole patch is applied.

## How many projects this would block

Measured on the compose staging (`.116`, `echno.in`), which is the environment with real usage:

| | count |
|---|---|
| projects | 27 |
| have the state field set | 0 |
| no field, state recovered from the address | 5 |
| neither, and not yet approved (would be blocked) | 21 |
| neither, and already approved (never re-gated) | 1 |

**21 would be refused.** They are demo and seed rows with placeholder addresses ("Emerald Heights Area", "Test 2 Address", "hgh"), not real project records. The count is high because the field only landed today, so nothing has one yet.

Worth being explicit that this removes no capability: none of those 21 could have generated compliance before this change either. They would have been approved and then failed generation silently. The gate moves the same failure to the request that can still fix it, with a message naming the field. The one already-approved row is project 27, address "Chennai", which is the exact case the state field exists for, and it is not re-gated because the check is on the transition rather than on the row.

## Not in scope

Geocoding auto-fill from the address is noted on the issue as needing a provider and a per-lookup cost. Left alone: it is Abhijith's call and independent of this.

## Verification

Every new test confirmed failing without its fix, on `lab-node-116-f`.

With `ProjectService` reverted to `development`:

```
approvingAProjectWithNoStateAnywhere_isRefusedAndPublishesNothing()  FAILED
theRefusalNamesTheFieldAndAnExampleOfWhatToPutInIt()                 FAILED
```

With the gate placed inside the patch loop instead of after it:

```
aPatchThatSetsTheStateAndApprovesInOneCall_isJudgedOnTheStateItSets()  FAILED
```

`ComplianceGenerationServiceTest` and `IndianStateResolverTest` pass unchanged, so routing both sides through `forProject` altered no existing behaviour. Full `./gradlew build`: BUILD SUCCESSFUL.

`ProjectApprovalStateTest` is a plain Mockito test in the style of `ProjectServicePaginationTest`. No Spring context, no entities, so nothing added to the context cache or the test heap.