### PR TITLE
Stop a controller being able to parse a payload it has not validated

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,11 +38,11 @@ import java.util.List;
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
-    public AttendanceController(AttendanceService attendanceService, ObjectMapper objectMapper) {
+    public AttendanceController(AttendanceService attendanceService, JsonPartBinder jsonPartBinder) {
         this.attendanceService = attendanceService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -58,9 +58,9 @@ public class AttendanceController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
-    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
+    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") String data,
                                                          @RequestParam(value = "photoUrl", required = false) MultipartFile photoUrl) throws JsonProcessingException {
-        AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
+        AttendanceCheckInDto dto = jsonPartBinder.read(data, AttendanceCheckInDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.checkIn(dto,photoUrl));
     }
 
@@ -80,9 +80,9 @@ public class AttendanceController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
-    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
+    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") String data,
                                                                   @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
-        AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
+        AttendanceClockEventDto dto = jsonPartBinder.read(data, AttendanceClockEventDto.class);
         return ResponseEntity.ok(attendanceService.recordClockEvent(dto,photo));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,11 +38,11 @@ import java.util.List;
 public class AttendanceControllerWeb {
 
     private final AttendanceService attendanceService;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
-    public AttendanceControllerWeb(AttendanceService attendanceService, ObjectMapper objectMapper) {
+    public AttendanceControllerWeb(AttendanceService attendanceService, JsonPartBinder jsonPartBinder) {
         this.attendanceService = attendanceService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -58,9 +58,9 @@ public class AttendanceControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
-    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") @Valid String data,
+    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") String data,
                                                          @RequestParam(value = "photo", required = false)MultipartFile photo) throws JsonProcessingException {
-        AttendanceCheckInDto dto = objectMapper.readValue(data, AttendanceCheckInDto.class);
+        AttendanceCheckInDto dto = jsonPartBinder.read(data, AttendanceCheckInDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.checkIn(dto,photo));
     }
 
@@ -78,9 +78,9 @@ public class AttendanceControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
-    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") @Valid String data,
+    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") String data,
                                                                     @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
-        AttendanceClockEventDto dto = objectMapper.readValue(data, AttendanceClockEventDto.class);
+        AttendanceClockEventDto dto = jsonPartBinder.read(data, AttendanceClockEventDto.class);
         return ResponseEntity.ok(attendanceService.recordClockEvent(dto,photo));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -1,9 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import jakarta.validation.ValidationException;
-import jakarta.validation.Validator;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +33,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -67,7 +64,7 @@ public class AttendanceService {
     private final AttachmentService attachmentService;
     private final FileStorageService fileStorageService;
     private final UserContextService userContextService;
-    private final Validator validator;
+    private final PayloadValidator payloadValidator;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              ShiftTimingRepository shiftTimingRepository,
@@ -81,7 +78,7 @@ public class AttendanceService {
                              AttachmentService attachmentService,
                              FileStorageService fileStorageService,
                              UserContextService userContextService,
-                             Validator validator) {
+                             PayloadValidator payloadValidator) {
         this.attendanceRepository = attendanceRepository;
         this.shiftTimingRepository = shiftTimingRepository;
         this.employeeRepository = employeeRepository;
@@ -94,26 +91,7 @@ public class AttendanceService {
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
         this.userContextService = userContextService;
-        this.validator = validator;
-    }
-
-    /**
-     * Runs bean validation over a payload the controller deserialized itself.
-     *
-     * <p>All four check-in and clock-event handlers take their payload as the JSON string part of
-     * a multipart request and read it by hand, so Spring never binds a bean and never validates
-     * one, and the constraints on these payloads would otherwise never fire. Doing it here covers
-     * the /web twin and the base controller at once, and any later caller by construction.
-     *
-     * @param payload The payload as deserialized from the request.
-     * @param <T> The payload type.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private <T> void requireValid(T payload) {
-        Set<ConstraintViolation<T>> violations = validator.validate(payload);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
+        this.payloadValidator = payloadValidator;
     }
 
     /**
@@ -132,7 +110,7 @@ public class AttendanceService {
      */
     @Transactional
     public AttendanceResponseDto checkIn(AttendanceCheckInDto dto, MultipartFile photo) {
-        requireValid(dto);
+        payloadValidator.requireValid(dto);
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -270,7 +248,7 @@ public class AttendanceService {
      */
     @Transactional
     public AttendanceResponseDto recordClockEvent(AttendanceClockEventDto dto, MultipartFile photo) {
-        requireValid(dto);
+        payloadValidator.requireValid(dto);
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -1,15 +1,12 @@
 package org.tornotron.echno_backend.chat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import jakarta.servlet.http.HttpServletResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
-import jakarta.validation.Validator;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -29,7 +26,6 @@ import org.tornotron.echno_backend.chat.dto.ReactionRequestDto;
 import org.tornotron.echno_backend.chat.dto.SendMessageDto;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * Employee-facing chat: rooms an employee belongs to and the messages within them. Every
@@ -48,35 +44,14 @@ import java.util.Set;
 public class ChatControllerWeb {
 
     private final ChatService chatService;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
     private final ChatStreamService chatStreamService;
-    private final Validator validator;
 
-    public ChatControllerWeb(ChatService chatService, ObjectMapper objectMapper,
-                             ChatStreamService chatStreamService, Validator validator) {
+    public ChatControllerWeb(ChatService chatService, JsonPartBinder jsonPartBinder,
+                             ChatStreamService chatStreamService) {
         this.chatService = chatService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
         this.chatStreamService = chatStreamService;
-        this.validator = validator;
-    }
-
-    /**
-     * Runs bean validation over a payload this class deserialized itself.
-     *
-     * <p>The multipart send takes its payload as the JSON string part of the request and reads it
-     * by hand, so Spring never binds a bean and never validates one. The JSON send next to it
-     * takes a bound {@code @Valid @RequestBody}, which Spring does validate, so this is the only
-     * place a {@link SendMessageDto} arrives unchecked. It cannot move into the service, which
-     * takes the message fields as separate arguments rather than the payload.
-     *
-     * @param dto The payload as deserialized from the request.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private void requireValid(SendMessageDto dto) {
-        Set<ConstraintViolation<SendMessageDto>> violations = validator.validate(dto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
     }
 
     @GetMapping("/rooms/web")
@@ -196,11 +171,10 @@ public class ChatControllerWeb {
     })
     public ResponseEntity<ChatMessageDto> sendMessageWithAttachments(
             @PathVariable Long roomId,
-            @RequestPart("data") @Valid String data,
+            @RequestPart("data") String data,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments)
             throws JsonProcessingException {
-        SendMessageDto dto = objectMapper.readValue(data, SendMessageDto.class);
-        requireValid(dto);
+        SendMessageDto dto = jsonPartBinder.read(data, SendMessageDto.class);
         return new ResponseEntity<>(
                 chatService.sendMessage(roomId, dto.getContent(), dto.getReplyToId(), attachments),
                 HttpStatus.CREATED);

--- a/src/main/java/org/tornotron/echno_backend/common/payload/JsonPartBinder.java
+++ b/src/main/java/org/tornotron/echno_backend/common/payload/JsonPartBinder.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.common.payload;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+
+import java.util.Map;
+
+/**
+ * Reads the JSON {@code data} part of a multipart request into a payload, and validates it.
+ *
+ * <p>A multipart create endpoint cannot take its payload as a {@code @RequestBody}, because the
+ * body is the multipart envelope, so the payload travels as a JSON string part and the endpoint
+ * deserializes it. Doing that by hand is what let every constraint on those payloads go unenforced
+ * for as long as the endpoints existed: {@code @Valid} was written on the {@code String} part,
+ * a {@code String} declares no constraints, and the bean that came out of {@code readValue} was
+ * never offered to a validator. Issue #490 counted 32 declared constraints across 11 endpoints
+ * that had never once run.
+ *
+ * <p>Parsing and validating are therefore one call here rather than two steps at a call site.
+ * A caller cannot obtain a payload from this class without its constraints having been checked,
+ * which is the property that survives the next endpoint being written by somebody who has not
+ * read this file. {@code MultipartPayloadValidationTest} keeps controllers from going back to
+ * parsing a part themselves.
+ *
+ * <p>{@link #readUpdates} is the partial-update counterpart. Those endpoints read the part into a
+ * {@code Map} of the fields the caller actually sent, so there is no bean and nothing to validate;
+ * it is here so that reading a part is one mechanism rather than two, and so the rule above needs
+ * no exceptions.
+ */
+@Component
+public class JsonPartBinder {
+
+    private static final TypeReference<Map<String, Object>> UPDATES = new TypeReference<>() {
+    };
+
+    private final ObjectMapper objectMapper;
+    private final PayloadValidator payloadValidator;
+
+    public JsonPartBinder(ObjectMapper objectMapper, PayloadValidator payloadValidator) {
+        this.objectMapper = objectMapper;
+        this.payloadValidator = payloadValidator;
+    }
+
+    /**
+     * Reads a required JSON part into a payload and checks its constraints.
+     *
+     * @param json The raw JSON carried by the part.
+     * @param type The payload type to read it into.
+     * @param <T> The payload type.
+     * @return The deserialized payload, already validated.
+     * @throws InvalidRequestException if the part is absent or carries nothing.
+     * @throws JsonProcessingException if the part is not JSON, or does not fit the payload.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    public <T> T read(String json, Class<T> type) throws JsonProcessingException {
+        if (json == null || json.isBlank()) {
+            throw new InvalidRequestException("The data part is required and must carry the payload as JSON");
+        }
+        return payloadValidator.requireValid(objectMapper.readValue(json, type));
+    }
+
+    /**
+     * Reads an optional JSON part into the map of fields a partial update is changing.
+     *
+     * <p>An absent part means "change nothing", which is how these endpoints have always treated
+     * it, so it answers with an empty map rather than refusing the request.
+     *
+     * @param json The raw JSON carried by the part, or {@code null} when the part is absent.
+     * @return The fields to change, empty when the part is absent.
+     * @throws JsonProcessingException if the part is not a JSON object.
+     */
+    public Map<String, Object> readUpdates(String json) throws JsonProcessingException {
+        return json != null ? objectMapper.readValue(json, UPDATES) : Map.of();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/payload/PayloadValidator.java
+++ b/src/main/java/org/tornotron/echno_backend/common/payload/PayloadValidator.java
@@ -1,0 +1,50 @@
+package org.tornotron.echno_backend.common.payload;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Runs bean validation over a payload that Spring did not bind, and refuses one that fails.
+ *
+ * <p>Spring validates a {@code @RequestBody} because it binds the bean itself. A payload that
+ * arrives as the JSON string part of a multipart request is deserialized by the application, so
+ * nothing in the framework ever sees a bean and no constraint on it fires. Every such payload has
+ * to be handed to this class instead, which is what {@link JsonPartBinder} does for the request
+ * path and what a service does for any caller that reaches it another way.
+ *
+ * <p>One implementation rather than a private copy per service. The copies were identical, and a
+ * rule that is re-typed for each new payload is a rule the twelfth payload will be written without.
+ *
+ * <p>The {@link ConstraintViolationException} it raises is mapped by
+ * {@code GlobalExceptionHandler} to the same 400 and the same {@code errors} map that a bound
+ * payload's failure produces, so the two paths answer a caller identically.
+ */
+@Component
+public class PayloadValidator {
+
+    private final Validator validator;
+
+    public PayloadValidator(Validator validator) {
+        this.validator = validator;
+    }
+
+    /**
+     * Checks every constraint declared on the payload.
+     *
+     * @param payload The payload to check.
+     * @param <T> The payload type.
+     * @return The same payload, so the call can be chained onto the one that produced it.
+     * @throws ConstraintViolationException if any constraint on the payload fails.
+     */
+    public <T> T requireValid(T payload) {
+        Set<ConstraintViolation<T>> violations = validator.validate(payload);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+        return payload;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -1,11 +1,10 @@
 package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -36,11 +35,11 @@ public class IssueController {
 
     private final IssueService issueService;
 
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
-    public IssueController(IssueService issueService, ObjectMapper objectMapper) {
+    public IssueController(IssueService issueService, JsonPartBinder jsonPartBinder) {
         this.issueService = issueService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
 //    @GetMapping
@@ -82,9 +81,9 @@ public class IssueController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority")
     })
-    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") @Valid String data,
+    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") String data,
                                                       @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
-        IssueCreationDto dto = objectMapper.readValue(data, IssueCreationDto.class);
+        IssueCreationDto dto = jsonPartBinder.read(data, IssueCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueService.addIssue(dto,attachments));
     }
@@ -108,8 +107,7 @@ public class IssueController {
             @PathVariable Long id,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
             @RequestParam(value = "entityType", required = false, defaultValue = "ISSUE_ATTACHMENTS") String entityType) throws JsonProcessingException {
-        Map<String, Object> updates = data != null
-                ? objectMapper.readValue(data, new com.fasterxml.jackson.core.type.TypeReference<>() {}) : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(issueService.partialUpdateAnIssue(updates, id, attachments, entityType));
     }

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -1,11 +1,10 @@
 package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -37,11 +36,11 @@ import java.util.Map;
 public class IssueControllerWeb {
 
     private final IssueService issueService;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
-    public IssueControllerWeb(IssueService issueService,ObjectMapper objectMapper) {
+    public IssueControllerWeb(IssueService issueService,JsonPartBinder jsonPartBinder) {
         this.issueService = issueService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     @GetMapping
@@ -147,9 +146,9 @@ public class IssueControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") @Valid String data,
+    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") String data,
                                                       @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
-        IssueCreationDto dto = objectMapper.readValue(data, IssueCreationDto.class);
+        IssueCreationDto dto = jsonPartBinder.read(data, IssueCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueService.addIssue(dto,attachments));
     }
@@ -173,8 +172,7 @@ public class IssueControllerWeb {
             @PathVariable Long id,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
             @RequestParam(value = "entityType", required = false, defaultValue = "ISSUE_ATTACHMENTS") String entityType) throws JsonProcessingException {
-        Map<String, Object> updates = data != null
-                ? objectMapper.readValue(data, new com.fasterxml.jackson.core.type.TypeReference<>() {}) : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(issueService.partialUpdateAnIssue(updates, id, attachments, entityType));
     }

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.issue;
 
-import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +30,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,7 +42,7 @@ public class IssueService {
     private final AttachmentService attachmentService;
     private final IssueMapper issueMapper;
     private final EmployeeRepository employeeRepository;
-    private final Validator validator;
+    private final PayloadValidator payloadValidator;
 
     /**
      * Constructs an IssueService with the necessary collaborators.
@@ -54,33 +52,15 @@ public class IssueService {
      * @param attachmentService  The service for attachment operations.
      * @param issueMapper        The mapper between issues and their DTOs.
      * @param employeeRepository The repository used to resolve the creator and the assignee.
-     * @param validator          Bean validator applied to the create payload.
+     * @param payloadValidator   Runs the create payload's own constraints.
      */
-    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository, Validator validator) {
+    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository, PayloadValidator payloadValidator) {
         this.issueRepository = issueRepository;
         this.taskRepository = taskRepository;
         this.attachmentService = attachmentService;
         this.issueMapper = issueMapper;
         this.employeeRepository = employeeRepository;
-        this.validator = validator;
-    }
-
-    /**
-     * Runs bean validation over the create payload.
-     *
-     * <p>Both issue controllers take the payload as the JSON string part of a multipart request
-     * and deserialize it by hand, so Spring never binds a bean and never validates one, and the
-     * constraints on {@link IssueCreationDto} would otherwise never fire. Doing it here covers
-     * both entry points at once, and covers any later caller by construction.
-     *
-     * @param issueCreationDto The payload as deserialized from the request.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private void requireValid(IssueCreationDto issueCreationDto) {
-        Set<ConstraintViolation<IssueCreationDto>> violations = validator.validate(issueCreationDto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
+        this.payloadValidator = payloadValidator;
     }
 
     /**
@@ -95,7 +75,7 @@ public class IssueService {
      */
     @Transactional
     public IssueSimpleDto addIssue(IssueCreationDto issueCreationDto, List<MultipartFile> attachments) {
-        requireValid(issueCreationDto);
+        payloadValidator.requireValid(issueCreationDto);
         Task task = taskRepository.findByIdAndOrganization_Id(issueCreationDto.getTaskId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task with ID " + issueCreationDto.getTaskId() + " was not found in this organization"));
         Employee creator = employeeRepository.findByIdAndOrganizationId(issueCreationDto.getCreatedById(), TenantContext.getCurrentOrgId())

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
@@ -1,7 +1,7 @@
 package org.tornotron.echno_backend.organization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,15 +41,15 @@ import java.util.Map;
 public class OrganizationController {
 
     private final OrganizationService service;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
     /**
      * Constructs an OrganizationController with the given OrganizationService.
      *
      * @param service The service to handle organization-related business logic.
      */
-    public OrganizationController(OrganizationService service,ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public OrganizationController(OrganizationService service,JsonPartBinder jsonPartBinder) {
+        this.jsonPartBinder = jsonPartBinder;
         this.service = service;
     }
 
@@ -82,9 +82,9 @@ public class OrganizationController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
-    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
+    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
-        OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
+        OrganizationCreationDto dto = jsonPartBinder.read(data, OrganizationCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addOrganization(dto,attachments));
     }
     /**

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.organization;
 
-import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +36,6 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -65,7 +63,7 @@ public class OrganizationService {
     private final org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper;
     private final org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity;
     private final OrganizationOnboardingSeeder onboardingSeeder;
-    private final Validator validator;
+    private final PayloadValidator payloadValidator;
 
     /**
      * Constructs an {@code OrganizationService} with the necessary dependencies.
@@ -75,9 +73,9 @@ public class OrganizationService {
      * @param keycloakGroupService The service for managing Keycloak groups.
      * @param subscriptionService The service for handling subscription billing.
      * @param onboardingSeeder Seeds the per-organization finance defaults for a new organization.
-     * @param validator Bean validator applied to the create payload.
+     * @param payloadValidator Runs the create payload's own constraints.
      */
-    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, OrganizationOnboardingSeeder onboardingSeeder, Validator validator) {
+    public OrganizationService(OrganizationRepository repository, AttachmentService attachmentService, FileStorageService fileStorageService, KeycloakGroupService keycloakGroupService, SubscriptionService subscriptionService, UserContextService userContextService, EmployeeService employeeService, org.tornotron.echno_backend.organization.mapper.OrganizationMapper organizationMapper, org.tornotron.echno_backend.common.service.OrganizationSecurityService orgSecurity, OrganizationOnboardingSeeder onboardingSeeder, PayloadValidator payloadValidator) {
         this.repository = repository;
         this.attachmentService = attachmentService;
         this.fileStorageService = fileStorageService;
@@ -88,26 +86,7 @@ public class OrganizationService {
         this.organizationMapper = organizationMapper;
         this.orgSecurity = orgSecurity;
         this.onboardingSeeder = onboardingSeeder;
-        this.validator = validator;
-    }
-
-    /**
-     * Runs bean validation over the create payload.
-     *
-     * <p>Both organization controllers take the payload as the JSON string part of a multipart
-     * request and deserialize it by hand, so Spring never binds a bean and never validates one,
-     * and the constraints on {@link OrganizationCreationDto} would otherwise never fire. Doing it
-     * here covers both entry points at once, and covers any later caller by construction.
-     *
-     * @param organizationCreationDto The payload as deserialized from the request.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private void requireValid(OrganizationCreationDto organizationCreationDto) {
-        Set<ConstraintViolation<OrganizationCreationDto>> violations =
-                validator.validate(organizationCreationDto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
+        this.payloadValidator = payloadValidator;
     }
 
     /**
@@ -159,7 +138,7 @@ public class OrganizationService {
      */
     @Transactional
     public OrganizationSimpleDto addOrganization(OrganizationCreationDto organizationCreationDto, List<MultipartFile> attachments) {
-        requireValid(organizationCreationDto);
+        payloadValidator.requireValid(organizationCreationDto);
         if(repository.existsByOrganizationEmail(organizationCreationDto.getOrganizationEmail())){
             throw new DuplicateResourceException("Organization with email '" + organizationCreationDto.getOrganizationEmail() + "' already exists");
         }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -1,12 +1,10 @@
 package org.tornotron.echno_backend.organization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,10 +33,10 @@ import java.util.Map;
 public class OrganizationWebController {
 
     private final OrganizationService service;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
 
-    public OrganizationWebController(OrganizationService service, ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public OrganizationWebController(OrganizationService service, JsonPartBinder jsonPartBinder) {
+        this.jsonPartBinder = jsonPartBinder;
         this.service = service;
     }
     /**
@@ -70,9 +68,9 @@ public class OrganizationWebController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
-    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") @Valid String data,
+    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") String data,
                                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
-        OrganizationCreationDto dto = objectMapper.readValue(data, OrganizationCreationDto.class);
+        OrganizationCreationDto dto = jsonPartBinder.read(data, OrganizationCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addOrganization(dto,attachments));
     }
 
@@ -155,8 +153,7 @@ public class OrganizationWebController {
             @PathVariable Long id,
             @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments,
             @RequestParam(value = "entityType",required = false,defaultValue = "ORGANIZATION_LOGO") String entityType) throws JsonProcessingException{
-        Map<String ,Object> updates = data != null
-                ? objectMapper.readValue(data, new TypeReference<>() {}) : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateAnOrganization(updates,id,attachments,entityType));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
@@ -1,7 +1,7 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,6 +43,7 @@ import java.util.Map;
 public class ProjectController {
 
     private final ProjectService service;
+    private final JsonPartBinder jsonPartBinder;
     /** Logger for this class. */
     private static final Logger logger = LoggerFactory.getLogger(ProjectController.class);
 
@@ -50,9 +51,11 @@ public class ProjectController {
      * Constructs a ProjectController with the given ProjectService.
      *
      * @param service The service to handle project-related business logic.
+     * @param jsonPartBinder Reads and validates the JSON part of a multipart request.
      */
-    public ProjectController(ProjectService service) {
+    public ProjectController(ProjectService service, JsonPartBinder jsonPartBinder) {
         this.service = service;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     /**
@@ -74,9 +77,9 @@ public class ProjectController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project create or admin authority")
     })
-    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") @Valid String data,
+    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") String data,
                                                           @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
-        ProjectCreationDto dto = new ObjectMapper().readValue(data, ProjectCreationDto.class);
+        ProjectCreationDto dto = jsonPartBinder.read(data, ProjectCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addProject(dto, attachments));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,7 +40,7 @@ public class ProjectControllerWeb {
 
     private final ProjectService service;
 
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
     /** Logger for this class. */
     private static final Logger logger = LoggerFactory.getLogger(ProjectControllerWeb.class);
 
@@ -50,9 +49,9 @@ public class ProjectControllerWeb {
      *
      * @param service The service to handle project-related business logic.
      */
-    public ProjectControllerWeb(ProjectService service, ObjectMapper objectMapper) {
+    public ProjectControllerWeb(ProjectService service, JsonPartBinder jsonPartBinder) {
         this.service = service;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     /**
@@ -75,9 +74,9 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") @Valid String data,
+    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") String data,
                                                           @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
-        ProjectCreationDto dto = objectMapper.readValue(data, ProjectCreationDto.class);
+        ProjectCreationDto dto = jsonPartBinder.read(data, ProjectCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addProject(dto, attachments));
     }
     /**
@@ -197,8 +196,7 @@ public class ProjectControllerWeb {
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
             @RequestParam(value = "entityType", required = false,defaultValue = "PROJECT_ATTACHMENTS") String entityType) throws JsonProcessingException
      {
-        Map<String, Object> updates = data != null
-                ? objectMapper.readValue(data, new TypeReference<>() {}) : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateAProject(updates,id,attachments,entityType));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -1,8 +1,6 @@
 package org.tornotron.echno_backend.project;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +34,6 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -57,7 +54,7 @@ public class ProjectService {
     private final EmployeeMapper employeeMapper;
     private final ApplicationEventPublisher eventPublisher;
     private final CustomerRepository customerRepository;
-    private final Validator validator;
+    private final PayloadValidator payloadValidator;
 
     /**
      * Constructs a ProjectService with the necessary repositories.
@@ -67,7 +64,7 @@ public class ProjectService {
      * @param employeeRepository     The repository for employee data access.
      * @param attachmentService      The service for attachment operations.
      * @param customerRepository     The repository used to validate the project's client.
-     * @param validator              Bean validator applied to the create payload.
+     * @param payloadValidator       Runs the create payload's own constraints.
      */
     public ProjectService(ProjectRepository repository,
                           OrganizationRepository organizationRepository,
@@ -76,7 +73,7 @@ public class ProjectService {
                           EmployeeMapper employeeMapper,
                           ApplicationEventPublisher eventPublisher,
                           CustomerRepository customerRepository,
-                          Validator validator) {
+                          PayloadValidator payloadValidator) {
         this.repository = repository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
@@ -85,7 +82,7 @@ public class ProjectService {
         this.employeeMapper = employeeMapper;
         this.eventPublisher = eventPublisher;
         this.customerRepository = customerRepository;
-        this.validator = validator;
+        this.payloadValidator = payloadValidator;
     }
 
     /**
@@ -97,7 +94,7 @@ public class ProjectService {
      */
     @Transactional
     public ProjectSimpleDto addProject(ProjectCreationDto projectDto,List<MultipartFile> attachments) {
-            requireValid(projectDto);
+            payloadValidator.requireValid(projectDto);
             Long orgId = TenantContext.getCurrentOrgId();
             Organization organization = organizationRepository.findById(orgId)
                     .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -344,24 +341,6 @@ public class ProjectService {
                             + "is built in, and neither the project's state nor its address names "
                             + "one. Set the project's state (for example Tamil Nadu) and approve it "
                             + "again.");
-        }
-    }
-
-    /**
-     * Runs bean validation over the create payload.
-     *
-     * <p>Both project controllers take the payload as the JSON string part of a multipart
-     * request and deserialize it by hand, so Spring never sees a bean to validate and the
-     * constraints on {@link ProjectCreationDto} would otherwise never fire. Doing it here covers
-     * both entry points at once, and covers any later caller by construction.
-     *
-     * @param projectDto The payload as deserialized from the request.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private void requireValid(ProjectCreationDto projectDto) {
-        Set<ConstraintViolation<ProjectCreationDto>> violations = validator.validate(projectDto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
         }
     }
 

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -1,7 +1,7 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,7 +42,7 @@ import java.util.Map;
 public class TaskController {
 
     private final TaskService service;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
     /** Logger for this class. */
     private static final Logger logger = LoggerFactory.getLogger(TaskController.class);
 
@@ -51,9 +51,9 @@ public class TaskController {
      *
      * @param service The service for handling task-related business logic.
      */
-    public TaskController(TaskService service, ObjectMapper objectMapper) {
+    public TaskController(TaskService service, JsonPartBinder jsonPartBinder) {
         this.service = service;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
     }
 
     /**
@@ -76,9 +76,9 @@ public class TaskController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task create or admin authority")
     })
-    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data,
+    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart String data,
                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
-        TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
+        TaskCreationDto dto = jsonPartBinder.read(data, TaskCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addTask(dto,attachments));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,7 +40,7 @@ import java.util.Map;
 public class TaskControllerWeb {
 
     private final TaskService service;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
     /** Logger for this class. */
     private static final Logger logger = LoggerFactory.getLogger(TaskController.class);
 
@@ -50,8 +49,8 @@ public class TaskControllerWeb {
      *
      * @param service The service for handling task-related business logic.
      */
-    public TaskControllerWeb(TaskService service,ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public TaskControllerWeb(TaskService service,JsonPartBinder jsonPartBinder) {
+        this.jsonPartBinder = jsonPartBinder;
         this.service = service;
     }
 
@@ -74,9 +73,9 @@ public class TaskControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart @Valid String data,
+    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart String data,
                                                     @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
-        TaskCreationDto dto = objectMapper.readValue(data, TaskCreationDto.class);
+        TaskCreationDto dto = jsonPartBinder.read(data, TaskCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addTask(dto,attachments));
     }
 
@@ -210,8 +209,7 @@ public class TaskControllerWeb {
                                                             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
                                                             @RequestParam(value = "entityType", required = false, defaultValue = "TASK_ATTACHMENTS") String entityType) throws JsonProcessingException
     {
-        Map<String, Object> updates = data != null
-                ? objectMapper.readValue(data, new TypeReference<>() {}) : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id,attachments, entityType));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.task;
 
-import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -51,8 +50,7 @@ public class TaskService {
     private final CategoryRepository categoryRepository;
     private final AttachmentService attachmentService;
     private final TaskMapper taskMapper;
-    private final Validator validator;
-
+    private final PayloadValidator payloadValidator;
 
     /**
      * Constructs a TaskService with the necessary repositories.
@@ -63,7 +61,7 @@ public class TaskService {
      * @param categoryRepository The repository for category data access.
      * @param attachmentService  The service for attachment operations.
      * @param taskMapper         The mapper between tasks and their DTOs.
-     * @param validator          Bean validator applied to the create payload.
+     * @param payloadValidator   Runs the create payload's own constraints.
      */
     public TaskService(TaskRepository taskRepository,
                        EmployeeRepository employeeRepository,
@@ -71,40 +69,21 @@ public class TaskService {
                        CategoryRepository categoryRepository,
                        AttachmentService attachmentService,
                        TaskMapper taskMapper,
-                       Validator validator) {
+                       PayloadValidator payloadValidator) {
         this.taskRepository = taskRepository;
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
         this.categoryRepository = categoryRepository;
         this.attachmentService = attachmentService;
         this.taskMapper = taskMapper;
-        this.validator = validator;
+        this.payloadValidator = payloadValidator;
     }
-
-    /**
-     * Runs bean validation over the create payload.
-     *
-     * <p>Both task controllers take the payload as the JSON string part of a multipart request
-     * and deserialize it by hand, so Spring never binds a bean and never validates one, and the
-     * constraints on {@link TaskCreationDto} would otherwise never fire. Doing it here covers
-     * both entry points at once, and covers any later caller by construction.
-     *
-     * @param taskCreationDto The payload as deserialized from the request.
-     * @throws ConstraintViolationException if any constraint on the payload fails.
-     */
-    private void requireValid(TaskCreationDto taskCreationDto) {
-        Set<ConstraintViolation<TaskCreationDto>> violations = validator.validate(taskCreationDto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
-    }
-
 
     /**
      * Creates a new task.
      *
      * @param taskCreationDto DTO containing the details for the new task.
-     * @throws jakarta.validation.ConstraintViolationException if the payload fails its own constraints.
+     * @throws ConstraintViolationException if the payload fails its own constraints.
      * @throws ResourceNotFoundException if the creator, project, or category is not found.
      * @throws InvalidRequestException if required fields like creatorId, projectId, or categoryId are missing,
      *                                 or if assigned employees do not belong to the project's organization.
@@ -112,7 +91,7 @@ public class TaskService {
      */
     @Transactional
     public TaskSimpleDto addTask(TaskCreationDto taskCreationDto, List<MultipartFile> attachments) {
-        requireValid(taskCreationDto);
+        payloadValidator.requireValid(taskCreationDto);
         Task task = new Task();
         task.setTitle(taskCreationDto.getTitle());
         task.setStartDate(taskCreationDto.getStartDate());

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -1,8 +1,7 @@
 package org.tornotron.echno_backend.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,18 +36,18 @@ import java.util.Map;
 public class UserControllerWeb {
 
     private final UserService userService;
-    private final ObjectMapper objectMapper;
+    private final JsonPartBinder jsonPartBinder;
     private final UserContextService userContextService;
 
     /**
      * Constructs a UserController with the given UserService.
      *
      * @param userService The service for handling user-related business logic.
-     * @param objectMapper The ObjectMapper for JSON processing.
+     * @param jsonPartBinder Reads and validates the JSON part of a multipart request.
      */
-    public UserControllerWeb(UserService userService, ObjectMapper objectMapper, UserContextService userContextService) {
+    public UserControllerWeb(UserService userService, JsonPartBinder jsonPartBinder, UserContextService userContextService) {
         this.userService = userService;
-        this.objectMapper = objectMapper;
+        this.jsonPartBinder = jsonPartBinder;
         this.userContextService = userContextService;
     }
 
@@ -180,10 +179,7 @@ public class UserControllerWeb {
             @PathVariable Long id,
             @RequestParam(value = "profilePicture", required = false) MultipartFile profilePicture,
             @RequestParam(value = "cv", required = false) MultipartFile cv) throws JsonProcessingException {
-        Map<String, Object> updates = data != null
-                ? objectMapper.readValue(data, new TypeReference<>() {
-        })
-                : Map.of();
+        Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK).body(userService.partialUpdateAnUser(updates, id, profilePicture, cv));
     }
     /**

--- a/src/test/java/org/tornotron/echno_backend/architecture/MultipartPayloadValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/MultipartPayloadValidationTest.java
@@ -1,0 +1,114 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet against an endpoint deserializing its own payload: a controller may not parse a request
+ * part itself, and may not ask for a {@code String} to be validated.
+ *
+ * <p>A multipart create endpoint cannot take a {@code @RequestBody}, because the body is the
+ * multipart envelope, so its payload travels as a JSON string part. Every one of these endpoints
+ * was written the same way: declare the part as {@code @RequestPart @Valid String data}, then call
+ * {@code objectMapper.readValue(data, SomeCreationDto.class)}. The {@code @Valid} lands on the
+ * {@code String}, a {@code String} declares no constraints, and the bean that comes out of
+ * {@code readValue} is never offered to a validator. The endpoint reads as validated, documents a
+ * 400 for a field that failed validation, and enforces nothing.
+ *
+ * <p>It is a quiet failure and a contagious one. Issue #490 counted 32 declared constraints across
+ * 11 endpoints in five modules that had never run, every one of them copied from the endpoint
+ * written before it. Fixing the eleven does nothing about the twelfth, which is what these rules
+ * are for.
+ *
+ * <p>The fix each endpoint now uses is
+ * {@code org.tornotron.echno_backend.common.payload.JsonPartBinder}, which parses and validates in
+ * one call, so a caller cannot hold an unvalidated payload. The first rule bans the hand-parse that
+ * goes around it. The second bans the annotation that made the bypass look deliberate, since
+ * {@code @Valid} on a {@code String} has never meant anything and reads as though it does.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's own
+ * cache, which every architecture test in this package shares and which holds it behind a soft
+ * reference. See {@link UnboundedRepositoryReadTest} for why that matters in a 1 GB test JVM.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class MultipartPayloadValidationTest {
+
+    /**
+     * A Jackson read that turns raw JSON into an object. Both entry points count:
+     * {@code ObjectMapper.readValue} is the one every affected endpoint used, and
+     * {@code ObjectReader.readValue} is the same thing reached through
+     * {@code objectMapper.reader()}.
+     */
+    private static final DescribedPredicate<JavaCall<?>> A_JACKSON_READ =
+            new DescribedPredicate<>("a Jackson read of raw JSON") {
+                @Override
+                public boolean test(JavaCall<?> call) {
+                    if (!call.getTarget().getName().startsWith("readValue")) {
+                        return false;
+                    }
+                    return call.getTargetOwner().isAssignableTo(ObjectMapper.class)
+                            || call.getTargetOwner().isAssignableTo(ObjectReader.class);
+                }
+            };
+
+    @ArchTest
+    static final ArchRule noControllerDeserializesItsOwnPayload = noClasses()
+            .that().areMetaAnnotatedWith(Controller.class)
+            .should().callMethodWhere(A_JACKSON_READ)
+            .because("a payload a controller parses itself is never validated by Spring, which is "
+                    + "how 32 constraints across 11 endpoints came to be unenforced; read the part "
+                    + "with JsonPartBinder, which parses and validates in one call");
+
+    /**
+     * The annotation half of the same defect.
+     *
+     * <p>{@code @Valid} asks for the constraints declared on a type to be checked. {@code String}
+     * declares none, so the annotation is inert wherever it lands on one. It is worth failing the
+     * build over rather than deleting quietly, because it is the marker that made every one of
+     * these endpoints look validated to the next person to read it, including in review.
+     *
+     * <p>Written against the imported parameters rather than in the fluent DSL, which has no
+     * predicate for a parameter annotation.
+     */
+    @ArchTest
+    static void noControllerAsksForAStringToBeValidated(JavaClasses productionClasses) {
+        List<String> offenders = productionClasses.stream()
+                .filter(javaClass -> javaClass.isMetaAnnotatedWith(Controller.class))
+                .flatMap(javaClass -> javaClass.getMethods().stream())
+                .flatMap(method -> method.getParameters().stream()
+                        .filter(parameter -> parameter.isAnnotatedWith(Valid.class))
+                        .filter(parameter -> parameter.getRawType().isEquivalentTo(String.class))
+                        .map(parameter -> describe(method, parameter)))
+                .sorted()
+                .toList();
+
+        assertThat(offenders)
+                .as("@Valid on a String validates nothing, because a String declares no "
+                        + "constraints; take the payload through JsonPartBinder instead, which "
+                        + "validates the bean it parses")
+                .isEmpty();
+    }
+
+    private static String describe(JavaMethod method, JavaParameter parameter) {
+        return method.getFullName() + " parameter " + parameter.getIndex();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * All four check-in and clock-event handlers take their payload as the JSON part of a multipart
@@ -68,7 +69,7 @@ class AttendancePayloadValidationTest {
         service = new AttendanceService(attendanceRepository, shiftTimingRepository,
                 employeeRepository, organizationRepository, projectRepository, settingsService,
                 calculationService, sequenceValidator, attendanceMapper, attachmentService,
-                fileStorageService, userContextService, validator);
+                fileStorageService, userContextService, new PayloadValidator(validator));
     }
 
     @AfterAll

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Unit tests for the approval attribution in {@link AttendanceService#approveAttendance}. The focus
@@ -68,7 +69,8 @@ class AttendanceServiceApprovalTest {
         service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
                 organizationRepository, projectRepository, settingsService, calculationService,
                 sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
-                userContextService, Validation.buildDefaultValidatorFactory().getValidator());
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()));
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/chat/ChatMessageValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/ChatMessageValidationTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 
 /**
  * The multipart send takes its payload as the JSON string part of the request and deserializes
@@ -43,8 +45,9 @@ class ChatMessageValidationTest {
     void setUp() {
         factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();
-        controller = new ChatControllerWeb(chatService, new ObjectMapper(), chatStreamService,
-                validator);
+        controller = new ChatControllerWeb(chatService,
+                new JsonPartBinder(new ObjectMapper(), new PayloadValidator(validator)),
+                chatStreamService);
     }
 
     @AfterAll

--- a/src/test/java/org/tornotron/echno_backend/chat/realtime/ChatStreamEndpointTest.java
+++ b/src/test/java/org/tornotron/echno_backend/chat/realtime/ChatStreamEndpointTest.java
@@ -29,6 +29,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Web-slice tests for the chat stream endpoint.
@@ -40,7 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * is present.
  */
 @WebMvcTest(ChatControllerWeb.class)
-@Import({ChatStreamEndpointTest.TestSecurityConfig.class, ChatStreamService.class, ChatStreamRegistry.class})
+@Import({ChatStreamEndpointTest.TestSecurityConfig.class, ChatStreamService.class, ChatStreamRegistry.class,
+        JsonPartBinder.class, PayloadValidator.class})
 class ChatStreamEndpointTest {
 
     private static final Long ORG = 1L;

--- a/src/test/java/org/tornotron/echno_backend/common/payload/JsonPartBinderTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/payload/JsonPartBinderTest.java
@@ -1,0 +1,94 @@
+package org.tornotron.echno_backend.common.payload;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.chat.dto.SendMessageDto;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The binder's own contract: a payload cannot leave it unvalidated.
+ *
+ * <p>This is the property the eleven endpoints of issue #490 were missing, so it is pinned here
+ * once rather than re-tested per endpoint. {@link SendMessageDto} stands in for any payload; it is
+ * used because it is the smallest one that declares a constraint.
+ *
+ * <p>A real Hibernate Validator and a real {@code ObjectMapper}, no Spring context: whether a
+ * constraint fires needs a genuine validator, and a mocked one would pin nothing.
+ */
+class JsonPartBinderTest {
+
+    private static ValidatorFactory factory;
+    private static JsonPartBinder binder;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        binder = new JsonPartBinder(new ObjectMapper(), new PayloadValidator(factory.getValidator()));
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    @Test
+    void read_refusesAPayloadThatFailsAConstraint() {
+        assertThatThrownBy(() -> binder.read("{\"content\":\"   \"}", SendMessageDto.class))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void read_refusesAPayloadMissingARequiredField() {
+        assertThatThrownBy(() -> binder.read("{\"replyToId\":1198}", SendMessageDto.class))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void read_returnsAValidPayload() throws JsonProcessingException {
+        SendMessageDto dto = binder.read(
+                "{\"content\":\"Concrete pour on block C is done.\",\"replyToId\":1198}",
+                SendMessageDto.class);
+
+        assertThat(dto.getContent()).isEqualTo("Concrete pour on block C is done.");
+        assertThat(dto.getReplyToId()).isEqualTo(1198L);
+    }
+
+    @Test
+    void read_refusesAnAbsentPart() {
+        assertThatThrownBy(() -> binder.read(null, SendMessageDto.class))
+                .isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> binder.read("   ", SendMessageDto.class))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void read_refusesAPartThatIsNotJson() {
+        assertThatThrownBy(() -> binder.read("not json at all", SendMessageDto.class))
+                .isInstanceOf(JsonProcessingException.class);
+    }
+
+    /**
+     * A partial update sends only the fields it is changing, so there is no bean and nothing to
+     * validate, and an absent part means "change nothing" rather than a bad request.
+     */
+    @Test
+    void readUpdates_readsTheFieldsSent_andTreatsAnAbsentPartAsNoChange() throws JsonProcessingException {
+        assertThat(binder.readUpdates("{\"title\":\"Repaint block B\",\"progress\":40}"))
+                .containsExactlyInAnyOrderEntriesOf(Map.of("title", "Repaint block B", "progress", 40));
+
+        assertThat(binder.readUpdates(null)).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Locks in read/write guard symmetry across the controllers that carried the asymmetry fixed
@@ -72,7 +74,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         IssueControllerWeb.class,
         IssueCommentControllerWeb.class
 })
-@Import(ReadWriteGuardSymmetryTest.TestSecurityConfig.class)
+@Import({ReadWriteGuardSymmetryTest.TestSecurityConfig.class, JsonPartBinder.class, PayloadValidator.class})
 class ReadWriteGuardSymmetryTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
@@ -20,6 +20,7 @@ import org.tornotron.echno_backend.task.TaskRepository;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Both issue controllers take the create payload as the JSON string part of a multipart request
@@ -54,7 +55,7 @@ class IssueCreationValidationTest {
         factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         service = new IssueService(issueRepository, taskRepository, attachmentService,
-                issueMapper, employeeRepository, validator);
+                issueMapper, employeeRepository, new PayloadValidator(validator));
     }
 
     @AfterAll

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationCreationValidationTest.java
@@ -24,6 +24,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Both organization controllers take the create payload as the JSON string part of a multipart
@@ -69,7 +70,7 @@ class OrganizationCreationValidationTest {
         validator = factory.getValidator();
         service = new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
-                organizationMapper, orgSecurity, onboardingSeeder, validator);
+                organizationMapper, orgSecurity, onboardingSeeder, new PayloadValidator(validator));
     }
 
     @AfterAll

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceBatchAuthzTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Batch organization update must authorize each id, because Organization is the
@@ -50,7 +51,7 @@ class OrganizationServiceBatchAuthzTest {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
                 organizationMapper, orgSecurity, onboardingSeeder,
-                Validation.buildDefaultValidatorFactory().getValidator());
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()));
     }
 
     private OrganizationPatchDto patch(long id) {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * The billing rule on creating an organization.
@@ -68,7 +69,7 @@ class OrganizationServiceEntitlementTest {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
                 organizationMapper, orgSecurity, onboardingSeeder,
-                Validation.buildDefaultValidatorFactory().getValidator());
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()));
     }
 
     private OrganizationCreationDto creationDto() {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceOnboardingTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Self-service onboarding wiring for {@code addOrganization}: the creator of an organization must be
@@ -61,7 +62,7 @@ class OrganizationServiceOnboardingTest {
         return new OrganizationService(repository, attachmentService, fileStorageService,
                 keycloakGroupService, subscriptionService, userContextService, employeeService,
                 organizationMapper, orgSecurity, onboardingSeeder,
-                Validation.buildDefaultValidatorFactory().getValidator());
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()));
     }
 
     private OrganizationCreationDto creationDto() {

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceScopingTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import jakarta.validation.Validator;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
@@ -24,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Unit tests for the row filtering behind the organization picker.
@@ -48,7 +48,7 @@ class OrganizationServiceScopingTest {
     @Mock private OrganizationSecurityService orgSecurity;
     @Mock private OrganizationOnboardingSeeder onboardingSeeder;
 
-    @Mock private Validator validator;
+    @Mock private PayloadValidator payloadValidator;
 
     @InjectMocks private OrganizationService service;
 

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationWebControllerAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationWebControllerAuthzTest.java
@@ -27,6 +27,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Web-slice authorization test for the organization list endpoint, the screen that populates
@@ -43,7 +45,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * OrganizationServiceScopingTest covers that filtering.
  */
 @WebMvcTest(OrganizationWebController.class)
-@Import(OrganizationWebControllerAuthzTest.TestSecurityConfig.class)
+@Import({OrganizationWebControllerAuthzTest.TestSecurityConfig.class, JsonPartBinder.class,
+        PayloadValidator.class})
 class OrganizationWebControllerAuthzTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebAuthzTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Web-slice authorization tests for the read endpoints on ProjectControllerWeb.
@@ -35,7 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * membership only, the role-without-membership test fails.
  */
 @WebMvcTest(ProjectControllerWeb.class)
-@Import(ProjectControllerWebAuthzTest.TestSecurityConfig.class)
+@Import({ProjectControllerWebAuthzTest.TestSecurityConfig.class, JsonPartBinder.class,
+        PayloadValidator.class})
 class ProjectControllerWebAuthzTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Both project controllers take the create payload as the JSON string part of a multipart
@@ -62,7 +63,7 @@ class ProjectCreationValidationTest {
         validator = factory.getValidator();
         service = new ProjectService(repository, organizationRepository, employeeRepository,
                 attachmentService, projectMapper, employeeMapper, eventPublisher,
-                customerRepository, validator);
+                customerRepository, new PayloadValidator(validator));
     }
 
     private ProjectCreationDto validDto() {

--- a/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
  * Both task controllers take the create payload as the JSON string part of a multipart request
@@ -60,7 +61,7 @@ class TaskCreationValidationTest {
         factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         service = new TaskService(taskRepository, employeeRepository, projectRepository,
-                categoryRepository, attachmentService, taskMapper, validator);
+                categoryRepository, attachmentService, taskMapper, new PayloadValidator(validator));
     }
 
     @AfterAll


### PR DESCRIPTION
Closes #490.

## What was left of the issue

The 11 endpoints and 32 constraints the issue names are already fixed on `development`, by the three PRs its own comment lists (#492 task and issue, #495 organization and chat, #500 attendance), plus #488 for project. I re-swept `readValue` across `src/main` and confirmed it: every creation payload is validated today, and nothing in this PR turns on a constraint that was not already running. **There is no behaviour change to any create payload, so nothing that succeeds today starts failing.**

What those PRs left behind is the reason the defect existed in the first place. Each added its own private `requireValid` to its own service, so there are now five identical copies of the same five lines, and, more to the point, nothing stops the twelfth endpoint being written exactly like the first eleven. The copies are the symptom. The pattern being trivial to write and invisible in review is the defect, and that is what this PR closes.

## The mechanism

`JsonPartBinder` reads every JSON part in the application:

```java
TaskCreationDto dto = jsonPartBinder.read(data, TaskCreationDto.class);   // parses, then validates
Map<String, Object> updates = jsonPartBinder.readUpdates(data);           // patch payloads, no bean to validate
```

`read` parses and validates in one call, so a caller cannot come away holding a payload whose constraints have not been checked. That is the property the eleven endpoints were missing, and it now holds by construction rather than by each author remembering. `readUpdates` covers the partial-update endpoints that read the part into a `Map`: there is no bean there and nothing to validate, and it is on the binder so that reading a part is one mechanism rather than two, which is what lets the guard rule below need no allowlist.

`PayloadValidator` is the single implementation of "check this bean or refuse it". The binder uses it at the request boundary; the five services keep their own call to it for any caller that reaches them another way. Both layers are deliberate: the binder guarantees the request path including an endpoint whose author never opens the service, the service guarantees the rest. It is a bean-validation pass over a small DTO, twice.

19 hand-parses across 12 controllers now go through the binder, and the five copies of `requireValid` are gone.

### Why here and not an argument resolver

The obvious alternative is a `HandlerMethodArgumentResolver` so the handler can declare `TaskCreationDto` directly. Two things rule it out. Custom resolvers are appended after Spring's own, so a parameter still annotated `@RequestPart` is claimed by `RequestPartMethodArgumentResolver` before mine is consulted, which means a new annotation. And springdoc builds the multipart request body from the handler's parameters, so a parameter it cannot interpret drops `data` out of the published OpenAPI document that Apidog syncs from. Keeping the signature and replacing the body costs one line per endpoint and changes the document not at all.

## The guard rail

`architecture/MultipartPayloadValidationTest`, alongside `EndpointAuthorizationTest` and `UnboundedRepositoryReadTest` and sharing their `@AnalyzeClasses` import cache. Two rules, because the defect had two halves:

- **`noControllerDeserializesItsOwnPayload`** bans a Jackson `readValue` inside anything meta-annotated `@Controller`. This is the half that actually skips validation. Banning the call rather than trying to prove a payload went unvalidated has no false positives and fails on the line that introduced it.
- **`noControllerAsksForAStringToBeValidated`** bans `@Valid` on a `String` parameter. It validates nothing, and it is worth failing the build over rather than deleting quietly, because it is the marker that made all eleven endpoints look validated to every reader including reviewers.

Against the parent commit they report **19 hand-parses and 13 inert `@Valid` annotations**. Both fail there and pass here.

## A fix that falls out of the consolidation

`ProjectController.createProject` built its own `new ObjectMapper()` instead of taking the configured one. A bare Jackson mapper has no `JavaTimeModule`, and `ProjectCreationDto` carries `startDate` and `endDate` as `LocalDateTime`, so that endpoint refused any project that named its dates, with `Java 8 date/time type not supported by default`. Its `/web` twin has always used the configured mapper, so the two disagreed. Both now go through the binder.

The same swap makes that endpoint tolerant of unknown properties, since the configured mapper disables `FAIL_ON_UNKNOWN_PROPERTIES` and a bare one does not. That is the looser direction and it matches every other create endpoint.

## No constraint looks wrong

The brief asked me to call out any constraint that looks wrong rather than enforce it silently. I read all 32 again against the DTOs and the web forms. There is nothing to report, because the six that were wrong were already corrected by the PRs that turned validation on, and each correction is recorded in the DTO next to the constraint:

| Constraint | Was | Is | Why |
|---|---|---|---|
| task/issue `title` | `@Size(max = 50)` | 255 | column is `VARCHAR(255)`, no form caps it |
| issue `description` | `@Size(max = 500)` | 2000 | `TEXT` column, message also claimed a minimum of ten against a constraint asking five |
| task `assigneeIds`, `tags` | `@NotNull` | optional | the service has always skipped an absent or empty list |
| `organizationAddress` | `@Size(max = 50)` | 255 | `TEXT` column behind a three-row textarea |
| `organizationPhone` | `@Size(9, 15)` | 9 to 16 | E.164 counted digits and forgot the leading plus |
| `organizationEmail` | TLD `{2,6}` | `{2,24}` | refused `.construction`, `.engineering`, `.contractors` |
| `organizationName` | `@Size(min = 3)` | 2 | refused "3M", "HP" |

The one client payload that newly fails is already filed: the issue form's "Save as Draft" sends `"description": ""` past `@NotBlank`, tracked as tornotron/echno-web#290. Nothing here changes that either way.

## Verification

Run on the lab build box (`10.24.6.116`), so the Testcontainers suites have a real CockroachDB. The tree there was checksum-matched against the branch before the run.

```
$ ./gradlew test
817 tests, BUILD SUCCESSFUL in 7m 13s
```

New tests, and what each is worth:

| Test | Broken by | Result |
|---|---|---|
| `MultipartPayloadValidationTest.noControllerDeserializesItsOwnPayload` | running it against the parent commit | **FAILED**, 19 violations |
| `MultipartPayloadValidationTest.noControllerAsksForAStringToBeValidated` | running it against the parent commit | **FAILED**, 13 violations |
| `JsonPartBinderTest.read_refusesAPayloadThatFailsAConstraint` | dropping the validate from `read` | **FAILED** |
| `JsonPartBinderTest.read_refusesAPayloadMissingARequiredField` | dropping the validate from `read` | **FAILED** |
| `JsonPartBinderTest.read_refusesAnAbsentPart` | dropping the absent-part guard | **FAILED** |
| `JsonPartBinderTest.read_returnsAValidPayload` | (holds either way, pins the pass-through) | passed |
| `JsonPartBinderTest.read_refusesAPartThatIsNotJson` | (holds either way, pins the parse failure) | passed |
| `JsonPartBinderTest.readUpdates_readsTheFieldsSent_andTreatsAnAbsentPartAsNoChange` | (holds either way, pins the patch contract) | passed |

All restored to green afterwards. Plain JUnit with a real Hibernate Validator and a real `ObjectMapper`, no new Spring context, so nothing is added to the test JVM's context cache.

The four `@WebMvcTest` slices over these controllers (`ProjectControllerWebAuthzTest`, `OrganizationWebControllerAuthzTest`, `ReadWriteGuardSymmetryTest`, `ChatStreamEndpointTest`) import the two new beans. A slice does not pick up a plain `@Component`, and without the import each fails to load its context.
