### PR TITLE
Give the local-dev fixture both halves of its identity

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.EmployeeService;
 import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
@@ -94,7 +95,15 @@ public class DevFixtureProvisioner {
         }
         User user = ensureUser(keycloakUserId, displayName, email);
         Organization organization = ensureOrganization(user);
+        if (organization == null) {
+            return;
+        }
         Long employeeId = ensureEmployee(user, organization);
+        // Reconciled on every pass rather than only at creation, so a run whose seeding failed after
+        // the organization row was written repairs itself on the next startup instead of leaving a
+        // permanently half-provisioned organization. Each seeder skips an organization that already
+        // has its data, so repeating this costs three lookups.
+        onboardingSeeder.seedFinanceDefaults(organization.getId());
         assignOrgRole(organization.getId(), employeeId);
         log.warn("Dev fixture identity ready: user {} is a {} of organization {} ('{}')",
                 user.getId(), DEV_ORG_ROLE.getGroupName(), organization.getId(), DEV_ORG_NAME);
@@ -123,43 +132,64 @@ public class DevFixtureProvisioner {
     }
 
     /**
-     * Finds or creates the fixture's own organization, together with its Keycloak group. The group
-     * has to exist before anyone joins it, and creating it here is what
-     * {@code OrganizationService.addOrganization} does for a real signup. The per-organization
-     * finance defaults are seeded afterwards so the finance screens are not empty.
+     * Finds or creates the fixture's own organization, or returns null when the name is taken by an
+     * organization that is not the fixture's.
+     *
+     * <p>The name alone cannot decide that. Where self-service registration is on, any authenticated
+     * user can create an organization and call it whatever they like, including this name, and
+     * adopting it would hand the fixture system-admin over somebody else's tenant: the exact failure
+     * this class exists to stop, reached from the other direction. So an existing organization is
+     * adopted only when it also carries the fixture's own contact address and was created by the
+     * fixture's user row, neither of which another tenant can set. Anything else is refused, and the
+     * fixture is left unprovisioned rather than pointed at a stranger's data.
      */
     private Organization ensureOrganization(User creator) {
-        return organizationRepository.findOrganizationByOrganizationName(DEV_ORG_NAME)
-                .orElseGet(() -> {
-                    Organization organization = new Organization();
-                    organization.setOrganizationName(DEV_ORG_NAME);
-                    organization.setOrganizationEmail(DEV_ORG_EMAIL);
-                    organization.setOrganizationAddress(DEV_ORG_ADDRESS);
-                    organization.setOrganizationPhone(DEV_ORG_PHONE);
-                    organization.setCreatedAt(LocalDateTime.now());
-                    organization.setCreatorId(creator.getId() == null ? null : creator.getId().intValue());
-                    organization.setIsActive(true);
-                    Organization saved = organizationRepository.save(organization);
+        Organization existing = organizationRepository.findOrganizationByOrganizationName(DEV_ORG_NAME)
+                .orElse(null);
+        if (existing != null) {
+            if (!isFixtureOrganization(existing, creator)) {
+                log.error("An organization named '{}' (id {}) already exists and is not the development "
+                                + "fixture's own, so it belongs to a real tenant. Leaving it alone and "
+                                + "skipping the fixture.",
+                        DEV_ORG_NAME, existing.getId());
+                return null;
+            }
+            return existing;
+        }
 
-                    keycloakGroupService.createOrganizationGroup(
-                            saved.getId().toString(), saved.getOrganizationName());
-                    onboardingSeeder.seedFinanceDefaults(saved.getId());
+        Organization organization = new Organization();
+        organization.setOrganizationName(DEV_ORG_NAME);
+        organization.setOrganizationEmail(DEV_ORG_EMAIL);
+        organization.setOrganizationAddress(DEV_ORG_ADDRESS);
+        organization.setOrganizationPhone(DEV_ORG_PHONE);
+        organization.setCreatedAt(LocalDateTime.now());
+        organization.setCreatorId(creator.getId() == null ? null : creator.getId().intValue());
+        organization.setIsActive(true);
+        Organization saved = organizationRepository.save(organization);
+        log.info("Created the dev fixture organization '{}' (id {})", DEV_ORG_NAME, saved.getId());
+        return saved;
+    }
 
-                    log.info("Created the dev fixture organization '{}' (id {})",
-                            DEV_ORG_NAME, saved.getId());
-                    return saved;
-                });
+    /** True only for an organization this class created for this fixture user. */
+    private static boolean isFixtureOrganization(Organization organization, User creator) {
+        return DEV_ORG_EMAIL.equalsIgnoreCase(organization.getOrganizationEmail())
+                && creator.getId() != null
+                && organization.getCreatorId() != null
+                && organization.getCreatorId().intValue() == creator.getId().intValue();
     }
 
     /**
      * Finds or creates the employee row. Creation goes through {@code joinOrganization}, which
      * writes the row and joins the parent {@code /org-{id}} group in one transaction, so the two
-     * halves cannot drift apart.
+     * halves cannot drift apart. The Keycloak group has to exist before that join, so it is ensured
+     * here rather than beside the organization row: a run that saved the row and then failed would
+     * otherwise never get its group, and every later startup would skip straight past it.
      */
     private Long ensureEmployee(User user, Organization organization) {
         return employeeRepository.findByUserIdAndOrganizationId(user.getId(), organization.getId())
-                .map(employee -> employee.getId())
+                .map(Employee::getId)
                 .orElseGet(() -> {
+                    ensureOrganizationGroup(organization);
                     EmployeeJoinOrgDto joinOrgDto = new EmployeeJoinOrgDto();
                     Long employeeId = employeeService
                             .joinOrganization(user.getId(), organization.getId(), joinOrgDto)
@@ -168,6 +198,23 @@ public class DevFixtureProvisioner {
                             employeeId, organization.getId());
                     return employeeId;
                 });
+    }
+
+    /**
+     * Makes sure the organization's Keycloak group tree exists. {@code createOrganizationGroup} has
+     * no create-if-absent form and rejects a name that is already taken, so a rejected create is how
+     * we learn the group is there. A genuine Keycloak failure is not hidden by this: the join that
+     * follows needs the group and reports it.
+     */
+    private void ensureOrganizationGroup(Organization organization) {
+        try {
+            keycloakGroupService.createOrganizationGroup(
+                    organization.getId().toString(), organization.getOrganizationName());
+            log.info("Created the Keycloak group for the dev fixture organization {}", organization.getId());
+        } catch (Exception e) {
+            log.info("Keycloak group for the dev fixture organization {} was not created now: {}",
+                    organization.getId(), e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
@@ -1,0 +1,191 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationOnboardingSeeder;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserRepository;
+import org.tornotron.echno_backend.user.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+/**
+ * Gives the local-development fixture account the application half of its identity.
+ *
+ * <p>An identity in Echno is two halves that are stored in two different places, and a login only
+ * works when both are present. Spring authorities come from the Keycloak group claims, so a role
+ * check such as {@code @orgSecurity.hasAnyOrgRoleForCurrentTenant(...)} passes only when the account
+ * sits in an {@code /org-{id}/{role}} subgroup. The organization picker resolves membership through
+ * the database instead: {@code GET /organization/web} runs
+ * {@code JOIN o.employees e JOIN e.user u} and lists nothing without an {@code Employee} row.
+ * {@link KeycloakInitializer} can create only the Keycloak half, so a fixture it provisions alone
+ * has no organization to select and no role to pass a check with.
+ *
+ * <p>This provisioner supplies the missing half through the application's own onboarding path
+ * rather than a second one: {@link EmployeeService#joinOrganization} writes the employee row and the
+ * parent-group membership together, and {@link EmployeeService#assignOrgRole} adds the role
+ * subgroup. That is exactly the sequence {@code OrganizationService.addOrganization} runs for a
+ * self-service signup, so the fixture ends up shaped like a real account instead of a special case.
+ *
+ * <p>The fixture gets its <b>own</b> organization, created here and used by nothing else. It never
+ * joins a seeded QA organization, for two reasons. A seeded organization exists only where the
+ * deployment's seed playbook has been run, so borrowing one produces a fixture that works on
+ * staging and nowhere else, which is the state this replaces. And every developer would then share
+ * one identity inside QA data, editing rows that QA is asserting against. A dedicated organization
+ * costs one extra creation step and keeps the fixture's writes where nothing else is looking.
+ *
+ * <p>Because that organization is private and disposable, the fixture is made its system admin: the
+ * level the product itself grants whoever creates an organization, and the level a developer needs
+ * to reach the screens behind the first one. The authority stops at the organization boundary, so it
+ * confers nothing over seeded or real data. The fixture holds no realm admin role.
+ *
+ * <p>Every step is idempotent, so a restart repairs a half-finished fixture instead of duplicating
+ * it. Nothing here runs unless {@code keycloak.dev-client-enabled} is true.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DevFixtureProvisioner {
+
+    /** Name of the organization created for the fixture. Looked up by name to stay idempotent. */
+    static final String DEV_ORG_NAME = "Local Development";
+    static final String DEV_ORG_EMAIL = "local-dev-org@echno.local";
+    static final String DEV_ORG_ADDRESS = "Local development fixture, no physical address";
+    static final String DEV_ORG_PHONE = "0000000000";
+
+    /** Placeholder profile values. The employee row copies these, and they are NOT NULL columns. */
+    static final String DEV_USER_GENDER = "unspecified";
+    static final String DEV_USER_PHONE = "0000000001";
+    private static final LocalDateTime DEV_USER_DATE_OF_BIRTH = LocalDateTime.of(2000, 1, 1, 0, 0);
+
+    /** The role the fixture holds, and only inside the organization created below. */
+    static final OrgRole DEV_ORG_ROLE = OrgRole.SYSTEM_ADMIN;
+
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
+    private final EmployeeRepository employeeRepository;
+    private final EmployeeService employeeService;
+    private final KeycloakGroupService keycloakGroupService;
+    private final OrganizationOnboardingSeeder onboardingSeeder;
+
+    /**
+     * Brings the fixture's application identity up to date: a user row bound to the Keycloak
+     * account, a development organization, an employee row joining the two, and the org role.
+     *
+     * @param keycloakUserId the fixture account's Keycloak id, which is the JWT subject the
+     *                       application resolves a user by.
+     * @param displayName    the name to store on the user row and copy onto the employee row.
+     * @param email          the address the organization picker matches on.
+     */
+    public void provision(String keycloakUserId, String displayName, String email) {
+        if (keycloakUserId == null || keycloakUserId.isBlank()) {
+            log.error("No Keycloak id for the dev fixture account; skipping its application identity. "
+                    + "The account would be able to log in but would see no organization.");
+            return;
+        }
+        User user = ensureUser(keycloakUserId, displayName, email);
+        Organization organization = ensureOrganization(user);
+        Long employeeId = ensureEmployee(user, organization);
+        assignOrgRole(organization.getId(), employeeId);
+        log.warn("Dev fixture identity ready: user {} is a {} of organization {} ('{}')",
+                user.getId(), DEV_ORG_ROLE.getGroupName(), organization.getId(), DEV_ORG_NAME);
+    }
+
+    /**
+     * Finds or creates the user row the Keycloak account resolves to. The profile fields are filled
+     * in because {@code joinOrganization} copies name, gender, phone, email and date of birth onto
+     * the employee row, where all five are NOT NULL.
+     */
+    private User ensureUser(String keycloakUserId, String displayName, String email) {
+        return userRepository.findUserByKeycloakId(keycloakUserId)
+                .orElseGet(() -> {
+                    User user = new User();
+                    user.setKeycloakId(keycloakUserId);
+                    user.setName(displayName);
+                    user.setEmail(email);
+                    user.setGender(DEV_USER_GENDER);
+                    user.setPhone(DEV_USER_PHONE);
+                    user.setDateOfBirth(DEV_USER_DATE_OF_BIRTH);
+                    user.setRole(UserRole.EMPLOYEE);
+                    User saved = userRepository.save(user);
+                    log.info("Created the dev fixture user row (id {})", saved.getId());
+                    return saved;
+                });
+    }
+
+    /**
+     * Finds or creates the fixture's own organization, together with its Keycloak group. The group
+     * has to exist before anyone joins it, and creating it here is what
+     * {@code OrganizationService.addOrganization} does for a real signup. The per-organization
+     * finance defaults are seeded afterwards so the finance screens are not empty.
+     */
+    private Organization ensureOrganization(User creator) {
+        return organizationRepository.findOrganizationByOrganizationName(DEV_ORG_NAME)
+                .orElseGet(() -> {
+                    Organization organization = new Organization();
+                    organization.setOrganizationName(DEV_ORG_NAME);
+                    organization.setOrganizationEmail(DEV_ORG_EMAIL);
+                    organization.setOrganizationAddress(DEV_ORG_ADDRESS);
+                    organization.setOrganizationPhone(DEV_ORG_PHONE);
+                    organization.setCreatedAt(LocalDateTime.now());
+                    organization.setCreatorId(creator.getId() == null ? null : creator.getId().intValue());
+                    organization.setIsActive(true);
+                    Organization saved = organizationRepository.save(organization);
+
+                    keycloakGroupService.createOrganizationGroup(
+                            saved.getId().toString(), saved.getOrganizationName());
+                    onboardingSeeder.seedFinanceDefaults(saved.getId());
+
+                    log.info("Created the dev fixture organization '{}' (id {})",
+                            DEV_ORG_NAME, saved.getId());
+                    return saved;
+                });
+    }
+
+    /**
+     * Finds or creates the employee row. Creation goes through {@code joinOrganization}, which
+     * writes the row and joins the parent {@code /org-{id}} group in one transaction, so the two
+     * halves cannot drift apart.
+     */
+    private Long ensureEmployee(User user, Organization organization) {
+        return employeeRepository.findByUserIdAndOrganizationId(user.getId(), organization.getId())
+                .map(employee -> employee.getId())
+                .orElseGet(() -> {
+                    EmployeeJoinOrgDto joinOrgDto = new EmployeeJoinOrgDto();
+                    Long employeeId = employeeService
+                            .joinOrganization(user.getId(), organization.getId(), joinOrgDto)
+                            .getId();
+                    log.info("Created the dev fixture employee row (id {}) in organization {}",
+                            employeeId, organization.getId());
+                    return employeeId;
+                });
+    }
+
+    /**
+     * Adds the role subgroup membership the authority checks read. {@code assignOrgRole} resolves
+     * the employee against {@code TenantContext}, so the tenant is set for the call and the previous
+     * value restored afterwards, exactly as the onboarding seeder does.
+     */
+    private void assignOrgRole(Long organizationId, Long employeeId) {
+        Long previous = TenantContext.getCurrentOrgId();
+        TenantContext.setCurrentOrgId(organizationId);
+        try {
+            employeeService.assignOrgRole(employeeId, DEV_ORG_ROLE);
+        } finally {
+            if (previous == null) {
+                TenantContext.clear();
+            } else {
+                TenantContext.setCurrentOrgId(previous);
+            }
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializer.java
@@ -79,9 +79,11 @@ public class KeycloakInitializer {
     @Value("${keycloak.client-id}")
     private String appClientId;
 
-    // Local-dev convenience client + account (issue #451). Gated OFF by default so a real production
-    // realm never carries a localhost redirect. A deploy that wants local login against its realm
-    // (staging only) sets keycloak.dev-client-enabled=true. See ensureDevClient().
+    // Local-dev convenience client + account + development organization (issue #451). Gated OFF by
+    // default so a real production realm never carries a localhost redirect. A deploy that wants
+    // local login against its realm (staging only) sets keycloak.dev-client-enabled=true. This flag
+    // is the whole guard, so see ensureDevClient() for what a mistaken enable would and would not
+    // expose.
     @Value("${keycloak.dev-client-enabled:false}")
     private boolean devClientEnabled;
 
@@ -95,19 +97,33 @@ public class KeycloakInitializer {
     private static final String DEV_CLIENT_ID = "echno-web-local";
     private static final String DEV_REDIRECT_URI = "http://localhost:3000/*";
     private static final String DEV_WEB_ORIGIN = "http://localhost:3000";
-    private static final String DEV_USERNAME = "amelia-price";
-    private static final String DEV_USER_EMAIL = "amelia.price@echno.local";
-    private static final String DEV_USER_FIRST_NAME = "Amelia";
-    private static final String DEV_USER_LAST_NAME = "Price";
+
+    // The fixture account. The name is deliberately not a person's: it used to be 'amelia-price',
+    // which is one of the 28 QA personas the deployment's seed playbook imports. On any seeded
+    // environment the create below came back 409 and the fixture silently became that persona,
+    // inheriting her groups and data and dropping its own email, name and password on the floor.
+    // A name no seed uses keeps the two apart.
+    static final String DEV_USERNAME = "echno-local-dev";
+    private static final String DEV_USER_EMAIL = "local-dev@echno.local";
+    private static final String DEV_USER_FIRST_NAME = "Local";
+    private static final String DEV_USER_LAST_NAME = "Dev";
+    private static final String DEV_USER_DISPLAY_NAME = DEV_USER_FIRST_NAME + " " + DEV_USER_LAST_NAME;
+
+    // Provisions the application half of the fixture's identity (user row, development organization,
+    // employee row, org role). Keycloak alone cannot make the fixture usable: the organization picker
+    // reads the employee table, not the token.
+    private final DevFixtureProvisioner devFixtureProvisioner;
 
     public KeycloakInitializer(Keycloak masterKeycloak,
                                KeycloakInitializerConfigurationProperties keycloakInitializerConfigurationProperties,
                                ObjectMapper objectMapper,
-                               KeycloakConfig keycloakConfig) {
+                               KeycloakConfig keycloakConfig,
+                               DevFixtureProvisioner devFixtureProvisioner) {
         this.masterKeycloak = masterKeycloak;
         this.keycloakInitializerConfigurationProperties = keycloakInitializerConfigurationProperties;
         this.mapper = objectMapper;
         this.keycloakConfig = keycloakConfig;
+        this.devFixtureProvisioner = devFixtureProvisioner;
     }
 
 
@@ -1011,8 +1027,16 @@ public class KeycloakInitializer {
      * a localhost redirect, so nothing is created unless a deploy (staging only) explicitly opts in.
      * When enabled it is fully idempotent and guarded so a failure only logs and never aborts startup:
      * the public 'echno-web-local' client mirrors the real web client (standard flow, PKCE S256, the
-     * groups mapper) but redirects to localhost, and the 'amelia-price' account is a throwaway login
-     * with a public dev password.
+     * groups mapper) but redirects to localhost, and the fixture account is a throwaway login with a
+     * public dev password.
+     *
+     * <p>That flag is the only thing standing between this fixture and a client's production realm,
+     * and it is a plain boolean nothing cross-checks, so the reconcile is built to be survivable if
+     * it is ever set by mistake. It is announced at WARN rather than INFO, so an accidental enable is
+     * visible in a production log instead of buried; the account holds no realm admin role; and the
+     * only organization it can administer is one this code creates for it, which holds no real data.
+     * The remaining exposure of a mistaken enable is the localhost redirect on the dev client, which
+     * is why the flag must stay off everywhere except a development or staging deployment.
      */
     private void ensureDevClient() {
         if (!devClientEnabled) {
@@ -1021,10 +1045,16 @@ public class KeycloakInitializer {
             return;
         }
         try {
-            log.info("Ensuring local-dev client '{}' and account '{}' (keycloak.dev-client-enabled=true)",
-                    DEV_CLIENT_ID, DEV_USERNAME);
+            log.warn("Provisioning the local-development fixture in realm '{}' "
+                            + "(keycloak.dev-client-enabled=true): client '{}' with a localhost redirect, "
+                            + "account '{}', and its own development organization. This must never be a "
+                            + "client production realm.",
+                    REALM_ID, DEV_CLIENT_ID, DEV_USERNAME);
             ensureDevWebLocalClient();
-            ensureDevUser();
+            String devUserId = ensureDevUser();
+            if (devUserId != null) {
+                devFixtureProvisioner.provision(devUserId, DEV_USER_DISPLAY_NAME, DEV_USER_EMAIL);
+            }
             log.info("Local-dev client reconcile complete");
         } catch (Exception e) {
             log.error("Failed to ensure local-dev client/account: {}", e.getMessage(), e);
@@ -1068,8 +1098,13 @@ public class KeycloakInitializer {
                 }
             } else {
                 // Keep the existing client's desired config in sync (public client, no secret to preserve).
-                String uuid = existing.get(0).getId();
+                // The representation above leaves several capability flags unset, and Keycloak reads an
+                // absent boolean on update as false, so it goes through preserveUnsetCapabilities like
+                // every other client update in this class rather than around it.
+                org.keycloak.representations.idm.ClientRepresentation existingClient = existing.get(0);
+                String uuid = existingClient.getId();
                 rep.setId(uuid);
+                preserveUnsetCapabilities(rep, existingClient);
                 realm.clients().get(uuid).update(rep);
                 log.info("Local-dev client '{}' already exists (id={}); config synced", DEV_CLIENT_ID, uuid);
             }
@@ -1078,16 +1113,92 @@ public class KeycloakInitializer {
         }
     }
 
-    /** Creates the throwaway 'amelia-price' dev account (with the 'user' role) idempotently. */
-    private void ensureDevUser() {
-        UserKeycloakDto devUser = new UserKeycloakDto();
-        devUser.setUserName(DEV_USERNAME);
-        devUser.setEmailId(DEV_USER_EMAIL);
-        devUser.setFirstName(DEV_USER_FIRST_NAME);
-        devUser.setLastName(DEV_USER_LAST_NAME);
-        devUser.setPassword(devUserPassword);
-        devUser.setAdmin(false);
-        initKeycloakUser(devUser);
+    /**
+     * Creates the throwaway fixture account idempotently and returns its Keycloak id, which is what
+     * the application resolves a user row by.
+     *
+     * <p>This does not reuse {@link #initKeycloakUser}, which cannot serve the fixture. That method
+     * treats a 409 as "already fine" and only adds a realm role, so it never learns whether the
+     * account it found is the one it meant to create, never applies the configured password to it,
+     * and returns nothing the caller can identify the account with. All three mattered here: the
+     * fixture used to carry a seeded QA persona's username, so on staging the 409 branch handed a
+     * developer a real QA account whose password was not the documented dev one.
+     *
+     * <p>So an account that already carries the fixture username is adopted only when its email is
+     * the fixture's own. Anything else is left untouched and the fixture is skipped, because a name
+     * collision with a real account is not a reason to reset that account's password. The email is
+     * the identifying mark rather than a custom attribute because Keycloak's declarative user profile
+     * discards unmanaged attributes by default, which would make the mark vanish between restarts.
+     * The fixture holds the flat 'user' realm role and nothing else; the role that gives it access to
+     * anything is org-scoped and granted by the provisioner.
+     */
+    private String ensureDevUser() {
+        RealmResource realm = admin.realm(REALM_ID);
+
+        List<UserRepresentation> existing = realm.users().search(DEV_USERNAME, true);
+        UserRepresentation match = existing.stream()
+                .filter(u -> DEV_USERNAME.equals(u.getUsername()))
+                .findFirst()
+                .orElse(null);
+
+        if (match != null) {
+            if (!isDevFixtureAccount(match)) {
+                log.error("An account named '{}' already exists in realm '{}' and was not created as a "
+                                + "development fixture, so it belongs to somebody else. Leaving it alone and "
+                                + "skipping the fixture; change the fixture username if this is deliberate.",
+                        DEV_USERNAME, REALM_ID);
+                return null;
+            }
+            // Reapply the configured password so the documented dev credential always works, even
+            // after it has been changed in the realm or the environment's value has been rotated.
+            resetDevUserPassword(realm, match.getId());
+            log.info("Dev fixture account '{}' already exists (id={}); password reapplied",
+                    DEV_USERNAME, match.getId());
+            return match.getId();
+        }
+
+        UserRepresentation rep = new UserRepresentation();
+        rep.setUsername(DEV_USERNAME);
+        rep.setEmail(DEV_USER_EMAIL);
+        rep.setFirstName(DEV_USER_FIRST_NAME);
+        rep.setLastName(DEV_USER_LAST_NAME);
+        rep.setEnabled(true);
+        rep.setEmailVerified(true);
+        rep.setCredentials(List.of(devPasswordCredential()));
+
+        try (Response response = realm.users().create(rep)) {
+            if (response.getStatus() != 201) {
+                log.error("Failed to create dev fixture account '{}'. Status: {}. Reason: {}",
+                        DEV_USERNAME, response.getStatus(), response.getStatusInfo().getReasonPhrase());
+                return null;
+            }
+            String userId = CreatedResponseUtil.getCreatedId(response);
+            realm.users().get(userId).roles().realmLevel()
+                    .add(Collections.singletonList(realm.roles().get("user").toRepresentation()));
+            log.info("Created dev fixture account '{}' with id {}", DEV_USERNAME, userId);
+            return userId;
+        }
+    }
+
+    /** True when the account found under the fixture username is the fixture's own, not a real one. */
+    static boolean isDevFixtureAccount(UserRepresentation user) {
+        return user != null && DEV_USER_EMAIL.equalsIgnoreCase(user.getEmail());
+    }
+
+    private void resetDevUserPassword(RealmResource realm, String userId) {
+        try {
+            realm.users().get(userId).resetPassword(devPasswordCredential());
+        } catch (Exception e) {
+            log.warn("Could not reapply the dev fixture password for '{}': {}", DEV_USERNAME, e.getMessage());
+        }
+    }
+
+    private CredentialRepresentation devPasswordCredential() {
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setTemporary(false);
+        credential.setValue(devUserPassword);
+        return credential;
     }
 
     /** The standard 'groups' membership mapper shared by the web clients. */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,10 +121,11 @@ keycloak:
   # org); the public shared instance sets KEYCLOAK_REGISTRATION_ALLOWED=true so a signed-up user
   # can create their own org.
   registration-allowed: ${KEYCLOAK_REGISTRATION_ALLOWED:false}
-  # Local-development convenience client + account (issue #451): the public 'echno-web-local' client
-  # (localhost redirect) and the 'amelia-price' dev login, reconciled into the realm so they survive a
-  # realm rebuild. Default false keeps them OUT of every real instance (a localhost redirect must never
-  # exist in a production realm); a staging deploy sets KEYCLOAK_DEV_CLIENT_ENABLED=true to enable them.
+  # Local-development convenience fixture (issue #451): the public 'echno-web-local' client (localhost
+  # redirect), the 'echno-local-dev' login, and the development organization that login is an employee
+  # of, reconciled into the realm so they survive a realm rebuild. Default false keeps them OUT of
+  # every real instance (a localhost redirect must never exist in a production realm); a staging deploy
+  # sets KEYCLOAK_DEV_CLIENT_ENABLED=true to enable them.
   dev-client-enabled: ${KEYCLOAK_DEV_CLIENT_ENABLED:false}
   dev-user:
     # Password for the dev account when the dev client is enabled. Public dev credential only, never a

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisionerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisionerTest.java
@@ -77,10 +77,13 @@ class DevFixtureProvisionerTest {
         return user;
     }
 
+    /** An organization shaped the way this class creates one for the fixture user with id 7. */
     private static Organization organization(Long id) {
         Organization organization = new Organization();
         organization.setId(id);
         organization.setOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME);
+        organization.setOrganizationEmail(DevFixtureProvisioner.DEV_ORG_EMAIL);
+        organization.setCreatorId(7);
         return organization;
     }
 
@@ -182,8 +185,76 @@ class DevFixtureProvisionerTest {
         verify(organizationRepository, never()).save(any(Organization.class));
         verify(keycloakGroupService, never()).createOrganizationGroup(any(), any());
         verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any(EmployeeJoinOrgDto.class));
-        // The role assignment is itself idempotent and is reapplied, so a membership removed by hand
-        // comes back on the next restart.
+        // The role assignment and the finance defaults are themselves idempotent and are reapplied,
+        // so a membership removed by hand or a seed that failed halfway comes back on the next start.
+        verify(employeeService).assignOrgRole(19L, OrgRole.SYSTEM_ADMIN);
+        verify(onboardingSeeder).seedFinanceDefaults(42L);
+    }
+
+    /**
+     * The name of the fixture's organization is not proof of ownership: where self-service
+     * registration is on, any user can create an organization and call it the same thing. Adopting it
+     * would hand the fixture system-admin over a real tenant, so it is refused instead.
+     */
+    @Test
+    void refusesAnOrganizationOfTheSameNameThatIsNotTheFixtures() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user(7L)));
+        Organization somebodyElses = new Organization();
+        somebodyElses.setId(3L);
+        somebodyElses.setOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME);
+        somebodyElses.setOrganizationEmail("contact@a-real-tenant.example");
+        somebodyElses.setCreatorId(101);
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.of(somebodyElses));
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any(EmployeeJoinOrgDto.class));
+        verify(employeeService, never()).assignOrgRole(anyLong(), any(OrgRole.class));
+        verify(onboardingSeeder, never()).seedFinanceDefaults(anyLong());
+        verify(keycloakGroupService, never()).createOrganizationGroup(any(), any());
+    }
+
+    /**
+     * A run that wrote the organization row and then failed before its Keycloak group existed used to
+     * be unrecoverable: the next startup found the row and skipped straight past the group. The group
+     * is ensured where it is needed, so the retry repairs it.
+     */
+    @Test
+    void createsTheMissingGroupWhenTheOrganizationRowSurvivedAFailedRun() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user(7L)));
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.of(organization(42L)));
+        when(employeeRepository.findByUserIdAndOrganizationId(7L, 42L)).thenReturn(Optional.empty());
+        when(employeeService.joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class)))
+                .thenReturn(employeeDto(19L));
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        verify(organizationRepository, never()).save(any(Organization.class));
+        verify(keycloakGroupService).createOrganizationGroup("42", DevFixtureProvisioner.DEV_ORG_NAME);
+        verify(employeeService).joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class));
+        verify(employeeService).assignOrgRole(19L, OrgRole.SYSTEM_ADMIN);
+    }
+
+    /**
+     * createOrganizationGroup has no create-if-absent form and rejects a name already taken, so a
+     * rejected create is how a present group announces itself. That must not abort the fixture.
+     */
+    @Test
+    void carriesOnWhenTheGroupAlreadyExists() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user(7L)));
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.of(organization(42L)));
+        when(employeeRepository.findByUserIdAndOrganizationId(7L, 42L)).thenReturn(Optional.empty());
+        when(keycloakGroupService.createOrganizationGroup("42", DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenThrow(new RuntimeException("Failed to create organization group 'org-42' (status 409)"));
+        when(employeeService.joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class)))
+                .thenReturn(employeeDto(19L));
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        verify(employeeService).joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class));
         verify(employeeService).assignOrgRole(19L, OrgRole.SYSTEM_ADMIN);
     }
 

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisionerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisionerTest.java
@@ -1,0 +1,199 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationOnboardingSeeder;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Plain Mockito test (no Spring context, no database) for the application half of the local-dev
+ * fixture's identity.
+ *
+ * <p>The bug this covers is the one that made the fixture unusable: it had a Keycloak account and
+ * nothing else, so the organization picker, which reads the employee table, showed it nothing, and
+ * its only group membership was a parent org group, which yields ORG_MEMBER_x and passes no role
+ * check. Both halves have to be written, in the fixture's own organization.
+ */
+@ExtendWith(MockitoExtension.class)
+class DevFixtureProvisionerTest {
+
+    private static final String KEYCLOAK_ID = "0e1e0b0c-dev-fixture-id";
+    private static final String DISPLAY_NAME = "Local Dev";
+    private static final String EMAIL = "local-dev@echno.local";
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private OrganizationRepository organizationRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private EmployeeService employeeService;
+    @Mock
+    private KeycloakGroupService keycloakGroupService;
+    @Mock
+    private OrganizationOnboardingSeeder onboardingSeeder;
+
+    @InjectMocks
+    private DevFixtureProvisioner provisioner;
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private static User user(Long id) {
+        User user = new User();
+        user.setId(id);
+        user.setKeycloakId(KEYCLOAK_ID);
+        user.setName(DISPLAY_NAME);
+        user.setEmail(EMAIL);
+        return user;
+    }
+
+    private static Organization organization(Long id) {
+        Organization organization = new Organization();
+        organization.setId(id);
+        organization.setOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME);
+        return organization;
+    }
+
+    private static EmployeeDto employeeDto(Long id) {
+        EmployeeDto dto = new EmployeeDto();
+        dto.setId(id);
+        return dto;
+    }
+
+    @Test
+    void provisionsBothHalvesOfTheIdentityInItsOwnOrganization() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User saved = invocation.getArgument(0);
+            saved.setId(7L);
+            return saved;
+        });
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.empty());
+        when(organizationRepository.save(any(Organization.class))).thenAnswer(invocation -> {
+            Organization saved = invocation.getArgument(0);
+            saved.setId(42L);
+            return saved;
+        });
+        when(employeeRepository.findByUserIdAndOrganizationId(7L, 42L)).thenReturn(Optional.empty());
+        when(employeeService.joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class)))
+                .thenReturn(employeeDto(19L));
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        // The user row is the link the application resolves a JWT subject by.
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        User savedUser = userCaptor.getValue();
+        assertThat(savedUser.getKeycloakId()).isEqualTo(KEYCLOAK_ID);
+        assertThat(savedUser.getEmail()).isEqualTo(EMAIL);
+        // joinOrganization copies these onto NOT NULL employee columns, so they cannot be left null.
+        assertThat(savedUser.getName()).isNotBlank();
+        assertThat(savedUser.getGender()).isNotBlank();
+        assertThat(savedUser.getPhone()).isNotBlank();
+        assertThat(savedUser.getDateOfBirth()).isNotNull();
+
+        // The fixture's own organization, with the Keycloak group that has to exist before anyone
+        // joins it, and the finance defaults a usable organization needs.
+        ArgumentCaptor<Organization> orgCaptor = ArgumentCaptor.forClass(Organization.class);
+        verify(organizationRepository).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getOrganizationName())
+                .isEqualTo(DevFixtureProvisioner.DEV_ORG_NAME);
+        verify(keycloakGroupService).createOrganizationGroup("42", DevFixtureProvisioner.DEV_ORG_NAME);
+        verify(onboardingSeeder).seedFinanceDefaults(42L);
+
+        // The employee row, written through the application's own onboarding path.
+        verify(employeeService).joinOrganization(eq(7L), eq(42L), any(EmployeeJoinOrgDto.class));
+
+        // And the role subgroup, which is the half the authority checks actually read.
+        verify(employeeService).assignOrgRole(19L, OrgRole.SYSTEM_ADMIN);
+    }
+
+    /**
+     * assignOrgRole resolves the employee against the tenant context, so the provisioner has to set
+     * it, and has to put it back afterwards: this runs on the startup thread, which is not a request.
+     */
+    @Test
+    void setsTheTenantForTheRoleAssignmentAndRestoresItAfterwards() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user(7L)));
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.of(organization(42L)));
+        Employee employee = new Employee();
+        employee.setId(19L);
+        when(employeeRepository.findByUserIdAndOrganizationId(7L, 42L)).thenReturn(Optional.of(employee));
+        when(employeeService.assignOrgRole(19L, OrgRole.SYSTEM_ADMIN)).thenAnswer(invocation -> {
+            assertThat(TenantContext.getCurrentOrgId())
+                    .as("the role assignment must run scoped to the fixture's organization")
+                    .isEqualTo(42L);
+            return employeeDto(19L);
+        });
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        assertThat(TenantContext.getCurrentOrgId())
+                .as("the startup thread must not be left carrying a tenant")
+                .isNull();
+    }
+
+    /** A restart must repair the fixture, not duplicate it. */
+    @Test
+    void isIdempotentWhenEverythingAlreadyExists() {
+        when(userRepository.findUserByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user(7L)));
+        when(organizationRepository.findOrganizationByOrganizationName(DevFixtureProvisioner.DEV_ORG_NAME))
+                .thenReturn(Optional.of(organization(42L)));
+        Employee employee = new Employee();
+        employee.setId(19L);
+        when(employeeRepository.findByUserIdAndOrganizationId(7L, 42L)).thenReturn(Optional.of(employee));
+        when(employeeService.assignOrgRole(19L, OrgRole.SYSTEM_ADMIN)).thenReturn(employeeDto(19L));
+
+        provisioner.provision(KEYCLOAK_ID, DISPLAY_NAME, EMAIL);
+
+        verify(userRepository, never()).save(any(User.class));
+        verify(organizationRepository, never()).save(any(Organization.class));
+        verify(keycloakGroupService, never()).createOrganizationGroup(any(), any());
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any(EmployeeJoinOrgDto.class));
+        // The role assignment is itself idempotent and is reapplied, so a membership removed by hand
+        // comes back on the next restart.
+        verify(employeeService).assignOrgRole(19L, OrgRole.SYSTEM_ADMIN);
+    }
+
+    /** Without a Keycloak id nothing can be bound to the login, so nothing is written. */
+    @Test
+    void writesNothingWithoutAKeycloakId() {
+        provisioner.provision(null, DISPLAY_NAME, EMAIL);
+
+        verify(userRepository, never()).save(any(User.class));
+        verify(organizationRepository, never()).save(any(Organization.class));
+        verify(employeeService, never()).joinOrganization(anyLong(), anyLong(), any(EmployeeJoinOrgDto.class));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerBackendClientSecretTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerBackendClientSecretTest.java
@@ -94,7 +94,8 @@ class KeycloakInitializerBackendClientSecretTest {
         when(clientsResource.get(CLIENT_UUID)).thenReturn(clientResource);
         when(grantProbe.tokenManager()).thenReturn(tokenManager);
 
-        initializer = new KeycloakInitializer(masterKeycloak, properties, new ObjectMapper(), keycloakConfig);
+        initializer = new KeycloakInitializer(masterKeycloak, properties, new ObjectMapper(), keycloakConfig,
+                org.mockito.Mockito.mock(DevFixtureProvisioner.class));
         ReflectionTestUtils.setField(initializer, "admin", adminClient);
         ReflectionTestUtils.setField(initializer, "appClientId", BACKEND_CLIENT_ID);
         ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", REALM);

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerDevClientTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerDevClientTest.java
@@ -4,22 +4,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
- * Light unit test (no Spring context, no Keycloak container) for the dev-client gate added in #451:
- * the local-dev client/account must only be reconciled when keycloak.dev-client-enabled is true.
+ * Light unit test (no Spring context, no Keycloak container) for the dev-fixture gate added in #451:
+ * the local-dev client, account and development organization must only be reconciled when
+ * keycloak.dev-client-enabled is true.
  */
 @ExtendWith(MockitoExtension.class)
 class KeycloakInitializerDevClientTest {
 
     private static final String REALM = "echno-realm";
+    private static final String DEV_CLIENT_UUID = "99999999-8888-7777-6666-555555555555";
 
     @Mock
     private Keycloak masterKeycloak;
@@ -33,9 +46,12 @@ class KeycloakInitializerDevClientTest {
     @Mock
     private KeycloakConfig keycloakConfig;
 
+    @Mock
+    private DevFixtureProvisioner devFixtureProvisioner;
+
     private KeycloakInitializer newInitializer() {
-        KeycloakInitializer initializer =
-                new KeycloakInitializer(masterKeycloak, properties, new ObjectMapper(), keycloakConfig);
+        KeycloakInitializer initializer = new KeycloakInitializer(
+                masterKeycloak, properties, new ObjectMapper(), keycloakConfig, devFixtureProvisioner);
         ReflectionTestUtils.setField(initializer, "admin", adminClient);
         ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", REALM);
         return initializer;
@@ -48,8 +64,10 @@ class KeycloakInitializerDevClientTest {
 
         ReflectionTestUtils.invokeMethod(initializer, "ensureDevClient");
 
-        // Gate off: not a single admin call is made against the realm.
+        // Gate off: not a single admin call is made against the realm, and no application row is
+        // written either. The fixture now touches the database, so the gate has to cover both.
         verifyNoInteractions(adminClient);
+        verifyNoInteractions(devFixtureProvisioner);
     }
 
     @Test
@@ -64,5 +82,73 @@ class KeycloakInitializerDevClientTest {
         // admin chain is unstubbed, so the guarded body no-ops after this call, which is enough to
         // prove the flag did not short-circuit.
         verify(adminClient, atLeastOnce()).realm(REALM);
+    }
+
+    /**
+     * The dev client's update has to send a complete representation like every other client update
+     * in this class. Keycloak reads an absent boolean on update as false, so a partial one turns off
+     * whatever it omits: that is what disabled authorization services and deleted a client's resource
+     * server live. This update used to go straight to Keycloak, around preserveUnsetCapabilities.
+     */
+    @Test
+    void devClientUpdateCarriesTheCapabilitiesItsRepresentationLeavesUnset() {
+        RealmResource realmResource = mock(RealmResource.class);
+        ClientsResource clientsResource = mock(ClientsResource.class);
+        ClientResource clientResource = mock(ClientResource.class);
+
+        ClientRepresentation live = new ClientRepresentation();
+        live.setId(DEV_CLIENT_UUID);
+        live.setClientId("echno-web-local");
+        live.setAuthorizationServicesEnabled(true);
+        live.setFrontchannelLogout(true);
+        live.setImplicitFlowEnabled(true);
+        live.setBearerOnly(false);
+
+        when(adminClient.realm(REALM)).thenReturn(realmResource);
+        when(realmResource.clients()).thenReturn(clientsResource);
+        when(clientsResource.findByClientId("echno-web-local")).thenReturn(List.of(live));
+        when(clientsResource.get(DEV_CLIENT_UUID)).thenReturn(clientResource);
+
+        KeycloakInitializer initializer = newInitializer();
+        ReflectionTestUtils.invokeMethod(initializer, "ensureDevWebLocalClient");
+
+        ArgumentCaptor<ClientRepresentation> sent = ArgumentCaptor.forClass(ClientRepresentation.class);
+        verify(clientResource).update(sent.capture());
+        ClientRepresentation update = sent.getValue();
+
+        assertThat(update.getId()).isEqualTo(DEV_CLIENT_UUID);
+        assertThat(update.getAuthorizationServicesEnabled())
+                .as("an omitted authorizationServicesEnabled deletes the client's resource server")
+                .isTrue();
+        assertThat(update.isFrontchannelLogout()).isTrue();
+        assertThat(update.isImplicitFlowEnabled()).isTrue();
+        assertThat(update.isBearerOnly()).isFalse();
+        // The values the dev client does state are still its own, not the live client's.
+        assertThat(update.isPublicClient()).isTrue();
+        assertThat(update.getRedirectUris()).containsExactly("http://localhost:3000/*");
+    }
+
+    /**
+     * The fixture identifies its own account by email, so that an account that merely shares the
+     * username is never adopted, password-reset or wired to the fixture's organization. The username
+     * used to be a seeded QA persona's, which is exactly how a developer ended up inside her account.
+     */
+    @Test
+    void onlyTheFixturesOwnAccountIsRecognised() {
+        UserRepresentation fixture = new UserRepresentation();
+        fixture.setUsername("echno-local-dev");
+        fixture.setEmail("local-dev@echno.local");
+
+        UserRepresentation somebodyElse = new UserRepresentation();
+        somebodyElse.setUsername("echno-local-dev");
+        somebodyElse.setEmail("amelia@echno.com");
+
+        UserRepresentation noEmail = new UserRepresentation();
+        noEmail.setUsername("echno-local-dev");
+
+        assertThat(KeycloakInitializer.isDevFixtureAccount(fixture)).isTrue();
+        assertThat(KeycloakInitializer.isDevFixtureAccount(somebodyElse)).isFalse();
+        assertThat(KeycloakInitializer.isDevFixtureAccount(noEmail)).isFalse();
+        assertThat(KeycloakInitializer.isDevFixtureAccount(null)).isFalse();
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/KeycloakInitializerScopedAdminIT.java
@@ -17,6 +17,8 @@ import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.InputStream;
@@ -55,6 +57,11 @@ class KeycloakInitializerScopedAdminIT {
     private static final String REALM_MANAGEMENT = "realm-management";
     private static final String REALM_ADMIN = "realm-admin";
     private static final String COMPOSITE_JOB_ROLE = "job-leadership";
+    private static final String DEV_CLIENT_ID = "echno-web-local";
+    private static final String DEV_USERNAME = "echno-local-dev";
+    private static final String DEV_EMAIL = "local-dev@echno.local";
+    // Public dev placeholder, not a credential for anything real.
+    private static final String DEV_PASSWORD = "dev-fixture-it-password";
 
     // Pin the server image to the tag matching the keycloak-admin-client version so the container
     // API and the client stay in lockstep.
@@ -65,6 +72,9 @@ class KeycloakInitializerScopedAdminIT {
     private static Keycloak master;
     private static KeycloakInitializerConfigurationProperties props;
     private static KeycloakConfig keycloakConfig;
+    // The application half of the dev fixture writes to the database, which this test has none of.
+    // A mock keeps the Keycloak half under test and records that it was asked to run.
+    private static DevFixtureProvisioner devFixtureProvisioner;
 
     @BeforeAll
     static void setUp() throws Exception {
@@ -97,6 +107,8 @@ class KeycloakInitializerScopedAdminIT {
         ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientId", INIT_CLIENT_ID);
         ReflectionTestUtils.setField(keycloakConfig, "initializerServiceClientSecret", INIT_SECRET);
 
+        devFixtureProvisioner = Mockito.mock(DevFixtureProvisioner.class);
+
         // REALM_ID is a static field normally set from ApplicationReadyEvent; set it directly here.
         ReflectionTestUtils.setField(KeycloakInitializer.class, "REALM_ID", TEST_REALM);
     }
@@ -122,7 +134,7 @@ class KeycloakInitializerScopedAdminIT {
         ObjectMapper lenientMapper = new ObjectMapper()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         KeycloakInitializer initializer =
-                new KeycloakInitializer(master, props, lenientMapper, keycloakConfig);
+                new KeycloakInitializer(master, props, lenientMapper, keycloakConfig, devFixtureProvisioner);
         ReflectionTestUtils.setField(initializer, "configOutput", configDir.toString());
         ReflectionTestUtils.setField(initializer, "appClientId", APP_CLIENT_ID);
         return initializer;
@@ -327,5 +339,93 @@ class KeycloakInitializerScopedAdminIT {
         assertThat(master.realm(TEST_REALM).clients().get(appUuid).authorization().getSettings())
                 .as("the client's resource server must survive a secret repair")
                 .isNotNull();
+    }
+
+    /**
+     * The local-development fixture, against a real Keycloak. Three things are proven, all of which
+     * the fixture was getting wrong:
+     *
+     * <ol>
+     *   <li>The account is created under the fixture's own username and email, and its Keycloak id
+     *       is handed to the provisioner that writes the application half of the identity. Without
+     *       that id nothing links the login to an employee row, and the organization picker is
+     *       empty no matter what the token says.</li>
+     *   <li>A second reconcile adopts the same account rather than creating another, and reapplies
+     *       the configured password, so the documented dev credential keeps working.</li>
+     *   <li>An account that already holds the fixture username but is somebody else's is left
+     *       untouched and the fixture is skipped. This is the staging failure in miniature: the
+     *       fixture used to be named after a seeded QA persona, so it took her account over.</li>
+     * </ol>
+     */
+    @Test
+    @Order(4)
+    void devFixture_isCreatedOnceAndNeverTakesOverAForeignAccount() {
+        if (!realmExists()) {
+            newInitializer().init(false);
+        }
+
+        KeycloakInitializer initializer = newInitializer();
+        // ensureDevClient runs at the end of a reconcile, through the admin client init() selected.
+        // Driving it directly means setting that field, which init() would otherwise do.
+        ReflectionTestUtils.setField(initializer, "admin", master);
+        ReflectionTestUtils.setField(initializer, "devClientEnabled", true);
+        ReflectionTestUtils.setField(initializer, "devUserPassword", DEV_PASSWORD);
+
+        // (1) First reconcile: client and account are created, and the provisioner is handed the id.
+        ReflectionTestUtils.invokeMethod(initializer, "ensureDevClient");
+
+        List<ClientRepresentation> devClients =
+                master.realm(TEST_REALM).clients().findByClientId(DEV_CLIENT_ID);
+        assertThat(devClients).hasSize(1);
+        assertThat(devClients.get(0).isPublicClient()).isTrue();
+        assertThat(devClients.get(0).getRedirectUris()).contains("http://localhost:3000/*");
+
+        List<UserRepresentation> created =
+                master.realm(TEST_REALM).users().search(DEV_USERNAME, true);
+        assertThat(created).hasSize(1);
+        String devUserId = created.get(0).getId();
+        assertThat(created.get(0).getEmail()).isEqualTo(DEV_EMAIL);
+
+        ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(devFixtureProvisioner)
+                .provision(idCaptor.capture(), Mockito.anyString(), Mockito.eq(DEV_EMAIL));
+        assertThat(idCaptor.getValue())
+                .as("the provisioner needs the Keycloak id to bind an employee row to this login")
+                .isEqualTo(devUserId);
+
+        // (2) Second reconcile: same account, no duplicate, password reapplied.
+        Mockito.clearInvocations(devFixtureProvisioner);
+        ReflectionTestUtils.invokeMethod(initializer, "ensureDevClient");
+
+        List<UserRepresentation> afterSecondRun =
+                master.realm(TEST_REALM).users().search(DEV_USERNAME, true);
+        assertThat(afterSecondRun).hasSize(1);
+        assertThat(afterSecondRun.get(0).getId()).isEqualTo(devUserId);
+        Mockito.verify(devFixtureProvisioner)
+                .provision(Mockito.eq(devUserId), Mockito.anyString(), Mockito.eq(DEV_EMAIL));
+
+        // (3) A foreign account holding the fixture username must be left alone.
+        master.realm(TEST_REALM).users().get(devUserId).remove();
+        UserRepresentation foreign = new UserRepresentation();
+        foreign.setUsername(DEV_USERNAME);
+        foreign.setEmail("a.real.person@example.com");
+        foreign.setEnabled(true);
+        String foreignId;
+        try (Response response = master.realm(TEST_REALM).users().create(foreign)) {
+            assertThat(response.getStatus()).isEqualTo(201);
+            foreignId = CreatedResponseUtil.getCreatedId(response);
+        }
+
+        Mockito.clearInvocations(devFixtureProvisioner);
+        ReflectionTestUtils.invokeMethod(initializer, "ensureDevClient");
+
+        List<UserRepresentation> afterCollision =
+                master.realm(TEST_REALM).users().search(DEV_USERNAME, true);
+        assertThat(afterCollision).hasSize(1);
+        assertThat(afterCollision.get(0).getId())
+                .as("the foreign account must survive untouched")
+                .isEqualTo(foreignId);
+        assertThat(afterCollision.get(0).getEmail()).isEqualTo("a.real.person@example.com");
+        Mockito.verifyNoInteractions(devFixtureProvisioner);
     }
 }


### PR DESCRIPTION
## What was wrong

An identity in Echno lives in two places, and a login only works when both are present:

- Spring authorities come from the JWT group claims, so `@PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant(...)")` passes only for an account sitting in an `/org-{id}/{role}` subgroup. Parent-only membership `/org-2` yields `ORG_MEMBER_2` and passes no role check.
- The organization picker resolves membership through the database: `GET /organization/web` runs `JOIN o.employees e JOIN e.user u` and lists nothing without an `Employee` row.

`ensureDevClient()` creates only the Keycloak half, so the fixture it provisions has no organization to select and no role to pass a check with.

## Where the employee row on staging actually comes from

Not from this code. It comes from the deployment repo's Ansible `seed` role, which is run explicitly (`make seed`) and is not part of the site build:

- `roles/seed/files/keycloak-seed.json` (vault) does a Keycloak `partialImport` of 28 QA users, one of which is `amelia-price`, email `amelia@echno.com`, groups `['/org-2']`, parent only.
- `roles/seed/files/echno_db_backup.tar.gz` restores the matching application rows, including that persona's user row and employee id 19 in organization 2.

The fixture used the same username, so `users().create()` returned 409 and the initializer silently adopted the QA persona: it inherited her groups and data, and its own configured email, first and last name and password were never applied (the 409 branch only adds a realm role). That is why the fixture looked half-working on staging and produced nothing at all anywhere the seed had not been run, which includes every client production instance and any freshly built local stack.

## Which organization the fixture should attach to

Its own, created here. Borrowing seeded organization 2 is what limited the fixture to one box, and it puts every developer inside a real QA persona editing rows QA asserts against. A dedicated organization costs one extra creation step and keeps the fixture's writes where nothing else is looking.

The organization is created through the application's own onboarding path rather than a second one, so the fixture ends up shaped like a real account: `EmployeeService.joinOrganization` writes the employee row and the parent-group membership in one transaction, and `EmployeeService.assignOrgRole` adds the role subgroup. That is the sequence `OrganizationService.addOrganization` already runs for a self-service signup.

Because that organization is private and holds nothing, the fixture is its system admin, which is the level the product itself grants whoever creates an organization and the level a developer needs to get past the first screen. The authority stops at the organization boundary and confers nothing over seeded or real data. The fixture holds no realm admin role.

## Is the production guard sound

Partly, and it is worth saying plainly: `keycloak.dev-client-enabled` is a single boolean that nothing cross-checks. It defaults false in `application.yml`, the Ansible template defaults it to `'false'`, and only `staging_iitm` sets it true, so the posture today is correct. But there is no Spring-profile or environment cross-check behind it, and the per-client production inventories are made by copying an existing one, so one copied line would provision a fixture plus a `http://localhost:3000/*` redirect into a client realm, silently and at INFO.

This PR does not invent a second signal, because none exists in-process that would be honest. It reduces what a mistaken enable costs:

- the reconcile announces itself at WARN naming the realm, so an accidental enable is visible instead of buried,
- the account holds no realm admin role,
- the only organization it can administer is one this code creates, which holds no real data,
- an account that already holds the fixture username but is not the fixture's is left untouched and the fixture is skipped.

The residual exposure is the localhost redirect on the dev client, which is why the flag must stay off outside development and staging. Worth a follow-up in `echno-deployment`: an assertion in the prod inventory that the variable is false.

## What changed

- `KeycloakInitializer`
  - the fixture username moves off the QA persona to `echno-local-dev` (`local-dev@echno.local`), so nothing collides with a seeded account;
  - `ensureDevUser` no longer goes through `initKeycloakUser`, which cannot serve the fixture: it treats a 409 as "already fine", never applies the configured password, and returns nothing the caller can identify the account with. It now returns the Keycloak id, adopts a pre-existing account only when its email is the fixture's own, and reapplies the configured password so the documented dev credential keeps working. Email is the identifying mark rather than a custom attribute because Keycloak's declarative user profile discards unmanaged attributes by default;
  - the dev client's update now goes through `preserveUnsetCapabilities` (#518). It was the one client update in the class still sending a partial representation, and Keycloak reads an absent boolean on update as false.
- `DevFixtureProvisioner` (new): the application half, idempotent at every step, setting and restoring `TenantContext` around the role assignment because that runs on the startup thread, not a request.

## Verification

Full suite on the lab build box, `BUILD SUCCESSFUL in 7m 37s`. The Keycloak work runs against the disposable Testcontainers Keycloak the existing IT already starts; no live realm or database was touched.

Each assertion was confirmed to fail without its fix:

| mutation | result |
|---|---|
| `isDevFixtureAccount` returns true for any account | `onlyTheFixturesOwnAccountIsRecognised` FAILED, `devFixture_isCreatedOnceAndNeverTakesOverAForeignAccount` FAILED |
| provisioner call removed from `ensureDevClient` | `devFixture_isCreatedOnceAndNeverTakesOverAForeignAccount` FAILED |
| role assignment removed | 3 of 4 `DevFixtureProvisionerTest` FAILED |
| employee row creation removed | 3 of 4 `DevFixtureProvisionerTest` FAILED |
| tenant not restored in the `finally` | `setsTheTenantForTheRoleAssignmentAndRestoresItAfterwards` FAILED |
| `preserveUnsetCapabilities` bypassed on the dev client | `devClientUpdateCarriesTheCapabilitiesItsRepresentationLeavesUnset` FAILED |

New tests are plain JUnit and Mockito. No new Spring context and no new entity, so nothing is added to the context cache or the JVM heap the suite runs under.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local development setup now provides a dedicated login account with an associated organization and employee access.
  * The account receives administrator access and required organization defaults automatically.
* **Improvements**
  * Re-running local setup safely reuses existing records and reapplies required credentials.
  * Existing accounts and client capabilities are preserved when they are not part of the fixture setup.
  * Conflicting accounts are left unchanged.
* **Tests**
  * Added coverage for fixture creation, repeated setup, access assignment, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->