### PR TITLE
Cache a copy of the subscription rather than the entity

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/billing/components/SubscriptionCache.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/components/SubscriptionCache.java
@@ -9,15 +9,43 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.tornotron.echno_backend.billing.Subscription;
+import org.tornotron.echno_backend.billing.snapshot.SubscriptionSnapshot;
 
 import java.time.Duration;
 
+/**
+ * Per-user cache of the active subscription, so the entitlement check on an annotated endpoint
+ * does not query the subscription and its plan graph on every request.
+ *
+ * <p>What it holds is a {@link SubscriptionSnapshot}: an immutable copy of the row and its
+ * plan, taken while the loading transaction is still open. It deliberately holds neither of
+ * the two obvious alternatives.
+ *
+ * <p>Not the {@code Subscription} entity, which is what it used to hold. An entity in a cache
+ * is detached by definition and outlives the persistence context that produced it, so anything
+ * left uninitialized on it throws {@code LazyInitializationException} on a later hit, in a
+ * transaction that cannot reattach it. That was survivable only as long as the loading query
+ * kept fetch-joining the whole graph, which no signature enforced. It is also a mutable object
+ * shared by every concurrent reader of that user, so any write path that touched it published a
+ * half-finished change to all of them at once.
+ *
+ * <p>Not {@code SubscriptionDto} either, which is the tempting fix. Two of its entitlement
+ * flags, {@code expired} and {@code inTrial}, are comparisons against the current instant, so
+ * caching them freezes them for the life of the entry and a subscription that lapses inside
+ * that window keeps reporting itself unexpired. The snapshot keeps the timestamps those flags
+ * are derived from and leaves the derivation to read time.
+ *
+ * <p>Freshness is bounded by the five minute expiry and by eviction: every write that changes
+ * a user's subscription evicts that user's entry, and every write that changes a plan evicts
+ * all of them, because a snapshot carries a copy of the plan it was taken against. The cache
+ * is in process, so those evictions reach one replica. Under more than one replica the
+ * remaining bound on the others is the expiry.
+ */
 @Component
 @Slf4j
 public class SubscriptionCache {
 
-    private final Cache<@NonNull Long, Subscription> cache;
+    private final Cache<@NonNull Long, SubscriptionSnapshot> cache;
 
     public SubscriptionCache() {
         this.cache = Caffeine.newBuilder()
@@ -27,11 +55,11 @@ public class SubscriptionCache {
                 .build();
     }
 
-    public Subscription get(Long userId) {
+    public SubscriptionSnapshot get(Long userId) {
         return cache.getIfPresent(userId);
     }
 
-    public void put(Long userId, Subscription subscription) {
+    public void put(Long userId, SubscriptionSnapshot subscription) {
         cache.put(userId, subscription);
     }
 
@@ -56,7 +84,29 @@ public class SubscriptionCache {
      */
     public void evictOnWrite(Long userId) {
         evict(userId);
+        againOnCompletion(() -> evict(userId));
+    }
 
+    /**
+     * Empties the cache for a write that is still in flight, both now and once the surrounding
+     * transaction has finished, on the same reasoning as {@link #evictOnWrite(Long)}.
+     *
+     * <p>The blunt instrument is for plan writes. A snapshot carries a copy of the plan it was
+     * taken against, so changing a plan changes what every subscriber of that plan is entitled
+     * to, and the entries to invalidate are not addressable by user without a query. Plan
+     * writes are rare administrative operations, so emptying the cache costs a re-read per
+     * active user rather than anything ongoing.
+     */
+    public void evictAllOnWrite() {
+        evictAll();
+        againOnCompletion(this::evictAll);
+    }
+
+    public void evictAll() {
+        cache.invalidateAll();
+    }
+
+    private void againOnCompletion(Runnable eviction) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             return;
         }
@@ -64,13 +114,9 @@ public class SubscriptionCache {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCompletion(int status) {
-                evict(userId);
+                eviction.run();
             }
         });
-    }
-
-    public void evictAll() {
-        cache.invalidateAll();
     }
 
     @Scheduled(fixedRate = 60000)

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/BillingMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/BillingMapper.java
@@ -1,35 +1,128 @@
 package org.tornotron.echno_backend.billing.dto;
 
 import org.tornotron.echno_backend.billing.*;
+import org.tornotron.echno_backend.billing.snapshot.PlanFeatureSnapshot;
+import org.tornotron.echno_backend.billing.snapshot.PlanSnapshot;
+import org.tornotron.echno_backend.billing.snapshot.SubscriptionSnapshot;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Builds the billing response DTOs, and the snapshots the subscription cache holds.
+ *
+ * <p>Every entity-to-DTO conversion here goes through a snapshot first, so the mapping from
+ * persistent state to response state is written once and the cached value and the response are
+ * built from the same reading of the row. The entity overloads therefore have to be called
+ * inside the transaction that loaded the entity, exactly as before: they touch the lazy
+ * {@code Subscription.plan} and {@code Plan.planFeatures}. The snapshot overloads have no such
+ * requirement, which is the point of taking a snapshot.
+ */
 public class BillingMapper {
 
     private BillingMapper() {
     }
 
+    /**
+     * Copies a plan and its features out of the persistence context.
+     *
+     * @param plan The plan entity to copy, with its features initialized.
+     * @return An immutable copy of the plan, or null if the plan was null.
+     */
+    public static PlanSnapshot toPlanSnapshot(Plan plan) {
+        if (plan == null) return null;
+
+        return new PlanSnapshot(
+                plan.getId(),
+                plan.getCode(),
+                plan.getName(),
+                plan.getDescription(),
+                plan.getVersion(),
+                plan.getMonthlyPrice(),
+                plan.getAnnualPrice(),
+                plan.getCurrency(),
+                plan.getIsActive(),
+                plan.getIsPublic(),
+                plan.getTrialDays(),
+                plan.getMaxUsers(),
+                plan.getSortOrder(),
+                plan.getPlanFeatures() != null
+                        ? plan.getPlanFeatures().stream()
+                        .map(BillingMapper::toPlanFeatureSnapshot)
+                        .collect(Collectors.toList())
+                        : Collections.emptyList());
+    }
+
+    /**
+     * Copies one of a plan's feature grants out of the persistence context, feature id included.
+     *
+     * @param planFeature The plan-feature entity to copy, with its feature initialized.
+     * @return An immutable copy of the grant, or null if the grant was null.
+     */
+    public static PlanFeatureSnapshot toPlanFeatureSnapshot(PlanFeature planFeature) {
+        if (planFeature == null) return null;
+
+        Feature feature = planFeature.getFeature();
+        return new PlanFeatureSnapshot(
+                planFeature.getId(),
+                feature != null ? feature.getId() : null,
+                feature != null ? feature.getCode() : null,
+                feature != null ? feature.getName() : null,
+                feature != null ? feature.getFeatureType() : null,
+                planFeature.getEnabled(),
+                planFeature.getQuotaLimit(),
+                planFeature.getQuotaPeriod());
+    }
+
+    /**
+     * Copies a subscription and the plan behind it out of the persistence context.
+     *
+     * @param subscription The subscription entity to copy, with its plan graph initialized.
+     * @return An immutable copy of the subscription, or null if the subscription was null.
+     */
+    public static SubscriptionSnapshot toSubscriptionSnapshot(Subscription subscription) {
+        if (subscription == null) return null;
+
+        return new SubscriptionSnapshot(
+                subscription.getId(),
+                subscription.getUserId(),
+                subscription.getStatus(),
+                subscription.getCurrentPeriodStart(),
+                subscription.getCurrentPeriodEnd(),
+                subscription.getTrialStart(),
+                subscription.getTrialEnd(),
+                subscription.getCancelAtPeriodEnd(),
+                subscription.getCanceledAt(),
+                subscription.getCreatedAt(),
+                subscription.getCancellationReason(),
+                toPlanSnapshot(subscription.getPlan()));
+    }
+
     public static PlanDto toPlanDto(Plan plan) {
+        return toPlanDto(toPlanSnapshot(plan));
+    }
+
+    public static PlanDto toPlanDto(PlanSnapshot plan) {
         if (plan == null) return null;
 
         return PlanDto.builder()
-                .id(plan.getId())
-                .code(plan.getCode())
-                .name(plan.getName())
-                .description(plan.getDescription())
-                .version(plan.getVersion())
-                .monthlyPrice(plan.getMonthlyPrice())
-                .annualPrice(plan.getAnnualPrice())
-                .currency(plan.getCurrency())
-                .isActive(plan.getIsActive())
-                .isPublic(plan.getIsPublic())
-                .trialDays(plan.getTrialDays())
-                .maxUsers(plan.getMaxUsers())
-                .sortOrder(plan.getSortOrder())
-                .features(plan.getPlanFeatures() != null
-                        ? plan.getPlanFeatures().stream()
+                .id(plan.id())
+                .code(plan.code())
+                .name(plan.name())
+                .description(plan.description())
+                .version(plan.version())
+                .monthlyPrice(plan.monthlyPrice())
+                .annualPrice(plan.annualPrice())
+                .currency(plan.currency())
+                .isActive(plan.isActive())
+                .isPublic(plan.isPublic())
+                .trialDays(plan.trialDays())
+                .maxUsers(plan.maxUsers())
+                .sortOrder(plan.sortOrder())
+                .features(plan.features() != null
+                        ? plan.features().stream()
                         .map(BillingMapper::toPlanFeatureDto)
                         .collect(Collectors.toList())
                         : Collections.emptyList())
@@ -57,17 +150,20 @@ public class BillingMapper {
     }
 
     public static PlanFeatureDto toPlanFeatureDto(PlanFeature planFeature) {
+        return toPlanFeatureDto(toPlanFeatureSnapshot(planFeature));
+    }
+
+    public static PlanFeatureDto toPlanFeatureDto(PlanFeatureSnapshot planFeature) {
         if (planFeature == null) return null;
 
-        Feature feature = planFeature.getFeature();
         return PlanFeatureDto.builder()
-                .id(planFeature.getId())
-                .featureCode(feature != null ? feature.getCode() : null)
-                .featureName(feature != null ? feature.getName() : null)
-                .featureType(feature != null ? feature.getFeatureType() : null)
-                .enabled(planFeature.getEnabled())
-                .quotaLimit(planFeature.getQuotaLimit())
-                .quotaPeriod(planFeature.getQuotaPeriod())
+                .id(planFeature.id())
+                .featureCode(planFeature.featureCode())
+                .featureName(planFeature.featureName())
+                .featureType(planFeature.featureType())
+                .enabled(planFeature.enabled())
+                .quotaLimit(planFeature.quotaLimit())
+                .quotaPeriod(planFeature.quotaPeriod())
                 .build();
     }
 
@@ -86,24 +182,40 @@ public class BillingMapper {
     }
 
     public static SubscriptionDto toSubscriptionDto(Subscription subscription) {
+        return toSubscriptionDto(toSubscriptionSnapshot(subscription));
+    }
+
+    /**
+     * Builds the response DTO from a snapshot, resolving the time-derived entitlement flags
+     * against the current instant.
+     *
+     * <p>{@code expired} and {@code inTrial} are computed here rather than carried on the
+     * snapshot, so a snapshot that has been sitting in the cache reports them for now and not
+     * for the moment it was taken.
+     *
+     * @param subscription The snapshot to render.
+     * @return The response DTO, or null if the snapshot was null.
+     */
+    public static SubscriptionDto toSubscriptionDto(SubscriptionSnapshot subscription) {
         if (subscription == null) return null;
 
+        Instant now = Instant.now();
         return SubscriptionDto.builder()
-                .id(subscription.getId())
-                .userId(subscription.getUserId())
-                .plan(toPlanDto(subscription.getPlan()))
-                .status(subscription.getStatus())
-                .currentPeriodStart(subscription.getCurrentPeriodStart())
-                .currentPeriodEnd(subscription.getCurrentPeriodEnd())
-                .trialStart(subscription.getTrialStart())
-                .trialEnd(subscription.getTrialEnd())
-                .cancelAtPeriodEnd(subscription.getCancelAtPeriodEnd())
-                .canceledAt(subscription.getCanceledAt())
-                .createdAt(subscription.getCreatedAt())
-                .cancellationReason(subscription.getCancellationReason())
+                .id(subscription.id())
+                .userId(subscription.userId())
+                .plan(toPlanDto(subscription.plan()))
+                .status(subscription.status())
+                .currentPeriodStart(subscription.currentPeriodStart())
+                .currentPeriodEnd(subscription.currentPeriodEnd())
+                .trialStart(subscription.trialStart())
+                .trialEnd(subscription.trialEnd())
+                .cancelAtPeriodEnd(subscription.cancelAtPeriodEnd())
+                .canceledAt(subscription.canceledAt())
+                .createdAt(subscription.createdAt())
+                .cancellationReason(subscription.cancellationReason())
                 .active(subscription.isActive())
-                .inTrial(subscription.isInTrial())
-                .expired(subscription.isExpired())
+                .inTrial(subscription.isInTrial(now))
+                .expired(subscription.isExpired(now))
                 .build();
     }
 

--- a/src/main/java/org/tornotron/echno_backend/billing/services/PlanService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/PlanService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.billing.Feature;
 import org.tornotron.echno_backend.billing.Plan;
 import org.tornotron.echno_backend.billing.PlanFeature;
+import org.tornotron.echno_backend.billing.components.SubscriptionCache;
 import org.tornotron.echno_backend.billing.dto.BillingMapper;
 import org.tornotron.echno_backend.billing.dto.PlanCreateDto;
 import org.tornotron.echno_backend.billing.dto.PlanDto;
@@ -23,6 +24,12 @@ import java.util.List;
  * Plan administration: reading plans with their assigned features, and creating, updating and
  * deactivating them.
  *
+ * <p>Every write here empties the subscription cache. A cached subscription carries a copy of
+ * the plan it was taken against, features and quotas included, so changing a plan changes what
+ * every subscriber of it is entitled to while their cached copies still say otherwise. The
+ * entries are not addressable by user without a query, and plan writes are rare administrative
+ * operations, so the whole cache goes.
+ *
  * <p>Entities never leave this class. Every method a caller can reach returns a DTO built while
  * the persistence context is still open, because {@code spring.jpa.open-in-view} is off and
  * {@link Plan#getPlanFeatures()} is a lazy collection: mapping a plan anywhere outside a
@@ -38,6 +45,7 @@ public class PlanService {
 
     private final PlanRepository planRepository;
     private final FeatureRepository featureRepository;
+    private final SubscriptionCache subscriptionCache;
 
     /**
      * Returns the plans that are both public and active, ordered for display.
@@ -130,6 +138,7 @@ public class PlanService {
         if (dto.getSortOrder() != null) plan.setSortOrder(dto.getSortOrder());
 
         plan = planRepository.save(plan);
+        subscriptionCache.evictAllOnWrite();
         log.info("Updated plan: {}", plan.getCode());
         return BillingMapper.toPlanDto(plan);
     }
@@ -139,6 +148,7 @@ public class PlanService {
         Plan plan = loadPlanById(id);
         plan.setIsActive(false);
         planRepository.save(plan);
+        subscriptionCache.evictAllOnWrite();
         log.info("Deactivated plan: {}", plan.getCode());
     }
 
@@ -148,6 +158,7 @@ public class PlanService {
                 .orElseThrow(() -> new PlanNotFoundException("Plan with ID " + id + " was not found"));
         plan.setIsActive(true);
         planRepository.save(plan);
+        subscriptionCache.evictAllOnWrite();
         log.info("Activated plan: {}", plan.getCode());
     }
 
@@ -177,6 +188,7 @@ public class PlanService {
 
         plan.addFeature(planFeature);
         plan = planRepository.save(plan);
+        subscriptionCache.evictAllOnWrite();
 
         log.info("Assigned feature {} to plan {}", dto.getFeatureCode(), plan.getCode());
         return BillingMapper.toPlanDto(plan);
@@ -195,6 +207,7 @@ public class PlanService {
 
         plan.removeFeature(planFeature);
         plan = planRepository.save(plan);
+        subscriptionCache.evictAllOnWrite();
 
         log.info("Removed feature {} from plan {}", featureCode, plan.getCode());
         return BillingMapper.toPlanDto(plan);

--- a/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
@@ -16,6 +16,8 @@ import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
 import org.tornotron.echno_backend.billing.repositories.PlanRepository;
 import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
 import org.tornotron.echno_backend.billing.repositories.UsageRecordRepository;
+import org.tornotron.echno_backend.billing.snapshot.PlanFeatureSnapshot;
+import org.tornotron.echno_backend.billing.snapshot.SubscriptionSnapshot;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.NoActiveSubscriptionException;
 import org.tornotron.echno_backend.common.exception.PlanNotFoundException;
@@ -36,11 +38,13 @@ import java.util.Optional;
  * bucket). Creating, changing, and canceling a subscription each evict the user's cache
  * entry so the next access re-reads the current state.
  *
- * <p>Entities never leave this class. Every method that a caller can reach returns a DTO
- * built while the persistence context is still open, because {@code spring.jpa.open-in-view}
- * is off and {@link Subscription#getPlan()} and {@link Plan#getPlanFeatures()} are both lazy:
- * mapping a subscription anywhere outside a transaction throws
- * {@code LazyInitializationException}.
+ * <p>Entities never leave this class, and never reach the cache either. Every method that a
+ * caller can reach returns a DTO built while the persistence context is still open, because
+ * {@code spring.jpa.open-in-view} is off and {@link Subscription#getPlan()} and
+ * {@link Plan#getPlanFeatures()} are both lazy: mapping a subscription anywhere outside a
+ * transaction throws {@code LazyInitializationException}. Reads that go through the cache work
+ * on a {@link SubscriptionSnapshot}, an immutable copy taken inside the loading transaction,
+ * which is the only form of the row that is safe to hold once that transaction is gone.
  */
 @Service
 @Slf4j
@@ -76,33 +80,36 @@ public class SubscriptionService {
     }
 
     /**
-     * Loads the user's active subscription entity, serving it from the cache when present.
+     * Loads a snapshot of the user's active subscription, serving it from the cache when present.
      *
-     * <p>On a cache miss it queries the repository and, if found, populates the cache.
+     * <p>On a cache miss it queries the repository and, if a subscription is found, copies it and
+     * its plan into a snapshot before the transaction that loaded it ends, then caches that. The
+     * entity itself is never handed out and never cached, so nothing downstream can be holding a
+     * detached instance whose uninitialized parts throw {@code LazyInitializationException} in a
+     * later transaction that cannot reattach it.
      *
-     * <p>A cached instance is detached, so anything it left uninitialized throws
-     * {@code LazyInitializationException} on the next hit, in a later transaction that cannot
-     * reattach it. What keeps that from happening is that the graph is always initialized before
-     * the session that loaded it closes: {@code findActiveSubscriptionByUserId} fetch-joins the
-     * plan, its plan features and each feature, and every caller below then maps or walks the
-     * whole graph inside its own transaction anyway. Either alone would do; do not remove both.
-     * A new caller that caches a subscription without touching its plan would be relying on the
-     * fetch joins by itself.
+     * <p>Taking the copy is what the fetch joins on {@code findActiveSubscriptionByUserId} are
+     * for now. Without them the copy still comes out complete, because it is built inside the
+     * transaction and the lazy reads resolve there, but it costs a query per plan feature on
+     * every miss instead of one query for the graph. Weakening them is a performance regression
+     * rather than a correctness one, which is a change of kind: it used to be the thing standing
+     * between the cache and a 500.
      *
      * @param userId The ID of the user whose subscription to resolve.
-     * @return The active subscription, or empty if the user has none.
+     * @return A snapshot of the active subscription, or empty if the user has none.
      */
-    private Optional<Subscription> loadActiveSubscription(Long userId) {
+    private Optional<SubscriptionSnapshot> loadActiveSubscription(Long userId) {
 
-        Subscription cached = subscriptionCache.get(userId);
+        SubscriptionSnapshot cached = subscriptionCache.get(userId);
         if(cached != null) {
             return Optional.of(cached);
         }
 
-        Optional<Subscription> subscription = subscriptionRepository
-                .findActiveSubscriptionByUserId(userId);
+        Optional<SubscriptionSnapshot> subscription = subscriptionRepository
+                .findActiveSubscriptionByUserId(userId)
+                .map(BillingMapper::toSubscriptionSnapshot);
 
-        subscription.ifPresent(sub -> subscriptionCache.put(userId, sub));
+        subscription.ifPresent(snapshot -> subscriptionCache.put(userId, snapshot));
 
         return subscription;
     }
@@ -111,14 +118,15 @@ public class SubscriptionService {
      * Loads the user's active subscription entity for a caller that is about to change it,
      * always from the database and never from the cache.
      *
-     * <p>{@link #loadActiveSubscription(Long)} hands back the very instance the cache holds,
-     * which every concurrent reader of this user shares and which is detached from any
-     * persistence context. A write path must not touch that instance: mutating it publishes a
-     * half-finished change to every reader at once, and leaves the cache holding state that
-     * never reached the database if the write then fails. Reading fresh gives the caller a
-     * managed entity of its own, so the change is confined to its transaction and reaches
-     * other callers only through the eviction on
-     * {@link SubscriptionCache#evictOnWrite(Long)}.
+     * <p>{@link #loadActiveSubscription(Long)} answers from the cache, with a snapshot that is
+     * immutable and detached from any persistence context. Nothing a write path did to it would
+     * reach the database, and the shape of the change a write needs to make is a change to a
+     * managed entity. Reading fresh gives the caller one of its own, so the change is confined
+     * to its transaction and reaches other callers only through the eviction on
+     * {@link SubscriptionCache#evictOnWrite(Long)}. That the snapshot cannot be mutated in the
+     * first place is what closed the older hazard here, where the write path resolved its
+     * subscription through the cache and set fields straight onto the instance every concurrent
+     * reader of that user was sharing.
      *
      * <p>The read deliberately does not populate the cache either. The row is about to change,
      * so caching what it looks like now would only have to be undone.
@@ -144,26 +152,22 @@ public class SubscriptionService {
      */
     @Transactional(readOnly = true)
     public FeatureAccessResultDto checkFeatureAccess(Long userId, String featureCode) {
-        Optional<Subscription> subscriptionOptional = loadActiveSubscription(userId);
+        Optional<SubscriptionSnapshot> subscriptionOptional = loadActiveSubscription(userId);
 
         if(subscriptionOptional.isEmpty()) {
             return FeatureAccessResultDto.noSubscription();
         }
 
-        Subscription subscription = subscriptionOptional.get();
-        Plan plan = subscription.getPlan();
-
-        Optional<PlanFeature> planFeatureOptional = plan.getPlanFeatures().stream()
-                .filter(pf -> pf.getFeature().getCode().equals(featureCode))
-                .findFirst();
+        Optional<PlanFeatureSnapshot> planFeatureOptional =
+                subscriptionOptional.get().feature(featureCode);
 
         if(planFeatureOptional.isEmpty()) {
             return FeatureAccessResultDto.featureNotInPlan();
         }
 
-        PlanFeature planFeature = planFeatureOptional.get();
+        PlanFeatureSnapshot planFeature = planFeatureOptional.get();
 
-        if(planFeature.getFeature().getFeatureType() == FeatureType.BOOLEAN) {
+        if(planFeature.featureType() == FeatureType.BOOLEAN) {
             return planFeature.isFeatureEnabled()
                     ? FeatureAccessResultDto.allowed()
                     : FeatureAccessResultDto.featureDisabled();
@@ -176,15 +180,24 @@ public class SubscriptionService {
         return FeatureAccessResultDto.allowed();
     }
 
-    private FeatureAccessResultDto checkQuotaAccess(Long userId, PlanFeature planFeature) {
-        Long quotaLimit = planFeature.getQuotaLimit();
-        QuotaPeriod period = planFeature.getQuotaPeriod();
+    /**
+     * Counts what the user has already used of a metered feature in the current period and
+     * compares it against the plan's limit.
+     *
+     * <p>The count is always a query. Usage moves on every metered request and is the one input
+     * to an entitlement decision that could not be cached behind the subscription without being
+     * wrong almost immediately, so it is deliberately left out of the snapshot. The snapshot
+     * supplies the limit, the period and the feature id the usage rows are keyed on.
+     */
+    private FeatureAccessResultDto checkQuotaAccess(Long userId, PlanFeatureSnapshot planFeature) {
+        Long quotaLimit = planFeature.quotaLimit();
+        QuotaPeriod period = planFeature.quotaPeriod();
 
         Instant[] periodBounds = calculatePeriodBounds(period);
 
         Long currentUsage = usageRecordRepository.sumUsageForPeriod(
                 userId,
-                planFeature.getFeature().getId(),
+                planFeature.featureId(),
                 periodBounds[0],
                 periodBounds[1]
         );
@@ -245,7 +258,13 @@ public class SubscriptionService {
      *
      * <p>If the user has no active subscription or the feature is not in their plan, the call is
      * logged and ignored rather than raising. On success it writes a usage record for the
-     * feature's current period and evicts the user's cached subscription.
+     * feature's current period.
+     *
+     * <p>It does not evict the user's cached subscription, and used to. Nothing about the
+     * subscription or its plan changes here, and the usage this writes is not part of what the
+     * cache holds: {@link #checkQuotaAccess} sums it from the usage table on every check. The
+     * eviction bought no freshness and cost the entry, on the one path that runs on every
+     * metered request, which is where the cache is meant to earn its keep.
      *
      * @param userId The ID of the user consuming the feature.
      * @param featureCode The code of the feature being consumed.
@@ -253,46 +272,37 @@ public class SubscriptionService {
      */
     @Transactional
     public void recordUsage(Long userId, String featureCode, Long amount) {
-        Optional<Subscription> subscriptionOptional = loadActiveSubscription(userId);
+        Optional<SubscriptionSnapshot> subscriptionOptional = loadActiveSubscription(userId);
         if(subscriptionOptional.isEmpty()) {
             log.warn("Attempted to record usage for user without active subscription: {}", userId);
             return;
         }
 
-        Subscription subscription = subscriptionOptional.get();
+        SubscriptionSnapshot subscription = subscriptionOptional.get();
 
-        Feature feature = subscription.getPlan().getPlanFeatures().stream()
-                .map(PlanFeature::getFeature)
-                .filter(f -> f.getCode().equals(featureCode))
-                .findFirst()
-                .orElse(null);
+        PlanFeatureSnapshot planFeature = subscription.feature(featureCode).orElse(null);
 
-        if(feature == null) {
+        if(planFeature == null) {
             log.warn("Feature {} not found in user's plan", featureCode);
             return;
         }
-        Instant now = Instant.now();
-        QuotaPeriod period = subscription.getPlan().getPlanFeatures().stream()
-                .filter(pf -> pf.getFeature().getCode().equals(featureCode))
-                .map(PlanFeature::getQuotaPeriod)
-                .findFirst()
-                .orElse(QuotaPeriod.MONTHLY);
+
+        QuotaPeriod period = planFeature.quotaPeriod() != null
+                ? planFeature.quotaPeriod()
+                : QuotaPeriod.MONTHLY;
 
         Instant[] periodBounds = calculatePeriodBounds(period);
 
         UsageRecord usageRecord = UsageRecord.builder()
                 .userId(userId)
-                .subscriptionId(subscription.getId())
-                .featureId(feature.getId())
+                .subscriptionId(subscription.id())
+                .featureId(planFeature.featureId())
                 .usageAmount(amount)
                 .periodStart(periodBounds[0])
                 .periodEnd(periodBounds[1])
                 .build();
 
         usageRecordRepository.save(usageRecord);
-
-        subscriptionCache.evict(userId);
-
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/billing/snapshot/PlanFeatureSnapshot.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/snapshot/PlanFeatureSnapshot.java
@@ -1,0 +1,54 @@
+package org.tornotron.echno_backend.billing.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.tornotron.echno_backend.billing.enums.FeatureType;
+import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
+
+/**
+ * One feature as a plan grants it, copied out of the {@code PlanFeature} and {@code Feature}
+ * rows behind it.
+ *
+ * <p>Carries {@link #featureId()}, which no response DTO does. Quota usage is recorded and
+ * summed against {@code UsageRecord.featureId}, a plain column rather than a relation, so a
+ * quota check needs that id and would otherwise have to go back to the database for it. It is
+ * on the snapshot because the snapshot is internal; putting it on {@code PlanFeatureDto} would
+ * have changed a public response contract to serve a caching decision.
+ *
+ * @param id Id of the plan-feature assignment row.
+ * @param featureId Id of the feature itself, the key usage records are written against.
+ * @param featureCode Code callers ask for, such as {@code report-export}.
+ * @param featureName Display name of the feature.
+ * @param featureType How the feature is measured.
+ * @param enabled Whether the plan enables the feature, null when the row left it unset.
+ * @param quotaLimit Usage allowed per quota period, null for an unmetered feature.
+ * @param quotaPeriod Period over which the quota resets, null for an unmetered feature.
+ */
+public record PlanFeatureSnapshot(
+        Long id,
+        Long featureId,
+        String featureCode,
+        String featureName,
+        FeatureType featureType,
+        Boolean enabled,
+        Long quotaLimit,
+        QuotaPeriod quotaPeriod) {
+
+    /**
+     * Derived from {@link #enabled()} rather than stored, and kept out of the serialized form
+     * for that reason: a shared cache holds the state a snapshot was taken with, never an
+     * answer computed from it.
+     *
+     * @return {@code true} if the plan enables this feature.
+     */
+    @JsonIgnore
+    public boolean isFeatureEnabled() {
+        return enabled != null && enabled;
+    }
+
+    /**
+     * @return {@code true} if this feature is metered against a quota on this plan.
+     */
+    public boolean hasQuota() {
+        return quotaLimit != null && quotaLimit > 0;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/billing/snapshot/PlanSnapshot.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/snapshot/PlanSnapshot.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.billing.snapshot;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An immutable copy of a plan and the features it grants, taken while the persistence context
+ * that loaded it is still open.
+ *
+ * <p>Holds no entity and no lazy collection, so it can be read, mapped and cached long after
+ * that context has closed.
+ *
+ * @param id Numeric id of the plan.
+ * @param code Unique code identifying the plan.
+ * @param name Display name of the plan.
+ * @param description Longer description shown on the pricing page.
+ * @param version Optimistic locking version of the plan record.
+ * @param monthlyPrice Price charged per month, in the plan currency.
+ * @param annualPrice Price charged per year, in the plan currency.
+ * @param currency ISO 4217 currency code for the plan prices.
+ * @param isActive Whether the plan currently accepts new subscriptions.
+ * @param isPublic Whether the plan is shown on the public pricing page.
+ * @param trialDays Number of trial days granted on first subscription.
+ * @param maxUsers Maximum number of users allowed under this plan, null for unlimited.
+ * @param sortOrder Display order relative to other plans, ascending.
+ * @param features Features this plan grants, empty when it grants none.
+ */
+public record PlanSnapshot(
+        Long id,
+        String code,
+        String name,
+        String description,
+        Integer version,
+        BigDecimal monthlyPrice,
+        BigDecimal annualPrice,
+        String currency,
+        Boolean isActive,
+        Boolean isPublic,
+        Integer trialDays,
+        Integer maxUsers,
+        Integer sortOrder,
+        List<PlanFeatureSnapshot> features) {
+
+    /**
+     * Copies the feature list defensively so a caller cannot change what a cached snapshot
+     * grants. {@code null} is kept as {@code null}, which is what a plan mapped without its
+     * features looks like.
+     */
+    public PlanSnapshot {
+        features = features == null ? null : List.copyOf(features);
+    }
+
+    /**
+     * Finds the plan's grant of one feature.
+     *
+     * @param featureCode The code of the feature to look for.
+     * @return The plan's grant of that feature, or empty if the plan does not grant it.
+     */
+    public Optional<PlanFeatureSnapshot> feature(String featureCode) {
+        if (features == null || featureCode == null) {
+            return Optional.empty();
+        }
+        return features.stream()
+                .filter(feature -> featureCode.equals(feature.featureCode()))
+                .findFirst();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/billing/snapshot/SubscriptionSnapshot.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/snapshot/SubscriptionSnapshot.java
@@ -1,0 +1,101 @@
+package org.tornotron.echno_backend.billing.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * An immutable copy of a user's active subscription and the plan it entitles them to. This is
+ * what {@code SubscriptionCache} holds.
+ *
+ * <p>The rule this type exists to enforce is that a cache stores facts and never verdicts.
+ * Two of the three entitlement flags on {@code SubscriptionDto} are answers to the question
+ * "as of when": {@code expired} compares {@link #currentPeriodEnd()} against the current
+ * instant and {@code inTrial} compares {@link #trialEnd()}. Cached as computed booleans they
+ * would be pinned for the life of the entry, and a subscription that lapsed inside that window
+ * would go on reporting itself unexpired for the rest of it. So the snapshot keeps the
+ * timestamps and answers the question when it is asked, through {@link #isExpired(Instant)}
+ * and {@link #isInTrial(Instant)}, which take the instant to judge against rather than reading
+ * the clock themselves.
+ *
+ * <p>{@link #isActive()} is deliberately not of that kind. It reads only {@link #status()}, so
+ * it is as old as the snapshot however it is computed, and no representation can change that.
+ * What bounds it is invalidation: the cache entry expires on its own timer, and every write
+ * that changes a subscription's status evicts the user's entry. Nothing outside
+ * {@code SubscriptionService} changes a status today, so that bound holds. A shorter bound is
+ * a shorter cache lifetime, not a different value type.
+ *
+ * @param id Numeric id of the subscription.
+ * @param userId Id of the subscribing user.
+ * @param status Lifecycle status the subscription had when the snapshot was taken.
+ * @param currentPeriodStart Start of the current billing period.
+ * @param currentPeriodEnd End of the current billing period.
+ * @param trialStart Start of the trial period, null if the subscription began without one.
+ * @param trialEnd End of the trial period, null if the subscription began without one.
+ * @param cancelAtPeriodEnd Whether the subscription is set to end at the current period's end.
+ * @param canceledAt When the subscription was canceled, null if it has not been.
+ * @param createdAt When the subscription was first created.
+ * @param cancellationReason Reason given for cancellation, null if none was given.
+ * @param plan The plan the subscription is on, with the features it grants.
+ */
+public record SubscriptionSnapshot(
+        Long id,
+        Long userId,
+        SubscriptionStatus status,
+        Instant currentPeriodStart,
+        Instant currentPeriodEnd,
+        Instant trialStart,
+        Instant trialEnd,
+        Boolean cancelAtPeriodEnd,
+        Instant canceledAt,
+        Instant createdAt,
+        String cancellationReason,
+        PlanSnapshot plan) {
+
+    /**
+     * Whether the subscription was in a state that grants access when the snapshot was taken.
+     *
+     * <p>Derived from {@link #status()} rather than stored, and kept out of the serialized form
+     * for that reason.
+     *
+     * @return {@code true} for an active or trialing subscription.
+     */
+    @JsonIgnore
+    public boolean isActive() {
+        return status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.TRIALING;
+    }
+
+    /**
+     * Whether the subscription is inside its trial window at a given instant.
+     *
+     * @param at The instant to judge against, normally now.
+     * @return {@code true} if the subscription is trialing and the trial has not ended by then.
+     */
+    public boolean isInTrial(Instant at) {
+        return status == SubscriptionStatus.TRIALING
+                && trialEnd != null
+                && at.isBefore(trialEnd);
+    }
+
+    /**
+     * Whether the current billing period has ended by a given instant.
+     *
+     * @param at The instant to judge against, normally now.
+     * @return {@code true} if the period end is known and lies before then.
+     */
+    public boolean isExpired(Instant at) {
+        return currentPeriodEnd != null && at.isAfter(currentPeriodEnd);
+    }
+
+    /**
+     * Finds the subscribed plan's grant of one feature.
+     *
+     * @param featureCode The code of the feature to look for.
+     * @return The plan's grant of that feature, or empty if the plan does not grant it.
+     */
+    public Optional<PlanFeatureSnapshot> feature(String featureCode) {
+        return plan == null ? Optional.empty() : plan.feature(featureCode);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/RedisConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/RedisConfig.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.common.configuration;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import lombok.extern.slf4j.Slf4j;
@@ -80,7 +82,7 @@ public class RedisConfig {
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
-                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+                        .fromSerializer(cacheValueSerializer()));
 
         Map<String, RedisCacheConfiguration> perCache = new HashMap<>();
         perCache.put("subscriptions", base.entryTtl(Duration.ofMinutes(5)));
@@ -89,6 +91,23 @@ public class RedisConfig {
                 .cacheDefaults(base)
                 .withInitialCacheConfigurations(perCache)
                 .build();
+    }
+
+    /**
+     * JSON serializer for cached values, with Java 8 date and time support registered.
+     *
+     * <p>The stock serializer's mapper has no {@code JavaTimeModule}, so it refuses to write an
+     * {@link java.time.Instant} at all. Every value worth caching here carries at least one:
+     * the subscription snapshot the {@code subscriptions} cache is sized for holds the billing
+     * period bounds and the trial window, which is exactly the state the entitlement flags are
+     * derived from. Dates are written as ISO-8601 strings rather than as numeric timestamps so
+     * an entry stays readable and keeps its precision.
+     */
+    private static GenericJackson2JsonRedisSerializer cacheValueSerializer() {
+        return new GenericJackson2JsonRedisSerializer()
+                .configure(mapper -> mapper
+                        .registerModule(new JavaTimeModule())
+                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
@@ -30,6 +30,7 @@ import org.tornotron.echno_backend.billing.enums.FeatureType;
 import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
 import org.tornotron.echno_backend.billing.repositories.PlanRepository;
 import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
+import org.tornotron.echno_backend.billing.snapshot.SubscriptionSnapshot;
 import org.tornotron.echno_backend.billing.services.PlanService;
 import org.tornotron.echno_backend.billing.services.SubscriptionService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -184,15 +185,11 @@ class BillingMappingIT extends AbstractIntegrationTest {
     }
 
     /**
-     * The counterpart to the test above, and the reason the cache may hold entities at all.
-     * {@code findActiveSubscriptionByUserId} fetch-joins the plan, its plan features and each
-     * feature, so what it returns is still mappable once its session has closed, which is the
-     * state every cache hit sees. Weaken those fetch joins and this fails where the query above
-     * already fails.
-     *
-     * <p>Nothing in the type system says the query has to keep them, and the cache is what makes
-     * it matter: an ordinary caller would notice a missing fetch join as extra queries, a caller
-     * served from the cache would notice it as a 500.
+     * What the fetch joins on {@code findActiveSubscriptionByUserId} are worth now that the
+     * cache holds a snapshot rather than the entity. The snapshot is copied inside the loading
+     * transaction, so the lazy reads resolve there either way and weakening the query costs a
+     * round trip per plan feature instead of a 500. This pins the query all the same: it is the
+     * one read whose result the cache is built from, so its shape is worth knowing.
      */
     @Test
     void theQueryBehindTheCacheReturnsAGraphThatOutlivesItsSession() {
@@ -203,39 +200,43 @@ class BillingMappingIT extends AbstractIntegrationTest {
     }
 
     /**
-     * The invariant the one above is only half of. What has to hold is that whatever reaches the
-     * cache is fully initialized by the time its session closes, which the fetch joins secure at
-     * the query and every current caller secures again by mapping or walking the graph inside its
-     * own transaction. This asserts it end to end, on the instance the cache is actually holding.
+     * The invariant that replaced it. What the cache holds is a complete copy: every field the
+     * response needs, the plan and its features included, resolved before the loading
+     * transaction ended. Nothing on it can throw {@link LazyInitializationException}, because
+     * there is no entity left on it to throw one, so this maps it with nothing open around it.
      */
     @Test
-    void whatTheCacheHoldsIsStillMappableOnceItsSessionHasClosed() {
+    void whatTheCacheHoldsIsACompleteCopyWithNoPersistenceStateLeftOnIt() {
         subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
 
-        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
+        SubscriptionSnapshot cached = subscriptionCache.get(SUBSCRIBED_USER);
         assertThat(cached).as("the read should have populated the cache").isNotNull();
 
         assertFullyMapped(BillingMapper.toSubscriptionDto(cached), CURRENT_PLAN);
     }
 
     /**
-     * The cached instance is shared by every concurrent reader of this user, so a write path
-     * must not change it in place. changeSubscription used to resolve its subscription through
-     * the cache and call setPlan on whatever came back, which published the new plan to every
-     * reader before the transaction had committed, and left the cache holding it if the
-     * transaction then rolled back.
+     * The cached value is shared by every concurrent reader of this user, so a write path must
+     * not change it in place. changeSubscription used to resolve its subscription through the
+     * cache and call setPlan on whatever came back, which published the new plan to every reader
+     * before the transaction had committed, and left the cache holding it if the transaction then
+     * rolled back. A snapshot has no setter to call, and this holds the pre-write value to say so.
      */
     @Test
-    void changeSubscription_leavesTheCachedInstanceAlone() {
+    void changeSubscription_leavesTheCachedValueAlone() {
         subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
-        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
-        assertThat(cached.getPlan().getCode()).isEqualTo(CURRENT_PLAN);
+        SubscriptionSnapshot cached = subscriptionCache.get(SUBSCRIBED_USER);
+        assertThat(cached.plan().code()).isEqualTo(CURRENT_PLAN);
 
         subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);
 
-        assertThat(cached.getPlan().getCode())
-                .as("the write must not have mutated the shared cached instance")
+        assertThat(cached.plan().code())
+                .as("the write must not have changed the shared cached value")
                 .isEqualTo(CURRENT_PLAN);
+        assertThat(subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow()
+                .getPlan().getCode())
+                .as("and the next read must see the new plan")
+                .isEqualTo(TARGET_PLAN);
     }
 
     /**
@@ -243,17 +244,45 @@ class BillingMappingIT extends AbstractIntegrationTest {
      * cancellation timestamp straight onto the cached instance.
      */
     @Test
-    void cancelSubscription_leavesTheCachedInstanceAlone() {
+    void cancelSubscription_leavesTheCachedValueAlone() {
         subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
-        Subscription cached = subscriptionCache.get(SUBSCRIBED_USER);
-        assertThat(cached.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        SubscriptionSnapshot cached = subscriptionCache.get(SUBSCRIBED_USER);
+        assertThat(cached.status()).isEqualTo(SubscriptionStatus.ACTIVE);
 
         subscriptionService.cancelSubscription(SUBSCRIBED_USER, true);
 
-        assertThat(cached.getStatus())
-                .as("the write must not have mutated the shared cached instance")
+        assertThat(cached.status())
+                .as("the write must not have changed the shared cached value")
                 .isEqualTo(SubscriptionStatus.ACTIVE);
-        assertThat(cached.getCanceledAt()).isNull();
+        assertThat(cached.canceledAt()).isNull();
+    }
+
+    /**
+     * A snapshot carries a copy of the plan it was taken against, so a plan write leaves every
+     * subscriber of that plan holding entitlements the plan no longer grants. Nothing about the
+     * subscription row changes, so no per-user eviction fires and the stale copies would stand
+     * for the rest of the five minute window. The plan writes therefore empty the cache.
+     *
+     * <p>This is a staleness the choice of cached value cannot fix. The entity cache had it too,
+     * for the same reason: what it held was a detached plan graph read at some earlier moment.
+     */
+    @Test
+    void removingAFeatureFromAPlan_invalidatesTheCachedSubscriptions() {
+        subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow();
+        assertThat(subscriptionCache.get(SUBSCRIBED_USER))
+                .as("the read should have populated the cache").isNotNull();
+
+        Long planId = inCommittedTx(() ->
+                planRepository.findByCodeWithFeatures(CURRENT_PLAN).orElseThrow().getId());
+        planService.removeFeatureFromPlan(planId, FEATURE_CODE);
+
+        assertThat(subscriptionCache.get(SUBSCRIBED_USER))
+                .as("a plan write must not leave subscribers holding the old plan")
+                .isNull();
+        assertThat(subscriptionService.getActiveSubscription(SUBSCRIBED_USER).orElseThrow()
+                .getPlan().getFeatures())
+                .as("and the next read must see the plan without the feature")
+                .isEmpty();
     }
 
     /**
@@ -267,8 +296,9 @@ class BillingMappingIT extends AbstractIntegrationTest {
      */
     @Test
     void changeSubscription_evictsAgainOnceItsTransactionHasCompleted() {
-        Subscription concurrentlyCachedRow = inCommittedTx(() ->
-                subscriptionRepository.findActiveSubscriptionByUserId(SUBSCRIBED_USER).orElseThrow());
+        SubscriptionSnapshot concurrentlyCachedRow = inCommittedTx(() ->
+                BillingMapper.toSubscriptionSnapshot(subscriptionRepository
+                        .findActiveSubscriptionByUserId(SUBSCRIBED_USER).orElseThrow()));
 
         inCommittedTx(() -> {
             subscriptionService.changeSubscription(SUBSCRIBED_USER, TARGET_PLAN);

--- a/src/test/java/org/tornotron/echno_backend/billing/services/SubscriptionServiceFeatureAccessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/services/SubscriptionServiceFeatureAccessTest.java
@@ -1,19 +1,25 @@
 package org.tornotron.echno_backend.billing.services;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.tornotron.echno_backend.billing.Feature;
 import org.tornotron.echno_backend.billing.Plan;
 import org.tornotron.echno_backend.billing.PlanFeature;
 import org.tornotron.echno_backend.billing.Subscription;
+import org.tornotron.echno_backend.billing.UsageRecord;
 import org.tornotron.echno_backend.billing.components.SubscriptionCache;
+import org.tornotron.echno_backend.billing.dto.BillingMapper;
 import org.tornotron.echno_backend.billing.dto.FeatureAccessResultDto;
+import org.tornotron.echno_backend.billing.dto.SubscriptionDto;
 import org.tornotron.echno_backend.billing.enums.FeatureType;
 import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
 import org.tornotron.echno_backend.billing.repositories.PlanRepository;
 import org.tornotron.echno_backend.billing.repositories.SubscriptionRepository;
 import org.tornotron.echno_backend.billing.repositories.UsageRecordRepository;
+import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,6 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -44,9 +53,20 @@ class SubscriptionServiceFeatureAccessTest {
     private static final String CODE = "advanced-reports";
 
     private void activeSubscriptionWith(PlanFeature... planFeatures) {
+        cacheSubscription(Instant.now().plus(30, ChronoUnit.DAYS), planFeatures);
+    }
+
+    private void cacheSubscription(Instant periodEnd, PlanFeature... planFeatures) {
         Plan plan = Plan.builder().id(1L).planFeatures(Set.of(planFeatures)).build();
-        Subscription sub = Subscription.builder().id(1L).plan(plan).build();
-        when(subscriptionCache.get(USER)).thenReturn(sub);
+        Subscription sub = Subscription.builder()
+                .id(1L)
+                .userId(USER)
+                .plan(plan)
+                .status(SubscriptionStatus.ACTIVE)
+                .currentPeriodStart(periodEnd.minus(30, ChronoUnit.DAYS))
+                .currentPeriodEnd(periodEnd)
+                .build();
+        when(subscriptionCache.get(USER)).thenReturn(BillingMapper.toSubscriptionSnapshot(sub));
     }
 
     private PlanFeature booleanFeature(boolean enabled) {
@@ -123,5 +143,73 @@ class SubscriptionServiceFeatureAccessTest {
         assertThat(r.isAllowed()).isFalse();
         assertThat(r.getReason()).isEqualTo("Quota exceeded");
         assertThat(r.getCurrentUsage()).isEqualTo(100L);
+    }
+
+    /**
+     * The reason the cached value carries a feature id that no response DTO does. Usage rows are
+     * keyed on {@code UsageRecord.featureId}, a plain column rather than a relation, so without
+     * it on the cached value every metered request would have to go back to the database for it.
+     */
+    @Test
+    void recordUsage_keysTheUsageRowOnTheFeatureIdFromTheCachedValue() {
+        activeSubscriptionWith(quotaFeature(100L));
+
+        svc.recordUsage(USER, CODE, 3L);
+
+        ArgumentCaptor<UsageRecord> saved = ArgumentCaptor.forClass(UsageRecord.class);
+        verify(usageRecordRepository).save(saved.capture());
+        assertThat(saved.getValue().getFeatureId()).isEqualTo(FEATURE_ID);
+        assertThat(saved.getValue().getSubscriptionId()).isEqualTo(1L);
+        assertThat(saved.getValue().getUsageAmount()).isEqualTo(3L);
+        verifyNoInteractions(subscriptionRepository);
+    }
+
+    /**
+     * Recording usage used to evict the user's entry. Nothing it writes is part of what the
+     * cache holds, since a quota check sums the usage table on every call, so the eviction
+     * bought no freshness and threw the entry away on the one path that runs on every metered
+     * request.
+     */
+    @Test
+    void recordUsage_doesNotEvictTheCachedSubscription() {
+        activeSubscriptionWith(quotaFeature(100L));
+
+        svc.recordUsage(USER, CODE, 1L);
+
+        verify(subscriptionCache, never()).evict(USER);
+        verify(subscriptionCache, never()).evictOnWrite(USER);
+    }
+
+    /**
+     * A plan may grant a metered feature without setting a quota period. Resolving it used to
+     * run the plan features through {@code map(...).findFirst()}, which throws on a null rather
+     * than falling through to the intended monthly default.
+     */
+    @Test
+    void recordUsage_fallsBackToAMonthlyPeriodWhenThePlanSetsNone() {
+        Feature f = Feature.builder().id(FEATURE_ID).code(CODE).featureType(FeatureType.QUOTA).build();
+        activeSubscriptionWith(PlanFeature.builder().feature(f).enabled(true).quotaLimit(10L).build());
+
+        svc.recordUsage(USER, CODE, 1L);
+
+        ArgumentCaptor<UsageRecord> saved = ArgumentCaptor.forClass(UsageRecord.class);
+        verify(usageRecordRepository).save(saved.capture());
+        assertThat(saved.getValue().getPeriodStart()).isBefore(saved.getValue().getPeriodEnd());
+    }
+
+    /**
+     * The reason the cache does not hold {@code SubscriptionDto}. {@code expired} is a
+     * comparison against the current instant, so a DTO cached at the start of the window would
+     * still report a lapsed subscription as unexpired at the end of it. Reading it off a cached
+     * value whose period has already ended must answer for now.
+     */
+    @Test
+    void aCachedSubscriptionWhosePeriodHasEnded_readsAsExpired() {
+        cacheSubscription(Instant.now().minus(1, ChronoUnit.HOURS), booleanFeature(true));
+
+        SubscriptionDto dto = svc.getActiveSubscription(USER).orElseThrow();
+
+        assertThat(dto.isExpired()).isTrue();
+        verifyNoInteractions(subscriptionRepository);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/billing/snapshot/SubscriptionSnapshotTest.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/snapshot/SubscriptionSnapshotTest.java
@@ -1,0 +1,185 @@
+package org.tornotron.echno_backend.billing.snapshot;
+
+import jakarta.persistence.Entity;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.billing.enums.FeatureType;
+import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
+import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What makes the snapshot safe to cache, asserted directly on the type.
+ *
+ * <p>Plain JUnit on purpose: none of this needs a Spring context or a database, and the test
+ * JVM keeps every context it builds.
+ */
+class SubscriptionSnapshotTest {
+
+    private static final Instant PERIOD_START = Instant.parse("2026-08-01T00:00:00Z");
+    private static final Instant PERIOD_END = Instant.parse("2026-09-01T00:00:00Z");
+    private static final Instant TRIAL_END = Instant.parse("2026-08-15T00:00:00Z");
+
+    /** The value types a snapshot may be built out of, beyond records and enums. */
+    private static final Set<Class<?>> VALUE_TYPES = Set.of(
+            Long.class, Integer.class, Boolean.class, String.class, Instant.class, BigDecimal.class);
+
+    private static SubscriptionSnapshot snapshot(SubscriptionStatus status) {
+        return new SubscriptionSnapshot(
+                1L, 42L, status,
+                PERIOD_START, PERIOD_END, PERIOD_START, TRIAL_END,
+                false, null, PERIOD_START, null,
+                new PlanSnapshot(
+                        7L, "professional-monthly", "Professional", "For growing teams", 1,
+                        new BigDecimal("4999.00"), new BigDecimal("49990.00"), "INR",
+                        true, true, 14, 25, 2,
+                        List.of(new PlanFeatureSnapshot(
+                                3L, 9L, "report-export", "PDF Report Export",
+                                FeatureType.QUOTA, true, 500L, QuotaPeriod.MONTHLY))));
+    }
+
+    /**
+     * The reason the cache holds this rather than {@code SubscriptionDto}. A DTO carries
+     * {@code expired} as a boolean settled when it was built, so a subscription that lapsed
+     * inside the cache window would go on reporting itself unexpired for the rest of it. The
+     * snapshot keeps the timestamp and answers for the instant it is asked about, so one
+     * cached value gives both answers as the window it describes passes.
+     */
+    @Test
+    void expiredIsAnsweredForTheInstantAsked() {
+        SubscriptionSnapshot subscription = snapshot(SubscriptionStatus.ACTIVE);
+
+        assertThat(subscription.isExpired(PERIOD_END.minus(1, ChronoUnit.HOURS))).isFalse();
+        assertThat(subscription.isExpired(PERIOD_END.plus(1, ChronoUnit.HOURS))).isTrue();
+    }
+
+    /** The same for the trial window, the other flag derived from the clock. */
+    @Test
+    void inTrialIsAnsweredForTheInstantAsked() {
+        SubscriptionSnapshot subscription = snapshot(SubscriptionStatus.TRIALING);
+
+        assertThat(subscription.isInTrial(TRIAL_END.minus(1, ChronoUnit.HOURS))).isTrue();
+        assertThat(subscription.isInTrial(TRIAL_END.plus(1, ChronoUnit.HOURS))).isFalse();
+    }
+
+    /**
+     * And the flag that is not of that kind, which is worth stating because it sits beside them
+     * on the DTO. {@code active} reads the status alone, so it is exactly as old as the snapshot
+     * however it is computed. Eviction and expiry bound it; no choice of value type does.
+     */
+    @Test
+    void activeReadsTheStatusAloneAndNotTheClock() {
+        assertThat(snapshot(SubscriptionStatus.ACTIVE).isActive()).isTrue();
+        assertThat(snapshot(SubscriptionStatus.TRIALING).isActive()).isTrue();
+        assertThat(snapshot(SubscriptionStatus.CANCELED).isActive()).isFalse();
+
+        SubscriptionSnapshot expired = snapshot(SubscriptionStatus.ACTIVE);
+        assertThat(expired.isExpired(PERIOD_END.plus(1, ChronoUnit.HOURS))).isTrue();
+        assertThat(expired.isActive())
+                .as("a lapsed period does not by itself change the recorded status")
+                .isTrue();
+    }
+
+    @Test
+    void featureLookupFindsTheGrantAndItsFeatureId() {
+        SubscriptionSnapshot subscription = snapshot(SubscriptionStatus.ACTIVE);
+
+        assertThat(subscription.feature("report-export"))
+                .get()
+                .satisfies(grant -> {
+                    assertThat(grant.featureId()).isEqualTo(9L);
+                    assertThat(grant.hasQuota()).isTrue();
+                    assertThat(grant.isFeatureEnabled()).isTrue();
+                });
+        assertThat(subscription.feature("something-else")).isEmpty();
+        assertThat(subscription.feature(null)).isEmpty();
+    }
+
+    /**
+     * A cached value is shared by every concurrent reader of that user, so nothing handed to it
+     * or taken from it may be changeable in place. The old cache held the entity, whose feature
+     * set was the live collection.
+     */
+    @Test
+    void theFeatureListIsCopiedInAndHandedOutUnmodifiable() {
+        List<PlanFeatureSnapshot> features = new ArrayList<>(List.of(new PlanFeatureSnapshot(
+                3L, 9L, "report-export", "PDF Report Export",
+                FeatureType.QUOTA, true, 500L, QuotaPeriod.MONTHLY)));
+        PlanSnapshot plan = new PlanSnapshot(
+                7L, "code", "name", null, 1, null, null, "INR",
+                true, true, 0, null, 0, features);
+
+        features.clear();
+
+        assertThat(plan.features()).hasSize(1);
+        assertThatThrownBy(() -> plan.features().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    /**
+     * The hazard the entity cache carried, closed structurally rather than by convention. A
+     * detached entity in a cache throws {@code LazyInitializationException} on any part of it
+     * that was left uninitialized, in a later transaction that cannot reattach it, and what kept
+     * that from happening was a fetch-join query that nothing obliged to stay that way. Nothing
+     * reachable from a snapshot is an entity, so there is nothing left to initialize.
+     */
+    @Test
+    void nothingReachableFromASnapshotIsAnEntity() {
+        Set<Class<?>> visited = new HashSet<>();
+        assertNoEntitiesReachableFrom(SubscriptionSnapshot.class, visited);
+
+        assertThat(visited).contains(PlanSnapshot.class, PlanFeatureSnapshot.class);
+    }
+
+    private static void assertNoEntitiesReachableFrom(Class<?> type, Set<Class<?>> visited) {
+        if (!visited.add(type)) {
+            return;
+        }
+
+        assertThat(type.isAnnotationPresent(Entity.class))
+                .as("%s is a persistent entity and must not be reachable from a cached snapshot",
+                        type.getName())
+                .isFalse();
+
+        if (type.isEnum() || VALUE_TYPES.contains(type)) {
+            return;
+        }
+
+        assertThat(type.isRecord())
+                .as("%s is neither a record, an enum nor a known value type, so what it drags "
+                        + "into the cache is not obvious", type.getName())
+                .isTrue();
+
+        for (RecordComponent component : type.getRecordComponents()) {
+            for (Class<?> reachable : reachableTypes(component.getGenericType())) {
+                assertNoEntitiesReachableFrom(reachable, visited);
+            }
+        }
+    }
+
+    private static List<Class<?>> reachableTypes(Type type) {
+        if (type instanceof Class<?> raw) {
+            return List.of(raw);
+        }
+        if (type instanceof ParameterizedType parameterized) {
+            List<Class<?>> types = new ArrayList<>();
+            for (Type argument : parameterized.getActualTypeArguments()) {
+                types.addAll(reachableTypes(argument));
+            }
+            return types;
+        }
+        throw new AssertionError("Unhandled component type in a cached snapshot: " + type);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/RedisDistributedStateIT.java
@@ -18,9 +18,17 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import org.tornotron.echno_backend.billing.enums.FeatureType;
+import org.tornotron.echno_backend.billing.enums.QuotaPeriod;
+import org.tornotron.echno_backend.billing.enums.SubscriptionStatus;
+import org.tornotron.echno_backend.billing.snapshot.PlanFeatureSnapshot;
+import org.tornotron.echno_backend.billing.snapshot.PlanSnapshot;
+import org.tornotron.echno_backend.billing.snapshot.SubscriptionSnapshot;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -106,6 +114,45 @@ class RedisDistributedStateIT {
         Cache.ValueWrapper fromReader = readerCache.get("user-42");
         assertThat(fromReader).isNotNull();
         assertThat(fromReader.get()).isEqualTo("premium-plan");
+    }
+
+    /**
+     * The {@code subscriptions} cache with the value it is sized for. A subscription snapshot is
+     * what the in-process cache holds, and moving it to the shared cache is what would make an
+     * eviction on one replica reach the others; that only works if the value survives Redis,
+     * which is the second reason the cache holds a snapshot and not the entity. Nothing about a
+     * detached entity graph with lazy proxies and a bidirectional plan-to-feature relation
+     * serializes.
+     *
+     * <p>It also pins the serializer configuration. The stock JSON value serializer has no
+     * {@code JavaTimeModule}, so it cannot write the period bounds this value is mostly made of,
+     * and the failure would only show the first time something real was cached.
+     */
+    @Test
+    void aSubscriptionSnapshotIsSharedAcrossTwoCacheManagersViaRedis() {
+        RedisCacheManager writerManager = redisConfig.cacheManager(newConnectionFactory());
+        writerManager.afterPropertiesSet();
+        RedisCacheManager readerManager = redisConfig.cacheManager(newConnectionFactory());
+        readerManager.afterPropertiesSet();
+
+        SubscriptionSnapshot snapshot = new SubscriptionSnapshot(
+                101L, 27L, SubscriptionStatus.TRIALING,
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-09-01T00:00:00Z"),
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-08-15T00:00:00Z"),
+                false, null, Instant.parse("2026-01-15T09:30:00Z"), null,
+                new PlanSnapshot(3L, "professional-monthly", "Professional", "For growing teams", 4,
+                        new BigDecimal("4999.00"), new BigDecimal("49990.00"), "INR",
+                        true, true, 14, 25, 2,
+                        List.of(new PlanFeatureSnapshot(7L, 9L, "report-export", "PDF Report Export",
+                                FeatureType.QUOTA, true, 500L, QuotaPeriod.MONTHLY))));
+
+        writerManager.getCache("subscriptions").put("subscription:27", snapshot);
+
+        Cache.ValueWrapper fromReader = readerManager.getCache("subscriptions").get("subscription:27");
+        assertThat(fromReader).isNotNull();
+        assertThat(fromReader.get()).isEqualTo(snapshot);
     }
 
     @Test


### PR DESCRIPTION
Closes #485.

## The decision

The cache holds an internal `SubscriptionSnapshot`: an immutable copy of the subscription row and its plan, taken inside the loading transaction, carrying the timestamps the entitlement flags are derived from rather than the flags themselves.

Neither of the two obvious options works.

**Not the entity**, which is what it held. A cached entity is detached by definition and outlives the persistence context that produced it, so anything left uninitialized on it throws `LazyInitializationException` on a later hit, in a transaction that cannot reattach it. That was survivable only while `findActiveSubscriptionByUserId` kept fetch-joining the whole graph, which no signature obliged it to do. It is also a mutable object shared by every concurrent reader of that user.

**Not `SubscriptionDto`**, for the reason the issue title gives. Which fields are computed, and when they change:

| DTO field | derived from | changes when |
|---|---|---|
| `expired` | `currentPeriodEnd` vs `Instant.now()` | on its own, as the clock passes the period end |
| `inTrial` | `status` + `trialEnd` vs `Instant.now()` | on its own, as the clock passes the trial end |
| `active` | `status` alone | only when a write changes the status |

The first two are answers to "as of when". Cached as booleans they are settled for the life of the entry, and a subscription that lapses inside the five minute window keeps reporting `expired = false` for the rest of it. Those are the fields the paywall will read.

`active` is not of that kind, and the issue lists it as though it were. It reads the status alone, so it is exactly as old as the cached value however that value is shaped. Eviction and the five minute expiry bound it; no choice of value type does, and if the paywall needs a tighter bound the lever is the TTL. A test states this beside the two that do depend on the clock.

So: **the cache stores facts, never verdicts.** `isExpired(Instant)` and `isInTrial(Instant)` take the instant to judge against, and `BillingMapper` resolves them against `Instant.now()` when it builds the response. Both are `@JsonIgnore` for the same reason, so a shared cache cannot persist an answer either.

## What must not be cached at all

Quota usage. It moves on every metered request and is the one input to an entitlement decision that could not be held behind the subscription without being wrong almost immediately. `checkQuotaAccess` still sums it from the usage table on every call, and the snapshot deliberately does not carry it.

## Point 2 of the issue, the feature id

Quota checks key on `UsageRecord.featureId`, a plain column rather than a relation, which no response DTO carries. That only forces a change to `PlanFeatureDto` if the cache has to hold the public DTO. The snapshot is internal, so it carries the id and `PlanFeatureDto` is untouched. No contract change, no core release.

## Two things that fall out

`recordUsage` no longer evicts the user's entry. Nothing it writes is part of what the cache holds, so the eviction bought no freshness and threw the entry away on the one path that runs on every metered request.

Resolving the quota period no longer goes through `map(...).findFirst()`, which throws on a plan that grants a metered feature without setting a period rather than falling through to the intended monthly default.

## The staleness the representation cannot fix

A snapshot carries a copy of the plan it was taken against, so a plan write changes what every subscriber of that plan is entitled to while their cached copies say otherwise, and no per-user eviction fires because no subscription row changed. The entity cache had this too, for the same reason: what it held was a detached plan graph read at some earlier moment. The entries are not addressable by user without a query and plan writes are rare administrative operations, so `PlanService` now empties the cache on every write, on the same evict-now-and-again-on-completion pattern as the per-user path.

## Redis

The cache is in process, so those evictions reach one replica. `RedisConfig` already carries the way out: it configures a `subscriptions` cache with the five minute TTL, in so many words, for a future `@Cacheable("subscriptions")`.

That cache would have failed on its first real value. `GenericJackson2JsonRedisSerializer`'s default mapper has no `JavaTimeModule` and refuses to write an `Instant` at all, and a snapshot is mostly period bounds and a trial window. Nothing caught it because the existing test caches a `String`. The value serializer now registers `JavaTimeModule` and writes ISO-8601 rather than numeric timestamps.

This is a serializer configuration inside the existing `@ConditionalOnProperty` bean method, not a Spring Data Redis repository, so it is not the shape of the boot crash we hit before. `RedisFullContextBootIT` (full context, `echno.cache.provider=redis`, real Redis container) and `RedisUnreachableBootIT` both pass.

Actually moving the cache onto `@Cacheable` is not in this change. The snapshot makes it possible; whether it is worth the Redis round trip on the hot entitlement path is a separate decision, and the payment gateway work will have opinions about what the cache must hold.

## The fetch joins

They stay, and now mean something different. The copy is taken inside the transaction, so without them it still comes out complete and merely costs a query per plan feature on a miss. Weakening them is a performance regression rather than the 500 it used to be. The test that pinned them says so.

## Verification

Full suite green on the lab box (`10.24.6.116`), 7m09s, including `BillingMappingIT` (19), `SubscriptionServiceFeatureAccessTest` (10), `SubscriptionSnapshotTest` (6), `RedisDistributedStateIT` (4), `RedisFullContextBootIT`, `RedisUnreachableBootIT`.

Each new test was checked against a mutation of the production code that should break it:

| Mutation | Test that failed |
|---|---|
| `isExpired`/`isInTrial` answer for a fixed moment instead of the instant asked | `expiredIsAnsweredForTheInstantAsked`, `inTrialIsAnsweredForTheInstantAsked`, `activeReadsTheStatusAloneAndNotTheClock` |
| `active` consults the period end as well as the status | `activeReadsTheStatusAloneAndNotTheClock` |
| feature lookup matches the display name instead of the code | `featureLookupFindsTheGrantAndItsFeatureId` |
| no defensive copy of the feature list | `theFeatureListIsCopiedInAndHandedOutUnmodifiable` |
| a persistent entity becomes reachable from the snapshot | `nothingReachableFromASnapshotIsAnEntity` |
| recording usage evicts the entry again | `recordUsage_doesNotEvictTheCachedSubscription` |
| the snapshot stops carrying the feature id | `recordUsage_keysTheUsageRowOnTheFeatureIdFromTheCachedValue` (and both quota tests) |
| the old quota-period resolution | `recordUsage_fallsBackToAMonthlyPeriodWhenThePlanSetsNone` |
| the response flags are settled when the snapshot is taken | `aCachedSubscriptionWhosePeriodHasEnded_readsAsExpired` |
| a plan write leaves the cached subscriptions alone | `removingAFeatureFromAPlan_invalidatesTheCachedSubscriptions` |
| the stock Redis value serializer | `aSubscriptionSnapshotIsSharedAcrossTwoCacheManagersViaRedis` |

No public API or response contract changes. `PlanFeatureDto`, `PlanDto` and `SubscriptionDto` are byte-for-byte the same shape.
