### PR TITLE
Refuse work that reaches tenant data with no tenant declared

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/DevFixtureProvisioner.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -87,6 +88,8 @@ public class DevFixtureProvisioner {
      * @param displayName    the name to store on the user row and copy onto the employee row.
      * @param email          the address the organization picker matches on.
      */
+    @WithoutTenant("The dev fixture creates the organization it then works inside, so the first "
+            + "steps run before any tenant exists")
     public void provision(String keycloakUserId, String displayName, String email) {
         if (keycloakUserId == null || keycloakUserId.isBlank()) {
             log.error("No Keycloak id for the dev fixture account; skipping its application identity. "

--- a/src/main/java/org/tornotron/echno_backend/common/exception/UnscopedTenantAccessException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/UnscopedTenantAccessException.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.common.exception;
+
+/**
+ * Thrown when work reaches tenant-scoped data with no tenant scope declared at all: no
+ * organization id, no {@code @BypassTenantFilter}, no {@code @WithoutTenant}.
+ *
+ * <p>It is not the caller asking for another organization's row, which is
+ * {@link TenantAccessDeniedException} proper. It is the application unable to say which
+ * organization the work belongs to, and refusing to guess. Before #507 that condition returned
+ * every organization's rows and logged nothing.
+ *
+ * <p>It extends {@link TenantAccessDeniedException} so a request that hits it answers 403 with
+ * the same non-committal body as any other isolation refusal, rather than describing the internal
+ * state to the caller. The detail belongs in the log, which
+ * {@code org.tornotron.echno_backend.common.multitenancy.UnscopedAccessGuard} writes.
+ */
+public class UnscopedTenantAccessException extends TenantAccessDeniedException {
+
+    public UnscopedTenantAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfig.java
@@ -12,6 +12,27 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Enables the Hibernate {@code orgFilter} on the session for the duration of a
+ * {@code @Transactional} method, so queries in that transaction see only the current
+ * organization's rows.
+ *
+ * <p>Three states arrive here and each is now answered explicitly:
+ *
+ * <ul>
+ *   <li>An organization id is in force, so the filter goes on. The ordinary case.
+ *   <li>Tenant isolation is deliberately off, either a {@code @BypassTenantFilter} reading across
+ *       organizations or a {@link WithoutTenant} method that belongs to none. The filter stays
+ *       off because that is what was asked for.
+ *   <li>Nothing at all was declared. Until #507 this fell in with the case above and the
+ *       transaction ran unfiltered, recorded only in a debug line no deployed environment has on.
+ *       It now goes to {@link UnscopedAccessGuard}.
+ * </ul>
+ *
+ * <p>This aspect reads the scope on entry, which is why anything that establishes one has to be
+ * in place before the aspect runs rather than inside the method body. Setting it in the body is
+ * one step too late and leaves the transaction unfiltered, which is what #508 was.
+ */
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -20,19 +41,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class HibernateFilterConfig {
 
     private final EntityManager entityManager;
+    private final UnscopedAccessGuard unscopedAccessGuard;
 
     @Around("within(org.tornotron.echno_backend..*) && @annotation(transactional)")
     public Object enableOrgFilter(ProceedingJoinPoint joinPoint, Transactional transactional) throws Throwable {
         Long orgId = TenantContext.getCurrentOrgId();
-        log.debug("[HibernateFilter] Aspect triggered for {}, orgId={}, bypassed={}",
-                joinPoint.getSignature().toShortString(), orgId, TenantContext.isBypassed());
+        log.debug("[HibernateFilter] Aspect triggered for {}, orgId={}, bypassed={}, unscoped={}",
+                joinPoint.getSignature().toShortString(), orgId, TenantContext.isBypassed(),
+                TenantContext.getUnscopedReason());
+
         if (orgId != null && !TenantContext.isBypassed()) {
             Session session = entityManager.unwrap(Session.class);
             session.enableFilter("orgFilter").setParameter("organizationId", orgId);
             log.debug("[HibernateFilter] orgFilter ENABLED for organization {}", orgId);
+        } else if (TenantContext.isScopeDeclared()) {
+            log.debug("[HibernateFilter] orgFilter NOT enabled, tenant scope declared (orgId={}, "
+                            + "bypassed={}, unscoped={})",
+                    orgId, TenantContext.isBypassed(), TenantContext.getUnscopedReason());
         } else {
-            log.debug("[HibernateFilter] orgFilter NOT enabled (orgId={}, bypassed={})", orgId, TenantContext.isBypassed());
+            unscopedAccessGuard.onUnscopedTransaction(joinPoint.getSignature().toShortString());
         }
+
         return joinPoint.proceed();
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantContext.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantContext.java
@@ -1,9 +1,41 @@
 package org.tornotron.echno_backend.common.multitenancy;
 
+/**
+ * The tenant scope in force on the current thread. Read by {@link HibernateFilterConfig} to
+ * decide whether to enable the Hibernate {@code orgFilter}, and by
+ * {@link TenantIsolationLoadListener} to decide whether a loaded row belongs to the caller.
+ *
+ * <p>There are three ways to declare a scope, and declaring one of them is mandatory for any
+ * work that reaches a {@link TenantScopedEntity}:
+ *
+ * <ul>
+ *   <li><b>An organization id.</b> The ordinary case. {@code TenantFilter} sets it from the
+ *       request, {@link TenantScopedJobRunner} sets it from durable state for background work.
+ *   <li><b>Bypass</b>, via {@code @BypassTenantFilter} or the global-admin branch of
+ *       {@code TenantFilter}. Means "read across organizations on purpose". It is the widest
+ *       declaration and the one that is audited at WARN where it is set.
+ *   <li><b>Unscoped</b>, via {@link WithoutTenant} or {@link #declareUnscoped}. Means "this work
+ *       belongs to no organization". It suppresses the missing-scope failure and nothing else:
+ *       where an organization id is also present, isolation stays fully in force. That is what
+ *       separates it from bypass, and it is why the annotation is safe to put on a method that
+ *       may also be called inside a tenant request.
+ * </ul>
+ *
+ * <p>None of the three is the same as the fourth state, which is no declaration at all. Before
+ * #507 that state read as "no tenant", both mechanisms above gave up on it, and the work ran
+ * across every organization with nothing in the logs to say so. It now means "somebody forgot",
+ * and {@link UnscopedAccessGuard} decides what happens.
+ *
+ * <p>Every field is a {@link ThreadLocal}, so nothing here crosses an {@code @Async} hop or a
+ * thread pool: there is no {@code TaskDecorator} propagating it. Whoever owns a thread owns
+ * clearing it, and both {@code TenantFilter} and {@link TenantScopedJobRunner} do that in a
+ * {@code finally}.
+ */
 public final class TenantContext {
 
     private static final ThreadLocal<Long> currentOrgId = new ThreadLocal<>();
     private static final ThreadLocal<Boolean> bypassed = ThreadLocal.withInitial(() -> false);
+    private static final ThreadLocal<String> unscopedReason = new ThreadLocal<>();
 
     private TenantContext() {}
 
@@ -23,8 +55,47 @@ public final class TenantContext {
         return Boolean.TRUE.equals(bypassed.get());
     }
 
+    /**
+     * Declares that the work on this thread belongs to no organization, so the absence of an
+     * organization id is a decision rather than an oversight.
+     *
+     * @param reason why this work has no tenant, recorded so the declaration can be audited and
+     *               so a stale one can be traced back to whoever set it. Required.
+     */
+    public static void declareUnscoped(String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException(
+                    "An unscoped declaration needs a reason; an unexplained one is what this replaces");
+        }
+        unscopedReason.set(reason);
+    }
+
+    /** The reason passed to {@link #declareUnscoped}, or null if nothing was declared. */
+    public static String getUnscopedReason() {
+        return unscopedReason.get();
+    }
+
+    public static boolean isUnscopedDeclared() {
+        return unscopedReason.get() != null;
+    }
+
+    /** Withdraws an unscoped declaration, leaving the organization id and bypass flag alone. */
+    public static void clearUnscoped() {
+        unscopedReason.remove();
+    }
+
+    /**
+     * Whether any of the three scopes is declared. False means the thread reached tenant-scoped
+     * work without saying what tenant it belongs to, which is what {@link UnscopedAccessGuard}
+     * acts on.
+     */
+    public static boolean isScopeDeclared() {
+        return getCurrentOrgId() != null || isBypassed() || isUnscopedDeclared();
+    }
+
     public static void clear() {
         currentOrgId.remove();
         bypassed.remove();
+        unscopedReason.remove();
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
@@ -32,6 +32,21 @@ public class TenantFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         try {
+            // Pre-tenant endpoints, declared rather than merely skipped. These run before a
+            // tenant exists or deliberately outside one, and at least /user/web materializes
+            // Attachment, which is tenant-scoped. Declaring it here is what keeps that a
+            // recorded decision instead of the missing-scope failure the guard now raises.
+            // Nothing else about these requests changes: no membership check, no bypass, no
+            // organization id, exactly as when they were skipped outright.
+            String preTenantReason = preTenantReason(request);
+            if (preTenantReason != null) {
+                TenantContext.declareUnscoped(preTenantReason);
+                log.debug("[TenantFilter] {} runs with no tenant: {}",
+                        request.getRequestURI(), preTenantReason);
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
             log.debug("[TenantFilter] path={}, auth={}, authorities={}",
@@ -41,6 +56,7 @@ public class TenantFilter extends OncePerRequestFilter {
 
             if (authentication == null || !authentication.isAuthenticated()) {
                 log.debug("[TenantFilter] No authentication, skipping");
+                TenantContext.declareUnscoped("Unauthenticated request to " + request.getRequestURI());
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -94,8 +110,18 @@ public class TenantFilter extends OncePerRequestFilter {
                     sendError(response, HttpServletResponse.SC_BAD_REQUEST,
                             "X-Organization-Id header required when user belongs to multiple organizations");
                     return;
+                } else {
+                    // No ORG_MEMBER_ authority at all. This is the state a user is in between
+                    // signing up and joining or creating an organization, and the endpoints that
+                    // get them out of it (the profile lookup, organization creation, invite-code
+                    // redemption) read and write tenant-scoped rows on the way. Their scoping
+                    // comes from the queries themselves, which are keyed on the caller's own user
+                    // id or on an invite code, and not from the tenant layer. Saying so here is
+                    // what separates it from a request that lost its organization by accident.
+                    TenantContext.declareUnscoped(
+                            "Authenticated user holds no organization membership");
+                    log.debug("[TenantFilter] No organization membership, running with no tenant");
                 }
-                // orgIds.isEmpty() — user has no org memberships, no tenant context set
             }
 
             filterChain.doFilter(request, response);
@@ -107,17 +133,41 @@ public class TenantFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        // Actuator is the one path the filter does not run on at all. It is served entirely by
+        // Spring Boot's own endpoints, reaches no entity, and a health check should not pay for
+        // a tenant decision. Everything else, including the three pre-tenant API paths that used
+        // to be listed here, now runs through doFilterInternal so the absence of a tenant is
+        // declared rather than merely implied by the filter never having run.
+        return request.getRequestURI().startsWith("/actuator");
+    }
+
+    /**
+     * The API paths that deliberately carry no tenant, and why. These were previously skipped by
+     * {@link #shouldNotFilter}, which had the same effect on the request and left nothing behind
+     * to say it was intended.
+     *
+     * <p>The organization and user endpoints in general are intentionally filtered: they rely on
+     * per-id membership checks, not a blanket exemption. Only the exact {@code /user/web} lookup
+     * is listed, not the paths beneath it. (Two earlier patterns, {@code /organizations} and
+     * {@code /users/profile}, never matched the real singular paths and were removed to avoid the
+     * false impression that those endpoints are unfiltered.)
+     *
+     * @return the reason to record, or null if this request is an ordinary tenant-scoped one
+     */
+    private String preTenantReason(HttpServletRequest request) {
         String path = request.getRequestURI();
-        // The organization and user endpoints are intentionally filtered: they
-        // rely on per-id membership checks, not a blanket bypass. Only the exact
-        // /user/web lookup and the pre-tenant / infra paths below skip the filter.
-        // (Two earlier patterns, /organizations and /users/profile, never matched
-        // the real singular paths and were removed to avoid the false impression
-        // that those endpoints are unfiltered.)
-        return path.startsWith("/actuator")
-                || path.equals("/api/" + backendVersion + "/auth/register")
-                || path.equals("/api/" + backendVersion + "/user/web")
-                || path.startsWith("/api/" + backendVersion + "/billing");
+        String apiRoot = "/api/" + backendVersion;
+
+        if (path.equals(apiRoot + "/auth/register")) {
+            return "Self-registration runs before the caller belongs to any organization";
+        }
+        if (path.equals(apiRoot + "/user/web")) {
+            return "The current-user lookup answers across every organization the caller belongs to";
+        }
+        if (path.startsWith(apiRoot + "/billing")) {
+            return "Billing is keyed on the user rather than the organization";
+        }
+        return null;
     }
 
     private boolean hasAuthority(Authentication authentication, String authority) {

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterBypassAspect.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterBypassAspect.java
@@ -3,10 +3,22 @@ package org.tornotron.echno_backend.common.multitenancy;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+/**
+ * Turns tenant isolation off for the duration of a {@code @BypassTenantFilter} method and
+ * restores the previous state on the way out.
+ *
+ * <p>Ordered ahead of {@link HibernateFilterConfig} for the same reason
+ * {@link WithoutTenantAspect} is: that aspect reads the tenant scope on entry, so a bypass set
+ * at the same order might be applied after it had already decided to enable the {@code orgFilter}
+ * and would then have no effect on the transaction it was meant to open up. Both aspects were
+ * previously unordered, which left that to chance.
+ */
 @Aspect
 @Component
+@Order(WithoutTenantAspect.ORDER)
 public class TenantFilterBypassAspect {
 
     @Around("@annotation(bypassTenantFilter)")

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationListenerRegistrar.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationListenerRegistrar.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class TenantIsolationListenerRegistrar {
 
     private final EntityManagerFactory entityManagerFactory;
+    private final UnscopedAccessGuard unscopedAccessGuard;
 
     @PostConstruct
     public void registerListener() {
@@ -24,6 +25,7 @@ public class TenantIsolationListenerRegistrar {
                 entityManagerFactory.unwrap(SessionFactoryImplementor.class);
         EventListenerRegistry registry =
                 sessionFactory.getServiceRegistry().getService(EventListenerRegistry.class);
-        registry.appendListeners(EventType.POST_LOAD, new TenantIsolationLoadListener());
+        registry.appendListeners(EventType.POST_LOAD,
+                new TenantIsolationLoadListener(unscopedAccessGuard));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListener.java
@@ -19,8 +19,22 @@ import org.tornotron.echno_backend.organization.Organization;
  * so under an active tenant context it is denied rather than leaked. Every create
  * path sets the organization, so a null here is legacy data pending backfill, and
  * denying is the safe failure.
+ *
+ * <p>Work that belongs to no organization at all declares that with {@link WithoutTenant}
+ * or {@code TenantContext.declareUnscoped}, and is let through the same way a bypass is.
+ * What is no longer let through is work that declares nothing: until #507 this listener
+ * returned early on a null organization id, which is the same condition
+ * {@link HibernateFilterConfig} skips the {@code orgFilter} on, so the two mechanisms that
+ * read as defence in depth in fact failed together on identical input. That case now goes
+ * to {@link UnscopedAccessGuard}, which denies it by default.
  */
 public class TenantIsolationLoadListener implements PostLoadEventListener {
+
+    private final UnscopedAccessGuard unscopedAccessGuard;
+
+    public TenantIsolationLoadListener(UnscopedAccessGuard unscopedAccessGuard) {
+        this.unscopedAccessGuard = unscopedAccessGuard;
+    }
 
     @Override
     public void onPostLoad(PostLoadEvent event) {
@@ -28,8 +42,17 @@ public class TenantIsolationLoadListener implements PostLoadEventListener {
             return;
         }
 
+        if (TenantContext.isBypassed()) {
+            return;
+        }
+
         Long contextOrgId = TenantContext.getCurrentOrgId();
-        if (contextOrgId == null || TenantContext.isBypassed()) {
+        if (contextOrgId == null) {
+            if (!TenantContext.isUnscopedDeclared()) {
+                unscopedAccessGuard.onUnscopedLoad(event.getEntity().getClass());
+            }
+            // Under an unscoped declaration, or a policy that only observes, there is no
+            // organization to compare the row against, so nothing more can be checked here.
             return;
         }
 

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunner.java
@@ -25,8 +25,14 @@ import java.util.function.Supplier;
  *
  * <p>Background work that skipped the context would therefore read every organization's
  * rows and look entirely healthy doing it. {@link #callForTenant} refuses a null org id
- * instead, which turns that silent leak into a failure at the call site. The wider problem
- * is tracked separately; this is the local answer for work we own.
+ * instead, which turns that silent leak into a failure at the call site.
+ *
+ * <p>{@link UnscopedAccessGuard} has since closed the wider hole (#507), so an undeclared
+ * scope is refused at the load boundary rather than ignored. This runner is still the entry
+ * point background work should use, and is the earlier and better failure of the two: it
+ * names the missing organization before any work runs, rather than at whatever row happens
+ * to be read first. Work that belongs to no organization says so with {@link WithoutTenant}
+ * instead, which is a different statement and a much weaker one.
  *
  * <p>{@link TenantContext} is backed by {@link ThreadLocal}s, so two further things matter
  * on a pooled thread and both are handled here. The context is restored in a
@@ -64,9 +70,15 @@ public class TenantScopedJobRunner {
 
         Long previousOrgId = TenantContext.getCurrentOrgId();
         boolean previousBypass = TenantContext.isBypassed();
+        String previousUnscopedReason = TenantContext.getUnscopedReason();
 
         TenantContext.setCurrentOrgId(orgId);
         TenantContext.setBypass(false);
+        // An unscoped declaration inherited from an enclosing method, or left on a pooled thread,
+        // would sit alongside a real organization id and say the opposite of what is true here.
+        // The id already wins wherever the two are read together, so this is about the state not
+        // lying rather than about what the isolation mechanisms do with it.
+        TenantContext.clearUnscoped();
         try {
             return work.get();
         } finally {
@@ -76,6 +88,9 @@ public class TenantScopedJobRunner {
             }
             if (previousBypass) {
                 TenantContext.setBypass(true);
+            }
+            if (previousUnscopedReason != null) {
+                TenantContext.declareUnscoped(previousUnscopedReason);
             }
         }
     }

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessGuard.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessGuard.java
@@ -1,0 +1,200 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * The single place that decides what happens when work reaches the database with no tenant scope
+ * declared: no organization id, no bypass, no {@link WithoutTenant}.
+ *
+ * <p>Both isolation mechanisms used to answer that question by doing nothing. {@link
+ * HibernateFilterConfig} skipped the {@code orgFilter} and logged at debug;
+ * {@link TenantIsolationLoadListener} returned early on the same condition. They read as defence
+ * in depth and were not: they cover different things (query shape against primary-key loads) but
+ * gave up on identical input, so a null scope removed isolation rather than narrowing it, and
+ * left nothing in the log to distinguish that from a correct run.
+ *
+ * <p>Both now call in here, and the answer is configured per boundary, because the two boundaries
+ * are not equally precise:
+ *
+ * <ul>
+ *   <li><b>The load boundary</b> fires when a {@link TenantScopedEntity} is actually read. That is
+ *       the leak itself rather than a proxy for it, so it defaults to {@code DENY}. Every path
+ *       that legitimately reads tenant-scoped rows outside a tenant has been enumerated and now
+ *       declares itself.
+ *   <li><b>The transaction boundary</b> fires on every {@code @Transactional} method in the
+ *       package tree, including the many that touch no tenant-scoped entity at all: users,
+ *       organizations, plans, subscriptions. Denying there would refuse work that was never at
+ *       risk, so it defaults to {@code WARN}. The counter and the log line below are what turn
+ *       the remaining call sites into a list instead of a guess, which is the step that has to
+ *       come before that default can move.
+ * </ul>
+ *
+ * <p>Either can be moved with {@code echno.multitenancy.load-boundary} and
+ * {@code echno.multitenancy.transaction-boundary}, so a deployment can tighten ahead of the
+ * default or step back during an incident without waiting on a code change.
+ *
+ * <p>The WARN is rate limited per call site. An unscoped read inside a loop would otherwise
+ * produce one line per row and bury the very thing it is reporting.
+ */
+@Component
+public class UnscopedAccessGuard {
+
+    private static final Logger logger = LoggerFactory.getLogger(UnscopedAccessGuard.class);
+
+    /**
+     * Counter for every unscoped access, tagged with the boundary that saw it, the call site, and
+     * the policy in force. Never rate limited: the log is sampled, the count is not, so a
+     * dashboard reports the true volume.
+     */
+    private static final String METRIC = "echno.multitenancy.unscoped";
+
+    /**
+     * Caps the rate-limiter map. A call site that arrives after the cap is logged every time
+     * rather than tracked, which is noisier than the alternative but never silent, and the cap is
+     * far above the number of distinct entity types and transactional methods the application has.
+     */
+    private static final int MAX_TRACKED_CALL_SITES = 2_000;
+
+    private final MeterRegistry meterRegistry;
+    private final UnscopedAccessPolicy loadBoundaryPolicy;
+    private final UnscopedAccessPolicy transactionBoundaryPolicy;
+    private final long warnIntervalNanos;
+    private final Map<String, AtomicLong> lastWarnedNanos = new ConcurrentHashMap<>();
+
+    public UnscopedAccessGuard(
+            MeterRegistry meterRegistry,
+            @Value("${echno.multitenancy.load-boundary:DENY}") String loadBoundary,
+            @Value("${echno.multitenancy.transaction-boundary:WARN}") String transactionBoundary,
+            @Value("${echno.multitenancy.warn-interval-seconds:60}") long warnIntervalSeconds) {
+        this.meterRegistry = meterRegistry;
+        this.loadBoundaryPolicy =
+                UnscopedAccessPolicy.parse("echno.multitenancy.load-boundary", loadBoundary);
+        this.transactionBoundaryPolicy =
+                UnscopedAccessPolicy.parse("echno.multitenancy.transaction-boundary", transactionBoundary);
+        this.warnIntervalNanos = Duration.ofSeconds(Math.max(0, warnIntervalSeconds)).toNanos();
+    }
+
+    public UnscopedAccessPolicy getLoadBoundaryPolicy() {
+        return loadBoundaryPolicy;
+    }
+
+    public UnscopedAccessPolicy getTransactionBoundaryPolicy() {
+        return transactionBoundaryPolicy;
+    }
+
+    /**
+     * Called when a {@link TenantScopedEntity} has been loaded and no scope is declared.
+     *
+     * @param entityType the entity that was read, which is the useful half of the report: it says
+     *                   what data was exposed, not merely that something was
+     * @throws UnscopedTenantAccessException under {@code DENY}
+     */
+    public void onUnscopedLoad(Class<?> entityType) {
+        act(Boundary.LOAD, loadBoundaryPolicy, entityType.getSimpleName(),
+                () -> "Tenant-scoped entity " + entityType.getSimpleName()
+                        + " was loaded with no tenant scope declared");
+    }
+
+    /**
+     * Called when a {@code @Transactional} method is entered and no scope is declared, so the
+     * transaction is about to run with the {@code orgFilter} off.
+     *
+     * @param callSite the advised method, so the log names something greppable
+     * @throws UnscopedTenantAccessException under {@code DENY}
+     */
+    public void onUnscopedTransaction(String callSite) {
+        act(Boundary.TRANSACTION, transactionBoundaryPolicy, callSite,
+                () -> "Transaction " + callSite
+                        + " was entered with no tenant scope declared, so orgFilter is off for it");
+    }
+
+    private void act(Boundary boundary, UnscopedAccessPolicy policy, String callSite,
+                     Supplier<String> message) {
+        if (policy == UnscopedAccessPolicy.ALLOW) {
+            return;
+        }
+
+        Counter.builder(METRIC)
+                .tag("boundary", boundary.tag)
+                .tag("call_site", callSite)
+                .tag("policy", policy.name())
+                .description("Work that reached tenant-scoped data with no tenant scope declared")
+                .register(meterRegistry)
+                .increment();
+
+        if (policy == UnscopedAccessPolicy.DENY) {
+            String detail = message.get();
+            // Not rate limited: a denial is one event that ended the work, not a stream, and it
+            // is the line whoever is holding the incident needs in full.
+            logger.error("[TenantScope] {}. Refused under {}={}.",
+                    detail, boundary.property, policy);
+            throw new UnscopedTenantAccessException(detail);
+        }
+
+        if (shouldWarn(boundary, callSite)) {
+            logger.warn("[TenantScope] {}. Allowed under {}={}; declare the scope with an "
+                            + "organization id, TenantScopedJobRunner, @WithoutTenant or "
+                            + "@BypassTenantFilter. Further reports for this call site are "
+                            + "suppressed briefly; the {} counter is not.",
+                    message.get(), boundary.property, policy, METRIC);
+        }
+    }
+
+    /**
+     * One WARN per call site per interval. Racing threads may both win the compare-and-set window
+     * and log twice, which is a better trade than a lock on a path that exists to observe.
+     */
+    private boolean shouldWarn(Boundary boundary, String callSite) {
+        if (warnIntervalNanos == 0) {
+            return true;
+        }
+        String key = boundary.tag + '|' + callSite;
+        long now = System.nanoTime();
+
+        AtomicLong last = lastWarnedNanos.get(key);
+        if (last == null) {
+            if (lastWarnedNanos.size() >= MAX_TRACKED_CALL_SITES) {
+                return true;
+            }
+            AtomicLong existing = lastWarnedNanos.putIfAbsent(key, new AtomicLong(now));
+            if (existing == null) {
+                // First sighting of this call site, which is the report that matters most.
+                return true;
+            }
+            last = existing;
+        }
+
+        long previous = last.get();
+        // Subtraction rather than comparison, because nanoTime has an arbitrary origin and wraps;
+        // the difference stays correct across the wrap where a direct comparison would not.
+        if (now - previous < warnIntervalNanos) {
+            return false;
+        }
+        return last.compareAndSet(previous, now);
+    }
+
+    private enum Boundary {
+        LOAD("load", "echno.multitenancy.load-boundary"),
+        TRANSACTION("transaction", "echno.multitenancy.transaction-boundary");
+
+        private final String tag;
+        private final String property;
+
+        Boundary(String tag, String property) {
+            this.tag = tag;
+            this.property = property;
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessPolicy.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessPolicy.java
@@ -1,0 +1,43 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import java.util.Locale;
+
+/**
+ * What to do when work reaches the database with no tenant scope declared at all: no
+ * organization id, no {@code @BypassTenantFilter}, no {@link WithoutTenant}.
+ *
+ * <p>The three values are the three stages of closing #507, and the property exists so an
+ * environment can sit at a different stage from the shipped default and so the strict setting
+ * can be stepped back during an incident without a code change.
+ */
+public enum UnscopedAccessPolicy {
+
+    /** Proceed silently. The pre-#507 behaviour, kept only as the incident escape hatch. */
+    ALLOW,
+
+    /** Proceed, but count the event and log it, so the real call sites can be enumerated. */
+    WARN,
+
+    /** Refuse the work. */
+    DENY;
+
+    /**
+     * Reads a configured value, accepting any case so an environment variable can be written
+     * either way.
+     *
+     * @throws IllegalArgumentException naming the property and the accepted values, so a typo
+     *                                  fails at startup rather than quietly selecting a default
+     */
+    static UnscopedAccessPolicy parse(String property, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                    property + " must be one of ALLOW, WARN, DENY but was empty");
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    property + " must be one of ALLOW, WARN, DENY but was '" + value + "'", e);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenant.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenant.java
@@ -1,0 +1,33 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares that the annotated method belongs to no organization, so reaching tenant-scoped data
+ * without an organization id is a decision here rather than a mistake.
+ *
+ * <p>Use it on work that genuinely runs outside every tenant: startup and bootstrap, a fixture
+ * provisioner, a pre-tenant endpoint. Do not use it to quieten a warning on work that does have
+ * a tenant. That work wants {@link TenantScopedJobRunner}, which pins the organization the job
+ * belongs to and refuses to run without one.
+ *
+ * <p>This is deliberately weaker than {@code @BypassTenantFilter}. Bypass turns tenant isolation
+ * off outright, including where an organization id is present, which is why it is audited at WARN
+ * where it is set. This only suppresses the missing-scope failure: if an organization id happens
+ * to be in force when the method runs, the {@code orgFilter} and the load-boundary check stay
+ * fully in force. So putting this on a method that is also called inside a tenant request cannot
+ * open that request up, which is the property that makes it safe to apply to shared service code.
+ *
+ * <p>The reason is required and is recorded on the audit line, because a bare annotation a year
+ * from now says only that somebody wanted the check off, not whether they were right.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithoutTenant {
+
+    /** Why this work has no organization. Recorded with the declaration. */
+    String value();
+}

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenantAspect.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenantAspect.java
@@ -1,0 +1,48 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Puts the {@link WithoutTenant} declaration on the thread for the duration of the annotated
+ * method and restores whatever was there before.
+ *
+ * <p>The order matters and is not cosmetic. {@link HibernateFilterConfig} sits at
+ * {@link Ordered#LOWEST_PRECEDENCE} and reads the tenant scope on entry, so an aspect that
+ * declared the scope at the same order might run after it and the declaration would arrive too
+ * late to be seen. That is exactly the ordering accident #508 was, one aspect over. Ordering this
+ * ahead of the filter aspect makes the declaration visible to it.
+ *
+ * <p>Restoring rather than clearing keeps the annotation safe on a method that is also called
+ * from inside a request or a tenant-scoped job: the caller's scope comes back on the way out.
+ */
+@Aspect
+@Component
+@Order(WithoutTenantAspect.ORDER)
+public class WithoutTenantAspect {
+
+    /**
+     * Ahead of {@link HibernateFilterConfig}, so the declaration is in place before the filter
+     * aspect decides what to do about the transaction.
+     */
+    public static final int ORDER = Ordered.LOWEST_PRECEDENCE - 100;
+
+    @Around("@annotation(withoutTenant)")
+    public Object declareUnscoped(ProceedingJoinPoint joinPoint, WithoutTenant withoutTenant) throws Throwable {
+        String previousReason = TenantContext.getUnscopedReason();
+        TenantContext.declareUnscoped(withoutTenant.value());
+        try {
+            return joinPoint.proceed();
+        } finally {
+            if (previousReason == null) {
+                TenantContext.clearUnscoped();
+            } else {
+                TenantContext.declareUnscoped(previousReason);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -179,6 +179,25 @@ echno:
     # container's, so a document raised at eight in the morning in Kerala is not stamped with
     # the previous year because the server happens to run on UTC.
     zone: ${ECHNO_DOCUMENT_NUMBER_ZONE:Asia/Kolkata}
+  multitenancy:
+    # What happens when work reaches tenant-scoped data with no tenant scope declared at all:
+    # no organization id, no @BypassTenantFilter, no @WithoutTenant. ALLOW proceeds silently,
+    # which is the pre-#507 behaviour and is kept only as the incident escape hatch. WARN
+    # proceeds but counts the event under echno.multitenancy.unscoped and logs the call site
+    # (rate limited per call site, see warn-interval-seconds). DENY refuses the work.
+    #
+    # The two boundaries differ because they are not equally precise. The load boundary fires
+    # when a tenant-scoped entity is actually read, which is the leak itself, so it denies. The
+    # transaction boundary fires on every @Transactional method in the package tree, including
+    # the many that touch no tenant-scoped entity at all (users, organizations, plans,
+    # subscriptions), so it observes rather than refuses until that list has been worked
+    # through on a real deployment.
+    load-boundary: ${ECHNO_TENANT_LOAD_BOUNDARY:DENY}
+    transaction-boundary: ${ECHNO_TENANT_TRANSACTION_BOUNDARY:WARN}
+    # How long to suppress repeat warnings for the same call site. An unscoped read inside a
+    # loop would otherwise produce one line per row and bury what it is reporting. The metric
+    # is never suppressed, so the count stays true whatever this is set to. Zero logs every one.
+    warn-interval-seconds: ${ECHNO_TENANT_WARN_INTERVAL_SECONDS:60}
   transaction:
     retry:
       # CockroachDB runs SERIALIZABLE and aborts one side of a read-write conflict with

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfigTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/HibernateFilterConfigTest.java
@@ -1,0 +1,108 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.persistence.EntityManager;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the transaction-boundary aspect does with each of the four scope states. The one that
+ * changed is the fourth: an undeclared scope used to fall in with a deliberate bypass and run the
+ * transaction unfiltered, recorded only in a debug line no deployed environment turns on.
+ */
+class HibernateFilterConfigTest {
+
+    private EntityManager entityManager;
+    private Session session;
+    private Filter filter;
+    private ProceedingJoinPoint joinPoint;
+
+    @BeforeEach
+    void setUp() throws Throwable {
+        filter = mock(Filter.class);
+        when(filter.setParameter(any(), any())).thenReturn(filter);
+        session = mock(Session.class);
+        when(session.enableFilter("orgFilter")).thenReturn(filter);
+        entityManager = mock(EntityManager.class);
+        when(entityManager.unwrap(Session.class)).thenReturn(session);
+
+        Signature signature = mock(Signature.class);
+        when(signature.toShortString()).thenReturn("SomeService.doWork()");
+        joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.proceed()).thenReturn("done");
+    }
+
+    @AfterEach
+    void clear() {
+        TenantContext.clear();
+    }
+
+    private HibernateFilterConfig aspectUnder(UnscopedAccessPolicy policy) {
+        return new HibernateFilterConfig(entityManager, new UnscopedAccessGuard(
+                new SimpleMeterRegistry(), policy.name(), policy.name(), 60));
+    }
+
+    @Test
+    void enablesTheFilterForTheCurrentOrganization() throws Throwable {
+        TenantContext.setCurrentOrgId(9L);
+
+        Object result = aspectUnder(UnscopedAccessPolicy.DENY).enableOrgFilter(joinPoint, null);
+
+        assertThat(result).isEqualTo("done");
+        verify(session).enableFilter("orgFilter");
+        verify(filter).setParameter("organizationId", 9L);
+    }
+
+    @Test
+    void leavesTheFilterOffForADeliberateBypass() throws Throwable {
+        TenantContext.setBypass(true);
+
+        assertThatCode(() -> aspectUnder(UnscopedAccessPolicy.DENY).enableOrgFilter(joinPoint, null))
+                .doesNotThrowAnyException();
+
+        verify(session, never()).enableFilter(any());
+    }
+
+    @Test
+    void leavesTheFilterOffForAnUnscopedDeclaration() throws Throwable {
+        TenantContext.declareUnscoped("startup, before any organization exists");
+
+        assertThatCode(() -> aspectUnder(UnscopedAccessPolicy.DENY).enableOrgFilter(joinPoint, null))
+                .doesNotThrowAnyException();
+
+        verify(session, never()).enableFilter(any());
+    }
+
+    @Test
+    void refusesATransactionThatDeclaresNoScopeAtAllWhenTheBoundaryDenies() {
+        assertThatExceptionOfType(UnscopedTenantAccessException.class)
+                .isThrownBy(() -> aspectUnder(UnscopedAccessPolicy.DENY).enableOrgFilter(joinPoint, null))
+                .withMessageContaining("SomeService.doWork()");
+    }
+
+    @Test
+    void proceedsUnderTheShippedTransactionBoundaryDefault() throws Throwable {
+        // WARN is what the application ships with for this boundary, because it fires on every
+        // @Transactional method including the many that touch no tenant-scoped entity.
+        Object result = aspectUnder(UnscopedAccessPolicy.WARN).enableOrgFilter(joinPoint, null);
+
+        assertThat(result).isEqualTo("done");
+        verify(session, never()).enableFilter(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantContextTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantContextTest.java
@@ -1,0 +1,85 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * The scope states, and in particular the difference between the three declared ones and the
+ * fourth state that is no declaration at all. That fourth state is what #507 was: it read as
+ * "no tenant" and both isolation mechanisms gave up on it.
+ */
+class TenantContextTest {
+
+    @AfterEach
+    void clear() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void nothingIsDeclaredOnAFreshThread() {
+        assertThat(TenantContext.isScopeDeclared()).isFalse();
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+        assertThat(TenantContext.getUnscopedReason()).isNull();
+    }
+
+    @Test
+    void anOrganizationIdIsADeclaration() {
+        TenantContext.setCurrentOrgId(7L);
+
+        assertThat(TenantContext.isScopeDeclared()).isTrue();
+    }
+
+    @Test
+    void aBypassIsADeclaration() {
+        TenantContext.setBypass(true);
+
+        assertThat(TenantContext.isScopeDeclared()).isTrue();
+    }
+
+    @Test
+    void anUnscopedDeclarationIsADeclarationAndKeepsItsReason() {
+        TenantContext.declareUnscoped("startup, before any organization exists");
+
+        assertThat(TenantContext.isScopeDeclared()).isTrue();
+        assertThat(TenantContext.isUnscopedDeclared()).isTrue();
+        assertThat(TenantContext.getUnscopedReason()).isEqualTo("startup, before any organization exists");
+    }
+
+    @Test
+    void anUnscopedDeclarationNeedsAReason() {
+        assertThatIllegalArgumentException().isThrownBy(() -> TenantContext.declareUnscoped(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> TenantContext.declareUnscoped("  "));
+
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+    }
+
+    @Test
+    void clearingTheUnscopedDeclarationLeavesTheRestAlone() {
+        TenantContext.setCurrentOrgId(7L);
+        TenantContext.setBypass(true);
+        TenantContext.declareUnscoped("temporary");
+
+        TenantContext.clearUnscoped();
+
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+        assertThat(TenantContext.getCurrentOrgId()).isEqualTo(7L);
+        assertThat(TenantContext.isBypassed()).isTrue();
+    }
+
+    @Test
+    void clearRemovesEveryPartOfTheScope() {
+        TenantContext.setCurrentOrgId(7L);
+        TenantContext.setBypass(true);
+        TenantContext.declareUnscoped("temporary");
+
+        TenantContext.clear();
+
+        assertThat(TenantContext.getCurrentOrgId()).isNull();
+        assertThat(TenantContext.isBypassed()).isFalse();
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+        assertThat(TenantContext.isScopeDeclared()).isFalse();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
@@ -1,0 +1,182 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The request-side half of #507. Every request now leaves the filter having declared what tenant
+ * scope it runs under, including the ones that run under none.
+ *
+ * <p>Before this, the pre-tenant paths were listed in {@code shouldNotFilter}, which meant the
+ * filter never ran and the request reached the database with a scope indistinguishable from a
+ * request that had lost its organization by accident. {@code GET /user/web} is the one that
+ * mattered: it materializes {@code Attachment}, which is tenant-scoped.
+ *
+ * <p>The behaviour of those requests is otherwise unchanged, which these assertions pin: no
+ * organization id is set, no membership check runs, and no bypass is granted. Only the
+ * declaration is new.
+ */
+class TenantFilterTest {
+
+    private static final String ORG_MEMBER_7 = "ORG_MEMBER_7";
+
+    private TenantFilter filter;
+    private MockHttpServletResponse response;
+
+    /** What the tenant scope looked like at the moment the request reached the application. */
+    private record ScopeAtChain(Long orgId, boolean bypassed, String unscopedReason) {}
+
+    private ScopeAtChain observed;
+
+    @BeforeEach
+    void setUp() {
+        filter = new TenantFilter();
+        ReflectionTestUtils.setField(filter, "backendVersion", "v1");
+        response = new MockHttpServletResponse();
+        observed = null;
+    }
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
+        TenantContext.clear();
+    }
+
+    private FilterChain capturingChain() {
+        return (req, res) -> observed = new ScopeAtChain(
+                TenantContext.getCurrentOrgId(),
+                TenantContext.isBypassed(),
+                TenantContext.getUnscopedReason());
+    }
+
+    private void authenticateWith(String... authorities) {
+        TestingAuthenticationToken token = new TestingAuthenticationToken(
+                "someone", "credentials",
+                List.of(authorities).stream().map(SimpleGrantedAuthority::new).toList());
+        token.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private void run(String path) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.setRequestURI(path);
+        filter.doFilter(request, response, capturingChain());
+    }
+
+    @Test
+    void actuatorIsTheOnlyPathTheFilterDoesNotRunOnAtAll() {
+        MockHttpServletRequest actuator = new MockHttpServletRequest("GET", "/actuator/health");
+        actuator.setRequestURI("/actuator/health");
+        MockHttpServletRequest api = new MockHttpServletRequest("GET", "/api/v1/billing/plans/web");
+        api.setRequestURI("/api/v1/billing/plans/web");
+
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(filter, "shouldNotFilter", actuator))
+                .isTrue();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(filter, "shouldNotFilter", api))
+                .isFalse();
+    }
+
+    @Test
+    void selfRegistrationDeclaresItselfUnscoped() throws Exception {
+        run("/api/v1/auth/register");
+
+        assertThat(observed.unscopedReason()).contains("Self-registration");
+        assertThat(observed.orgId()).isNull();
+        assertThat(observed.bypassed()).isFalse();
+    }
+
+    @Test
+    void theCurrentUserLookupDeclaresItselfUnscoped() throws Exception {
+        // This one loads Attachment, a tenant-scoped entity, so without the declaration the
+        // fail-closed load boundary would refuse the caller's own profile.
+        authenticateWith(ORG_MEMBER_7);
+
+        run("/api/v1/user/web");
+
+        assertThat(observed.unscopedReason()).contains("current-user lookup");
+        assertThat(observed.orgId()).isNull();
+    }
+
+    @Test
+    void thePathsBeneathUserWebAreStillOrdinaryTenantRequests() throws Exception {
+        authenticateWith(ORG_MEMBER_7);
+
+        run("/api/v1/user/web/employees");
+
+        assertThat(observed.orgId()).isEqualTo(7L);
+        assertThat(observed.unscopedReason()).isNull();
+    }
+
+    @Test
+    void billingDeclaresItselfUnscoped() throws Exception {
+        authenticateWith(ORG_MEMBER_7);
+
+        run("/api/v1/billing/subscriptions/web/current");
+
+        assertThat(observed.unscopedReason()).contains("Billing");
+        assertThat(observed.orgId()).isNull();
+    }
+
+    @Test
+    void anAuthenticatedUserWithNoMembershipDeclaresItselfUnscoped() throws Exception {
+        // The state between signing up and joining an organization. The endpoints that get a
+        // user out of it read and write tenant-scoped rows, scoped by the caller's own user id.
+        authenticateWith("ROLE_USER");
+
+        run("/api/v1/organization/web");
+
+        assertThat(observed.unscopedReason()).contains("no organization membership");
+        assertThat(observed.orgId()).isNull();
+        assertThat(observed.bypassed()).isFalse();
+    }
+
+    @Test
+    void anUnauthenticatedRequestDeclaresItselfUnscoped() throws Exception {
+        run("/api/v1/project/web");
+
+        assertThat(observed.unscopedReason()).contains("Unauthenticated");
+        assertThat(observed.orgId()).isNull();
+    }
+
+    @Test
+    void anOrdinaryMemberRequestSetsTheOrganizationAndDeclaresNothingElse() throws Exception {
+        authenticateWith(ORG_MEMBER_7);
+
+        run("/api/v1/project/web");
+
+        assertThat(observed.orgId()).isEqualTo(7L);
+        assertThat(observed.unscopedReason()).isNull();
+        assertThat(observed.bypassed()).isFalse();
+    }
+
+    @Test
+    void aGlobalAdminStillBypassesRatherThanDeclaringItselfUnscoped() throws Exception {
+        authenticateWith("organization:admin");
+
+        run("/api/v1/project/web");
+
+        assertThat(observed.bypassed()).isTrue();
+        assertThat(observed.unscopedReason()).isNull();
+    }
+
+    @Test
+    void everyScopeIsClearedOnTheWayOut() throws Exception {
+        authenticateWith(ORG_MEMBER_7);
+        run("/api/v1/user/web");
+
+        assertThat(TenantContext.isScopeDeclared()).isFalse();
+        assertThat(TenantContext.getUnscopedReason()).isNull();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationIT.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.common.multitenancy;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.AfterEach;
@@ -12,21 +13,29 @@ import org.springframework.context.annotation.Import;
 import org.tornotron.echno_backend.category.Category;
 import org.tornotron.echno_backend.category.CategoryRepository;
 import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Proves that tenant isolation is fail-closed for reads. A category belongs to
- * organization B; loading it by primary key (which the Hibernate org filter never
- * covers) is rejected when the request is scoped to organization A, allowed for
- * organization B, and allowed when the tenant filter is explicitly bypassed.
+ * Proves that tenant isolation is fail-closed for reads, through the real Hibernate event
+ * pipeline against a real database rather than a hand-built listener. A category belongs to
+ * organization B; loading it by primary key (which the Hibernate org filter never covers) is
+ * rejected when the request is scoped to organization A, allowed for organization B, and
+ * allowed when the tenant filter is explicitly bypassed.
+ *
+ * <p>Since #507 it is also rejected when nothing declared a tenant scope at all, and allowed
+ * again once the caller declares itself unscoped. That is the case that used to return the row
+ * with no check of any kind, so it is the one worth running against a database: the early return
+ * it replaces sat in the listener, but what it let through was a real cross-tenant read.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(TenantIsolationListenerRegistrar.class)
+@Import({TenantIsolationListenerRegistrar.class, UnscopedAccessGuard.class, SimpleMeterRegistry.class})
 class TenantIsolationIT extends AbstractIntegrationTest {
 
     @Autowired
@@ -87,6 +96,38 @@ class TenantIsolationIT extends AbstractIntegrationTest {
         } finally {
             TenantContext.setBypass(false);
         }
+    }
+
+    @Test
+    void findById_withNoTenantScopeDeclaredAtAll_isRefused() {
+        // No organization id, no bypass, no @WithoutTenant. This is the state a background job
+        // that forgot its tenant is in, and until #507 it read every organization's rows.
+        assertThatThrownBy(() -> categoryRepository.findById(categoryId))
+                .isInstanceOf(UnscopedTenantAccessException.class)
+                .hasMessageContaining("Category");
+    }
+
+    @Test
+    void findById_declaredUnscoped_returnsTheEntity() {
+        TenantContext.declareUnscoped("a startup path that belongs to no organization");
+
+        assertThat(categoryRepository.findById(categoryId)).isPresent();
+    }
+
+    @Test
+    void anUnscopedDeclarationDoesNotWeakenAnActiveTenant() {
+        // The declaration only answers the missing-scope question. With an organization in
+        // force the cross-tenant check still runs, which is what keeps @WithoutTenant safe on
+        // shared service code that a tenant request may also call.
+        TenantContext.setCurrentOrgId(orgAId);
+        TenantContext.declareUnscoped("a shared helper that usually has no tenant");
+
+        assertThatThrownBy(() -> categoryRepository.findById(categoryId))
+                .isInstanceOf(TenantAccessDeniedException.class);
+        assertThatCode(() -> {
+            TenantContext.setCurrentOrgId(orgBId);
+            assertThat(categoryRepository.findById(categoryId)).isPresent();
+        }).doesNotThrowAnyException();
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListenerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantIsolationLoadListenerTest.java
@@ -1,9 +1,11 @@
 package org.tornotron.echno_backend.common.multitenancy;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.tornotron.echno_backend.common.exception.TenantAccessDeniedException;
+import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
 import org.tornotron.echno_backend.organization.Organization;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -16,10 +18,20 @@ import static org.mockito.Mockito.when;
  * different organization than the request, and also one with no organization at
  * all (a null org cannot be proven to belong to the caller, and letting it
  * through let any tenant read a null-org row by id).
+ *
+ * <p>Since #507 it also denies a load that declares no tenant scope at all. That case used
+ * to be an early return on the same condition {@code HibernateFilterConfig} skips the
+ * {@code orgFilter} on, so the two mechanisms failed together rather than covering each other.
  */
 class TenantIsolationLoadListenerTest {
 
-    private final TenantIsolationLoadListener listener = new TenantIsolationLoadListener();
+    private final TenantIsolationLoadListener listener =
+            listenerUnder(UnscopedAccessPolicy.DENY);
+
+    private static TenantIsolationLoadListener listenerUnder(UnscopedAccessPolicy policy) {
+        return new TenantIsolationLoadListener(new UnscopedAccessGuard(
+                new SimpleMeterRegistry(), policy.name(), policy.name(), 60));
+    }
 
     @AfterEach
     void clear() {
@@ -80,5 +92,41 @@ class TenantIsolationLoadListenerTest {
     void ignoresNonTenantScopedEntities() {
         TenantContext.setCurrentOrgId(1L);
         assertThatCode(() -> listener.onPostLoad(eventFor("not a tenant entity"))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void deniesALoadThatDeclaresNoScopeAtAll() {
+        // No organization id, no bypass, no @WithoutTenant. This used to return early, which
+        // meant the row was handed over with no check of any kind.
+        assertThatExceptionOfType(UnscopedTenantAccessException.class)
+                .isThrownBy(() -> listener.onPostLoad(eventFor(scoped(2L))));
+    }
+
+    @Test
+    void allowsALoadThatDeclaresItselfUnscoped() {
+        TenantContext.declareUnscoped("startup, before any organization exists");
+
+        assertThatCode(() -> listener.onPostLoad(eventFor(scoped(2L)))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsAnUndeclaredLoadWhileThePolicyOnlyObserves() {
+        // The staged rollout: an environment can sit on WARN and collect the call sites before
+        // the default refuses them.
+        TenantIsolationLoadListener observing = listenerUnder(UnscopedAccessPolicy.WARN);
+
+        assertThatCode(() -> observing.onPostLoad(eventFor(scoped(2L)))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void anUnscopedDeclarationDoesNotWeakenAnActiveTenant() {
+        // @WithoutTenant only suppresses the missing-scope failure. Where an organization id is
+        // present the cross-tenant check stays in force, which is what makes the annotation safe
+        // on a method that is also called inside a request.
+        TenantContext.setCurrentOrgId(1L);
+        TenantContext.declareUnscoped("shared helper that usually has no tenant");
+
+        assertThatExceptionOfType(TenantAccessDeniedException.class)
+                .isThrownBy(() -> listener.onPostLoad(eventFor(scoped(2L))));
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunnerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantScopedJobRunnerTest.java
@@ -89,4 +89,26 @@ class TenantScopedJobRunnerTest {
         assertThat(bypassedDuringWork.get()).isFalse();
         assertThat(TenantContext.isBypassed()).isTrue();
     }
+
+    @Test
+    void withdrawsAnUnscopedDeclarationForTheWorkAndRestoresIt() {
+        // An inherited or leaked "this work has no tenant" would sit alongside a real
+        // organization id and say the opposite of what is true for the duration of the job.
+        TenantContext.declareUnscoped("an enclosing method that belongs to no organization");
+        AtomicReference<String> reasonDuringWork = new AtomicReference<>("unset");
+
+        runner.runForTenant(ORG_ID, () -> reasonDuringWork.set(TenantContext.getUnscopedReason()));
+
+        assertThat(reasonDuringWork.get()).isNull();
+        assertThat(TenantContext.getUnscopedReason())
+                .isEqualTo("an enclosing method that belongs to no organization");
+    }
+
+    @Test
+    void leavesNoUnscopedDeclarationBehindOnAThreadThatHadNone() {
+        runner.runForTenant(ORG_ID, () -> {});
+
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+        assertThat(TenantContext.isScopeDeclared()).isFalse();
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessGuardTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/UnscopedAccessGuardTest.java
@@ -1,0 +1,128 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.UnscopedTenantAccessException;
+import org.tornotron.echno_backend.organization.Organization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * The policy the two isolation mechanisms now share. The point of the counter is that it is not
+ * rate limited: the log is sampled so a loop cannot bury the report, and the count has to stay
+ * true anyway or the dashboard that decides when the transaction boundary can move to DENY is
+ * reading a sampled number as a total.
+ */
+class UnscopedAccessGuardTest {
+
+    private SimpleMeterRegistry registry;
+
+    private UnscopedAccessGuard guard(String loadBoundary, String transactionBoundary) {
+        return guard(loadBoundary, transactionBoundary, 60);
+    }
+
+    private UnscopedAccessGuard guard(String loadBoundary, String transactionBoundary, long warnInterval) {
+        registry = new SimpleMeterRegistry();
+        return new UnscopedAccessGuard(registry, loadBoundary, transactionBoundary, warnInterval);
+    }
+
+    private double count(String boundary) {
+        return registry.find("echno.multitenancy.unscoped").tag("boundary", boundary).counters()
+                .stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @Test
+    void allowProceedsAndRecordsNothing() {
+        UnscopedAccessGuard guard = guard("ALLOW", "ALLOW");
+
+        assertThatCode(() -> guard.onUnscopedLoad(Organization.class)).doesNotThrowAnyException();
+        assertThatCode(() -> guard.onUnscopedTransaction("Svc.method()")).doesNotThrowAnyException();
+
+        assertThat(registry.find("echno.multitenancy.unscoped").counters()).isEmpty();
+    }
+
+    @Test
+    void warnProceedsButCounts() {
+        UnscopedAccessGuard guard = guard("WARN", "WARN");
+
+        assertThatCode(() -> guard.onUnscopedLoad(Organization.class)).doesNotThrowAnyException();
+        assertThatCode(() -> guard.onUnscopedTransaction("Svc.method()")).doesNotThrowAnyException();
+
+        assertThat(count("load")).isEqualTo(1);
+        assertThat(count("transaction")).isEqualTo(1);
+    }
+
+    @Test
+    void denyRefusesAndNamesTheEntity() {
+        UnscopedAccessGuard guard = guard("DENY", "DENY");
+
+        assertThatExceptionOfType(UnscopedTenantAccessException.class)
+                .isThrownBy(() -> guard.onUnscopedLoad(Organization.class))
+                .withMessageContaining("Organization")
+                .withMessageContaining("no tenant scope declared");
+
+        assertThatExceptionOfType(UnscopedTenantAccessException.class)
+                .isThrownBy(() -> guard.onUnscopedTransaction("Svc.method()"))
+                .withMessageContaining("Svc.method()");
+    }
+
+    @Test
+    void theTwoBoundariesAreConfiguredIndependently() {
+        UnscopedAccessGuard guard = guard("DENY", "WARN");
+
+        assertThatExceptionOfType(UnscopedTenantAccessException.class)
+                .isThrownBy(() -> guard.onUnscopedLoad(Organization.class));
+        assertThatCode(() -> guard.onUnscopedTransaction("Svc.method()")).doesNotThrowAnyException();
+
+        assertThat(guard.getLoadBoundaryPolicy()).isEqualTo(UnscopedAccessPolicy.DENY);
+        assertThat(guard.getTransactionBoundaryPolicy()).isEqualTo(UnscopedAccessPolicy.WARN);
+    }
+
+    @Test
+    void theCounterIsNotRateLimitedEvenThoughTheLogIs() {
+        UnscopedAccessGuard guard = guard("WARN", "WARN", 3600);
+
+        for (int i = 0; i < 25; i++) {
+            guard.onUnscopedLoad(Organization.class);
+        }
+
+        // A one-hour suppression window means one log line for those 25 reads. The count is what
+        // says there were 25, and it is the number the decision to tighten the policy rests on.
+        assertThat(count("load")).isEqualTo(25);
+    }
+
+    @Test
+    void distinctCallSitesAreCountedSeparately() {
+        UnscopedAccessGuard guard = guard("WARN", "WARN");
+
+        guard.onUnscopedTransaction("First.method()");
+        guard.onUnscopedTransaction("Second.method()");
+
+        assertThat(registry.find("echno.multitenancy.unscoped")
+                .tag("call_site", "First.method()").counter().count()).isEqualTo(1);
+        assertThat(registry.find("echno.multitenancy.unscoped")
+                .tag("call_site", "Second.method()").counter().count()).isEqualTo(1);
+    }
+
+    @Test
+    void aMistypedPolicyFailsAtStartupAndNamesTheProperty() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> guard("DNEY", "WARN"))
+                .withMessageContaining("echno.multitenancy.load-boundary")
+                .withMessageContaining("DNEY")
+                .withMessageContaining("ALLOW, WARN, DENY");
+    }
+
+    @Test
+    void aPolicyIsReadInAnyCaseSoAnEnvironmentVariableCanBeWrittenEitherWay() {
+        UnscopedAccessGuard guard = guard(" deny ", "warn");
+
+        assertThat(guard.getLoadBoundaryPolicy()).isEqualTo(UnscopedAccessPolicy.DENY);
+        assertThat(guard.getTransactionBoundaryPolicy()).isEqualTo(UnscopedAccessPolicy.WARN);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenantAspectTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/WithoutTenantAspectTest.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.common.multitenancy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.Order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The aspect behind {@link WithoutTenant}, and the ordering invariant it depends on.
+ */
+class WithoutTenantAspectTest {
+
+    private final WithoutTenantAspect aspect = new WithoutTenantAspect();
+
+    @AfterEach
+    void clear() {
+        TenantContext.clear();
+    }
+
+    /** Carries a real annotation instance, which is easier to obtain than to synthesize. */
+    @SuppressWarnings("unused")
+    private static class Sample {
+        @WithoutTenant("startup, before any organization exists")
+        void annotated() {
+        }
+    }
+
+    private static WithoutTenant annotation() throws NoSuchMethodException {
+        return Sample.class.getDeclaredMethod("annotated").getAnnotation(WithoutTenant.class);
+    }
+
+    private ProceedingJoinPoint joinPointThat(Runnable body) throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.proceed()).thenAnswer(invocation -> {
+            body.run();
+            return "done";
+        });
+        return joinPoint;
+    }
+
+    @Test
+    void theReasonIsVisibleWhileTheMethodRuns() throws Throwable {
+        String[] seen = new String[1];
+
+        Object result = aspect.declareUnscoped(
+                joinPointThat(() -> seen[0] = TenantContext.getUnscopedReason()), annotation());
+
+        assertThat(result).isEqualTo("done");
+        assertThat(seen[0]).isEqualTo("startup, before any organization exists");
+    }
+
+    @Test
+    void theDeclarationIsWithdrawnAfterwards() throws Throwable {
+        aspect.declareUnscoped(joinPointThat(() -> {}), annotation());
+
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+    }
+
+    @Test
+    void theDeclarationIsWithdrawnWhenTheMethodThrows() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.proceed()).thenThrow(new IllegalStateException("boom"));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> aspect.declareUnscoped(joinPoint, annotation()));
+
+        assertThat(TenantContext.isUnscopedDeclared()).isFalse();
+    }
+
+    @Test
+    void anEnclosingDeclarationIsRestoredRatherThanDiscarded() throws Throwable {
+        TenantContext.declareUnscoped("the caller's own reason");
+
+        aspect.declareUnscoped(joinPointThat(() -> {}), annotation());
+
+        assertThat(TenantContext.getUnscopedReason()).isEqualTo("the caller's own reason");
+    }
+
+    @Test
+    void anOrganizationIdInForceIsLeftUntouched() throws Throwable {
+        // This is what separates the annotation from @BypassTenantFilter. A method carrying it
+        // may also be called from inside a tenant request, and there it must not widen anything.
+        TenantContext.setCurrentOrgId(42L);
+        Long[] seen = new Long[1];
+
+        aspect.declareUnscoped(joinPointThat(() -> seen[0] = TenantContext.getCurrentOrgId()), annotation());
+
+        assertThat(seen[0]).isEqualTo(42L);
+        assertThat(TenantContext.getCurrentOrgId()).isEqualTo(42L);
+    }
+
+    @Test
+    void theScopeDeclaringAspectsRunAheadOfTheFilterAspect() {
+        // HibernateFilterConfig reads the scope on entry. An aspect that declares the scope at
+        // the same order might run after it, and the declaration would arrive too late to be
+        // seen, which is the ordering accident #508 was one aspect over. Lower order is outer.
+        int filterOrder = HibernateFilterConfig.class.getAnnotation(Order.class).value();
+        int bypassOrder = TenantFilterBypassAspect.class.getAnnotation(Order.class).value();
+
+        assertThat(WithoutTenantAspect.ORDER)
+                .as("@WithoutTenant must be applied before HibernateFilterConfig reads the scope")
+                .isLessThan(filterOrder);
+        assertThat(bypassOrder)
+                .as("@BypassTenantFilter must be applied before HibernateFilterConfig reads the scope")
+                .isLessThan(filterOrder);
+    }
+}


### PR DESCRIPTION
Closes #507.

## The problem

Tenant isolation had two mechanisms and both failed open on a null tenant context.

`HibernateFilterConfig` skipped the `orgFilter` and logged at debug, a level no deployed environment turns on. `TenantIsolationLoadListener` returned early on the same condition. They read as defence in depth and were not: they cover different things, query shape against primary-key loads, but gave up on identical input. A null tenant did not narrow isolation, it removed it, and left nothing behind to distinguish that from a correct run.

## The shape of the fix

The absent case now has to say which of two things it is. There are three ways to declare a tenant scope, and declaring one is mandatory for work that reaches tenant-scoped data:

- **an organization id**, set by `TenantFilter` from the request or by `TenantScopedJobRunner` from durable state,
- **a bypass** (`@BypassTenantFilter`), meaning read across organizations on purpose, already audited at WARN where it is set,
- **`@WithoutTenant("reason")`**, new here, meaning this work belongs to no organization.

Anything else is a fourth state, undeclared, and goes to the new `UnscopedAccessGuard`.

`@WithoutTenant` is deliberately weaker than `@BypassTenantFilter`. It suppresses the missing-scope failure and nothing else, so where an organization id is in force the `orgFilter` and the cross-tenant check stay fully on. That is what makes it safe on shared service code a tenant request may also call, and it is pinned by a test in both the unit suite and the IT.

## Why the two boundaries get different defaults

`echno.multitenancy.load-boundary` defaults to **DENY**. It fires when a `TenantScopedEntity` is actually read, which is the leak itself rather than a proxy for it, so the refusal is precise and attributable to the row that caused it.

`echno.multitenancy.transaction-boundary` defaults to **WARN**. It fires on every `@Transactional` method in the package tree, including the many that touch no tenant-scoped entity at all: users, organizations, plans, subscriptions. Denying there would refuse work that was never at risk.

Both take ALLOW, WARN or DENY, so a deployment can tighten ahead of the default or step back during an incident without a code change. Under WARN each event increments `echno.multitenancy.unscoped` (tagged with boundary, call site and policy) and logs the call site, rate limited per call site so an unscoped read inside a loop cannot bury what it is reporting. The counter is never rate limited, so the dashboard number stays a total rather than a sample.

**The transaction boundary should move to DENY on evidence, not on a decision.** The condition is the warning having been silent for a week under real staging traffic. That is the observation step #507 asks for, and it exists because the alternative is trusting the enumeration below, which is the next section's problem.

## Where the soft edge is

**The fail-closed guarantee rests on the completeness of the tenant-less enumeration.** That enumeration is static analysis of controller-to-service chains, including materialization through MapStruct lazy collections, so it is a claim about code paths rather than a measurement of them. If a path was missed, it answers 403 rather than leaking, which is the right direction to fail, but it is a production incident and the lever for it is `ECHNO_TENANT_LOAD_BOUNDARY=WARN`.

The paths found, all of which legitimately reach tenant-scoped data with no tenant:

| Path | What it touches | How it is declared now |
|---|---|---|
| The no-membership state: profile lookup, organization creation, invite-code redemption, the organization picker | `Employee`, `Project`, `Attachment`, `Task`, `ShiftTiming`, `ProjectInviteCode` | `TenantFilter`, when the token carries no `ORG_MEMBER_` authority |
| `GET /user/web` | `Attachment` | `TenantFilter`, pre-tenant path |
| `/billing/**` | keyed on the user, not the organization | `TenantFilter`, pre-tenant path |
| `/auth/register` | pre-tenant by definition | `TenantFilter`, pre-tenant path |
| Startup: `KeycloakInitializer` to `DevFixtureProvisioner.provision` | `Employee`, `ShiftTiming` | `@WithoutTenant`, the only annotation site in the codebase |

The request-side declarations are handled centrally in `TenantFilter` rather than by annotating the ten or so service methods they reach. The exemptions then sit in one place that can be read as a list, and the services stay honest about having no opinion on the matter.

Behaviour of those requests is otherwise unchanged, which the tests pin: no organization id, no membership check, no bypass. Only the declaration is new. `shouldNotFilter` now covers `/actuator` alone, so the three pre-tenant API paths run through `doFilterInternal` to declare themselves instead of being skipped outright; the early branch replicates the old skip exactly, plus the declaration and the `finally` clear.

## Ordering

`WithoutTenantAspect` and `TenantFilterBypassAspect` are now both ordered ahead of `HibernateFilterConfig`, which reads the scope on entry. Neither was ordered at all before, which left to chance the same one-step ordering that #508 turned out to be. A reflection test asserts the relation rather than trusting the annotation to stay put.

## Tests

60 new or changed tests in the multitenancy package, plain JUnit and Mockito except the IT, which reuses the existing `TenantIsolationIT` context and adds no new one.

Every new test was checked by breaking its own fix and confirming it goes red:

| Mutation | Test that caught it |
|---|---|
| Load listener returns early on a null org again | `TenantIsolationIT.findById_withNoTenantScopeDeclaredAtAll_isRefused`, `TenantIsolationLoadListenerTest.deniesALoadThatDeclaresNoScopeAtAll` |
| Transaction boundary logs instead of calling the guard | `HibernateFilterConfigTest.refusesATransactionThatDeclaresNoScopeAtAllWhenTheBoundaryDenies` |
| `/auth/register` stops declaring | `TenantFilterTest.selfRegistrationDeclaresItselfUnscoped` |
| `/user/web` stops declaring | `TenantFilterTest.theCurrentUserLookupDeclaresItselfUnscoped` |
| No-membership branch stops declaring | `TenantFilterTest.anAuthenticatedUserWithNoMembershipDeclaresItselfUnscoped` |
| `TenantScopedJobRunner` keeps an inherited unscoped declaration | `TenantScopedJobRunnerTest.withdrawsAnUnscopedDeclarationForTheWorkAndRestoresIt` |
| Aspect order collides with the filter aspect | `WithoutTenantAspectTest.theScopeDeclaringAspectsRunAheadOfTheFilterAspect` |
| Counter becomes rate limited like the log | `UnscopedAccessGuardTest.theCounterIsNotRateLimitedEvenThoughTheLogIs` |
| `declareUnscoped` stops requiring a reason | `TenantContextTest.anUnscopedDeclarationNeedsAReason` |

Full suite green on the lab build box: 854 tests, 141 classes, 0 failures, 0 errors.

## Scope

No API change, no schema change, no `echno-core` or `echno-web` change.

#508 needed nothing here: it was fixed and closed by #514, which merged into `development` this morning. This branch is built on top of it. The pairing rationale still applied while building, since making #507 fail closed is what would have turned #508 from a silent ordering accident into a loud one.

## Related

- #507, closed here
- #508, the ordering accident, already fixed by #514
- #514, the compliance transaction boundary, which this builds on
- #482, the background-job design where both were found
- #330, the fail-closed load-listener work whose null-context early return was half of this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit support for operations that intentionally run without an organization scope.
  * Added configurable handling for unscoped database access: allow, warn, or deny.
  * Added metrics and warnings for unscoped access, with denial enabled by default for data loads.
  * Improved tenant isolation by rejecting undeclared tenant scope instead of silently proceeding.
* **Bug Fixes**
  * Corrected tenant-scope handling across requests, background jobs, and database loads.
  * Preserved and restored tenant context reliably during nested operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->