### PR TITLE
Let a new account create its first organization, and say what a denial wanted

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/aspect/SubscriptionAspect.java
+++ b/src/main/java/org/tornotron/echno_backend/aspect/SubscriptionAspect.java
@@ -38,10 +38,14 @@ public class SubscriptionAspect {
 
         if(!accessResultDto.isAllowed()) {
 
+            // The feature code is passed through so the refusal names the entitlement that was
+            // missing. Without it the response carried no feature at all and the log line read
+            // "Feature: null", leaving nobody able to tell which entitlement to look at.
             throw new SubscriptionAccessDeniedException(
                     requireSubscription.errorMessage().isEmpty()
                     ? (accessResultDto.getMessage() != null ? accessResultDto.getMessage() : accessResultDto.getReason())
                             : requireSubscription.errorMessage(),
+                    featureCode,
                     accessResultDto
             );
         }

--- a/src/main/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirement.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirement.java
@@ -11,15 +11,22 @@ import java.util.regex.Pattern;
  * What a {@code @PreAuthorize} guard asked for, read back out of its own expression.
  *
  * <p>Spring answers every denied {@code @PreAuthorize} with the same two words, "Access Denied",
- * so a caller is told that something was refused but never which permission would have let it
- * through. The expression that did the refusing is available on the failure itself, and it is the
- * one place that states the requirement exactly. This parses it into the role and permission names
- * it names, so the API can say what was missing instead of only that something was.
+ * so a caller is told that something was refused but never what. The expression that did the
+ * refusing is available on the failure itself, and it is the one place that states the requirement
+ * exactly. This parses it into the role and permission names it names, so the API can say what was
+ * missing instead of only that something was.
  *
- * <p>The parse is deliberately shallow: it walks the {@code name(arguments)} calls in the
- * expression and keeps the quoted literals from the ones it recognises. An expression it does not
- * recognise yields {@link #isDescribable()} false, and the caller falls back to the generic
- * message rather than guessing.
+ * <p>The parse keeps the shape of the expression as well as its names. An expression is first split
+ * on its top-level {@code or} into the alternatives that each independently grant access; within an
+ * alternative, everything found is required together. That distinction matters: a guard reading
+ * {@code hasAuthority('organization:delete') and @orgSecurity.isMember(#id)} grants nothing to a
+ * caller holding only the permission, and a message offering the two as separate routes would send
+ * them back for a second refusal.
+ *
+ * <p>Within an alternative the parse is deliberately shallow: it walks the {@code name(arguments)}
+ * calls and keeps the quoted literals from the ones it recognises. An expression it does not
+ * recognise yields {@link #isDescribable()} false, and the caller falls back to the generic message
+ * rather than guessing.
  *
  * <p>Nothing here reveals more than the endpoint's own annotation already does. It names the role
  * or permission an endpoint wants, never who holds it, and never anything about the caller.
@@ -48,17 +55,47 @@ public final class AuthorizationRequirement {
     private static final Set<String> SELF_CALLS = Set.of(
             "isSelfUser", "isSelfInCurrentTenant", "isSelfOrHasAnyOrgRole");
 
-    private final List<String> organizationRoles;
-    private final List<String> authorities;
-    private final boolean organizationMembership;
-    private final boolean ownRecord;
+    /**
+     * One route through the guard: everything it names has to hold at the same time.
+     *
+     * @param organizationRoles org-scoped roles, any one of which satisfies the role part.
+     * @param authorities global authorities, any one of which satisfies the permission part.
+     * @param organizationMembership whether membership of the organization is also required.
+     * @param ownRecord whether owning the record is also accepted.
+     */
+    private record Alternative(List<String> organizationRoles, List<String> authorities,
+                               boolean organizationMembership, boolean ownRecord) {
 
-    private AuthorizationRequirement(List<String> organizationRoles, List<String> authorities,
-                                     boolean organizationMembership, boolean ownRecord) {
-        this.organizationRoles = List.copyOf(organizationRoles);
-        this.authorities = List.copyOf(authorities);
-        this.organizationMembership = organizationMembership;
-        this.ownRecord = ownRecord;
+        boolean isEmpty() {
+            return organizationRoles.isEmpty() && authorities.isEmpty() && !organizationMembership && !ownRecord;
+        }
+
+        /** This route in words, with its parts joined by "and" because all of them are needed. */
+        String describe() {
+            List<String> parts = new ArrayList<>();
+            if (!organizationRoles.isEmpty()) {
+                parts.add(joinQuoted(organizationRoles)
+                        + (organizationRoles.size() == 1 ? " role" : " roles")
+                        + " in this organization");
+            }
+            if (!authorities.isEmpty()) {
+                parts.add(joinQuoted(authorities)
+                        + (authorities.size() == 1 ? " permission" : " permissions"));
+            }
+            if (organizationMembership) {
+                parts.add("membership of this organization");
+            }
+            if (ownRecord) {
+                parts.add("that the record belongs to you");
+            }
+            return String.join(" and ", parts);
+        }
+    }
+
+    private final List<Alternative> alternatives;
+
+    private AuthorizationRequirement(List<Alternative> alternatives) {
+        this.alternatives = List.copyOf(alternatives);
     }
 
     /**
@@ -69,48 +106,37 @@ public final class AuthorizationRequirement {
      *         this knows how to name.
      */
     public static AuthorizationRequirement from(String expression) {
-        Set<String> roles = new LinkedHashSet<>();
-        Set<String> permissions = new LinkedHashSet<>();
-        boolean membership = false;
-        boolean self = false;
-
+        List<Alternative> parsed = new ArrayList<>();
         if (expression != null) {
-            Matcher call = CALL.matcher(expression);
-            while (call.find()) {
-                String name = simpleName(call.group(1));
-                String arguments = call.group(2);
-
-                if (ORG_ROLE_CALLS.contains(name)) {
-                    roles.addAll(literals(arguments));
-                }
-                if (AUTHORITY_CALLS.contains(name)) {
-                    permissions.addAll(literals(arguments));
-                }
-                if (MEMBERSHIP_CALLS.contains(name)) {
-                    membership = true;
-                }
-                if (SELF_CALLS.contains(name)) {
-                    self = true;
+            for (String alternative : splitOnTopLevelOr(expression)) {
+                Alternative read = readAlternative(alternative);
+                if (!read.isEmpty()) {
+                    parsed.add(read);
                 }
             }
         }
-
-        return new AuthorizationRequirement(new ArrayList<>(roles), new ArrayList<>(permissions), membership, self);
+        return new AuthorizationRequirement(parsed);
     }
 
     /** Whether the expression named anything worth telling the caller about. */
     public boolean isDescribable() {
-        return !organizationRoles.isEmpty() || !authorities.isEmpty() || organizationMembership || ownRecord;
+        return !alternatives.isEmpty();
     }
 
-    /** The org-scoped role names the endpoint accepts, in the order the expression lists them. */
+    /** Every org-scoped role name the expression mentions, in the order it lists them. */
     public List<String> getOrganizationRoles() {
-        return organizationRoles;
+        return alternatives.stream()
+                .flatMap(alternative -> alternative.organizationRoles().stream())
+                .distinct()
+                .toList();
     }
 
-    /** The global authority names the endpoint accepts, in the order the expression lists them. */
+    /** Every global authority name the expression mentions, in the order it lists them. */
     public List<String> getAuthorities() {
-        return authorities;
+        return alternatives.stream()
+                .flatMap(alternative -> alternative.authorities().stream())
+                .distinct()
+                .toList();
     }
 
     /**
@@ -123,32 +149,91 @@ public final class AuthorizationRequirement {
             return null;
         }
 
-        List<String> alternatives = new ArrayList<>();
-        if (!organizationRoles.isEmpty()) {
-            alternatives.add(joinQuoted(organizationRoles)
-                    + (organizationRoles.size() == 1 ? " role" : " roles")
-                    + " in this organization");
-        }
-        if (!authorities.isEmpty()) {
-            alternatives.add(joinQuoted(authorities)
-                    + (authorities.size() == 1 ? " permission" : " permissions"));
-        }
-        if (organizationMembership) {
-            alternatives.add("membership of this organization");
-        }
-        if (ownRecord) {
-            alternatives.add("that the record belongs to you");
-        }
+        String routes = String.join(", or ", alternatives.stream().map(Alternative::describe).toList());
+        StringBuilder sentence = new StringBuilder("This action requires ").append(routes).append(".");
 
-        StringBuilder sentence = new StringBuilder("This action requires ")
-                .append(String.join(", or ", alternatives))
-                .append(".");
-
-        if (!organizationRoles.isEmpty() || organizationMembership) {
+        boolean organizationScoped = alternatives.stream()
+                .anyMatch(alternative -> !alternative.organizationRoles().isEmpty()
+                        || alternative.organizationMembership());
+        if (organizationScoped) {
             sentence.append(" Your roles are read from the session you signed in with, so if one was "
                     + "granted just now, sign out and back in to pick it up.");
         }
         return sentence.toString();
+    }
+
+    /**
+     * Splits an expression on the {@code or} operators that sit outside any bracket.
+     *
+     * <p>Only a top-level {@code or} separates two independent routes through the guard. An
+     * {@code or} nested inside brackets belongs to whichever clause encloses it, and splitting on
+     * it would break a conjunction apart and turn "both of these" into "either of these".
+     */
+    private static List<String> splitOnTopLevelOr(String expression) {
+        List<String> parts = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        boolean inLiteral = false;
+
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+            if (c == '\'') {
+                inLiteral = !inLiteral;
+            } else if (!inLiteral && c == '(') {
+                depth++;
+            } else if (!inLiteral && c == ')') {
+                depth--;
+            } else if (!inLiteral && depth == 0 && isOperatorAt(expression, i, "or")) {
+                parts.add(expression.substring(start, i));
+                start = i + 2;
+            } else if (!inLiteral && depth == 0 && isOperatorAt(expression, i, "||")) {
+                parts.add(expression.substring(start, i));
+                start = i + 2;
+            }
+        }
+        parts.add(expression.substring(start));
+        return parts;
+    }
+
+    /** Whether the token at this position is the given operator standing on its own. */
+    private static boolean isOperatorAt(String expression, int index, String operator) {
+        if (!expression.startsWith(operator, index)) {
+            return false;
+        }
+        boolean beforeIsBoundary = index == 0 || !Character.isLetterOrDigit(expression.charAt(index - 1));
+        int after = index + operator.length();
+        boolean afterIsBoundary = after >= expression.length()
+                || !Character.isLetterOrDigit(expression.charAt(after));
+        return beforeIsBoundary && afterIsBoundary;
+    }
+
+    /** Reads one alternative, treating everything it names as required together. */
+    private static Alternative readAlternative(String expression) {
+        Set<String> roles = new LinkedHashSet<>();
+        Set<String> permissions = new LinkedHashSet<>();
+        boolean membership = false;
+        boolean self = false;
+
+        Matcher call = CALL.matcher(expression);
+        while (call.find()) {
+            String name = simpleName(call.group(1));
+            String arguments = call.group(2);
+
+            if (ORG_ROLE_CALLS.contains(name)) {
+                roles.addAll(literals(arguments));
+            }
+            if (AUTHORITY_CALLS.contains(name)) {
+                permissions.addAll(literals(arguments));
+            }
+            if (MEMBERSHIP_CALLS.contains(name)) {
+                membership = true;
+            }
+            if (SELF_CALLS.contains(name)) {
+                self = true;
+            }
+        }
+
+        return new Alternative(new ArrayList<>(roles), new ArrayList<>(permissions), membership, self);
     }
 
     /** Strips a bean reference and package qualification, leaving the method name. */

--- a/src/main/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirement.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirement.java
@@ -1,0 +1,182 @@
+package org.tornotron.echno_backend.common.exception;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * What a {@code @PreAuthorize} guard asked for, read back out of its own expression.
+ *
+ * <p>Spring answers every denied {@code @PreAuthorize} with the same two words, "Access Denied",
+ * so a caller is told that something was refused but never which permission would have let it
+ * through. The expression that did the refusing is available on the failure itself, and it is the
+ * one place that states the requirement exactly. This parses it into the role and permission names
+ * it names, so the API can say what was missing instead of only that something was.
+ *
+ * <p>The parse is deliberately shallow: it walks the {@code name(arguments)} calls in the
+ * expression and keeps the quoted literals from the ones it recognises. An expression it does not
+ * recognise yields {@link #isDescribable()} false, and the caller falls back to the generic
+ * message rather than guessing.
+ *
+ * <p>Nothing here reveals more than the endpoint's own annotation already does. It names the role
+ * or permission an endpoint wants, never who holds it, and never anything about the caller.
+ */
+public final class AuthorizationRequirement {
+
+    /** Matches a {@code name(arguments)} call, including a bean reference such as {@code @orgSecurity.hasOrgRole(...)}. */
+    private static final Pattern CALL = Pattern.compile("([@A-Za-z][\\w.]*)\\s*\\(([^()]*)\\)");
+
+    /** Matches a single-quoted literal inside an argument list. */
+    private static final Pattern LITERAL = Pattern.compile("'([^']*)'");
+
+    /** Calls whose quoted arguments are org-scoped role names. */
+    private static final Set<String> ORG_ROLE_CALLS = Set.of(
+            "hasOrgRole", "hasAnyOrgRole", "hasAnyOrgRoleForCurrentTenant", "isSelfOrHasAnyOrgRole");
+
+    /** Calls whose quoted arguments are global authority names. */
+    private static final Set<String> AUTHORITY_CALLS = Set.of(
+            "hasAuthority", "hasAnyAuthority", "hasRole", "hasAnyRole");
+
+    /** Calls that ask for membership of an organization rather than a role within one. */
+    private static final Set<String> MEMBERSHIP_CALLS = Set.of(
+            "isMember", "isMemberOrAdmin", "isMemberOfCurrentTenant");
+
+    /** Calls that let the caller through on their own record. */
+    private static final Set<String> SELF_CALLS = Set.of(
+            "isSelfUser", "isSelfInCurrentTenant", "isSelfOrHasAnyOrgRole");
+
+    private final List<String> organizationRoles;
+    private final List<String> authorities;
+    private final boolean organizationMembership;
+    private final boolean ownRecord;
+
+    private AuthorizationRequirement(List<String> organizationRoles, List<String> authorities,
+                                     boolean organizationMembership, boolean ownRecord) {
+        this.organizationRoles = List.copyOf(organizationRoles);
+        this.authorities = List.copyOf(authorities);
+        this.organizationMembership = organizationMembership;
+        this.ownRecord = ownRecord;
+    }
+
+    /**
+     * Reads the requirement out of a {@code @PreAuthorize} expression.
+     *
+     * @param expression the expression as written on the endpoint, may be null.
+     * @return the requirement it states, empty of everything when the expression says nothing
+     *         this knows how to name.
+     */
+    public static AuthorizationRequirement from(String expression) {
+        Set<String> roles = new LinkedHashSet<>();
+        Set<String> permissions = new LinkedHashSet<>();
+        boolean membership = false;
+        boolean self = false;
+
+        if (expression != null) {
+            Matcher call = CALL.matcher(expression);
+            while (call.find()) {
+                String name = simpleName(call.group(1));
+                String arguments = call.group(2);
+
+                if (ORG_ROLE_CALLS.contains(name)) {
+                    roles.addAll(literals(arguments));
+                }
+                if (AUTHORITY_CALLS.contains(name)) {
+                    permissions.addAll(literals(arguments));
+                }
+                if (MEMBERSHIP_CALLS.contains(name)) {
+                    membership = true;
+                }
+                if (SELF_CALLS.contains(name)) {
+                    self = true;
+                }
+            }
+        }
+
+        return new AuthorizationRequirement(new ArrayList<>(roles), new ArrayList<>(permissions), membership, self);
+    }
+
+    /** Whether the expression named anything worth telling the caller about. */
+    public boolean isDescribable() {
+        return !organizationRoles.isEmpty() || !authorities.isEmpty() || organizationMembership || ownRecord;
+    }
+
+    /** The org-scoped role names the endpoint accepts, in the order the expression lists them. */
+    public List<String> getOrganizationRoles() {
+        return organizationRoles;
+    }
+
+    /** The global authority names the endpoint accepts, in the order the expression lists them. */
+    public List<String> getAuthorities() {
+        return authorities;
+    }
+
+    /**
+     * The requirement in a sentence a non-engineer can act on.
+     *
+     * @return the sentence, or null when the expression named nothing to describe.
+     */
+    public String describe() {
+        if (!isDescribable()) {
+            return null;
+        }
+
+        List<String> alternatives = new ArrayList<>();
+        if (!organizationRoles.isEmpty()) {
+            alternatives.add(joinQuoted(organizationRoles)
+                    + (organizationRoles.size() == 1 ? " role" : " roles")
+                    + " in this organization");
+        }
+        if (!authorities.isEmpty()) {
+            alternatives.add(joinQuoted(authorities)
+                    + (authorities.size() == 1 ? " permission" : " permissions"));
+        }
+        if (organizationMembership) {
+            alternatives.add("membership of this organization");
+        }
+        if (ownRecord) {
+            alternatives.add("that the record belongs to you");
+        }
+
+        StringBuilder sentence = new StringBuilder("This action requires ")
+                .append(String.join(", or ", alternatives))
+                .append(".");
+
+        if (!organizationRoles.isEmpty() || organizationMembership) {
+            sentence.append(" Your roles are read from the session you signed in with, so if one was "
+                    + "granted just now, sign out and back in to pick it up.");
+        }
+        return sentence.toString();
+    }
+
+    /** Strips a bean reference and package qualification, leaving the method name. */
+    private static String simpleName(String call) {
+        int lastDot = call.lastIndexOf('.');
+        return lastDot < 0 ? call.replace("@", "") : call.substring(lastDot + 1);
+    }
+
+    /** Every single-quoted literal in an argument list, in order. */
+    private static List<String> literals(String arguments) {
+        List<String> found = new ArrayList<>();
+        Matcher literal = LITERAL.matcher(arguments);
+        while (literal.find()) {
+            String value = literal.group(1);
+            if (!value.isBlank()) {
+                found.add(value);
+            }
+        }
+        return found;
+    }
+
+    /** Renders names as {@code the 'a', 'b' or 'c'}, which reads the same for one name or several. */
+    private static String joinQuoted(List<String> names) {
+        List<String> quoted = names.stream().map(name -> "'" + name + "'").toList();
+        if (quoted.size() == 1) {
+            return "the " + quoted.getFirst();
+        }
+        return "the " + String.join(", ", quoted.subList(0, quoted.size() - 1))
+                + " or " + quoted.getLast();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.validation.FieldError;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -219,11 +220,68 @@ public class GlobalExceptionHandler {
         return problem(HttpStatus.BAD_REQUEST, "Invalid Invite Code", ex.getMessage(), request);
     }
 
+    /**
+     * A refused {@code @PreAuthorize}, answered with the permission that would have satisfied it.
+     *
+     * <p>Spring's own message is the fixed string "Access Denied", which tells a caller that
+     * something was refused but never what. The expression that refused it travels on the failure,
+     * and it is the one authoritative statement of the requirement, so it is read back out and
+     * named here. The role and permission names are also exposed as problem properties, so the
+     * frontend can act on them without parsing the sentence.
+     *
+     * <p>An expression this cannot describe falls back to Spring's message rather than to a guess.
+     */
     @ExceptionHandler(AuthorizationDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ProblemDetail handleAuthorizationDeniedException(AuthorizationDeniedException ex, WebRequest request) {
-        logger.error("Access denied: ", ex);
+        String expression = deniedExpression(ex);
+        AuthorizationRequirement requirement = AuthorizationRequirement.from(expression);
+        String described = requirement.describe();
+
+        logger.warn("Authorization denied on {} by expression [{}]", request.getDescription(false), expression);
+
+        String detail = described == null
+                ? ex.getMessage()
+                : "You do not have permission for this action. " + described;
+
+        ProblemDetail pd = problem(HttpStatus.FORBIDDEN, "Access Denied", detail, request);
+        if (!requirement.getOrganizationRoles().isEmpty()) {
+            pd.setProperty("requiredOrganizationRoles", requirement.getOrganizationRoles());
+        }
+        if (!requirement.getAuthorities().isEmpty()) {
+            pd.setProperty("requiredAuthorities", requirement.getAuthorities());
+        }
+        return pd;
+    }
+
+    /**
+     * Handles a refusal raised by our own code rather than by an annotation.
+     *
+     * <p>Services throw Spring Security's {@code AccessDeniedException} with a message that already
+     * says what was wrong ("Only the sender can edit this message"). Without this handler that
+     * exception fell through to the catch-all and came back as a 500, which is both the wrong
+     * status and the wrong story. The message is written for the caller, so it is passed through.
+     */
+    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ProblemDetail handleSecurityAccessDeniedException(
+            org.springframework.security.access.AccessDeniedException ex, WebRequest request) {
+        logger.warn("Access denied on {}: {}", request.getDescription(false), ex.getMessage());
         return problem(HttpStatus.FORBIDDEN, "Access Denied", ex.getMessage(), request);
+    }
+
+    /**
+     * The {@code @PreAuthorize} expression behind a denial, when the failure carries one.
+     *
+     * <p>Method security attaches an {@link ExpressionAuthorizationDecision} holding the very
+     * expression that was evaluated. Anything else (a denial from an {@code AuthorizationManager}
+     * written in Java, for instance) carries no expression and yields null.
+     */
+    private String deniedExpression(AuthorizationDeniedException ex) {
+        if (ex.getAuthorizationResult() instanceof ExpressionAuthorizationDecision decision) {
+            return decision.getExpression().getExpressionString();
+        }
+        return null;
     }
 
     @ExceptionHandler(DatabaseOperationException.class)

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
@@ -14,13 +14,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.tornotron.echno_backend.common.customAnnotation.RequireSubscription;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.organization.dto.OrganizationCreationDto;
 import org.tornotron.echno_backend.organization.dto.OrganizationDto;
 import org.tornotron.echno_backend.organization.dto.OrganizationPatchDto;
 import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
-import org.tornotron.echno_backend.common.customAnnotation.RequireSubscription;
 
 import java.util.List;
 import java.util.Map;
@@ -57,22 +55,32 @@ public class OrganizationController {
 
     /**
      * Creates a new organization.
+     *
+     * <p>The guard is authentication alone, and deliberately so. Creating an organization is how a
+     * new account bootstraps itself: it starts a tenant of its own and touches no existing one, and
+     * the creator becomes that tenant's system-admin. Requiring an organization authority first
+     * meant a self-registered account could never obtain one, since the only endpoint that grants
+     * it was the one being guarded. The billing side of the same rule lives in
+     * {@code OrganizationService}, which exempts a user's first organization and charges the rest.
+     *
      *  organizationCreationDto DTO containing the details for the new organization.
      * @return A {@link ResponseEntity} with the created organization's simple DTO and HTTP status 201 (Created).
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasAuthority('organization:create') or hasAuthority('organization:admin')")
-    @RequireSubscription(feature = "CREATE_ORGANIZATION", recordUsage = true)
+    @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "Create an organization",
             description = "Creates an organization from a multipart request. The data part carries the "
                     + "organization details as JSON and the optional attachments part carries supporting "
-                    + "files such as a logo. Counts against the CREATE_ORGANIZATION subscription feature."
+                    + "files such as a logo. The caller becomes the organization's system admin. A "
+                    + "user's first organization is part of signing up and needs no subscription; "
+                    + "each one after it counts against the CREATE_ORGANIZATION subscription feature."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Organization created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid organization JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the organization create or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
     public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationRepository.java
@@ -33,6 +33,14 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
 
     boolean existsByOrganizationEmail(String organizationEmail);
 
+    /**
+     * Whether the given user has ever created an organization.
+     *
+     * @param creatorId The ID of the user to check.
+     * @return {@code true} if at least one organization records them as its creator.
+     */
+    boolean existsByCreatorId(Integer creatorId);
+
     @Query(
             "SELECT DISTINCT o FROM Organization o " +
                     "JOIN o.employees e " +

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -123,6 +123,17 @@ public class OrganizationService {
      * and mobile, create through here, and the fact the rule turns on (whether this user has
      * created an organization before) is only known at this level.
      *
+     * <p>The read and the insert it guards run in one transaction against CockroachDB, whose
+     * isolation is SERIALIZABLE, so two concurrent first creations by the same user cannot both
+     * pass: the second insert invalidates the other's read and that transaction retries, by which
+     * point the first organization exists and the check applies normally.
+     *
+     * <p>Deleting an organization does restore the exemption, and that is intended rather than a
+     * gap. Deletion already refunds the CREATE_ORGANIZATION usage it recorded, so a create followed
+     * by a delete leaves the account exactly where it started. Making the exemption permanent
+     * instead would mean a user who deletes the organization they made by mistake can never create
+     * another without buying a plan, which is a worse answer than the one it replaces.
+     *
      * @param currentUser The user creating the organization.
      * @throws SubscriptionAccessDeniedException if this is not their first and their plan does not
      *         cover it.

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -7,10 +7,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.billing.dto.FeatureAccessResultDto;
 import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.exception.SubscriptionAccessDeniedException;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
@@ -48,6 +51,9 @@ import java.util.stream.Collectors;
 public class OrganizationService {
 
     private static final String ORGANIZATION_FOLDER = "organizations";
+
+    /** The billing feature that covers creating an organization. */
+    private static final String CREATE_ORGANIZATION_FEATURE = "CREATE_ORGANIZATION";
 
     private final OrganizationRepository repository;
     private final AttachmentService attachmentService;
@@ -105,6 +111,36 @@ public class OrganizationService {
     }
 
     /**
+     * Applies the CREATE_ORGANIZATION entitlement, exempting the caller's very first organization.
+     *
+     * <p>Creating an organization is how a new account bootstraps itself: a self-registered user
+     * holds no subscription and belongs to nothing, so billing the first creation leaves the
+     * account with no action it can take and no way to buy one. The first organization is therefore
+     * part of signing up and is not gated; every organization after it goes through the normal
+     * feature check.
+     *
+     * <p>This lives in the service rather than on the controllers because both entry points, web
+     * and mobile, create through here, and the fact the rule turns on (whether this user has
+     * created an organization before) is only known at this level.
+     *
+     * @param currentUser The user creating the organization.
+     * @throws SubscriptionAccessDeniedException if this is not their first and their plan does not
+     *         cover it.
+     */
+    private void requireCreateOrganizationEntitlement(User currentUser) {
+        if (!repository.existsByCreatorId(currentUser.getId().intValue())) {
+            log.info("User {} is creating their first organization; no subscription required", currentUser.getId());
+            return;
+        }
+
+        FeatureAccessResultDto access = subscriptionService.checkFeatureAccess(currentUser.getId(), CREATE_ORGANIZATION_FEATURE);
+        if (!access.isAllowed()) {
+            String message = access.getMessage() != null ? access.getMessage() : access.getReason();
+            throw new SubscriptionAccessDeniedException(message, CREATE_ORGANIZATION_FEATURE, access);
+        }
+    }
+
+    /**
      * Creates and persists a new organization based on the provided data.
      * @param organizationCreationDto A DTO containing the details for the new organization.
      * @return An {@link OrganizationSimpleDto} representing the newly created organization.
@@ -117,6 +153,11 @@ public class OrganizationService {
             throw new DuplicateResourceException("Organization with email '" + organizationCreationDto.getOrganizationEmail() + "' already exists");
         }
         User currentUser = userContextService.getCurrentUser();
+        if (currentUser == null) {
+            throw new AccessDeniedException(
+                    "Your account is not provisioned yet, so an organization cannot be created for it");
+        }
+        requireCreateOrganizationEntitlement(currentUser);
         Organization organization = new Organization();
         organization.setOrganizationName(organizationCreationDto.getOrganizationName());
         organization.setOrganizationAddress(organizationCreationDto.getOrganizationAddress());
@@ -157,7 +198,27 @@ public class OrganizationService {
         // idempotent seeder see the committed org and run in its own transaction.
         scheduleFinanceSeeding(savedOrganization.getId());
 
+        // Count the creation against the user's CREATE_ORGANIZATION quota, after commit for the
+        // same reason as the seeding: a usage-recording failure must not lose the organization.
+        // The first organization is exempt from the check above but still counted, so the quota
+        // stays an honest record of what was created.
+        afterCommit(() -> recordOrganizationCreated(currentUser.getId()));
+
         return organizationMapper.toSimpleDto(savedOrganization);
+    }
+
+    /**
+     * Records one CREATE_ORGANIZATION usage, swallowing any failure.
+     *
+     * <p>Usage accounting is bookkeeping, not part of the creation: an organization that exists
+     * must not be reported as failed because its meter could not be written.
+     */
+    private void recordOrganizationCreated(Long userId) {
+        try {
+            subscriptionService.recordUsage(userId, CREATE_ORGANIZATION_FEATURE, 1L);
+        } catch (Exception e) {
+            log.error("Failed to record organization creation usage for user {}", userId, e);
+        }
     }
 
     /**
@@ -166,16 +227,24 @@ public class OrganizationService {
      * there is no active transaction (the seeding is idempotent and independently guarded either way).
      */
     private void scheduleFinanceSeeding(Long organizationId) {
+        afterCommit(() -> onboardingSeeder.seedFinanceDefaults(organizationId));
+    }
+
+    /**
+     * Defers work until the current transaction commits, or runs it inline when there is no
+     * transaction to wait for (which is the case in unit tests and in any direct call).
+     */
+    private void afterCommit(Runnable action) {
         if (org.springframework.transaction.support.TransactionSynchronizationManager.isSynchronizationActive()) {
             org.springframework.transaction.support.TransactionSynchronizationManager.registerSynchronization(
                     new org.springframework.transaction.support.TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
-                            onboardingSeeder.seedFinanceDefaults(organizationId);
+                            action.run();
                         }
                     });
         } else {
-            onboardingSeeder.seedFinanceDefaults(organizationId);
+            action.run();
         }
     }
 
@@ -335,7 +404,7 @@ public class OrganizationService {
 
         if (creatorId != null) {
             try {
-                subscriptionService.recordUsage(creatorId.longValue(), "CREATE_ORGANIZATION", -1L);
+                subscriptionService.recordUsage(creatorId.longValue(), CREATE_ORGANIZATION_FEATURE, -1L);
             } catch (Exception e) {
                 log.warn("Failed to decrement organization usage for user {}", creatorId);
             }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -14,7 +14,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.tornotron.echno_backend.common.customAnnotation.RequireSubscription;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.organization.dto.OrganizationCreationDto;
 import org.tornotron.echno_backend.organization.dto.OrganizationDto;
@@ -45,22 +44,30 @@ public class OrganizationWebController {
     /**
      * Creates a new organization.
      *
+     * <p>This is the endpoint a freshly registered account uses to bootstrap itself, so the guard
+     * is authentication alone: the caller starts a tenant of their own, touches no existing one,
+     * and becomes its system-admin. The billing rule lives in {@code OrganizationService}, which
+     * exempts a user's first organization from the CREATE_ORGANIZATION entitlement and charges
+     * every one after it. Gating the first creation on a subscription left a self-registered
+     * account with nothing it could do, which is what the onboarding screen walked into.
+     *
      * organizationCreationDto DTO containing the details for the new organization.
      * @return A {@link ResponseEntity} with the created organization's simple DTO and HTTP status 201 (Created).
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @RequireSubscription(feature = "CREATE_ORGANIZATION",recordUsage = true)
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "Create an organization",
             description = "Creates an organization from a multipart request. The data part carries the "
                     + "organization details as JSON and the optional attachments part carries supporting "
-                    + "files such as a logo. The caller becomes the organization's initial member. Counts "
-                    + "against the CREATE_ORGANIZATION subscription feature."
+                    + "files such as a logo. The caller becomes the organization's system admin. A "
+                    + "user's first organization is part of signing up and needs no subscription; "
+                    + "each one after it counts against the CREATE_ORGANIZATION subscription feature."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Organization created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid organization JSON, or a field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
     public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,

--- a/src/test/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirementTest.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.common.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reading a {@code @PreAuthorize} expression back into the requirement it states.
+ *
+ * <p>The expressions used here are copied from real endpoints, so a change to the guard vocabulary
+ * that this parser stops recognising shows up as a failure rather than as a silently generic
+ * refusal in production.
+ */
+class AuthorizationRequirementTest {
+
+    @Test
+    void namesTheOrgScopedRolesAnEndpointAccepts() {
+        // OrganizationWebController.partialUpdateAnOrganization
+        AuthorizationRequirement requirement =
+                AuthorizationRequirement.from("@orgSecurity.hasAnyOrgRole(#id, 'system-admin', 'hr-admin')");
+
+        assertThat(requirement.isDescribable()).isTrue();
+        assertThat(requirement.getOrganizationRoles()).containsExactly("system-admin", "hr-admin");
+        assertThat(requirement.describe())
+                .contains("the 'system-admin' or 'hr-admin' roles in this organization");
+    }
+
+    @Test
+    void namesASingleOrgScopedRole() {
+        // OrganizationWebController.deleteOrganization
+        AuthorizationRequirement requirement =
+                AuthorizationRequirement.from("@orgSecurity.hasOrgRole(#id, 'system-admin')");
+
+        assertThat(requirement.getOrganizationRoles()).containsExactly("system-admin");
+        assertThat(requirement.describe()).contains("the 'system-admin' role in this organization");
+    }
+
+    @Test
+    void namesGlobalAuthorities() {
+        AuthorizationRequirement requirement =
+                AuthorizationRequirement.from("hasAuthority('organization:admin')");
+
+        assertThat(requirement.getAuthorities()).containsExactly("organization:admin");
+        assertThat(requirement.getOrganizationRoles()).isEmpty();
+        assertThat(requirement.describe()).contains("the 'organization:admin' permission");
+    }
+
+    @Test
+    void readsEveryAlternativeOfACompositeExpression() {
+        // OrganizationController.deleteOrganization, the widest guard in the codebase.
+        AuthorizationRequirement requirement = AuthorizationRequirement.from(
+                "@orgSecurity.hasOrgRole(#id, 'system-admin') or "
+                        + "(hasAuthority('organization:delete') and @orgSecurity.isMember(#id)) or "
+                        + "hasAuthority('organization:admin')");
+
+        assertThat(requirement.getOrganizationRoles()).containsExactly("system-admin");
+        assertThat(requirement.getAuthorities()).containsExactly("organization:delete", "organization:admin");
+
+        String described = requirement.describe();
+        assertThat(described).contains("the 'system-admin' role in this organization");
+        assertThat(described).contains("the 'organization:delete' or 'organization:admin' permissions");
+        assertThat(described).contains("membership of this organization");
+    }
+
+    @Test
+    void recognisesASelfOrRoleGuard() {
+        AuthorizationRequirement requirement =
+                AuthorizationRequirement.from("@orgSecurity.isSelfOrHasAnyOrgRole(#id, 'hr-admin')");
+
+        assertThat(requirement.getOrganizationRoles()).containsExactly("hr-admin");
+        assertThat(requirement.describe()).contains("that the record belongs to you");
+    }
+
+    @Test
+    void tellsTheCallerToSignInAgainWhenAnOrgRoleIsWhatIsMissing() {
+        // The case right after creating an organization: the role exists in Keycloak but the
+        // token in hand was minted before it, so the fix is a fresh sign-in, not a new grant.
+        String described = AuthorizationRequirement
+                .from("@orgSecurity.hasOrgRole(#id, 'system-admin')")
+                .describe();
+
+        assertThat(described).contains("sign out and back in");
+    }
+
+    @Test
+    void doesNotOfferTheSignInHintForAPurelyGlobalPermission() {
+        String described = AuthorizationRequirement.from("hasAuthority('organization:admin')").describe();
+
+        assertThat(described).doesNotContain("sign out and back in");
+    }
+
+    @Test
+    void describesNothingForAnExpressionItDoesNotRecognise() {
+        // isAuthenticated() names no permission, so there is nothing useful to say; the caller
+        // falls back to the generic message rather than inventing one.
+        AuthorizationRequirement requirement = AuthorizationRequirement.from("isAuthenticated()");
+
+        assertThat(requirement.isDescribable()).isFalse();
+        assertThat(requirement.describe()).isNull();
+    }
+
+    @Test
+    void describesNothingForANullExpression() {
+        // A denial raised by an AuthorizationManager written in Java carries no expression.
+        AuthorizationRequirement requirement = AuthorizationRequirement.from(null);
+
+        assertThat(requirement.isDescribable()).isFalse();
+        assertThat(requirement.describe()).isNull();
+        assertThat(requirement.getOrganizationRoles()).isEmpty();
+        assertThat(requirement.getAuthorities()).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/AuthorizationRequirementTest.java
@@ -47,7 +47,10 @@ class AuthorizationRequirementTest {
 
     @Test
     void readsEveryAlternativeOfACompositeExpression() {
-        // OrganizationController.deleteOrganization, the widest guard in the codebase.
+        // OrganizationController.deleteOrganization, the widest guard in the codebase, and the one
+        // that matters most for this: its middle branch needs the permission AND membership
+        // together. Offering them as two separate routes would send a caller holding only
+        // 'organization:delete' back for a second refusal.
         AuthorizationRequirement requirement = AuthorizationRequirement.from(
                 "@orgSecurity.hasOrgRole(#id, 'system-admin') or "
                         + "(hasAuthority('organization:delete') and @orgSecurity.isMember(#id)) or "
@@ -56,10 +59,36 @@ class AuthorizationRequirementTest {
         assertThat(requirement.getOrganizationRoles()).containsExactly("system-admin");
         assertThat(requirement.getAuthorities()).containsExactly("organization:delete", "organization:admin");
 
-        String described = requirement.describe();
-        assertThat(described).contains("the 'system-admin' role in this organization");
-        assertThat(described).contains("the 'organization:delete' or 'organization:admin' permissions");
-        assertThat(described).contains("membership of this organization");
+        assertThat(requirement.describe()).startsWith(
+                "This action requires the 'system-admin' role in this organization, "
+                        + "or the 'organization:delete' permission and membership of this organization, "
+                        + "or the 'organization:admin' permission.");
+    }
+
+    @Test
+    void keepsAConjunctionTogetherRatherThanOfferingItAsTwoRoutes() {
+        // Nothing here is optional, so nothing should read as an alternative.
+        String described = AuthorizationRequirement
+                .from("hasAuthority('organization:delete') and @orgSecurity.isMember(#id)")
+                .describe();
+
+        assertThat(described).isEqualTo(
+                "This action requires the 'organization:delete' permission and membership of this "
+                        + "organization. Your roles are read from the session you signed in with, so if "
+                        + "one was granted just now, sign out and back in to pick it up.");
+        assertThat(described).doesNotContain(", or ");
+    }
+
+    @Test
+    void doesNotSplitOnAnOrNestedInsideBrackets() {
+        // The nested 'or' belongs to the bracketed clause; splitting on it would break the
+        // surrounding 'and' apart and turn "both of these" into "either of these".
+        String described = AuthorizationRequirement
+                .from("(hasAuthority('a') or hasAuthority('b')) and @orgSecurity.isMemberOfCurrentTenant()")
+                .describe();
+
+        assertThat(described).contains("the 'a' or 'b' permissions and membership of this organization");
+        assertThat(described).doesNotContain(", or ");
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
@@ -1,8 +1,11 @@
 package org.tornotron.echno_backend.common.exception;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -99,6 +102,68 @@ class GlobalExceptionHandlerTest {
         assertThat(pd.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
         assertThat(pd.getTitle()).isEqualTo("Internal Server Error");
         assertThat(pd.getDetail()).isEqualTo("An unexpected error occurred: boom");
+    }
+
+    @Test
+    void authorizationDenied_namesTheRoleTheEndpointWanted() {
+        // Spring's own message here is the fixed string "Access Denied", which is exactly the
+        // problem: the caller learns nothing about what would have let them through.
+        ProblemDetail pd = handler.handleAuthorizationDeniedException(
+                deniedBy("@orgSecurity.hasAnyOrgRole(#id, 'system-admin', 'hr-admin')"),
+                requestWithPath("uri=/api/v1/organization/web/3"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getTitle()).isEqualTo("Access Denied");
+        assertThat(pd.getDetail())
+                .startsWith("You do not have permission for this action.")
+                .contains("the 'system-admin' or 'hr-admin' roles in this organization");
+        assertThat(pd.getProperties())
+                .containsEntry("requiredOrganizationRoles", List.of("system-admin", "hr-admin"));
+    }
+
+    @Test
+    void authorizationDenied_exposesTheRequiredAuthoritiesForTheFrontend() {
+        ProblemDetail pd = handler.handleAuthorizationDeniedException(
+                deniedBy("hasAuthority('organization:admin')"),
+                requestWithPath("uri=/api/v1/organization/creator/4"));
+
+        assertThat(pd.getProperties()).containsEntry("requiredAuthorities", List.of("organization:admin"));
+        assertThat(pd.getProperties()).doesNotContainKey("requiredOrganizationRoles");
+    }
+
+    @Test
+    void authorizationDenied_fallsBackToSpringsMessageWhenNoExpressionIsAttached() {
+        // A denial raised by an AuthorizationManager written in Java carries no expression, so
+        // there is nothing to name and nothing should be invented.
+        ProblemDetail pd = handler.handleAuthorizationDeniedException(
+                new AuthorizationDeniedException("Access Denied"), requestWithPath("uri=/api/v1/x"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getDetail()).isEqualTo("Access Denied");
+        assertThat(pd.getProperties()).doesNotContainKey("requiredOrganizationRoles");
+    }
+
+    @Test
+    void securityAccessDenied_isA403CarryingTheServicesOwnMessage() {
+        // Services throw this with a message written for the caller. It used to reach the
+        // catch-all handler and come back as a 500, hiding both the status and the reason.
+        ProblemDetail pd = handler.handleSecurityAccessDeniedException(
+                new org.springframework.security.access.AccessDeniedException(
+                        "Only the sender can edit this message"),
+                requestWithPath("uri=/api/v1/chat/messages/9"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getTitle()).isEqualTo("Access Denied");
+        assertThat(pd.getDetail()).isEqualTo("Only the sender can edit this message");
+        assertThat(pd.getProperties()).containsEntry("message", "Only the sender can edit this message");
+    }
+
+    /** A method-security denial carrying the expression that refused it, as Spring builds one. */
+    private AuthorizationDeniedException deniedBy(String expression) {
+        Expression parsed = mock(Expression.class);
+        when(parsed.getExpressionString()).thenReturn(expression);
+        return new AuthorizationDeniedException("Access Denied",
+                new ExpressionAuthorizationDecision(false, parsed));
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreateBootstrapWiringTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreateBootstrapWiringTest.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.tornotron.echno_backend.common.customAnnotation.RequireSubscription;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two annotations that decided whether a new account could get started at all.
+ *
+ * <p>Creating an organization is the first thing a self-registered account does and the only way it
+ * acquires a role, so anything the endpoint demands up front, an organization authority it cannot
+ * hold yet or a subscription it cannot have bought, closes the door on the account permanently.
+ * Both guards were doing exactly that. This reads the annotations back off the handlers so a guard
+ * put back by habit fails here rather than on someone's first day using the product.
+ *
+ * <p>Creating an organization is still not unguarded. The caller must be authenticated, the new
+ * organization is a tenant of its own that touches no existing one, and the billing rule now lives
+ * in {@code OrganizationService}, which exempts a user's first organization and charges the rest.
+ */
+class OrganizationCreateBootstrapWiringTest {
+
+    private Method createOrganization(Class<?> controller) {
+        return Arrays.stream(controller.getDeclaredMethods())
+                .filter(method -> method.getName().equals("createOrganization"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No createOrganization handler on " + controller.getName()));
+    }
+
+    @Test
+    void webCreateAsksOnlyForAnAuthenticatedCaller() {
+        PreAuthorize guard = createOrganization(OrganizationWebController.class).getAnnotation(PreAuthorize.class);
+
+        assertThat(guard).isNotNull();
+        assertThat(guard.value()).isEqualTo("isAuthenticated()");
+    }
+
+    @Test
+    void mobileCreateAsksOnlyForAnAuthenticatedCaller() {
+        // This one required 'organization:create', an authority a self-registered account has no
+        // way to obtain, because the endpoint that grants roles is the one being guarded.
+        PreAuthorize guard = createOrganization(OrganizationController.class).getAnnotation(PreAuthorize.class);
+
+        assertThat(guard).isNotNull();
+        assertThat(guard.value()).isEqualTo("isAuthenticated()");
+    }
+
+    @Test
+    void neitherCreateEndpointGatesOnASubscriptionUpFront() {
+        // The subscription check has to know whether this is the caller's first organization, and
+        // only the service knows that. Left on the handler it refused every new account with 402
+        // "No active subscription" before the first organization could ever exist.
+        assertThat(createOrganization(OrganizationWebController.class).getAnnotation(RequireSubscription.class))
+                .isNull();
+        assertThat(createOrganization(OrganizationController.class).getAnnotation(RequireSubscription.class))
+                .isNull();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
@@ -1,0 +1,184 @@
+package org.tornotron.echno_backend.organization;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.billing.dto.FeatureAccessResultDto;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.exception.SubscriptionAccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationCreationDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The billing rule on creating an organization.
+ *
+ * <p>A self-registered account holds no subscription and belongs to nothing, so charging it for the
+ * organization it needs in order to do anything at all is a closed loop: the account cannot act and
+ * cannot buy its way out. Creating the first organization is therefore treated as part of signing
+ * up. Everything after the first still goes through the feature check, which is what these tests
+ * hold apart.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationServiceEntitlementTest {
+
+    @Mock private OrganizationRepository repository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private KeycloakGroupService keycloakGroupService;
+    @Mock private SubscriptionService subscriptionService;
+    @Mock private UserContextService userContextService;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationMapper organizationMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+
+    private static final Long CREATOR_USER_ID = 7L;
+    private static final Long NEW_ORG_ID = 42L;
+    private static final Long CREATOR_EMPLOYEE_ID = 5L;
+    private static final String CREATE_ORGANIZATION = "CREATE_ORGANIZATION";
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private OrganizationService service() {
+        return new OrganizationService(repository, attachmentService, fileStorageService,
+                keycloakGroupService, subscriptionService, userContextService, employeeService,
+                organizationMapper, orgSecurity, onboardingSeeder,
+                Validation.buildDefaultValidatorFactory().getValidator());
+    }
+
+    private OrganizationCreationDto creationDto() {
+        OrganizationCreationDto dto = new OrganizationCreationDto();
+        dto.setOrganizationName("Acme Builders");
+        dto.setOrganizationEmail("acme@example.test");
+        dto.setOrganizationAddress("1 Site Road");
+        dto.setOrganizationPhone("0000000000");
+        return dto;
+    }
+
+    /** Stubs the collaborators a creation needs once it is past the entitlement check. */
+    private void stubSuccessfulCreation() {
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+        when(repository.save(any(Organization.class))).thenAnswer(invocation -> {
+            Organization toSave = invocation.getArgument(0);
+            toSave.setId(NEW_ORG_ID);
+            return toSave;
+        });
+
+        EmployeeDto creatorEmployee = new EmployeeDto();
+        creatorEmployee.setId(CREATOR_EMPLOYEE_ID);
+        when(employeeService.joinOrganization(eq(CREATOR_USER_ID), eq(NEW_ORG_ID), any()))
+                .thenReturn(creatorEmployee);
+        when(organizationMapper.toSimpleDto(any())).thenReturn(new OrganizationSimpleDto());
+    }
+
+    private User creator() {
+        User creator = mock(User.class);
+        when(creator.getId()).thenReturn(CREATOR_USER_ID);
+        when(userContextService.getCurrentUser()).thenReturn(creator);
+        return creator;
+    }
+
+    @Test
+    void firstOrganizationIsCreatedWithoutAnySubscriptionCheck() {
+        // Aneesh's case: registered through the public page, holds no subscription, owns nothing.
+        // Before this, the entitlement check refused him with 402 "No active subscription" and
+        // onboarding had nowhere left to go.
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(false);
+        stubSuccessfulCreation();
+
+        service().addOrganization(creationDto(), null);
+
+        verify(repository).save(any(Organization.class));
+        verify(subscriptionService, never()).checkFeatureAccess(any(), any());
+    }
+
+    @Test
+    void firstOrganizationIsStillCountedAgainstTheQuota() {
+        // Exempt from the check is not the same as invisible: the meter must still show it, or the
+        // second organization looks like the first.
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(false);
+        stubSuccessfulCreation();
+
+        service().addOrganization(creationDto(), null);
+
+        verify(subscriptionService).recordUsage(CREATOR_USER_ID, CREATE_ORGANIZATION, 1L);
+    }
+
+    @Test
+    void aSecondOrganizationIsRefusedWhenThePlanDoesNotCoverIt() {
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(true);
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+        when(subscriptionService.checkFeatureAccess(CREATOR_USER_ID, CREATE_ORGANIZATION))
+                .thenReturn(FeatureAccessResultDto.noSubscription());
+
+        assertThatExceptionOfType(SubscriptionAccessDeniedException.class)
+                .isThrownBy(() -> service().addOrganization(creationDto(), null))
+                .satisfies(ex -> {
+                    // The refusal names the entitlement, so support can tell which one to look at.
+                    org.assertj.core.api.Assertions.assertThat(ex.getFeatureCode())
+                            .isEqualTo(CREATE_ORGANIZATION);
+                    org.assertj.core.api.Assertions.assertThat(ex.getMessage())
+                            .isEqualTo("No active subscription");
+                });
+
+        // Nothing was created, and no Keycloak group was left behind for an org that does not exist.
+        verify(repository, never()).save(any(Organization.class));
+        verifyNoInteractions(keycloakGroupService);
+    }
+
+    @Test
+    void aSecondOrganizationIsCreatedWhenThePlanCoversIt() {
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(true);
+        when(subscriptionService.checkFeatureAccess(CREATOR_USER_ID, CREATE_ORGANIZATION))
+                .thenReturn(FeatureAccessResultDto.allowed());
+        stubSuccessfulCreation();
+
+        service().addOrganization(creationDto(), null);
+
+        verify(repository).save(any(Organization.class));
+        verify(subscriptionService).recordUsage(CREATOR_USER_ID, CREATE_ORGANIZATION, 1L);
+    }
+
+    @Test
+    void anUnprovisionedAccountIsRefusedRatherThanFailingOnANullUser() {
+        // Authenticated against Keycloak but with no local user record yet. Reading the id off
+        // null would have surfaced as a 500 with nothing in it for the caller.
+        when(userContextService.getCurrentUser()).thenReturn(null);
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+
+        assertThatExceptionOfType(org.springframework.security.access.AccessDeniedException.class)
+                .isThrownBy(() -> service().addOrganization(creationDto(), null))
+                .withMessageContaining("not provisioned yet");
+
+        verify(repository, never()).save(any(Organization.class));
+    }
+}


### PR DESCRIPTION
Closes #521.

## What Aneesh actually hit

Not a 403. The staging access log on `.116` records four attempts from the onboarding screen, all **402**:

```
"POST /api/v1/organization/web HTTP/1.1" 402 204 "https://ui.echno.in/users/onboarding"
```

and the backend log gives the reason:

```
Subscription access denied: No active subscription | Path: /api/v1/organization/web | Feature: null
```

`POST /organization/web` already guarded on `isAuthenticated()`, so the `@PreAuthorize` was not the blocker. `@RequireSubscription(feature = "CREATE_ORGANIZATION")` was. A self-registered account holds no subscription, no plan is seeded at registration, and the only way to obtain one is inside an organization the account cannot create. That is a closed loop, and it is why the screen dead-ended. Note the `Feature: null` too: the aspect never passed the feature code, so even the 402 did not say which entitlement was missing.

The sibling mobile endpoint `POST /api/v1/organization` had the same shape one layer up, requiring `hasAuthority('organization:create')`, an authority only granted by joining an organization.

## Product assumption

**Creating your first organization is part of signing up and is not billed. Every organization after the first goes through the normal `CREATE_ORGANIZATION` entitlement check.** Whoever creates an organization becomes its system-admin, which is what `addOrganization` already does via `joinOrganization` plus `assignOrgRole`.

Stating it rather than blocking on it, per the issue. If the intended rule is different (a free plan auto-assigned at registration, say, or an invite-only route into an existing tenant), the change to make is in `OrganizationService.requireCreateOrganizationEntitlement`, which is now the single place the rule lives.

The check moved from the two controller annotations into the service because the fact it turns on, whether this user has created an organization before, is only known there, and because both entry points create through the same method. That also removes the double-enforcement that keeping the annotation would have caused.

Creating an organization is still guarded: the caller must be authenticated, and the new organization is a tenant of its own that touches no existing one.

## Hrishi's `error-message-refactor`

Salvaged, and it turned out not to need rescuing. The branch was merged as **#317** on 25 July, so nothing was at risk from stale-branch cleanup. It rewrote `ResourceNotFoundException` and `ValidationException` messages across ~45 services into a self-describing format (entity, identifier, tenant scope) and replaced 17 generic `IllegalArgumentException` throws with domain exceptions.

What it did not cover is `AuthorizationDeniedException`, which is the one in the issue: it carries no service-authored message at all, because Spring hardcodes it to the string "Access Denied". So there was no message of Hrishi's to improve, and this builds on his work rather than over it:

- The wording follows his convention: name the thing, name the identifier, say it in terms a caller can act on.
- His pass established that a message deliberately carries scope but no PII. The denial text names roles and permissions only, never who holds them and nothing about the caller.
- `SubscriptionAccessDeniedException` gets the same treatment his other exceptions already had, the feature code passed through so the refusal names what it refused on.

## The denial message

`AuthorizationDeniedException` carries an `ExpressionAuthorizationDecision` holding the very `@PreAuthorize` expression that refused the call. That expression is the one authoritative statement of the requirement, so `AuthorizationRequirement` reads it back and turns it into a sentence:

> You do not have permission for this action. This action requires the 'system-admin' or 'hr-admin' roles in this organization. Your roles are read from the session you signed in with, so if one was granted just now, sign out and back in to pick it up.

The role and permission names also go on the problem as `requiredOrganizationRoles` and `requiredAuthorities`, so the frontend can act on them without parsing prose. An expression the parser does not recognise falls back to Spring's message rather than to a guess.

The closing hint is there for the step straight after this one: the creator's system-admin role is granted in Keycloak during creation, but the token in hand was minted before it, so `GET /organization/web/{id}` refuses until the next sign-in. The remedy is a fresh session, not a new grant, and the message now says so.

## Also fixed on the way

Spring Security's `AccessDeniedException`, thrown by `ChatService` and `UserService` with messages already written for the caller ("Only the sender can edit this message"), had no handler. Only `java.nio.file.AccessDeniedException` was mapped, which is an unrelated class, so these reached the catch-all and came back as **500** with the reason buried in "An unexpected error occurred". Now a 403 carrying the service's own message.

## Verification

Full `./gradlew build` green on lab `.116` (7m14s, includes the Testcontainers suites and the jacoco coverage gate). All new tests are plain JUnit and Mockito, so no new Spring context is cached and the 1024m test-JVM budget is untouched.

Each new test was re-run against a mutant that reverts the fix it covers. Mutants and the script are namespaced per issue; the script asserts it is operating on this branch's build tree before it touches anything.

| Test | M1: org sources at `development` | M2: denial message reverted to `ex.getMessage()` | M3: security denial back to the 500 path |
|---|---|---|---|
| `OrganizationServiceEntitlementTest.firstOrganizationIsCreatedWithoutAnySubscriptionCheck` | FAILED | | |
| `OrganizationServiceEntitlementTest.firstOrganizationIsStillCountedAgainstTheQuota` | FAILED | | |
| `OrganizationServiceEntitlementTest.aSecondOrganizationIsRefusedWhenThePlanDoesNotCoverIt` | FAILED | | |
| `OrganizationServiceEntitlementTest.aSecondOrganizationIsCreatedWhenThePlanCoversIt` | FAILED | | |
| `OrganizationServiceEntitlementTest.anUnprovisionedAccountIsRefusedRatherThanFailingOnANullUser` | FAILED | | |
| `OrganizationCreateBootstrapWiringTest.mobileCreateAsksOnlyForAnAuthenticatedCaller` | FAILED | | |
| `OrganizationCreateBootstrapWiringTest.neitherCreateEndpointGatesOnASubscriptionUpFront` | FAILED | | |
| `OrganizationCreateBootstrapWiringTest.webCreateAsksOnlyForAnAuthenticatedCaller` | passed | | |
| `GlobalExceptionHandlerTest.authorizationDenied_namesTheRoleTheEndpointWanted` | | FAILED | |
| `GlobalExceptionHandlerTest.authorizationDenied_exposesTheRequiredAuthoritiesForTheFrontend` | | FAILED | |
| `GlobalExceptionHandlerTest.securityAccessDenied_isA403CarryingTheServicesOwnMessage` | | | FAILED |

Two honest caveats about that table:

- `webCreateAsksOnlyForAnAuthenticatedCaller` passes under M1 and is not proof of a fix. That endpoint already asked for `isAuthenticated()`; the test is a regression guard against the authority check being put back, which is exactly what its sibling shows happened on the mobile endpoint.
- `AuthorizationRequirementTest` (9 tests) cannot be shown red under any mutant, because the class it tests is new. Reverting the fix removes the class and the test stops compiling rather than failing. Its value is the behaviour it pins: the real expressions from the organization controllers, the composite three-alternative guard, the sign-in hint appearing only for org-scoped roles, and null and unrecognised expressions describing nothing.

`OrganizationServiceOnboardingTest` was run alongside as a control and passes in every configuration.

## Not touched

Nothing under tenant isolation: `HibernateFilterConfig`, `TenantIsolationLoadListener` and the compliance listener are untouched, since #507 and #508 are in flight there. The known `isMemberOfCurrentTenant()` versus `hasAnyOrgRole()` asymmetry on the organization read path is left alone as well, since narrowing or widening it is a separate decision from unblocking onboarding. What this change does give that path is a denial that finally says which role it wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authorization errors with clearer explanations of required roles and permissions.
  * Added structured permission details to access-denied responses.
  * Added support for reporting security access denials as proper 403 responses.
  * Allowed a user’s first organization to be created without a subscription; additional organizations require the relevant entitlement.
  * Included the missing feature identifier in subscription access-denied errors.

* **Bug Fixes**
  * Prevented unprovisioned users from encountering unexpected errors during organization creation.
  * Improved organization usage tracking after creation and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->