### PR TITLE
Stop the backend client secret drifting away from the deployment

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfig.java
@@ -60,6 +60,22 @@ public class KeycloakConfig {
                 .build();
     }
 
+    /**
+     * Builds a throwaway admin client that authenticates with the client-credentials grant as an
+     * arbitrary confidential client of the application realm. Used only to establish whether a given
+     * clientId/secret pair is the credential Keycloak currently validates, which is the check that
+     * distinguishes a drifted secret from a working one. The caller closes it.
+     */
+    public Keycloak buildClientCredentialsKeycloak(String clientId, String clientSecret) {
+        return KeycloakBuilder.builder()
+                .serverUrl(keycloakInitializerConfigurationProperties.getUrl())
+                .realm(keycloakInitializerConfigurationProperties.getApplicationRealm())
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build();
+    }
+
     public String getInitializerServiceClientId() {
         return initializerServiceClientId;
     }

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGenerator.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGenerator.java
@@ -18,6 +18,14 @@ public class KeycloakConfigGenerator {
     @Value("${keycloak.client-id}")
     private String clientId;
 
+    // Secret of the confidential backend client. It is written into the generated realm JSON so a
+    // freshly created realm is born with the secret this deployment already holds, rather than a
+    // Keycloak-generated random one that nothing else knows. Without it, KeycloakGroupService's
+    // client_credentials grant is rejected as unauthorized_client from the first boot of any rebuilt
+    // environment, and employee onboarding and org-role assignment fail for everyone.
+    @Value("${keycloak.secret}")
+    private String clientSecret;
+
     @Value("${keycloak.redirect-uri}")
     private String redirectUri;
 
@@ -86,6 +94,7 @@ public class KeycloakConfigGenerator {
 
         String config = template
                 .replace("${KEYCLOAK_CLIENT_ID}",clientId)
+                .replace("${KEYCLOAK_CLIENT_SECRET}",escapeJson(clientSecret))
                 .replace("${KEYCLOAK_REDIRECT_URI}",formatListString(redirectUri))
                 .replace("${KEYCLOAK_WEB_ORIGIN}",formatListString(webOrigin))
                 .replace("${KEYCLOAK_FRONTEND_CLIENT_ID}",frontendClientId)
@@ -128,6 +137,38 @@ public class KeycloakConfigGenerator {
 
         Path outputFile = outputDir.resolve(filename);
         Files.writeString(outputFile, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    /**
+     * Escapes a value for embedding inside a JSON string literal. Configured values reach the
+     * templates verbatim, so a value carrying a quote or a backslash would otherwise produce a
+     * malformed realm file. Never log the argument or the result: this is used for secrets.
+     */
+    static String escapeJson(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     private String formatListString(String input) {

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -442,8 +442,10 @@ public class KeycloakInitializer {
         }
     }
 
-    private void syncSingleClient(org.keycloak.representations.idm.ClientRepresentation clientFromConfig) {
+    void syncSingleClient(org.keycloak.representations.idm.ClientRepresentation clientFromConfig) {
         String clientId = clientFromConfig.getClientId();
+        // Read the configured secret before the representation is rewritten below.
+        String configuredSecret = clientFromConfig.getSecret();
         try {
             List<org.keycloak.representations.idm.ClientRepresentation> existingClients = admin.realm(REALM_ID).clients().findByClientId(clientId);
             if (existingClients.isEmpty()) {
@@ -454,16 +456,122 @@ public class KeycloakInitializer {
             org.keycloak.representations.idm.ClientRepresentation existingClient = existingClients.get(0);
             org.keycloak.admin.client.resource.ClientResource clientResource = admin.realm(REALM_ID).clients().get(existingClient.getId());
 
-            // Update fields from config on the existing client.
-            // We preserve the ID and Secret from the existing client so a rotated secret survives.
+            // Update fields from config on the existing client, keeping the live id.
             clientFromConfig.setId(existingClient.getId());
-            clientFromConfig.setSecret(existingClient.getSecret());
+            clientFromConfig.setSecret(resolveSecretForSync(clientId, configuredSecret, existingClient));
+            preserveUnsetCapabilities(clientFromConfig, existingClient);
 
             clientResource.update(clientFromConfig);
             log.info("Client '{}' configuration synced successfully.", clientId);
 
         } catch (Exception e) {
             log.error("Failed to sync client '{}': {}", clientId, e.getMessage());
+        }
+    }
+
+    /**
+     * Decides which secret a client sync should carry.
+     *
+     * <p>For every client except the backend one the live secret is preserved, so a secret rotated
+     * directly in Keycloak survives a deploy. That is a sound default wherever nothing outside
+     * Keycloak knows the value.
+     *
+     * <p>The backend client is the exception, because something outside Keycloak does know its
+     * value: {@code KeycloakGroupService} authenticates as this client with the configured secret on
+     * every employee-onboarding and org-role call. If Keycloak's stored copy drifts, the blanket
+     * preserve keeps the drift forever and those calls fail for every user. So the configured secret
+     * is proven the same way {@code verifyScoped} proves the initializer client: perform the real
+     * client_credentials grant. The configured value is pushed only when that grant fails, which
+     * leaves a deliberate rotation done through the vault working and repairs a drift automatically.
+     */
+    private String resolveSecretForSync(String clientId,
+                                        String configuredSecret,
+                                        org.keycloak.representations.idm.ClientRepresentation existingClient) {
+        if (!clientId.equals(appClientId)) {
+            return existingClient.getSecret();
+        }
+        if (configuredSecret == null || configuredSecret.isBlank()) {
+            log.warn("No secret configured for backend client '{}'; leaving the stored secret as it is. "
+                    + "Set keycloak.secret so a drifted secret can be repaired.", clientId);
+            return existingClient.getSecret();
+        }
+        if (clientCredentialsGrantSucceeds(clientId, configuredSecret)) {
+            log.info("Backend client '{}' accepted the configured secret; leaving the stored secret as it is.",
+                    clientId);
+            return existingClient.getSecret();
+        }
+        log.warn("Backend client '{}' rejected the configured secret (client_credentials returned "
+                + "unauthorized); restoring the configured secret onto the client so employee onboarding "
+                + "and org-role assignment keep working.", clientId);
+        return configuredSecret;
+    }
+
+    /**
+     * Performs the real client_credentials grant for a confidential client of the application realm
+     * and reports whether Keycloak accepted the secret. Mirrors {@link #verifyScoped(Keycloak)}: an
+     * assumption about a stored secret is worth nothing, so the grant is actually attempted.
+     */
+    private boolean clientCredentialsGrantSucceeds(String clientId, String secret) {
+        Keycloak probe = null;
+        try {
+            probe = keycloakConfig.buildClientCredentialsKeycloak(clientId, secret);
+            String token = probe.tokenManager().getAccessTokenString();
+            return token != null && !token.isBlank();
+        } catch (Exception e) {
+            // The message is the OAuth error (for example unauthorized_client), never the secret.
+            log.warn("client_credentials grant for '{}' did not succeed: {}", clientId, e.getMessage());
+            return false;
+        } finally {
+            closeQuietly(probe);
+        }
+    }
+
+    /**
+     * Copies onto {@code target} every capability flag the config representation leaves unset, taking
+     * the live client's value.
+     *
+     * <p>This exists because of a real outage. Keycloak's client update reads an absent boolean as
+     * false, so a representation that omits {@code authorizationServicesEnabled} does not leave it
+     * alone, it turns it OFF and deletes the client's resource server with it. Every authenticated
+     * request then fails until the backend is restarted and rebuilds the resource server. The same
+     * trap applies to {@code serviceAccountsEnabled}, which the client_credentials grant depends on:
+     * clearing it would break exactly the thing this reconcile is meant to protect. Whatever this
+     * class sends must therefore be a complete representation.
+     */
+    static void preserveUnsetCapabilities(org.keycloak.representations.idm.ClientRepresentation target,
+                                          org.keycloak.representations.idm.ClientRepresentation existing) {
+        if (target == null || existing == null) {
+            return;
+        }
+        if (target.getAuthorizationServicesEnabled() == null) {
+            target.setAuthorizationServicesEnabled(existing.getAuthorizationServicesEnabled());
+        }
+        if (target.isServiceAccountsEnabled() == null) {
+            target.setServiceAccountsEnabled(existing.isServiceAccountsEnabled());
+        }
+        if (target.isStandardFlowEnabled() == null) {
+            target.setStandardFlowEnabled(existing.isStandardFlowEnabled());
+        }
+        if (target.isDirectAccessGrantsEnabled() == null) {
+            target.setDirectAccessGrantsEnabled(existing.isDirectAccessGrantsEnabled());
+        }
+        if (target.isImplicitFlowEnabled() == null) {
+            target.setImplicitFlowEnabled(existing.isImplicitFlowEnabled());
+        }
+        if (target.isPublicClient() == null) {
+            target.setPublicClient(existing.isPublicClient());
+        }
+        if (target.isEnabled() == null) {
+            target.setEnabled(existing.isEnabled());
+        }
+        if (target.isBearerOnly() == null) {
+            target.setBearerOnly(existing.isBearerOnly());
+        }
+        if (target.isFrontchannelLogout() == null) {
+            target.setFrontchannelLogout(existing.isFrontchannelLogout());
+        }
+        if (target.getProtocol() == null) {
+            target.setProtocol(existing.getProtocol());
         }
     }
 

--- a/src/main/resources/keycloak-templates/init-keycloak.json.template
+++ b/src/main/resources/keycloak-templates/init-keycloak.json.template
@@ -16,6 +16,7 @@
     {
       "clientId": "${KEYCLOAK_CLIENT_ID}",
       "publicClient": false,
+      "secret": "${KEYCLOAK_CLIENT_SECRET}",
       "serviceAccountsEnabled": true,
       "authorizationServicesEnabled": true,
       "protocol": "openid-connect",

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGeneratorRealmTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakConfigGeneratorRealmTest.java
@@ -1,0 +1,92 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for the generated realm file (no Spring context).
+ *
+ * <p>The realm template used to describe the backend client without a secret, so a realm created
+ * from it was given a Keycloak-generated random one that no deployment could ever know. The
+ * client_credentials grant KeycloakGroupService performs was therefore rejected from the first boot
+ * of any rebuilt environment, and employee onboarding and org-role assignment failed for everyone.
+ * The generated realm now carries the configured secret, so a fresh realm is born matching what the
+ * deployment already holds.
+ */
+class KeycloakConfigGeneratorRealmTest {
+
+    // Placeholder values only. Nothing here is, or resembles, a real credential.
+    private static final String BACKEND_CLIENT_ID = "echno-backend-client";
+    private static final String BACKEND_SECRET = "configured-value";
+
+    @TempDir
+    Path outputDir;
+
+    private RealmRepresentation generateRealm() throws IOException {
+        KeycloakConfigGenerator generator = new KeycloakConfigGenerator();
+        ReflectionTestUtils.setField(generator, "clientId", BACKEND_CLIENT_ID);
+        ReflectionTestUtils.setField(generator, "clientSecret", BACKEND_SECRET);
+        ReflectionTestUtils.setField(generator, "redirectUri", "https://backend.example.test/*");
+        ReflectionTestUtils.setField(generator, "webOrigin", "https://backend.example.test");
+        ReflectionTestUtils.setField(generator, "frontendClientId", "echno-frontend-client");
+        ReflectionTestUtils.setField(generator, "frontendRedirectUri", "https://ui.example.test/*");
+        ReflectionTestUtils.setField(generator, "frontendWebOrigin", "https://ui.example.test");
+        ReflectionTestUtils.setField(generator, "registrationAllowed", false);
+        ReflectionTestUtils.setField(generator, "outputPath", outputDir.toString());
+
+        ReflectionTestUtils.invokeMethod(generator, "generateRealmConfig");
+
+        return new ObjectMapper().readValue(outputDir.resolve("init-keycloak.json").toFile(),
+                RealmRepresentation.class);
+    }
+
+    @Test
+    void generatedRealmGivesTheBackendClientTheConfiguredSecret() throws IOException {
+        ClientRepresentation backend = generateRealm().getClients().stream()
+                .filter(c -> BACKEND_CLIENT_ID.equals(c.getClientId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(backend.getSecret()).isEqualTo(BACKEND_SECRET);
+    }
+
+    @Test
+    void generatedRealmKeepsTheBackendClientCapabilities() throws IOException {
+        ClientRepresentation backend = generateRealm().getClients().stream()
+                .filter(c -> BACKEND_CLIENT_ID.equals(c.getClientId()))
+                .findFirst()
+                .orElseThrow();
+
+        // Adding the secret must not disturb the two flags the client_credentials grant and the
+        // authorization services depend on.
+        assertThat(backend.isServiceAccountsEnabled()).isTrue();
+        assertThat(backend.getAuthorizationServicesEnabled()).isTrue();
+        assertThat(backend.isPublicClient()).isFalse();
+    }
+
+    @Test
+    void generatedRealmLeavesNoPlaceholderUnsubstituted() throws IOException {
+        generateRealm();
+
+        String rendered = Files.readString(outputDir.resolve("init-keycloak.json"));
+
+        assertThat(rendered).doesNotContain("${");
+    }
+
+    @Test
+    void escapeJsonKeepsAValueWithQuotesOrBackslashesParseable() {
+        assertThat(KeycloakConfigGenerator.escapeJson("a\"b\\c")).isEqualTo("a\\\"b\\\\c");
+        assertThat(KeycloakConfigGenerator.escapeJson(null)).isEmpty();
+        assertThat(KeycloakConfigGenerator.escapeJson("plain")).isEqualTo("plain");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerBackendClientSecretTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerBackendClientSecretTest.java
@@ -1,0 +1,273 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.token.TokenManager;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests (no Spring context, no Keycloak container) for the client sync in KeycloakInitializer.
+ *
+ * <p>Two behaviours are pinned here.
+ *
+ * <p>The first is the backend client's secret. Its value is known outside Keycloak, because
+ * KeycloakGroupService authenticates as this client with the configured secret on every
+ * employee-onboarding and org-role call. So the sync must not blindly preserve whatever Keycloak
+ * holds: it proves the configured secret with a real client_credentials grant and pushes it back
+ * only when that grant fails. Every other client keeps the preserve behaviour, because nothing
+ * outside Keycloak knows those values and a deliberate rotation should survive a deploy.
+ *
+ * <p>The second is the more valuable one: the update must never be a partial representation.
+ * Keycloak reads an absent boolean in a client update as false, so sending a representation without
+ * authorizationServicesEnabled disables authorization services and deletes the client's resource
+ * server, which fails every authenticated request until the backend restarts and rebuilds it. The
+ * same trap on serviceAccountsEnabled would break the client_credentials grant this whole change
+ * exists to protect. The failure is silent, total, and looks unrelated to a secret change, so it is
+ * asserted directly.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KeycloakInitializerBackendClientSecretTest {
+
+    private static final String REALM = "echno-realm";
+    private static final String BACKEND_CLIENT_ID = "echno-backend-client";
+    private static final String FRONTEND_CLIENT_ID = "echno-frontend-client";
+    private static final String CLIENT_UUID = "11111111-2222-3333-4444-555555555555";
+
+    // Placeholder values only. Nothing here is, or resembles, a real credential.
+    private static final String CONFIGURED_SECRET = "configured-value";
+    private static final String LIVE_SECRET = "live-value";
+
+    @Mock
+    private Keycloak masterKeycloak;
+
+    @Mock
+    private Keycloak adminClient;
+
+    @Mock
+    private Keycloak grantProbe;
+
+    @Mock
+    private TokenManager tokenManager;
+
+    @Mock
+    private RealmResource realmResource;
+
+    @Mock
+    private ClientsResource clientsResource;
+
+    @Mock
+    private ClientResource clientResource;
+
+    @Mock
+    private KeycloakInitializerConfigurationProperties properties;
+
+    @Mock
+    private KeycloakConfig keycloakConfig;
+
+    private KeycloakInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        when(adminClient.realm(REALM)).thenReturn(realmResource);
+        when(realmResource.clients()).thenReturn(clientsResource);
+        when(clientsResource.get(CLIENT_UUID)).thenReturn(clientResource);
+        when(grantProbe.tokenManager()).thenReturn(tokenManager);
+
+        initializer = new KeycloakInitializer(masterKeycloak, properties, new ObjectMapper(), keycloakConfig);
+        ReflectionTestUtils.setField(initializer, "admin", adminClient);
+        ReflectionTestUtils.setField(initializer, "appClientId", BACKEND_CLIENT_ID);
+        ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", REALM);
+    }
+
+    /** The live client as Keycloak currently holds it: confidential, with both capabilities on. */
+    private ClientRepresentation liveBackendClient() {
+        ClientRepresentation live = new ClientRepresentation();
+        live.setId(CLIENT_UUID);
+        live.setClientId(BACKEND_CLIENT_ID);
+        live.setSecret(LIVE_SECRET);
+        live.setPublicClient(false);
+        live.setServiceAccountsEnabled(true);
+        live.setAuthorizationServicesEnabled(true);
+        live.setStandardFlowEnabled(true);
+        return live;
+    }
+
+    /** The client as the generated realm JSON describes it, carrying the configured secret. */
+    private ClientRepresentation configuredBackendClient() {
+        ClientRepresentation fromConfig = new ClientRepresentation();
+        fromConfig.setClientId(BACKEND_CLIENT_ID);
+        fromConfig.setSecret(CONFIGURED_SECRET);
+        fromConfig.setPublicClient(false);
+        fromConfig.setServiceAccountsEnabled(true);
+        fromConfig.setAuthorizationServicesEnabled(true);
+        fromConfig.setStandardFlowEnabled(true);
+        return fromConfig;
+    }
+
+    private void keycloakHolds(ClientRepresentation live) {
+        when(clientsResource.findByClientId(live.getClientId())).thenReturn(List.of(live));
+    }
+
+    private void grantSucceeds() {
+        when(keycloakConfig.buildClientCredentialsKeycloak(anyString(), anyString())).thenReturn(grantProbe);
+        when(tokenManager.getAccessTokenString()).thenReturn("an-access-token");
+    }
+
+    private void grantFails() {
+        when(keycloakConfig.buildClientCredentialsKeycloak(anyString(), anyString())).thenReturn(grantProbe);
+        when(tokenManager.getAccessTokenString())
+                .thenThrow(new RuntimeException("HTTP 401 Unauthorized: unauthorized_client"));
+    }
+
+    private ClientRepresentation captureUpdate() {
+        ArgumentCaptor<ClientRepresentation> sent = ArgumentCaptor.forClass(ClientRepresentation.class);
+        verify(clientResource).update(sent.capture());
+        return sent.getValue();
+    }
+
+    @Test
+    void backendClientWhoseGrantSucceeds_keepsTheSecretKeycloakAlreadyHolds() {
+        keycloakHolds(liveBackendClient());
+        grantSucceeds();
+
+        initializer.syncSingleClient(configuredBackendClient());
+
+        // The grant proves Keycloak validates the configured secret, so there is nothing to repair
+        // and the sync leaves the stored credential exactly as it was.
+        assertThat(captureUpdate().getSecret()).isEqualTo(LIVE_SECRET);
+    }
+
+    @Test
+    void backendClientWhoseGrantFails_restoresTheConfiguredSecret() {
+        keycloakHolds(liveBackendClient());
+        grantFails();
+
+        initializer.syncSingleClient(configuredBackendClient());
+
+        // Drift: Keycloak rejected the value the deployment holds, so the reconcile pushes it back
+        // instead of preserving the drift forever.
+        assertThat(captureUpdate().getSecret()).isEqualTo(CONFIGURED_SECRET);
+    }
+
+    @Test
+    void nonBackendClient_keepsTheLiveSecretAndIsNeverProbed() {
+        ClientRepresentation live = new ClientRepresentation();
+        live.setId(CLIENT_UUID);
+        live.setClientId(FRONTEND_CLIENT_ID);
+        live.setSecret(LIVE_SECRET);
+        live.setPublicClient(true);
+        keycloakHolds(live);
+
+        ClientRepresentation fromConfig = new ClientRepresentation();
+        fromConfig.setClientId(FRONTEND_CLIENT_ID);
+        fromConfig.setSecret(CONFIGURED_SECRET);
+        fromConfig.setPublicClient(true);
+
+        initializer.syncSingleClient(fromConfig);
+
+        // "A rotated secret survives" stays the default everywhere nothing outside Keycloak knows
+        // the value, and no grant is attempted for such a client.
+        assertThat(captureUpdate().getSecret()).isEqualTo(LIVE_SECRET);
+        verify(keycloakConfig, never()).buildClientCredentialsKeycloak(anyString(), anyString());
+    }
+
+    @Test
+    void backendClientWithNoConfiguredSecret_leavesTheStoredSecretAlone() {
+        keycloakHolds(liveBackendClient());
+
+        ClientRepresentation fromConfig = configuredBackendClient();
+        fromConfig.setSecret(null);
+
+        initializer.syncSingleClient(fromConfig);
+
+        assertThat(captureUpdate().getSecret()).isEqualTo(LIVE_SECRET);
+        verify(keycloakConfig, never()).buildClientCredentialsKeycloak(anyString(), anyString());
+    }
+
+    @Test
+    void updateNeverClearsAuthorizationServicesOrServiceAccounts() {
+        keycloakHolds(liveBackendClient());
+        grantSucceeds();
+
+        // A representation that says nothing about the capability flags. Sent as it is, Keycloak
+        // reads the absent booleans as false: authorization services go off, the client's resource
+        // server is deleted, and every authenticated request fails until the backend restarts.
+        ClientRepresentation partial = new ClientRepresentation();
+        partial.setClientId(BACKEND_CLIENT_ID);
+        partial.setSecret(CONFIGURED_SECRET);
+
+        initializer.syncSingleClient(partial);
+
+        ClientRepresentation sent = captureUpdate();
+        assertThat(sent.getAuthorizationServicesEnabled()).isTrue();
+        assertThat(sent.isServiceAccountsEnabled()).isTrue();
+        assertThat(sent.isStandardFlowEnabled()).isTrue();
+        assertThat(sent.isPublicClient()).isFalse();
+    }
+
+    @Test
+    void secretRepairStillSendsACompleteRepresentation() {
+        keycloakHolds(liveBackendClient());
+        grantFails();
+
+        // The dangerous combination: a drifted secret that has to be pushed, on a representation
+        // that does not restate the capabilities. The repair must not be the thing that takes
+        // authorization services down.
+        ClientRepresentation partial = new ClientRepresentation();
+        partial.setClientId(BACKEND_CLIENT_ID);
+        partial.setSecret(CONFIGURED_SECRET);
+
+        initializer.syncSingleClient(partial);
+
+        ClientRepresentation sent = captureUpdate();
+        assertThat(sent.getSecret()).isEqualTo(CONFIGURED_SECRET);
+        assertThat(sent.getAuthorizationServicesEnabled()).isTrue();
+        assertThat(sent.isServiceAccountsEnabled()).isTrue();
+    }
+
+    @Test
+    void preserveUnsetCapabilities_neverOverwritesAValueTheConfigStates() {
+        ClientRepresentation live = liveBackendClient();
+        ClientRepresentation target = new ClientRepresentation();
+        target.setClientId(BACKEND_CLIENT_ID);
+        // The config deliberately turns a flag off; that intent must win over the live value.
+        target.setStandardFlowEnabled(false);
+
+        KeycloakInitializer.preserveUnsetCapabilities(target, live);
+
+        assertThat(target.isStandardFlowEnabled()).isFalse();
+        assertThat(target.getAuthorizationServicesEnabled()).isTrue();
+        assertThat(target.isServiceAccountsEnabled()).isTrue();
+    }
+
+    @Test
+    void syncKeepsTheLiveClientId() {
+        keycloakHolds(liveBackendClient());
+        grantSucceeds();
+
+        initializer.syncSingleClient(configuredBackendClient());
+
+        assertThat(captureUpdate().getId()).isEqualTo(CLIENT_UUID);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
@@ -49,6 +49,9 @@ class KeycloakInitializerScopedAdminIT {
     private static final String INIT_SECRET = "echno-initializer-it-secret";
     private static final String WRONG_SECRET = "deliberately-wrong-secret";
     private static final String APP_CLIENT_ID = "echno-backend";
+    // Matches the secret the staged realm fixture gives the backend client, i.e. what the
+    // deployment "knows". Placeholder only, nothing here resembles a real credential.
+    private static final String APP_CLIENT_SECRET = "echno-backend-it-secret";
     private static final String REALM_MANAGEMENT = "realm-management";
     private static final String REALM_ADMIN = "realm-admin";
     private static final String COMPOSITE_JOB_ROLE = "job-leadership";
@@ -144,6 +147,19 @@ class KeycloakInitializerScopedAdminIT {
                 .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
                 .build()) {
             return scoped.tokenManager().getAccessTokenString();
+        }
+    }
+
+    /** Builds a client_credentials client for the backend client and returns the access token string. */
+    private String fetchAppToken(String secret) {
+        try (Keycloak app = KeycloakBuilder.builder()
+                .serverUrl(KEYCLOAK.getAuthServerUrl())
+                .realm(TEST_REALM)
+                .clientId(APP_CLIENT_ID)
+                .clientSecret(secret)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build()) {
+            return app.tokenManager().getAccessTokenString();
         }
     }
 
@@ -252,5 +268,64 @@ class KeycloakInitializerScopedAdminIT {
         List<RoleRepresentation> saClientRoles = master.realm(TEST_REALM).users()
                 .get(serviceAccount.getId()).roles().clientLevel(realmMgmtUuid).listAll();
         assertThat(saClientRoles).extracting(RoleRepresentation::getName).contains(REALM_ADMIN);
+    }
+
+    /**
+     * The backend client's own secret, which is what KeycloakGroupService authenticates with on
+     * every employee-onboarding and org-role call. Two things are proven against a real Keycloak:
+     *
+     * <ol>
+     *   <li>A realm built from the generated JSON gives the backend client the secret the
+     *       deployment already holds, so the grant works from the very first boot rather than
+     *       against a Keycloak-generated random value nothing else knows.</li>
+     *   <li>When Keycloak's stored copy drifts, the reconcile repairs it in place, and the update it
+     *       sends is a complete representation: authorization services stay enabled and the client's
+     *       resource server survives. Sending only the secret is what disabled authorization
+     *       services and deleted the resource server live, failing every authenticated request.</li>
+     * </ol>
+     */
+    @Test
+    @Order(3)
+    void backendClientSecretDrift_isRepairedWithoutLosingAuthorizationServices() {
+        if (!realmExists()) {
+            newInitializer().init(false);
+        }
+
+        // (1) The realm was built from the JSON, so the configured secret already authenticates.
+        assertThatCode(() -> assertThat(fetchAppToken(APP_CLIENT_SECRET)).isNotBlank())
+                .as("a realm created from the generated JSON must accept the configured backend secret")
+                .doesNotThrowAnyException();
+
+        String appUuid = master.realm(TEST_REALM).clients().findByClientId(APP_CLIENT_ID).get(0).getId();
+        assertThat(master.realm(TEST_REALM).clients().get(appUuid).authorization().getSettings())
+                .as("the backend client starts with an authorization resource server")
+                .isNotNull();
+
+        // Drift the stored secret away from the configured one, exactly as happened live. This uses
+        // Keycloak's own regenerate endpoint, so it is a genuine drift and not a doctored fixture.
+        master.realm(TEST_REALM).clients().get(appUuid).generateNewSecret();
+        assertThatCode(() -> fetchAppToken(APP_CLIENT_SECRET))
+                .as("client_credentials must fail while the stored secret has drifted")
+                .isInstanceOf(Exception.class);
+
+        assertThatCode(() -> newInitializer().init(false)).doesNotThrowAnyException();
+
+        // (2a) The grant works again with the secret the deployment holds.
+        assertThatCode(() -> assertThat(fetchAppToken(APP_CLIENT_SECRET)).isNotBlank())
+                .as("the reconcile must restore the configured backend secret")
+                .doesNotThrowAnyException();
+
+        // (2b) The repair was an in-place update, not a delete and recreate.
+        ClientRepresentation repairedApp =
+                master.realm(TEST_REALM).clients().findByClientId(APP_CLIENT_ID).get(0);
+        assertThat(repairedApp.getId()).isEqualTo(appUuid);
+
+        // (2c) The update carried a complete representation, so neither capability was cleared and
+        // the resource server the whole authorization stack depends on is still there.
+        assertThat(repairedApp.getAuthorizationServicesEnabled()).isTrue();
+        assertThat(repairedApp.isServiceAccountsEnabled()).isTrue();
+        assertThat(master.realm(TEST_REALM).clients().get(appUuid).authorization().getSettings())
+                .as("the client's resource server must survive a secret repair")
+                .isNotNull();
     }
 }


### PR DESCRIPTION
## Why

`KeycloakGroupService` authenticates as `echno-backend-client` with the `client_credentials` grant on every employee onboarding and every org-role assignment. When Keycloak's stored secret stops matching the one the deployment holds, that grant is refused as `unauthorized_client` and both operations fail for every user, while the container stays healthy and nothing else notices. This happened on the compose staging.

Three things were established by measurement:

1. The vault value, the rendered `backend.env` and the running container env all agreed. Only Keycloak's stored copy had drifted.
2. The realm template described the backend client with **no** `secret`, so a realm created from it got a Keycloak-generated random one that no deployment could ever know. Any rebuilt environment was broken from its first boot.
3. `syncSingleClient` deliberately preserved whatever Keycloak held ("so a rotated secret survives"), so the steady-state reconcile could never repair the drift either.

## What changed

**The realm template carries the secret.** `init-keycloak.json.template` now declares `"secret": "${KEYCLOAK_CLIENT_SECRET}"` for the backend client, substituted by `KeycloakConfigGenerator` from `keycloak.secret` the way the other values are. A fresh realm is born with the secret the deployment already holds. The substitution references the configuration key, never a literal, and the value is JSON-escaped so a secret carrying a quote or a backslash cannot produce a malformed realm file.

**The reconcile proves the secret instead of preserving it, for the backend client only.** `resolveSecretForSync` performs the real `client_credentials` grant, the same way `verifyScoped` proves the initializer client, and pushes the configured secret back **only when that grant fails**. Every other client keeps the preserve behaviour: that is a sound default where nothing outside Keycloak knows the value, and a deliberate rotation should survive a deploy. A vault-driven rotation still works, because the grant succeeds with the new value and nothing is pushed.

**The update is never a partial representation.** This is the part worth reviewing closely. Keycloak reads an absent boolean in a client update as `false`, so sending a representation that omits `authorizationServicesEnabled` does not leave it alone: it turns authorization services **off** and deletes the client's resource server with them, failing every authenticated request until the backend restarts and rebuilds it. Sending `{"secret": "..."}` on its own is exactly how the outage started. `preserveUnsetCapabilities` now fills in every capability flag the config leaves unset from the live client, before the update goes out.

## Verification

Every test was confirmed to fail without its fix, by reverting that one change and re-running.

| Baseline reverted | Tests that go red |
|---|---|
| `setSecret(resolveSecretForSync(...))` back to the blanket `setSecret(existingClient.getSecret())` | `backendClientWhoseGrantFails_restoresTheConfiguredSecret`, `secretRepairStillSendsACompleteRepresentation`, and the container test |
| `preserveUnsetCapabilities` call removed | `updateNeverClearsAuthorizationServicesOrServiceAccounts`, `secretRepairStillSendsACompleteRepresentation` |
| `secret` line removed from the realm template | `generatedRealmGivesTheBackendClientTheConfiguredSecret` |

`KeycloakInitializerBackendClientSecretTest` (8 tests) and `KeycloakConfigGeneratorRealmTest` (4 tests) are plain JUnit and Mockito with no Spring context, so they add nothing to the test-context cache.

`KeycloakInitializerScopedAdminIT` gains a third ordered case that drives the whole thing against a real Keycloak 26.0.7 container: it drifts the stored secret with Keycloak's own regenerate endpoint, confirms the grant then fails, runs the reconcile, and asserts the grant works again, that the repair was an **in-place** update (same client UUID, so no delete and recreate is needed on this version), that both capability flags are still on, and that the client's authorization resource server survived.

Full backend suite green on the lab build box: `BUILD SUCCESSFUL in 7m 44s`. Nothing was run against the live staging realm.

## Notes

- No secret value appears in any code, test, fixture or log line. The grant failure is logged as the OAuth error only.
- The one extra cost at runtime is a single token request per startup reconcile.
- Companion change in `echno-deployment`: a post-deploy assertion that performs the same grant and fails the run on a rejection, so a drift that somehow survives the reconcile is loud rather than silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of the backend client’s credentials with the configured secret.
  * Preserved active client settings, including service accounts, authorization services, and flow capabilities, during updates.
  * Added safe handling for special characters in generated Keycloak configuration.
  * Ensured temporary credential checks do not expose secrets or leave resources open.

* **Tests**
  * Added coverage for credential recovery, configuration generation, JSON escaping, and preservation of client settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->