### PR TITLE
Make compliance generation fail loudly instead of quietly wrong (#509, #510)

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/exception/ComplianceAiException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/ComplianceAiException.java
@@ -1,0 +1,31 @@
+package org.tornotron.echno_backend.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Raised when the compliance model call did not produce a usable answer: the endpoint
+ * could not be reached, it answered with an error, or it answered with something that is
+ * not a complete set of decisions (a response cut short by the token cap, a JSON array
+ * that does not close, or a reply that leaves some candidate rules unassessed).
+ *
+ * <p>It exists so that "the model produced nothing usable" cannot be confused with "the
+ * model assessed every rule and none of them applied". Both used to arrive as an empty
+ * list, which meant a truncated response was reported to the user as a clean, successful
+ * run that happened to create no compliances.
+ *
+ * <p>Answered as {@code 502 Bad Gateway}: the request was well formed and the caller has
+ * nothing to correct, an upstream service is at fault, and the same request is worth
+ * retrying once it is behaving.
+ */
+@ResponseStatus(HttpStatus.BAD_GATEWAY)
+public class ComplianceAiException extends RuntimeException {
+
+    public ComplianceAiException(String message) {
+        super(message);
+    }
+
+    public ComplianceAiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -130,6 +130,27 @@ public class GlobalExceptionHandler {
         return pd;
     }
 
+    /**
+     * The compliance model produced nothing usable: unreachable, an error from the
+     * endpoint, or an answer cut short by its token limit. Answered as 502 because the
+     * request was well formed and the caller has nothing to correct, and marked retryable
+     * because the same request is worth sending again once the endpoint is behaving.
+     *
+     * <p>The detail is the exception's own message on purpose. It names which of those
+     * happened, and for a truncated answer it carries the token budget and what the model
+     * spent against it, which is what the operator needs to size the limit. Before this
+     * existed the same failures were absorbed into an empty result and reported to the
+     * user as a successful run that produced no compliances.
+     */
+    @ExceptionHandler(ComplianceAiException.class)
+    @ResponseStatus(HttpStatus.BAD_GATEWAY)
+    public ProblemDetail handleComplianceAiFailure(ComplianceAiException ex, WebRequest request) {
+        logger.error("Compliance AI generation failed: {}", ex.getMessage());
+        ProblemDetail pd = problem(HttpStatus.BAD_GATEWAY, "Compliance AI Unavailable", ex.getMessage(), request);
+        pd.setProperty("retryable", true);
+        return pd;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ProblemDetail handleValidationException(MethodArgumentNotValidException exception, WebRequest request) {

--- a/src/main/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetector.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/SerializationFailureDetector.java
@@ -14,19 +14,14 @@ import java.sql.SQLException;
  * the code varies between versions and carries transaction ids and node addresses, so matching
  * on it is brittle in exactly the situation where a false negative costs the user their write.
  *
- * <p>By the time the failure reaches application code Spring has wrapped it, typically as a
- * {@code CannotAcquireLockException} over a Hibernate exception over the driver's
- * {@link SQLException}, so the cause chain has to be walked. {@code SQLException} also keeps its
- * siblings on a second chain of its own ({@link SQLException#getNextException()}), which the
- * PostgreSQL driver uses for batch failures, so that chain is followed too.
+ * <p>Walking the wrapped exception to find that state is {@link SqlStateDetector}'s job, since
+ * the same walk serves any SQLSTATE; see its javadoc for why both the cause chain and
+ * {@link SQLException#getNextException()} have to be followed.
  */
 public final class SerializationFailureDetector {
 
     /** SQLSTATE class 40, code 001: serialization failure. */
-    public static final String SERIALIZATION_FAILURE_SQL_STATE = "40001";
-
-    /** Guards against a cause chain that loops back on itself. */
-    private static final int MAX_CHAIN_DEPTH = 32;
+    public static final String SERIALIZATION_FAILURE_SQL_STATE = SqlStateDetector.SERIALIZATION_FAILURE;
 
     private SerializationFailureDetector() {
     }
@@ -36,26 +31,6 @@ public final class SerializationFailureDetector {
      * caller may safely run again.
      */
     public static boolean isSerializationFailure(Throwable throwable) {
-        Throwable current = throwable;
-        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
-            if (current instanceof SQLException sqlException && carriesSerializationState(sqlException)) {
-                return true;
-            }
-            Throwable cause = current.getCause();
-            current = (cause == current) ? null : cause;
-        }
-        return false;
-    }
-
-    private static boolean carriesSerializationState(SQLException sqlException) {
-        SQLException current = sqlException;
-        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
-            if (SERIALIZATION_FAILURE_SQL_STATE.equals(current.getSQLState())) {
-                return true;
-            }
-            SQLException next = current.getNextException();
-            current = (next == current) ? null : next;
-        }
-        return false;
+        return SqlStateDetector.carriesSqlState(throwable, SERIALIZATION_FAILURE_SQL_STATE);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/retry/SqlStateDetector.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/SqlStateDetector.java
@@ -1,0 +1,61 @@
+package org.tornotron.echno_backend.common.retry;
+
+import java.sql.SQLException;
+
+/**
+ * Finds a given SQLSTATE anywhere in the exception a database failure arrived as.
+ *
+ * <p>By the time a driver error reaches application code Spring has wrapped it, typically
+ * as a {@code DataAccessException} over a Hibernate exception over the driver's
+ * {@link SQLException}, so the cause chain has to be walked. {@code SQLException} also
+ * keeps its siblings on a second chain of its own
+ * ({@link SQLException#getNextException()}), which the PostgreSQL driver uses for batch
+ * failures, so that chain is followed too.
+ *
+ * <p>The test is always the SQLSTATE, never the message text: the wording the server puts
+ * around a code varies between versions and carries transaction ids and node addresses,
+ * so matching on it is brittle in exactly the situation where a false negative costs the
+ * user their write.
+ */
+public final class SqlStateDetector {
+
+    /** SQLSTATE class 40, code 001: serialization failure, the loser of a conflict. */
+    public static final String SERIALIZATION_FAILURE = "40001";
+
+    /** SQLSTATE class 23, code 505: a write violated a unique constraint or index. */
+    public static final String UNIQUE_VIOLATION = "23505";
+
+    /** Guards against a cause chain that loops back on itself. */
+    private static final int MAX_CHAIN_DEPTH = 32;
+
+    private SqlStateDetector() {
+    }
+
+    /**
+     * Returns true when {@code throwable}, or anything it wraps, is a {@link SQLException}
+     * reporting {@code sqlState}.
+     */
+    public static boolean carriesSqlState(Throwable throwable, String sqlState) {
+        Throwable current = throwable;
+        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
+            if (current instanceof SQLException sqlException && matches(sqlException, sqlState)) {
+                return true;
+            }
+            Throwable cause = current.getCause();
+            current = (cause == current) ? null : cause;
+        }
+        return false;
+    }
+
+    private static boolean matches(SQLException sqlException, String sqlState) {
+        SQLException current = sqlException;
+        for (int depth = 0; current != null && depth < MAX_CHAIN_DEPTH; depth++) {
+            if (sqlState.equals(current.getSQLState())) {
+                return true;
+            }
+            SQLException next = current.getNextException();
+            current = (next == current) ? null : next;
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
+++ b/src/main/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplate.java
@@ -10,11 +10,14 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.tornotron.echno_backend.common.exception.TransactionRetriesExhaustedException;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
  * Runs a unit of work in a transaction and starts it over when the database aborts it with a
- * serialization failure (SQLSTATE {@code 40001}).
+ * serialization failure (SQLSTATE {@code 40001}), or with any other conflict the call site
+ * nominates as one a fresh attempt resolves (see
+ * {@link #execute(String, java.util.function.Predicate, Supplier)}).
  *
  * <p>Under {@code SERIALIZABLE} an abort is the database telling the client that its snapshot
  * no longer holds and the whole transaction has to run again. Retrying a statement inside the
@@ -124,6 +127,27 @@ public class TransactionRetryTemplate {
      * @throws TransactionRetriesExhaustedException when every attempt was aborted
      */
     public <T> T execute(String operation, Supplier<T> work) {
+        return execute(operation, failure -> false, work);
+    }
+
+    /**
+     * As {@link #execute(String, Supplier)}, but also restarts the transaction when
+     * {@code alsoRestartOn} recognises the failure.
+     *
+     * <p>A serialization abort is not the only failure a fresh attempt resolves. Work made
+     * idempotent by a check-then-write against a unique constraint loses the race the same
+     * way: the check passes, a concurrent transaction commits the row, and this one's
+     * insert is rejected by the constraint (SQLSTATE {@code 23505},
+     * {@link SqlStateDetector#UNIQUE_VIOLATION}). The second attempt's check now sees the
+     * committed row and skips it, which is the outcome the caller wanted, so the request
+     * succeeds instead of answering 500 for a duplicate the user never asked to create.
+     *
+     * <p>The predicate is per call site rather than built in because a duplicate key is
+     * usually a permanent error: retrying one that a fresh read cannot resolve only delays
+     * the failure and reports it as a conflict instead of as itself. Pass a predicate only
+     * for work whose first act is to re-read the state the conflict changed.
+     */
+    public <T> T execute(String operation, Predicate<Throwable> alsoRestartOn, Supplier<T> work) {
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             // A caller already owns the transaction, so there is no boundary here to restart:
             // an abort dooms their transaction, not one of ours. Run the work once and let the
@@ -136,16 +160,17 @@ public class TransactionRetryTemplate {
             try {
                 return runner.runInTransaction(work);
             } catch (RuntimeException failure) {
-                if (!SerializationFailureDetector.isSerializationFailure(failure)) {
+                if (!SerializationFailureDetector.isSerializationFailure(failure)
+                        && !alsoRestartOn.test(failure)) {
                     throw failure;
                 }
                 lastFailure = failure;
                 if (attempt == maxAttempts) {
                     break;
                 }
-                counter(ATTEMPTS_METRIC, "Transactions restarted after a database serialization failure",
+                counter(ATTEMPTS_METRIC, "Transactions restarted after a retryable database conflict",
                         operation).increment();
-                logger.info("Serialization failure on {}, restarting the transaction (attempt {} of {})",
+                logger.info("Retryable database conflict on {}, restarting the transaction (attempt {} of {})",
                         operation, attempt + 1, maxAttempts);
                 if (!backOff(attempt)) {
                     throw failure;
@@ -153,9 +178,9 @@ public class TransactionRetryTemplate {
             }
         }
 
-        counter(EXHAUSTED_METRIC, "Units of work abandoned after using up their serialization retries",
+        counter(EXHAUSTED_METRIC, "Units of work abandoned after using up their conflict retries",
                 operation).increment();
-        logger.warn("Gave up on {} after {} serialization failures", operation, maxAttempts, lastFailure);
+        logger.warn("Gave up on {} after {} database conflicts", operation, maxAttempts, lastFailure);
         throw new TransactionRetriesExhaustedException(
                 "The operation kept colliding with a concurrent change and was abandoned after "
                         + maxAttempts + " attempts", lastFailure);

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -7,7 +7,8 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
-import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
@@ -44,6 +45,33 @@ import java.util.stream.Collectors;
  * only adds compliances that are missing. The document number series is shared with
  * manual inspections ({@code INSP}).
  *
+ * <h2>How that idempotence survives two runs at once</h2>
+ *
+ * <p>The skip is an ordinary read, and a read cannot be the guarantee: two overlapping
+ * runs both see "no such row" and both insert. They do not conflict in the database's
+ * eyes either, because each inserts a different row (its own id, its own inspection
+ * number), so {@code SERIALIZABLE} has nothing to abort. Two clicks on regenerate, or a
+ * regenerate started while approval's automatic run is still going, produced two
+ * compliance inspections for the same rule.
+ *
+ * <p>The guarantee is therefore in the schema: a unique index on
+ * {@code (organization_id, project_id, compliance_rule_ref)} over the rows that carry a
+ * rule reference (changelog {@code 060}). The loser of the race has its insert rejected
+ * rather than duplicated.
+ *
+ * <p>The rejection cannot be caught per rule and skipped. Calling {@code save} does not
+ * send the insert; Hibernate holds it until it next has to flush, which is the following
+ * rule's existence query or the commit, so by the time the constraint speaks the loop has
+ * moved on from the rule it is about. And wherever the failure lands, a failed statement
+ * leaves the transaction unusable, so there is nothing left to continue into either. The
+ * write phase is instead run through
+ * {@link TransactionRetryTemplate} with the unique violation nominated as retryable: the
+ * whole phase restarts, and on the restart the existence check reads the row the other
+ * run has now committed and skips it, which was the intended outcome all along. The
+ * request answers 200 with whatever this run genuinely created, and the user never learns
+ * there was a race. Only a run that keeps losing until its attempts are gone surfaces a
+ * 409, which is the honest answer at that point.
+ *
  * <h2>Why this class owns no transaction of its own</h2>
  *
  * <p>The model call takes 34 to 47 seconds today and grows with the size of the curated
@@ -53,8 +81,9 @@ import java.util.stream.Collectors;
  * three phases: read the inputs in one transaction, call the model with no transaction
  * and no connection held, then persist in a second transaction.
  *
- * <p>Both transactions are opened by calling {@link TransactionalWorkRunner}, and that
- * choice is load bearing rather than stylistic. {@code HibernateFilterConfig} advises
+ * <p>Both transactions are opened by calling {@link TransactionRetryTemplate}, which opens
+ * them through {@code TransactionalWorkRunner}, and that choice is load bearing rather
+ * than stylistic. {@code HibernateFilterConfig} advises
  * {@code @Transactional} methods in this package tree to enable the {@code orgFilter}
  * tenant filter on the session. A programmatic {@code TransactionTemplate} carries no
  * such annotation, so splitting the boundary that way would have run both phases with
@@ -79,7 +108,7 @@ public class ComplianceGenerationService {
     private final EntryNumberGenerator numberGen;
     private final TenantEntityHelper tenantEntityHelper;
     private final InspectionMapper inspectionMapper;
-    private final TransactionalWorkRunner workRunner;
+    private final TransactionRetryTemplate retryTemplate;
 
     /**
      * What the read phase hands to the phases after it. The entities are detached once the
@@ -111,24 +140,36 @@ public class ComplianceGenerationService {
      * @param orgId     the owning organization; must match the current tenant context
      */
     public List<InspectionDto> generateForProject(Long projectId, Long orgId) {
-        GenerationInputs inputs = workRunner.runInTransaction(() -> loadInputs(projectId, orgId));
+        GenerationInputs inputs = retryTemplate.execute(
+                "ComplianceGenerationService.loadInputs", () -> loadInputs(projectId, orgId));
 
         // Outside any transaction: this is the 34 to 47 second call, and it must not be
         // holding a pool connection while it waits.
         List<ComplianceSuggestion> suggestions = complianceAiService.suggestCompliances(
                 inputs.project(), inputs.state(), inputs.candidateRules());
 
+        // An empty list now means only "there was nothing to ask": the AI service raises a
+        // ComplianceAiException for a call that failed or answered with something unusable,
+        // rather than returning empty and letting a truncated response read as a clean run
+        // in which nothing applied. A model that assessed every rule and found none
+        // applicable still returns one element per rule.
         if (suggestions.isEmpty()) {
             if (!complianceAiService.isConfigured()) {
                 throw new InvalidRequestException(
                         "The compliance AI service is not configured, so suggestions cannot be "
                                 + "generated. Set the compliance AI key and try again.");
             }
-            log.info("Compliance AI returned no suggestions for project {}", projectId);
+            log.info("Compliance AI had nothing to assess for project {}", projectId);
             return List.of();
         }
 
-        return workRunner.runInTransaction(() -> persist(projectId, orgId, inputs, suggestions));
+        // Restarted on a unique violation as well as on a serialization abort: losing the
+        // race to another run is exactly the case the retry resolves, because the second
+        // attempt's existence check sees the row the winner committed.
+        return retryTemplate.execute(
+                "ComplianceGenerationService.persist",
+                failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
+                () -> persist(projectId, orgId, inputs, suggestions));
     }
 
     /**
@@ -181,6 +222,13 @@ public class ComplianceGenerationService {
      * inspection. The document-number sequence is locked here, inside the second
      * transaction, so it is held for the length of a few inserts rather than the length of
      * the model call.
+     *
+     * <p>Written to be safe to run from the start again, because the caller restarts it on
+     * a conflict: it holds no state across attempts, re-reads what already exists, and
+     * returns a list built fresh each time. Nothing outside the database has changed by the
+     * time a conflict can surface, which is the condition the retry template asks for. A restart re-draws document numbers, so an
+     * abandoned attempt leaves a gap in the {@code INSP} series; the series is a
+     * human-readable identifier and not a count, so a gap costs nothing.
      */
     private List<InspectionDto> persist(Long projectId,
                                         Long orgId,
@@ -205,6 +253,9 @@ public class ComplianceGenerationService {
         for (ComplianceSuggestion suggestion : ordered) {
             ComplianceRule rule = rulesByCode.get(suggestion.ruleCode());
 
+            // The fast path, and the one that makes a restarted attempt converge. It is not
+            // the guarantee: the unique index from changelog 060 is, and it is what a run
+            // that raced past this check collides with. See the class javadoc.
             if (inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
                     projectId, rule.getCode(), orgId)) {
                 log.debug("Compliance {} already exists for project {}; skipping", rule.getCode(), projectId);

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReader.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReader.java
@@ -2,12 +2,15 @@ package org.tornotron.echno_backend.compliance.ai;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.tornotron.echno_backend.common.exception.ComplianceAiException;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -47,12 +50,13 @@ import java.util.Set;
  * so the per-rule token cost can be read off a real failure rather than measured
  * separately.
  */
+@Slf4j
 final class ComplianceResponseReader {
 
     /** Stop reasons that mean the model was cut off at the token cap, lower-cased. */
     private static final Set<String> TRUNCATED_STOP_REASONS = Set.of("length", "max_tokens");
 
-    /** How many missing rule codes to name in a coverage failure before trailing off. */
+    /** How many rule codes to name in a coverage failure before trailing off. */
     private static final int MAX_MISSING_CODES_REPORTED = 5;
 
     /** Longest excerpt of the model's own words to put in an error message. */
@@ -81,7 +85,8 @@ final class ComplianceResponseReader {
     List<ComplianceSuggestion> read(String responseJson, List<ComplianceRule> candidateRules) {
         Envelope envelope = parseEnvelope(responseJson);
         rejectTruncatedStopReason(envelope, candidateRules.size());
-        List<ComplianceSuggestion> suggestions = parseSuggestions(envelope);
+        List<ComplianceSuggestion> suggestions =
+                canonicaliseRuleCodes(parseSuggestions(envelope), candidateRules);
         rejectIncompleteCoverage(suggestions, candidateRules, envelope);
         return suggestions;
     }
@@ -97,9 +102,10 @@ final class ComplianceResponseReader {
         try {
             root = objectMapper.readTree(responseJson);
         } catch (Exception e) {
+            log.warn("Compliance AI response body was not JSON: {}", e.getMessage());
             throw new ComplianceAiException(
                     "The compliance AI service returned a response that is not JSON, so no "
-                            + "compliances were generated. (" + e.getMessage() + ")", e);
+                            + "compliances were generated.", e);
         }
 
         JsonNode choice = root.path("choices").path(0);
@@ -142,6 +148,15 @@ final class ComplianceResponseReader {
      * array in prose or a code fence. The tolerance now stops at the array's own closing
      * bracket instead of the last bracket anywhere in the text, and a parse failure is
      * reported rather than absorbed.
+     *
+     * <p>Every {@code [} in the text is tried in turn, not just the first, because the prose
+     * a model wraps its answer in can contain one of its own ("based on the rules [1] above")
+     * and anchoring on that would slice out the citation and refuse a perfectly complete
+     * answer. The first candidate whose matched slice actually parses is the answer.
+     *
+     * <p>A candidate with no matching bracket ends the search rather than being skipped: the
+     * text ran out inside that array, so anything after it is nested within it and cannot be
+     * the answer either. That is the truncation, and it is reported as such.
      */
     private List<ComplianceSuggestion> parseSuggestions(Envelope envelope) {
         String responseText = envelope.text();
@@ -151,54 +166,126 @@ final class ComplianceResponseReader {
                             + tokenBudgetHint(envelope));
         }
 
-        int start = responseText.indexOf('[');
-        if (start < 0) {
+        Exception lastParseFailure = null;
+        for (int start = responseText.indexOf('['); start >= 0; start = responseText.indexOf('[', start + 1)) {
+            int end = findMatchingArrayEnd(responseText, start);
+            if (end < 0) {
+                throw new ComplianceAiException(
+                        "The compliance AI response opened a JSON array that never closes, so it was "
+                                + "cut off before it finished and no compliances were generated. "
+                                + tokenBudgetHint(envelope));
+            }
+            try {
+                ComplianceSuggestion[] parsed = objectMapper.readValue(
+                        responseText.substring(start, end + 1), ComplianceSuggestion[].class);
+                return List.of(parsed);
+            } catch (Exception e) {
+                lastParseFailure = e;
+            }
+        }
+
+        if (lastParseFailure == null) {
             throw new ComplianceAiException(
                     "The compliance AI response contained no JSON array of assessments, so no "
                             + "compliances were generated. The model answered: " + excerpt(responseText));
         }
-
-        int end = findMatchingArrayEnd(responseText, start);
-        if (end < 0) {
-            throw new ComplianceAiException(
-                    "The compliance AI response opened a JSON array that never closes, so it was cut "
-                            + "off before it finished and no compliances were generated. "
-                            + tokenBudgetHint(envelope));
-        }
-
-        String json = responseText.substring(start, end + 1);
-        try {
-            ComplianceSuggestion[] parsed = objectMapper.readValue(json, ComplianceSuggestion[].class);
-            return List.of(parsed);
-        } catch (Exception e) {
-            throw new ComplianceAiException(
-                    "The compliance AI response was not a readable array of assessments, so no "
-                            + "compliances were generated. " + tokenBudgetHint(envelope)
-                            + " (" + e.getMessage() + ")", e);
-        }
+        // The parser's own message quotes the fragment it choked on, which belongs in the log
+        // rather than in an API response body.
+        log.warn("Compliance AI response held no readable array of assessments: {}",
+                lastParseFailure.getMessage());
+        throw new ComplianceAiException(
+                "The compliance AI response was not a readable array of assessments, so no "
+                        + "compliances were generated. " + tokenBudgetHint(envelope), lastParseFailure);
     }
 
     /**
-     * Refuses a response that left some candidate rule unassessed. This catches the
-     * truncation the other two checks cannot see: an answer that happens to stop on a
-     * valid closing bracket, from a provider that reports no stop reason. Codes the model
-     * invented are ignored (the generation service already drops them); only unassessed
-     * candidates are a failure.
+     * Puts a rule code the model echoed back in a different case, or with whitespace around
+     * it, onto the candidate's exact spelling.
+     *
+     * <p>Both checks downstream match codes by exact string equality: coverage here, and the
+     * generation service's own {@code rulesByCode} lookup when it decides what to create. A
+     * code of " tn-bpa " would therefore fail coverage as an unassessed rule, and if coverage
+     * were relaxed instead it would sail through and then be dropped without a word when the
+     * inspection was built. Normalising once, at the edge, keeps both from happening.
+     *
+     * <p>Only spelling is normalised. A code that matches no candidate at all is left as it
+     * is, so an invented compliance stays visibly invented.
+     */
+    private List<ComplianceSuggestion> canonicaliseRuleCodes(List<ComplianceSuggestion> suggestions,
+                                                             List<ComplianceRule> candidateRules) {
+        Map<String, String> canonicalByNormalised = new LinkedHashMap<>();
+        for (ComplianceRule rule : candidateRules) {
+            String code = rule.getCode();
+            if (code != null) {
+                canonicalByNormalised.putIfAbsent(normalise(code), code);
+            }
+        }
+
+        List<ComplianceSuggestion> canonicalised = new ArrayList<>(suggestions.size());
+        for (ComplianceSuggestion suggestion : suggestions) {
+            String canonical = suggestion.ruleCode() == null
+                    ? null
+                    : canonicalByNormalised.get(normalise(suggestion.ruleCode()));
+            if (canonical == null || canonical.equals(suggestion.ruleCode())) {
+                canonicalised.add(suggestion);
+                continue;
+            }
+            log.debug("Compliance AI returned rule code '{}' for candidate '{}'; using the candidate's",
+                    suggestion.ruleCode(), canonical);
+            canonicalised.add(new ComplianceSuggestion(canonical, suggestion.applies(),
+                    suggestion.riskLevel(), suggestion.resolutionOptions(), suggestion.rationale(),
+                    suggestion.phase()));
+        }
+        return List.copyOf(canonicalised);
+    }
+
+    private static String normalise(String code) {
+        return code.strip().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Refuses a response that did not assess each candidate rule exactly once.
+     *
+     * <p>Missing candidates catch the truncation the other two checks cannot see: an answer
+     * that happens to stop on a valid closing bracket, from a provider that reports no stop
+     * reason. Codes the model invented are ignored, since the generation service already
+     * drops them; only unassessed candidates are a failure.
+     *
+     * <p>Repeated candidates are refused too, and for a different reason. Counting distinct
+     * codes would let a response that says {@code TN-1} does not apply and then that
+     * {@code TN-1} does apply satisfy coverage, and the generation service, which stops at
+     * the first element it can use, would create an inspection off one half of a
+     * contradiction without anyone seeing the other half. An answer that cannot make up its
+     * mind is not a result to act on.
      */
     private void rejectIncompleteCoverage(List<ComplianceSuggestion> suggestions,
                                           List<ComplianceRule> candidateRules,
                                           Envelope envelope) {
-        Set<String> assessed = new LinkedHashSet<>();
+        Map<String, Integer> assessmentsByCode = new LinkedHashMap<>();
         for (ComplianceSuggestion suggestion : suggestions) {
             if (suggestion.ruleCode() != null) {
-                assessed.add(suggestion.ruleCode());
+                assessmentsByCode.merge(suggestion.ruleCode(), 1, Integer::sum);
             }
         }
 
-        List<String> missing = candidateRules.stream()
-                .map(ComplianceRule::getCode)
-                .filter(code -> !assessed.contains(code))
-                .toList();
+        List<String> missing = new ArrayList<>();
+        List<String> repeated = new ArrayList<>();
+        for (ComplianceRule rule : candidateRules) {
+            int count = assessmentsByCode.getOrDefault(rule.getCode(), 0);
+            if (count == 0) {
+                missing.add(rule.getCode());
+            } else if (count > 1) {
+                repeated.add(rule.getCode());
+            }
+        }
+
+        if (!repeated.isEmpty()) {
+            throw new ComplianceAiException(
+                    "The compliance AI returned more than one assessment for " + repeated.size()
+                            + " rule(s) (" + nameSome(repeated) + "), so its answer contradicts itself "
+                            + "and no compliances were generated.");
+        }
+
         if (missing.isEmpty()) {
             return;
         }
@@ -206,15 +293,16 @@ final class ComplianceResponseReader {
         int covered = candidateRules.size() - missing.size();
         throw new ComplianceAiException(
                 "The compliance AI assessed only " + covered + " of " + candidateRules.size()
-                        + " rules, leaving " + missing.size() + " unassessed (" + nameMissing(missing)
+                        + " rules, leaving " + missing.size() + " unassessed (" + nameSome(missing)
                         + "), so the result is incomplete and no compliances were generated. "
                         + tokenBudgetHint(envelope));
     }
 
-    private static String nameMissing(List<String> missing) {
-        String named = String.join(", ", missing.subList(0, Math.min(missing.size(), MAX_MISSING_CODES_REPORTED)));
-        if (missing.size() > MAX_MISSING_CODES_REPORTED) {
-            named = named + ", and " + (missing.size() - MAX_MISSING_CODES_REPORTED) + " more";
+    /** Names the first few codes and counts the rest, so a big catalogue does not fill the message. */
+    private static String nameSome(List<String> codes) {
+        String named = String.join(", ", codes.subList(0, Math.min(codes.size(), MAX_MISSING_CODES_REPORTED)));
+        if (codes.size() > MAX_MISSING_CODES_REPORTED) {
+            named = named + ", and " + (codes.size() - MAX_MISSING_CODES_REPORTED) + " more";
         }
         return named;
     }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReader.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReader.java
@@ -1,0 +1,281 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Turns one chat-completions response body into the list of compliance decisions it was
+ * asked for, or refuses it.
+ *
+ * <h2>Why this is its own class</h2>
+ *
+ * <p>Everything here is a pure function of the response text and the rules that were sent,
+ * so it can be tested against canned provider responses with no network, no key and no
+ * Spring context. The behaviour being tested (recognising an answer the token cap cut
+ * short) is exactly the behaviour that is otherwise only observable by making a real call
+ * with a large enough rule catalogue.
+ *
+ * <h2>The three truncation checks</h2>
+ *
+ * <p>None of them needs to know what the token ceiling actually is, which matters because
+ * that number has not been measured and measuring it needs a key that is not configured
+ * yet. They read the failure out of the response instead:
+ *
+ * <ol>
+ *   <li><b>The stop reason.</b> {@code choices[0].finish_reason} of {@code length} (or
+ *       {@code max_tokens}) is the provider stating that it stopped at the cap rather
+ *       than at the end of its answer. This signal was previously not read at all.</li>
+ *   <li><b>The shape of the JSON.</b> An array that opens and never closes, or one that
+ *       closes but does not parse. Finding the <em>matching</em> bracket rather than the
+ *       last bracket in the text is what makes this visible: in a response cut off
+ *       mid-element the last {@code ]} closes some element's inner
+ *       {@code resolutionOptions} array, so a slice ending there is a fragment that looks
+ *       plausible and is not.</li>
+ *   <li><b>Coverage.</b> The prompt asks for one element per candidate rule, so a rule
+ *       that comes back unassessed means the answer stopped early even when it happened
+ *       to stop on a valid bracket and the provider reported no stop reason.</li>
+ * </ol>
+ *
+ * <p>Each refusal quotes the configured cap and the reported {@code completion_tokens},
+ * so the per-rule token cost can be read off a real failure rather than measured
+ * separately.
+ */
+final class ComplianceResponseReader {
+
+    /** Stop reasons that mean the model was cut off at the token cap, lower-cased. */
+    private static final Set<String> TRUNCATED_STOP_REASONS = Set.of("length", "max_tokens");
+
+    /** How many missing rule codes to name in a coverage failure before trailing off. */
+    private static final int MAX_MISSING_CODES_REPORTED = 5;
+
+    /** Longest excerpt of the model's own words to put in an error message. */
+    private static final int MAX_EXCERPT_LENGTH = 200;
+
+    private final ObjectMapper objectMapper;
+    private final int maxTokens;
+
+    ComplianceResponseReader(ObjectMapper objectMapper, int maxTokens) {
+        this.objectMapper = objectMapper;
+        this.maxTokens = maxTokens;
+    }
+
+    /** What one chat completion said, beyond the assistant text itself. */
+    private record Envelope(String text, String finishReason, Integer completionTokens) {}
+
+    /**
+     * Reads the decisions out of a chat-completions response body.
+     *
+     * @param responseJson  the raw response body from the endpoint
+     * @param candidateRules the rules the prompt asked about, used to check coverage
+     * @return one suggestion per candidate rule
+     * @throws ComplianceAiException when the answer was cut short, unparseable, or did
+     *                               not cover every candidate rule
+     */
+    List<ComplianceSuggestion> read(String responseJson, List<ComplianceRule> candidateRules) {
+        Envelope envelope = parseEnvelope(responseJson);
+        rejectTruncatedStopReason(envelope, candidateRules.size());
+        List<ComplianceSuggestion> suggestions = parseSuggestions(envelope);
+        rejectIncompleteCoverage(suggestions, candidateRules, envelope);
+        return suggestions;
+    }
+
+    private Envelope parseEnvelope(String responseJson) {
+        if (responseJson == null || responseJson.isBlank()) {
+            throw new ComplianceAiException(
+                    "The compliance AI service returned an empty response body, so no compliances "
+                            + "were generated.");
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(responseJson);
+        } catch (Exception e) {
+            throw new ComplianceAiException(
+                    "The compliance AI service returned a response that is not JSON, so no "
+                            + "compliances were generated. (" + e.getMessage() + ")", e);
+        }
+
+        JsonNode choice = root.path("choices").path(0);
+        JsonNode content = choice.path("message").path("content");
+
+        // Providers are not consistent about the field name: OpenAI and the DigitalOcean
+        // Gradient endpoint report finish_reason, some gateways relay stop_reason instead.
+        JsonNode finishReason = choice.path("finish_reason");
+        if (!finishReason.isTextual()) {
+            finishReason = choice.path("stop_reason");
+        }
+
+        JsonNode completionTokens = root.path("usage").path("completion_tokens");
+
+        return new Envelope(
+                content.isTextual() ? content.asText() : "",
+                finishReason.isTextual() ? finishReason.asText() : null,
+                completionTokens.isInt() ? completionTokens.asInt() : null);
+    }
+
+    /**
+     * Refuses a response the provider itself says it truncated. This is the signal that
+     * used to be dropped: the old reader took {@code choices[0].message.content} and never
+     * looked at why generation ended, so a cap-truncated answer was indistinguishable from
+     * a complete one until Jackson choked on it and the throw was swallowed.
+     */
+    private void rejectTruncatedStopReason(Envelope envelope, int ruleCount) {
+        String reason = envelope.finishReason();
+        if (reason == null || !TRUNCATED_STOP_REASONS.contains(reason.toLowerCase(Locale.ROOT))) {
+            return;
+        }
+        throw new ComplianceAiException(
+                "The compliance AI response was cut short by its token limit (stop reason '" + reason
+                        + "'), so the assessment of " + ruleCount + " rule(s) is incomplete and no "
+                        + "compliances were generated. " + tokenBudgetHint(envelope));
+    }
+
+    /**
+     * Parses the assistant text into suggestions, still tolerating the model wrapping its
+     * array in prose or a code fence. The tolerance now stops at the array's own closing
+     * bracket instead of the last bracket anywhere in the text, and a parse failure is
+     * reported rather than absorbed.
+     */
+    private List<ComplianceSuggestion> parseSuggestions(Envelope envelope) {
+        String responseText = envelope.text();
+        if (responseText == null || responseText.isBlank()) {
+            throw new ComplianceAiException(
+                    "The compliance AI returned no text at all, so no compliances were generated. "
+                            + tokenBudgetHint(envelope));
+        }
+
+        int start = responseText.indexOf('[');
+        if (start < 0) {
+            throw new ComplianceAiException(
+                    "The compliance AI response contained no JSON array of assessments, so no "
+                            + "compliances were generated. The model answered: " + excerpt(responseText));
+        }
+
+        int end = findMatchingArrayEnd(responseText, start);
+        if (end < 0) {
+            throw new ComplianceAiException(
+                    "The compliance AI response opened a JSON array that never closes, so it was cut "
+                            + "off before it finished and no compliances were generated. "
+                            + tokenBudgetHint(envelope));
+        }
+
+        String json = responseText.substring(start, end + 1);
+        try {
+            ComplianceSuggestion[] parsed = objectMapper.readValue(json, ComplianceSuggestion[].class);
+            return List.of(parsed);
+        } catch (Exception e) {
+            throw new ComplianceAiException(
+                    "The compliance AI response was not a readable array of assessments, so no "
+                            + "compliances were generated. " + tokenBudgetHint(envelope)
+                            + " (" + e.getMessage() + ")", e);
+        }
+    }
+
+    /**
+     * Refuses a response that left some candidate rule unassessed. This catches the
+     * truncation the other two checks cannot see: an answer that happens to stop on a
+     * valid closing bracket, from a provider that reports no stop reason. Codes the model
+     * invented are ignored (the generation service already drops them); only unassessed
+     * candidates are a failure.
+     */
+    private void rejectIncompleteCoverage(List<ComplianceSuggestion> suggestions,
+                                          List<ComplianceRule> candidateRules,
+                                          Envelope envelope) {
+        Set<String> assessed = new LinkedHashSet<>();
+        for (ComplianceSuggestion suggestion : suggestions) {
+            if (suggestion.ruleCode() != null) {
+                assessed.add(suggestion.ruleCode());
+            }
+        }
+
+        List<String> missing = candidateRules.stream()
+                .map(ComplianceRule::getCode)
+                .filter(code -> !assessed.contains(code))
+                .toList();
+        if (missing.isEmpty()) {
+            return;
+        }
+
+        int covered = candidateRules.size() - missing.size();
+        throw new ComplianceAiException(
+                "The compliance AI assessed only " + covered + " of " + candidateRules.size()
+                        + " rules, leaving " + missing.size() + " unassessed (" + nameMissing(missing)
+                        + "), so the result is incomplete and no compliances were generated. "
+                        + tokenBudgetHint(envelope));
+    }
+
+    private static String nameMissing(List<String> missing) {
+        String named = String.join(", ", missing.subList(0, Math.min(missing.size(), MAX_MISSING_CODES_REPORTED)));
+        if (missing.size() > MAX_MISSING_CODES_REPORTED) {
+            named = named + ", and " + (missing.size() - MAX_MISSING_CODES_REPORTED) + " more";
+        }
+        return named;
+    }
+
+    /**
+     * Index of the {@code ]} that closes the array opened at {@code start}, or -1 when the
+     * text ends before it. Brackets inside string literals are skipped, so a rationale
+     * mentioning "section 3[b]" cannot close the array early, and a {@code \"} escape does
+     * not end the string it sits in.
+     */
+    private static int findMatchingArrayEnd(String text, int start) {
+        boolean inString = false;
+        boolean escaped = false;
+        int depth = 0;
+        for (int i = start; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (c == '"') {
+                inString = true;
+            } else if (c == '[') {
+                depth++;
+            } else if (c == ']') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Names the budget and what was spent against it. This is what turns a failure into
+     * the per-rule token figure, so the ceiling can be sized from a run that actually hit
+     * it rather than from a separate measurement.
+     */
+    private String tokenBudgetHint(Envelope envelope) {
+        StringBuilder sb = new StringBuilder("The limit (compliance.ai.max-tokens) is ")
+                .append(maxTokens)
+                .append(" tokens");
+        if (envelope.completionTokens() != null) {
+            sb.append(" and the model reported using ").append(envelope.completionTokens());
+        }
+        sb.append('.');
+        return sb.toString();
+    }
+
+    /** Keeps the model's own prose out of the log and the error body at full length. */
+    private static String excerpt(String text) {
+        String collapsed = text.strip().replace('\n', ' ');
+        return collapsed.length() <= MAX_EXCERPT_LENGTH
+                ? collapsed
+                : collapsed.substring(0, MAX_EXCERPT_LENGTH) + "...";
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -1,15 +1,14 @@
 package org.tornotron.echno_backend.compliance.ai;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.project.Project;
 
@@ -25,18 +24,37 @@ import java.util.List;
  * default, or OpenAI, or a self-hosted OSS-model gateway), selected purely through
  * {@code compliance.ai.*} config.
  *
- * <p>The service is deliberately fail-soft: it never throws into the approval flow.
- * If the AI is disabled, has no API key, or the call/parse fails, it logs and
- * returns an empty list, and the caller generates nothing for that project (a
- * manual regenerate can be retried once the key is set).
+ * <h2>What an empty result means, and what it no longer means</h2>
+ *
+ * <p>The service stays fail-soft about being switched off: with the AI disabled, with no
+ * API key, or with no candidate rules it returns an empty list and the caller generates
+ * nothing. Those are configuration states rather than failures, and they must not break
+ * project approval.
+ *
+ * <p>Every other outcome now raises {@link ComplianceAiException}. An empty list used to
+ * stand for the call failing, the response being cut short by the token cap and the JSON
+ * failing to parse as well, so the worst outcome available (the rule catalogue outgrows
+ * the token budget, and from then on every run produces nothing) reached the user as a
+ * successful run in which no compliances happened to apply. A model that assessed every
+ * rule and found none applicable answers with one element per rule carrying
+ * {@code applies: false}, never with an empty array, so nothing legitimate is lost by
+ * treating an empty or short answer as a failure.
+ *
+ * <p>{@link ComplianceResponseReader} holds the checks that decide this, and its javadoc
+ * explains how a truncated answer is recognised from the response alone.
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class OpenAiCompatibleComplianceService {
 
     private final ComplianceAiProperties props;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ComplianceResponseReader responseReader;
+
+    public OpenAiCompatibleComplianceService(ComplianceAiProperties props) {
+        this.props = props;
+        this.responseReader = new ComplianceResponseReader(objectMapper, props.getMaxTokens());
+    }
 
     /**
      * Whether the AI service is switched on and has an API key, decided purely from
@@ -48,9 +66,14 @@ public class OpenAiCompatibleComplianceService {
     }
 
     /**
-     * Asks the model which of the candidate rules apply to the project. Returns one
-     * suggestion per rule the model reasoned about; an empty list means "generate
-     * nothing" (either the AI is off/unconfigured or the call failed).
+     * Asks the model which of the candidate rules apply to the project, returning one
+     * suggestion per candidate rule.
+     *
+     * <p>Returns an empty list only when there was nothing to ask: the AI is disabled or
+     * unconfigured, or there are no candidate rules.
+     *
+     * @throws ComplianceAiException when the call failed, or the answer was cut short,
+     *                               unparseable, or did not cover every candidate rule
      */
     public List<ComplianceSuggestion> suggestCompliances(Project project,
                                                          String state,
@@ -64,6 +87,17 @@ public class OpenAiCompatibleComplianceService {
             return List.of();
         }
 
+        String responseJson = callModel(project, state, candidateRules);
+        return responseReader.read(responseJson, candidateRules);
+    }
+
+    /**
+     * Issues the chat completion and returns the raw response body. Every way the call
+     * itself can fail (a connect or read timeout, a proxy refusing, a 4xx or 5xx from the
+     * endpoint) arrives here and leaves as a {@link ComplianceAiException}, so the caller
+     * is told the run failed instead of being handed an empty result to interpret.
+     */
+    private String callModel(Project project, String state, List<ComplianceRule> candidateRules) {
         try {
             String systemPrompt = buildSystemPrompt();
             String userPrompt = buildUserPrompt(project, state, candidateRules);
@@ -75,7 +109,7 @@ public class OpenAiCompatibleComplianceService {
                     .baseUrl(props.getBaseUrl())
                     .build();
 
-            String responseJson = client.post()
+            return client.post()
                     .uri("/chat/completions")
                     .header("Authorization", "Bearer " + props.getApiKey())
                     .contentType(MediaType.APPLICATION_JSON)
@@ -83,12 +117,11 @@ public class OpenAiCompatibleComplianceService {
                     .body(requestBody)
                     .retrieve()
                     .body(String.class);
-
-            String responseText = extractText(responseJson);
-            return parseSuggestions(responseText);
         } catch (Exception e) {
-            log.error("Compliance AI call failed for project {}: {}", project.getId(), e.getMessage());
-            return List.of();
+            log.error("Compliance AI call failed for project {}: {}", project.getId(), e.getMessage(), e);
+            throw new ComplianceAiException(
+                    "The compliance AI service could not be reached or returned an error, so no "
+                            + "compliances were generated. Try again in a moment. (" + e.getMessage() + ")", e);
         }
     }
 
@@ -131,7 +164,9 @@ public class OpenAiCompatibleComplianceService {
     private String buildSystemPrompt() {
         return "You are a construction-compliance assistant for India. Decide which statutory "
                 + "compliances apply to a construction project, reasoning ONLY over the candidate "
-                + "rules provided. Do not invent compliances outside this list.";
+                + "rules provided. Do not invent compliances outside this list. Assess every rule "
+                + "you are given, including the ones that do not apply, and keep each rationale to "
+                + "one short sentence so the whole answer fits within the response limit.";
     }
 
     private String buildUserPrompt(Project project, String state, List<ComplianceRule> rules) {
@@ -166,7 +201,9 @@ public class OpenAiCompatibleComplianceService {
                 .append("\"resolutionOptions\": array of short strings, ")
                 .append("\"rationale\": short string, ")
                 .append("\"phase\": one of [pre-construction, ongoing, post-construction]}. ")
-                .append("Include one element for every candidate rule.");
+                .append("Include one element for every candidate rule: the array must hold exactly ")
+                .append(rules.size())
+                .append(" elements, one per ruleCode listed above, and none may be omitted.");
         return sb.toString();
     }
 
@@ -175,34 +212,5 @@ public class OpenAiCompatibleComplianceService {
             return "";
         }
         return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ");
-    }
-
-    /** Pulls the assistant text out of {@code choices[0].message.content}. */
-    private String extractText(String responseJson) throws Exception {
-        if (responseJson == null || responseJson.isBlank()) {
-            return "";
-        }
-        JsonNode root = objectMapper.readTree(responseJson);
-        JsonNode content = root.path("choices").path(0).path("message").path("content");
-        return content.isTextual() ? content.asText() : "";
-    }
-
-    /**
-     * Parses the model's response into suggestions. Tolerates the model wrapping the
-     * array in prose or code fences by slicing from the first '[' to the last ']'.
-     */
-    private List<ComplianceSuggestion> parseSuggestions(String responseText) throws Exception {
-        if (responseText == null || responseText.isBlank()) {
-            return List.of();
-        }
-        int start = responseText.indexOf('[');
-        int end = responseText.lastIndexOf(']');
-        if (start < 0 || end <= start) {
-            log.warn("Compliance AI response contained no JSON array; got: {}", responseText);
-            return List.of();
-        }
-        String json = responseText.substring(start, end + 1);
-        ComplianceSuggestion[] parsed = objectMapper.readValue(json, ComplianceSuggestion[].class);
-        return List.of(parsed);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -118,10 +118,14 @@ public class OpenAiCompatibleComplianceService {
                     .retrieve()
                     .body(String.class);
         } catch (Exception e) {
+            // The message stays out of the response body on purpose: for an HTTP error the
+            // RestClient exception carries the provider's own response text, which names the
+            // endpoint and is more of the upstream than an API client has any use for. The log
+            // is where it belongs, and the cause chain keeps it for whoever is debugging.
             log.error("Compliance AI call failed for project {}: {}", project.getId(), e.getMessage(), e);
             throw new ComplianceAiException(
                     "The compliance AI service could not be reached or returned an error, so no "
-                            + "compliances were generated. Try again in a moment. (" + e.getMessage() + ")", e);
+                            + "compliances were generated. Try again in a moment.", e);
         }
     }
 

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -50,7 +50,9 @@ public class ComplianceControllerWeb {
             @ApiResponse(responseCode = "200", description = "Generation ran; the created inspections are returned (possibly empty when nothing new applied)"),
             @ApiResponse(responseCode = "400", description = "No organization context set (the X-Organization-Id header is required), or a precondition is unmet: the project has no type, its address carries no recognisable state, no rules are registered for its jurisdiction, or the AI service is not configured. The detail message states what to fix."),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant"),
+            @ApiResponse(responseCode = "409", description = "Another generation run for the same project kept winning the race to create the same compliances; nothing was created by this call and the request can be sent again"),
+            @ApiResponse(responseCode = "502", description = "The compliance AI endpoint could not be reached, returned an error, or returned an answer that was cut short by its token limit and so did not cover every candidate rule. Nothing was created; the detail message says which")
     })
     public List<InspectionDto> regenerate(@RequestParam Long projectId) {
         Long orgId = TenantContext.getCurrentOrgId();

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Inspection.java
@@ -169,6 +169,16 @@ public class Inspection implements TenantScopedEntity {
     @Column(name = "resolution_options", columnDefinition = "TEXT")
     private String resolutionOptions;
 
+    /**
+     * The compliance rule this inspection was generated for, null on every manual
+     * inspection.
+     *
+     * <p>Carries a unique index across (organization_id, project_id, compliance_rule_ref)
+     * over the rows where it is set, so a project cannot hold two inspections for the same
+     * rule however many generation runs overlap. The index is partial and therefore lives
+     * only in changelog {@code 060}: JPA cannot express the {@code WHERE} clause, and
+     * without it every manual inspection's null would be indexed for nothing.
+     */
     @Column(name = "compliance_rule_ref", length = 100)
     private String complianceRuleRef;
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -313,4 +313,7 @@
     <!-- v4.0 - Inspection QA/QC: non-conformance reports and their assignment and closure trail -->
     <include file="db/changelog/v4.0/059-create-ncrs.xml"/>
 
+    <!-- v4.0 - Compliance: one inspection per rule per project, enforced in the schema -->
+    <include file="db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml
+++ b/src/main/resources/db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml
@@ -11,17 +11,28 @@
             compliance inspections that the unguarded generation could already have created.
 
             Only rows the user has not touched are removed: AI-generated and still SUGGESTED,
-            with no check items, defects, attendees or NCRs hanging off them. Of each duplicate
-            group the oldest row is kept, so the one a user is most likely to have already seen
-            is the survivor. A duplicate that someone has since scheduled, assigned or worked on
-            is left alone for a human to resolve, and the index changeset reports it rather than
+            with no check items, defects, attendees or NCRs hanging off them. Anything else is
+            left alone for a human to resolve, and the index changeset reports it rather than
             failing the deploy.
 
-            The survivor is picked with row_number() rather than by comparing against min(created_at),
-            because two rows written by a race can carry the same timestamp: on a tie every row
-            would then be "not later than the first" and the whole group would survive, which is
-            the case this exists to clear. Ordering by (created_at, id) breaks the tie and leaves
-            exactly one row per group whatever the timestamps say.
+            Which row survives is decided by ranking each group and deleting the untouched rows
+            below rank one. Two details in that ranking are load bearing.
+
+            Protected rows rank first, so a group whose oldest row is an untouched suggestion and
+            whose newer row someone has since scheduled still resolves: the untouched row goes and
+            the one carrying the user's work stays. Ranking purely by age would have kept the
+            untouched row, found the newer one ineligible, and left the duplicate standing for no
+            gain.
+
+            Then age, then id. row_number() rather than a comparison against min(created_at),
+            because two rows written by a race can carry the same timestamp: on a tie every row is
+            "not later than the first", so a min-comparison would spare the whole group, which is
+            the case this exists to clear. The id breaks a remaining tie so exactly one row per
+            group survives whatever the timestamps say.
+
+            The eligibility conditions are repeated on the DELETE itself rather than trusted to the
+            ranking. A group of two protected rows ranks them one and two, and the second must not
+            be deleted just for ranking below the first.
 
             Audited on the IITM staging database before writing this: 14 inspections, 8 with a
             compliance rule reference, no duplicate (organization_id, project_id,
@@ -32,17 +43,27 @@
             DELETE FROM inspections
             WHERE id IN (
                 SELECT ranked.id FROM (
-                    SELECT i.id,
+                    SELECT flagged.id,
                            row_number() OVER (
-                               PARTITION BY i.organization_id, i.project_id, i.compliance_rule_ref
-                               ORDER BY i.created_at, i.id
+                               PARTITION BY flagged.organization_id, flagged.project_id,
+                                            flagged.compliance_rule_ref
+                               ORDER BY flagged.is_protected DESC, flagged.created_at, flagged.id
                            ) AS rank_in_group
-                    FROM inspections i
-                    WHERE i.compliance_rule_ref IS NOT NULL
-                      AND i.organization_id IS NOT NULL
-                      AND i.project_id IS NOT NULL
+                    FROM (
+                        SELECT i.id, i.organization_id, i.project_id, i.compliance_rule_ref, i.created_at,
+                               (i.origin &lt;&gt; 'AI_GENERATED'
+                                OR i.status &lt;&gt; 'SUGGESTED'
+                                OR EXISTS (SELECT 1 FROM inspection_check_items c WHERE c.inspection_id = i.id)
+                                OR EXISTS (SELECT 1 FROM inspection_defects f WHERE f.inspection_id = i.id)
+                                OR EXISTS (SELECT 1 FROM inspection_attendees a WHERE a.inspection_id = i.id)
+                                OR EXISTS (SELECT 1 FROM ncrs n WHERE n.inspection_id = i.id)) AS is_protected
+                        FROM inspections i
+                        WHERE i.compliance_rule_ref IS NOT NULL
+                          AND i.organization_id IS NOT NULL
+                          AND i.project_id IS NOT NULL
+                    ) flagged
                 ) ranked
-                WHERE ranked.rank_in_group > 1
+                WHERE ranked.rank_in_group &gt; 1
             )
             AND origin = 'AI_GENERATED'
             AND status = 'SUGGESTED'

--- a/src/main/resources/db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml
+++ b/src/main/resources/db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="060-dedupe-compliance-inspection-rule-refs" author="echno">
+        <comment>
+            Clears the way for the unique index in the next changeset by removing duplicate
+            compliance inspections that the unguarded generation could already have created.
+
+            Only rows the user has not touched are removed: AI-generated and still SUGGESTED,
+            with no check items, defects, attendees or NCRs hanging off them. Of each duplicate
+            group the oldest row is kept, so the one a user is most likely to have already seen
+            is the survivor. A duplicate that someone has since scheduled, assigned or worked on
+            is left alone for a human to resolve, and the index changeset reports it rather than
+            failing the deploy.
+
+            The survivor is picked with row_number() rather than by comparing against min(created_at),
+            because two rows written by a race can carry the same timestamp: on a tie every row
+            would then be "not later than the first" and the whole group would survive, which is
+            the case this exists to clear. Ordering by (created_at, id) breaks the tie and leaves
+            exactly one row per group whatever the timestamps say.
+
+            Audited on the IITM staging database before writing this: 14 inspections, 8 with a
+            compliance rule reference, no duplicate (organization_id, project_id,
+            compliance_rule_ref) group at all, so this deletes nothing there.
+        </comment>
+
+        <sql>
+            DELETE FROM inspections
+            WHERE id IN (
+                SELECT ranked.id FROM (
+                    SELECT i.id,
+                           row_number() OVER (
+                               PARTITION BY i.organization_id, i.project_id, i.compliance_rule_ref
+                               ORDER BY i.created_at, i.id
+                           ) AS rank_in_group
+                    FROM inspections i
+                    WHERE i.compliance_rule_ref IS NOT NULL
+                      AND i.organization_id IS NOT NULL
+                      AND i.project_id IS NOT NULL
+                ) ranked
+                WHERE ranked.rank_in_group > 1
+            )
+            AND origin = 'AI_GENERATED'
+            AND status = 'SUGGESTED'
+            AND NOT EXISTS (SELECT 1 FROM inspection_check_items c WHERE c.inspection_id = inspections.id)
+            AND NOT EXISTS (SELECT 1 FROM inspection_defects f WHERE f.inspection_id = inspections.id)
+            AND NOT EXISTS (SELECT 1 FROM inspection_attendees a WHERE a.inspection_id = inspections.id)
+            AND NOT EXISTS (SELECT 1 FROM ncrs n WHERE n.inspection_id = inspections.id);
+        </sql>
+
+        <rollback>
+            <comment>
+                Rows deleted as duplicates are not recoverable from the changelog; the rollback
+                is a no-op rather than a lie about restoring them.
+            </comment>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="060-compliance-inspection-rule-ref-unique" author="echno">
+        <preConditions onFail="CONTINUE"
+                       onFailMessage="Duplicate compliance inspections remain, so the unique index
+                                      was not created and concurrent generation can still duplicate
+                                      them. List them with: SELECT organization_id, project_id,
+                                      compliance_rule_ref, count(*) FROM inspections WHERE
+                                      compliance_rule_ref IS NOT NULL GROUP BY 1, 2, 3 HAVING
+                                      count(*) > 1; resolve each group by hand, and this changeset
+                                      applies itself on the next startup.">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM (
+                    SELECT 1
+                    FROM inspections
+                    WHERE compliance_rule_ref IS NOT NULL
+                      AND organization_id IS NOT NULL
+                      AND project_id IS NOT NULL
+                    GROUP BY organization_id, project_id, compliance_rule_ref
+                    HAVING count(*) > 1
+                ) remaining_duplicates;
+            </sqlCheck>
+        </preConditions>
+
+        <comment>
+            Compliance generation is idempotent by intent: a rule that already has an inspection
+            on a project is skipped. That skip was an unlocked read with nothing behind it, so
+            two overlapping runs (two clicks on regenerate, or a manual regenerate racing the
+            automatic run on approval) both read "no such row" and both inserted. SERIALIZABLE
+            does not catch it, because the two transactions do not conflict: each inserts a
+            different row, with its own id and its own inspection number, so there is nothing
+            for the database to detect.
+
+            This index makes the invariant true in the schema instead. It is partial because
+            compliance_rule_ref is null on every manual inspection, and SQL treats each null as
+            distinct, so an ordinary unique constraint would index every manual row for nothing.
+            The rows it does not cover are the ones with no organization or no project, which
+            no compliance inspection has.
+
+            The loser of the race now has its insert rejected, which the generation service
+            handles by restarting its write transaction: the retried attempt's existence check
+            reads the committed row and skips it, so the user sees a successful run rather than
+            an error.
+
+            The precondition above keeps a deploy from failing on data this cannot be applied to.
+            Nothing is skipped silently: the message names the query that lists what is in the
+            way, and the changeset stays unapplied so it runs again once that is cleared.
+        </comment>
+
+        <sql>
+            CREATE UNIQUE INDEX IF NOT EXISTS uk_inspections_org_project_compliance_rule
+            ON inspections (organization_id, project_id, compliance_rule_ref)
+            WHERE compliance_rule_ref IS NOT NULL;
+        </sql>
+
+        <rollback>
+            DROP INDEX IF EXISTS inspections@uk_inspections_org_project_compliance_rule;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/retry/TransactionRetryTemplateTest.java
@@ -138,6 +138,68 @@ class TransactionRetryTemplateTest {
         assertThat(counter("echno.transaction.retry.exhausted")).isZero();
     }
 
+    /**
+     * A caller may nominate a further failure as one a fresh attempt resolves. The case this
+     * exists for is a check-then-write made idempotent by a unique constraint: the check
+     * passes, a concurrent transaction commits the row, the insert is rejected, and the
+     * retried attempt's check now sees the committed row and skips it. Nominating it is what
+     * turns the loser of that race from a 500 into the skip the caller intended.
+     */
+    @Test
+    void restartsAConflictTheCallerNominatesAsRetryable() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = template.execute(OPERATION, TransactionRetryTemplateTest::isDuplicateKey, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw duplicateKey();
+            }
+            return "committed";
+        });
+
+        assertThat(result).isEqualTo("committed");
+        assertThat(attempts).hasValue(2);
+        assertThat(transactionManager.begun).isEqualTo(2);
+        assertThat(transactionManager.rolledBack).isEqualTo(1);
+        assertThat(counter("echno.transaction.retry.attempts")).isEqualTo(1.0);
+    }
+
+    @Test
+    void leavesAFailureTheNominationDoesNotCoverAlone() {
+        // The predicate has to be narrow: a duplicate key a fresh read cannot resolve is a
+        // permanent error, and retrying every integrity failure would only delay it and then
+        // report it as a concurrency conflict instead of as itself.
+        AtomicInteger attempts = new AtomicInteger();
+        DataIntegrityViolationException notNull = new DataIntegrityViolationException(
+                "null value in column violates not-null constraint",
+                new SQLException("null value in column", "23502"));
+
+        assertThatExceptionOfType(DataIntegrityViolationException.class)
+                .isThrownBy(() -> template.execute(OPERATION, TransactionRetryTemplateTest::isDuplicateKey,
+                        () -> {
+                            attempts.incrementAndGet();
+                            throw notNull;
+                        }))
+                .isSameAs(notNull);
+
+        assertThat(attempts).hasValue(1);
+        assertThat(counter("echno.transaction.retry.attempts")).isZero();
+    }
+
+    @Test
+    void stillRestartsASerializationAbortWhenANominationIsGiven() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = template.execute(OPERATION, TransactionRetryTemplateTest::isDuplicateKey, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw serializationFailure();
+            }
+            return "committed";
+        });
+
+        assertThat(result).isEqualTo("committed");
+        assertThat(attempts).hasValue(2);
+    }
+
     @Test
     void doesNotRetryInsideACallersTransaction() {
         // Nothing to restart: the boundary belongs to the caller and their transaction is
@@ -220,6 +282,16 @@ class TransactionRetryTemplateTest {
         assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis", -1L)).isZero();
         assertThat(TransactionRetryTemplate.clampBackoff("initial-backoff-millis", Long.MIN_VALUE))
                 .isZero();
+    }
+
+    /** A unique-index rejection in the shape Spring hands to application code. */
+    private static DataIntegrityViolationException duplicateKey() {
+        return new DataIntegrityViolationException("duplicate key value violates unique constraint",
+                new SQLException("duplicate key value violates unique constraint", "23505"));
+    }
+
+    private static boolean isDuplicateKey(Throwable failure) {
+        return SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION);
     }
 
     /** A CockroachDB serializable abort in the shape Spring hands to application code. */

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationConcurrencyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationConcurrencyTest.java
@@ -1,0 +1,240 @@
+package org.tornotron.echno_backend.compliance;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.tornotron.echno_backend.common.exception.TransactionRetriesExhaustedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
+import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
+import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What happens when two compliance generations for the same project overlap.
+ *
+ * <p>The idempotency check is a plain read, so it cannot be the guarantee: both runs see
+ * "no such row" and both insert. Nor does {@code SERIALIZABLE} catch it, because the two
+ * transactions do not conflict; each inserts a different row with its own id and its own
+ * inspection number, so there is nothing for the database to detect. The guarantee is the
+ * unique index from changelog {@code 060}, and what these tests cover is the half that
+ * lives in code: the loser's rejected insert has to become a skip rather than a 500.
+ *
+ * <p>The retry template is the real one here rather than a mock, because the cooperation
+ * between the constraint and the restart is the behaviour under test. Everything around it
+ * is a mock, so no database, no context and no Testcontainer is involved.
+ */
+class ComplianceGenerationConcurrencyTest {
+
+    private static final Long PROJECT_ID = 42L;
+    private static final Long ORG_ID = 7L;
+    private static final String RULE_CODE = "TN-BPA";
+
+    private ProjectRepository projectRepository;
+    private ComplianceRuleRepository ruleRepository;
+    private OpenAiCompatibleComplianceService complianceAiService;
+    private InspectionRepository inspectionRepository;
+    private EntryNumberGenerator numberGen;
+    private TenantEntityHelper tenantEntityHelper;
+    private InspectionMapper inspectionMapper;
+    private ComplianceGenerationService service;
+
+    @BeforeEach
+    void setUp() {
+        projectRepository = mock(ProjectRepository.class);
+        ruleRepository = mock(ComplianceRuleRepository.class);
+        complianceAiService = mock(OpenAiCompatibleComplianceService.class);
+        inspectionRepository = mock(InspectionRepository.class);
+        numberGen = mock(EntryNumberGenerator.class);
+        tenantEntityHelper = mock(TenantEntityHelper.class);
+        inspectionMapper = mock(InspectionMapper.class);
+
+        // Backoff at zero so the restarts cost the build no wall-clock time.
+        TransactionRetryTemplate retryTemplate = new TransactionRetryTemplate(
+                new TransactionalWorkRunner(), new SimpleMeterRegistry(), 4, 0L, 0L);
+
+        service = new ComplianceGenerationService(
+                projectRepository, ruleRepository, complianceAiService, inspectionRepository,
+                numberGen, tenantEntityHelper, inspectionMapper, retryTemplate);
+
+        Project project = new Project();
+        project.setProjectName("Race Test");
+        project.setProjectType(ProjectType.RESIDENTIAL);
+        project.setProjectState("Tamil Nadu");
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project));
+        when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
+                .thenReturn(List.of(rule()));
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+                .thenReturn(List.of(suggestion()));
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        when(numberGen.next(anyString())).thenReturn("INSP-0001");
+    }
+
+    private static ComplianceRule rule() {
+        ComplianceRule rule = new ComplianceRule();
+        rule.setCode(RULE_CODE);
+        rule.setName("Building Plan Approval");
+        rule.setPhase(CompliancePhase.PRE_CONSTRUCTION);
+        rule.setDefaultRiskLevel(ComplianceRiskLevel.CRITICAL);
+        rule.setState("Tamil Nadu");
+        rule.setProjectType(ProjectType.RESIDENTIAL);
+        return rule;
+    }
+
+    private static ComplianceSuggestion suggestion() {
+        return new ComplianceSuggestion(RULE_CODE, true, "critical", List.of("Apply"),
+                "Required.", "pre-construction");
+    }
+
+    /** A unique-index rejection in the shape Spring hands to application code. */
+    private static DataIntegrityViolationException duplicateComplianceRow() {
+        return new DataIntegrityViolationException(
+                "could not execute statement [duplicate key value violates unique constraint "
+                        + "\"uk_inspections_org_project_compliance_rule\"]",
+                new SQLException("duplicate key value violates unique constraint", "23505"));
+    }
+
+    /**
+     * The race, end to end. The first attempt's existence check passes, the concurrent run
+     * commits its row in the gap, and this run's insert is rejected by the unique index. The
+     * write phase restarts, the second attempt's check now reads the committed row and skips
+     * it, and the request answers with what this run genuinely created (nothing).
+     *
+     * <p>Without the retry the rejection travels straight out: a duplicate the user never
+     * asked to create, reported to them as a failure.
+     */
+    @Test
+    void losingTheRaceToAConcurrentRunSkipsTheRuleInsteadOfFailingTheRequest() {
+        AtomicInteger existsCalls = new AtomicInteger();
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID))
+                // First attempt: nothing there yet. Second attempt: the winner's row is
+                // committed and visible, which is what makes the restart converge.
+                .thenAnswer(invocation -> existsCalls.incrementAndGet() > 1);
+        when(inspectionRepository.save(any(Inspection.class))).thenThrow(duplicateComplianceRow());
+
+        List<InspectionDto> created = service.generateForProject(PROJECT_ID, ORG_ID);
+
+        assertThat(created).isEmpty();
+        assertThat(existsCalls).hasValue(2);
+        verify(inspectionRepository, times(1)).save(any(Inspection.class));
+    }
+
+    /**
+     * The ordinary case has to stay ordinary: no conflict, one attempt, one row, no restart.
+     */
+    @Test
+    void createsTheInspectionWhenNothingRacesIt() {
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID)).thenReturn(false);
+        Inspection saved = new Inspection();
+        when(inspectionRepository.save(any(Inspection.class))).thenReturn(saved);
+
+        // The mapper's own output is not what is under test here, only that the row was
+        // created and mapped once, so its default null return is left as it is.
+        assertThat(service.generateForProject(PROJECT_ID, ORG_ID)).hasSize(1);
+
+        verify(inspectionRepository, times(1)).save(any(Inspection.class));
+        verify(inspectionMapper, times(1)).toDto(saved);
+    }
+
+    /**
+     * A rule that already has an inspection is skipped without ever reaching the constraint,
+     * which is what keeps a re-run cheap: the index is the guarantee, the check is the fast
+     * path.
+     */
+    @Test
+    void skipsARuleThatAlreadyHasAnInspection() {
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID)).thenReturn(true);
+
+        assertThat(service.generateForProject(PROJECT_ID, ORG_ID)).isEmpty();
+
+        verify(inspectionRepository, times(0)).save(any(Inspection.class));
+    }
+
+    /**
+     * The restart is bounded. A conflict that a fresh read never resolves gives up as a
+     * conflict (409) rather than retrying forever or surfacing as an unknown 500.
+     */
+    @Test
+    void givesUpAsAConflictWhenTheDuplicateNeverResolves() {
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID)).thenReturn(false);
+        when(inspectionRepository.save(any(Inspection.class))).thenThrow(duplicateComplianceRow());
+
+        assertThatExceptionOfType(TransactionRetriesExhaustedException.class)
+                .isThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID));
+
+        verify(inspectionRepository, times(4)).save(any(Inspection.class));
+    }
+
+    /**
+     * Only a unique violation is nominated as retryable. Anything else the write can fail
+     * with is a real fault and must surface as itself on the first attempt, not be retried
+     * three more times and then reported as a concurrency conflict.
+     */
+    @Test
+    void doesNotRestartOnAnIntegrityFailureThatIsNotADuplicate() {
+        DataIntegrityViolationException notNull = new DataIntegrityViolationException(
+                "null value in column violates not-null constraint",
+                new SQLException("null value in column", "23502"));
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID)).thenReturn(false);
+        when(inspectionRepository.save(any(Inspection.class))).thenThrow(notNull);
+
+        assertThatExceptionOfType(DataIntegrityViolationException.class)
+                .isThrownBy(() -> service.generateForProject(PROJECT_ID, ORG_ID))
+                .isSameAs(notNull);
+
+        verify(inspectionRepository, times(1)).save(any(Inspection.class));
+    }
+
+    /**
+     * The model call sits between the two transactions and must not be repeated by a restart
+     * of the write phase. It is the 34 to 47 second part of the run and, unlike the write, it
+     * is not free to run again.
+     */
+    @Test
+    void restartingTheWritePhaseDoesNotCallTheModelAgain() {
+        AtomicInteger existsCalls = new AtomicInteger();
+        when(inspectionRepository.existsByProjectIdAndComplianceRuleRefAndOrganization_Id(
+                PROJECT_ID, RULE_CODE, ORG_ID))
+                .thenAnswer(invocation -> existsCalls.incrementAndGet() > 1);
+        when(inspectionRepository.save(any(Inspection.class))).thenThrow(duplicateComplianceRow());
+
+        service.generateForProject(PROJECT_ID, ORG_ID);
+
+        verify(complianceAiService, times(1))
+                .suggestCompliances(any(Project.class), eq("Tamil Nadu"), any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.compliance;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.AfterEach;
@@ -9,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -16,6 +20,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
@@ -34,6 +40,7 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -49,8 +56,22 @@ import static org.mockito.Mockito.when;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ComplianceGenerationService.class, InspectionMapperImpl.class,
-        TenantEntityHelper.class, EntryNumberGenerator.class, TransactionalWorkRunner.class})
+        TenantEntityHelper.class, EntryNumberGenerator.class, TransactionalWorkRunner.class,
+        TransactionRetryTemplate.class, ComplianceGenerationServiceIT.RetryMetrics.class})
 class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
+
+    /**
+     * The retry template counts its restarts, and a {@code @DataJpaTest} slice carries no
+     * metrics autoconfiguration, so the registry it needs is supplied here. Nothing reads the
+     * counters in this test; they simply have somewhere to go.
+     */
+    @TestConfiguration
+    static class RetryMetrics {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
 
     private static final String RULE_PRE = "TN-BPA";        // pre-construction
     private static final String RULE_POST = "TN-OCC-CERT";  // post-construction
@@ -160,6 +181,42 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
                 .setParameter("org", orgAId)
                 .getSingleResult()).longValue();
         assertThat(total).isEqualTo(2L);
+    }
+
+    /**
+     * The half of the concurrency fix that only a real database can show: the unique index
+     * from changelog 060 exists, applies to this table, and rejects a second inspection for
+     * a rule that already has one on the project.
+     *
+     * <p>The insert is deliberately raw rather than a second call to the service, because
+     * what is under test is the schema's guarantee and not the application's check. Before
+     * the index this row was accepted, which is precisely how two overlapping runs each
+     * created their own compliance inspection for the same rule.
+     */
+    @Test
+    void theDatabaseRefusesASecondInspectionForTheSameRuleOnTheSameProject() {
+        service.generateForProject(projectId, orgAId);
+        entityManager.flush();
+
+        assertThatThrownBy(() -> {
+            entityManager.createNativeQuery(
+                            "INSERT INTO inspections (id, inspection_number, title, type, category, "
+                                    + "status, origin, project_id, compliance_rule_ref, organization_id, "
+                                    + "total_check_points, passed_check_points, failed_check_points, "
+                                    + "defects_found, created_at, updated_at) VALUES "
+                                    + "(gen_random_uuid(), 'INSP-DUPLICATE', 'Duplicate of an existing "
+                                    + "compliance', 'COMPLIANCE', 'COMPLIANCE', 'SUGGESTED', "
+                                    + "'AI_GENERATED', :project, :rule, :org, 0, 0, 0, 0, "
+                                    + "now()::timestamp, now()::timestamp)")
+                    .setParameter("project", projectId)
+                    .setParameter("rule", RULE_PRE)
+                    .setParameter("org", orgAId)
+                    .executeUpdate();
+            entityManager.flush();
+        }).satisfies(failure -> assertThat(
+                SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION))
+                .as("the insert must be rejected by a unique violation (SQLSTATE 23505)")
+                .isTrue());
     }
 
     private void inCommittedTx(Runnable work) {

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
@@ -12,7 +12,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
-import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
 import org.tornotron.echno_backend.inspection.mapper.InspectionMapper;
@@ -25,12 +25,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,20 +62,25 @@ class ComplianceGenerationServiceTest {
     @Mock
     private InspectionMapper inspectionMapper;
     @Mock
-    private TransactionalWorkRunner workRunner;
+    private TransactionRetryTemplate retryTemplate;
 
     @InjectMocks
     private ComplianceGenerationService service;
 
     /**
-     * The runner is the transaction boundary in production; here it only has to run the
-     * block it is handed, so the phase split is exercised without a database. Every test
-     * reaches at least the read phase, so this stub is always used.
+     * The retry template is the transaction boundary in production; here it only has to run
+     * the block it is handed, so the phase split is exercised without a database. The read
+     * phase every test reaches uses the two-argument form; the write phase uses the form
+     * that also nominates a unique violation as retryable, and only the tests that get past
+     * the model call reach it, so that stub is lenient.
      */
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void runWorkInline() {
-        when(workRunner.runInTransaction(any()))
-                .thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+        when(retryTemplate.execute(anyString(), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(1, Supplier.class).get());
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }
 
     private Project project(ProjectType type, String address) {
@@ -178,7 +185,7 @@ class ComplianceGenerationServiceTest {
      * external model call measured at 34 to 47 seconds. A {@code @Transactional} here would
      * put that call back inside a transaction and pin one of twenty pool connections for
      * its duration. The two transactions belong to the read and write phases, which reach
-     * them through {@code TransactionalWorkRunner}.
+     * them through {@code TransactionRetryTemplate}.
      */
     @Test
     @MockitoSettings(strictness = Strictness.LENIENT)

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReaderTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReaderTest.java
@@ -113,12 +113,13 @@ class ComplianceResponseReaderTest {
      */
     @Test
     void refusesAnAnswerTheProviderSaysItCutOffAtTheTokenLimit() {
-        // Deliberately well formed JSON: only the stop reason gives the truncation away, so
-        // this fails unless finish_reason is actually being read.
+        // Deliberately well formed JSON that covers every rule asked about, so neither the
+        // shape check nor the coverage check has anything to catch: this fails unless
+        // finish_reason is actually being read.
         String json = envelope(completeAnswer(3), "length", MAX_TOKENS);
 
         assertThatExceptionOfType(ComplianceAiException.class)
-                .isThrownBy(() -> reader.read(json, rules(30)))
+                .isThrownBy(() -> reader.read(json, rules(3)))
                 .withMessageContaining("cut short")
                 .withMessageContaining("length")
                 .withMessageContaining(String.valueOf(MAX_TOKENS));
@@ -160,7 +161,7 @@ class ComplianceResponseReaderTest {
 
         assertThatExceptionOfType(ComplianceAiException.class)
                 .isThrownBy(() -> reader.read(envelope(content, null, 120), rules(2)))
-                .withMessageContaining("not a readable array");
+                .withMessageContaining("not a readable array of assessments");
     }
 
     /**
@@ -238,6 +239,64 @@ class ComplianceResponseReaderTest {
 
         assertThat(suggestions).hasSize(2);
         assertThat(suggestions.get(0).rationale()).contains("section 3[b]");
+    }
+
+    /**
+     * The prose a model wraps its answer in can contain a bracket of its own. Anchoring on
+     * the first one in the text would slice out the citation, fail to parse it, and refuse a
+     * complete answer, so every candidate opening bracket is tried.
+     */
+    @Test
+    void findsTheArrayWhenTheProseBeforeItContainsABracketOfItsOwn() {
+        String content = "Based on the rules [1] and [2] listed above, here is the assessment:\n"
+                + completeAnswer(3);
+
+        assertThat(reader.read(envelope(content, "stop", 500), rules(3))).hasSize(3);
+    }
+
+    /**
+     * A response that says a rule both does and does not apply is not a result to act on.
+     * Counting distinct codes would let it satisfy coverage, and the generation service stops
+     * at the first element it can use, so it would create an inspection off one half of a
+     * contradiction with nobody seeing the other half.
+     */
+    @Test
+    void refusesAnAnswerThatAssessesTheSameRuleTwice() {
+        String content = "[{\"ruleCode\":\"TN-1\",\"applies\":false,\"rationale\":\"Not applicable.\"},"
+                + element("TN-1") + "," + element("TN-2") + "]";
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(envelope(content, "stop", 400), rules(2)))
+                .withMessageContaining("more than one assessment")
+                .withMessageContaining("TN-1");
+    }
+
+    /**
+     * A code echoed back in a different case or with whitespace is put back on the
+     * candidate's spelling. Both the coverage check here and the generation service's own
+     * lookup match codes exactly, so left alone it would either fail coverage as a missing
+     * rule or, if coverage were relaxed instead, pass and then be dropped without a word when
+     * the inspection was built.
+     */
+    @Test
+    void putsARuleCodeReturnedInADifferentCaseBackOnTheCandidateSpelling() {
+        String content = "[{\"ruleCode\":\" tn-1 \",\"applies\":true,\"riskLevel\":\"high\","
+                + "\"rationale\":\"Required.\"},{\"ruleCode\":\"TN-2\",\"applies\":false,"
+                + "\"rationale\":\"Not applicable.\"}]";
+
+        List<ComplianceSuggestion> suggestions = reader.read(envelope(content, "stop", 200), rules(2));
+
+        assertThat(suggestions).extracting(ComplianceSuggestion::ruleCode)
+                .containsExactly("TN-1", "TN-2");
+    }
+
+    @Test
+    void leavesAnInventedCodeAsTheModelSpeltIt() {
+        String content = "[" + element("TN-1") + "," + element("TN-2") + "," + element("XX-MADE-UP") + "]";
+
+        assertThat(reader.read(envelope(content, "stop", 400), rules(2)))
+                .extracting(ComplianceSuggestion::ruleCode)
+                .containsExactly("TN-1", "TN-2", "XX-MADE-UP");
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReaderTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceResponseReaderTest.java
@@ -1,0 +1,278 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * A truncated compliance answer must be refused, not quietly turned into "nothing applies".
+ *
+ * <p>This is the failure mode the compliance module could not survive: past some rule count
+ * the model's answer is cut off at the token cap, the old reader sliced it to the last
+ * bracket it could find, Jackson threw on the fragment, the throw was swallowed, and the run
+ * reported success with zero results. Nothing about that outcome told anyone the catalogue
+ * had outgrown the budget, and the symptom (a clean empty result) points at rule curation
+ * rather than at truncation.
+ *
+ * <p>Every case here is a canned provider response, so the checks are proven without a key,
+ * without the network and without knowing where the token ceiling actually falls. That last
+ * point is deliberate: the ceiling has not been measured, and none of these checks depends
+ * on the number.
+ */
+class ComplianceResponseReaderTest {
+
+    private static final int MAX_TOKENS = 4096;
+
+    private final ComplianceResponseReader reader =
+            new ComplianceResponseReader(new ObjectMapper(), MAX_TOKENS);
+
+    private static ComplianceRule rule(String code) {
+        ComplianceRule rule = new ComplianceRule();
+        rule.setState("Tamil Nadu");
+        rule.setProjectType(ProjectType.RESIDENTIAL);
+        rule.setPhase(CompliancePhase.PRE_CONSTRUCTION);
+        rule.setCode(code);
+        rule.setName("Rule " + code);
+        rule.setDefaultRiskLevel(ComplianceRiskLevel.HIGH);
+        return rule;
+    }
+
+    private static List<ComplianceRule> rules(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> rule("TN-" + i))
+                .toList();
+    }
+
+    /** One assessment element, in the shape the prompt asks for. */
+    private static String element(String code) {
+        return "{\"ruleCode\":\"" + code + "\",\"applies\":true,\"riskLevel\":\"high\","
+                + "\"resolutionOptions\":[\"Apply to the authority\",\"Attach the sanctioned plan\"],"
+                + "\"rationale\":\"Required for this project.\",\"phase\":\"pre-construction\"}";
+    }
+
+    /** A chat-completions envelope carrying {@code content} and the given stop reason. */
+    private static String envelope(String content, String finishReason, Integer completionTokens) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            var root = mapper.createObjectNode();
+            var choice = root.putArray("choices").addObject();
+            choice.putObject("message").put("role", "assistant").put("content", content);
+            if (finishReason != null) {
+                choice.put("finish_reason", finishReason);
+            }
+            if (completionTokens != null) {
+                root.putObject("usage").put("completion_tokens", completionTokens);
+            }
+            return mapper.writeValueAsString(root);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String completeAnswer(int ruleCount) {
+        return "[" + IntStream.rangeClosed(1, ruleCount)
+                .mapToObj(i -> element("TN-" + i))
+                .reduce((a, b) -> a + "," + b)
+                .orElse("") + "]";
+    }
+
+    @Test
+    void readsEveryAssessmentOutOfACompleteAnswer() {
+        String json = envelope(completeAnswer(6), "stop", 800);
+
+        List<ComplianceSuggestion> suggestions = reader.read(json, rules(6));
+
+        assertThat(suggestions).hasSize(6);
+        assertThat(suggestions).extracting(ComplianceSuggestion::ruleCode)
+                .containsExactly("TN-1", "TN-2", "TN-3", "TN-4", "TN-5", "TN-6");
+        assertThat(suggestions.get(0).resolutionOptions()).hasSize(2);
+    }
+
+    @Test
+    void stillToleratesTheModelWrappingItsArrayInProseAndAFence() {
+        String content = "Here is my assessment:\n```json\n" + completeAnswer(2) + "\n```\nLet me know.";
+
+        assertThat(reader.read(envelope(content, "stop", 300), rules(2))).hasSize(2);
+    }
+
+    /**
+     * The provider said it stopped at the cap. That is the one signal that needs no guessing
+     * at the shape of the answer, and it was read by nothing at all: the old reader took
+     * {@code choices[0].message.content} and never looked at {@code finish_reason}, so a
+     * cap-truncated answer was indistinguishable from a finished one.
+     */
+    @Test
+    void refusesAnAnswerTheProviderSaysItCutOffAtTheTokenLimit() {
+        // Deliberately well formed JSON: only the stop reason gives the truncation away, so
+        // this fails unless finish_reason is actually being read.
+        String json = envelope(completeAnswer(3), "length", MAX_TOKENS);
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(json, rules(30)))
+                .withMessageContaining("cut short")
+                .withMessageContaining("length")
+                .withMessageContaining(String.valueOf(MAX_TOKENS));
+    }
+
+    @Test
+    void readsStopReasonWhenTheProviderNamesTheFieldThatWayInstead() {
+        String content = completeAnswer(3);
+        String json = "{\"choices\":[{\"message\":{\"content\":" + quote(content)
+                + "},\"stop_reason\":\"max_tokens\"}]}";
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(json, rules(3)))
+                .withMessageContaining("cut short");
+    }
+
+    /**
+     * The truncation with no stop reason to give it away. The answer stops mid-element, so
+     * the last {@code ]} in the text closes an element's own {@code resolutionOptions}
+     * array rather than the outer one. Slicing to it produces a fragment that ends
+     * mid-object: the old reader did exactly that, Jackson threw, and the throw became an
+     * empty list and a successful run.
+     */
+    @Test
+    void refusesAnArrayThatStopsMidElement() {
+        String content = "[" + element("TN-1") + "," + element("TN-2") + ",{\"ruleCode\":\"TN-3\","
+                + "\"applies\":true,\"riskLevel\":\"high\",\"resolutionOptions\":[\"Apply to the "
+                + "authority\",\"Attach the sanct";
+        String json = envelope(content, null, null);
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(json, rules(6)))
+                .withMessageContaining("never closes");
+    }
+
+    @Test
+    void refusesAnArrayThatClosesButDoesNotParse() {
+        String content = "[" + element("TN-1") + ", {\"ruleCode\": }]";
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(envelope(content, null, 120), rules(2)))
+                .withMessageContaining("not a readable array");
+    }
+
+    /**
+     * The truncation neither of the other two checks can see: the answer happens to stop on
+     * a valid closing bracket and the provider reported no stop reason, so the only thing
+     * wrong with it is that rules went unassessed. The prompt asks for one element per
+     * candidate rule, which is what makes that detectable without knowing the ceiling.
+     */
+    @Test
+    void refusesAnAnswerThatLeavesCandidateRulesUnassessed() {
+        String json = envelope(completeAnswer(2), "stop", 900);
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(json, rules(6)))
+                .withMessageContaining("assessed only 2 of 6")
+                .withMessageContaining("TN-3");
+    }
+
+    @Test
+    void namesOnlyTheFirstFewMissingRulesAndCountsTheRest() {
+        String json = envelope(completeAnswer(1), "stop", 200);
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(json, rules(12)))
+                .withMessageContaining("leaving 11 unassessed")
+                .withMessageContaining("and 6 more");
+    }
+
+    /**
+     * An empty array is not "nothing applies": a model that assessed every rule and found
+     * none of them applicable answers with one element per rule carrying
+     * {@code applies: false}. Reading it as a legitimate outcome is what let a broken run
+     * pass for a successful one.
+     */
+    @Test
+    void refusesAnEmptyArrayRatherThanReadingItAsNothingApplies() {
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(envelope("[]", "stop", 5), rules(4)))
+                .withMessageContaining("assessed only 0 of 4");
+    }
+
+    @Test
+    void acceptsAnAnswerInWhichNothingApplies() {
+        String content = "[" + IntStream.rangeClosed(1, 3)
+                .mapToObj(i -> "{\"ruleCode\":\"TN-" + i + "\",\"applies\":false,"
+                        + "\"rationale\":\"Not applicable.\"}")
+                .reduce((a, b) -> a + "," + b)
+                .orElse("") + "]";
+
+        List<ComplianceSuggestion> suggestions = reader.read(envelope(content, "stop", 90), rules(3));
+
+        assertThat(suggestions).hasSize(3);
+        assertThat(suggestions).allMatch(s -> !s.applies());
+    }
+
+    @Test
+    void ignoresCodesTheModelInventedAsLongAsEveryCandidateWasAssessed() {
+        String content = "[" + element("TN-1") + "," + element("TN-2") + "," + element("TN-INVENTED") + "]";
+
+        assertThat(reader.read(envelope(content, "stop", 400), rules(2))).hasSize(3);
+    }
+
+    /**
+     * Regression guard on the bracket scan: a rationale that mentions a bracketed clause
+     * must not be mistaken for the end of the array.
+     */
+    @Test
+    void doesNotEndTheArrayOnABracketInsideAString() {
+        String content = "[{\"ruleCode\":\"TN-1\",\"applies\":true,"
+                + "\"rationale\":\"Required under section 3[b] of the Act [see also 4].\","
+                + "\"resolutionOptions\":[\"Apply\"]},"
+                + "{\"ruleCode\":\"TN-2\",\"applies\":false,\"rationale\":\"Not applicable.\"}]";
+
+        List<ComplianceSuggestion> suggestions = reader.read(envelope(content, "stop", 200), rules(2));
+
+        assertThat(suggestions).hasSize(2);
+        assertThat(suggestions.get(0).rationale()).contains("section 3[b]");
+    }
+
+    @Test
+    void refusesAnAnswerWithNoArrayInItAtAll() {
+        String content = "I cannot determine which compliances apply without the sanctioned plan.";
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(envelope(content, "stop", 20), rules(3)))
+                .withMessageContaining("no JSON array")
+                .withMessageContaining("sanctioned plan");
+    }
+
+    @Test
+    void refusesAnEmptyAssistantMessage() {
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read(envelope("   ", "stop", 0), rules(3)))
+                .withMessageContaining("no text at all");
+    }
+
+    @Test
+    void refusesAnEmptyOrUnreadableResponseBody() {
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read("", rules(3)))
+                .withMessageContaining("empty response body");
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> reader.read("<html>502 Bad Gateway</html>", rules(3)))
+                .withMessageContaining("not JSON");
+    }
+
+    private static String quote(String s) {
+        try {
+            return new ObjectMapper().writeValueAsString(s);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes two ways compliance generation produced a wrong result without saying so.

Closes #510. Closes #509.

## #510: concurrent generation duplicated inspections

The idempotency check is an unlocked read. Two overlapping runs both see "no such row" and both insert, and `SERIALIZABLE` does not catch it: each inserts a different row, with its own id and its own inspection number, so the transactions do not conflict and there is nothing for the database to detect.

**The constraint.** Changelog `060` adds a unique index on `(organization_id, project_id, compliance_rule_ref)` over the rows that carry a rule reference. It is partial because `compliance_rule_ref` is null on every manual inspection and SQL treats each null as distinct, so an ordinary unique constraint would index every manual row for nothing.

A first changeset clears the way by deleting duplicates the unguarded path could already have created, and only the ones nobody has touched: AI-generated, still `SUGGESTED`, with no check items, defects, attendees or NCRs. The survivor of each group is picked with `row_number()` over `(is_protected DESC, created_at, id)`. Protected first, so a group whose oldest row is an untouched suggestion and whose newer row someone has since scheduled resolves by dropping the untouched row and keeping the one carrying the work, rather than resolving to nothing. Then age, then id: two rows written by a race can carry the same timestamp, and on a tie every row is "not later than the first", so comparing against `min(created_at)` would have left the whole group intact in exactly the case it exists to clear. The eligibility conditions stay on the DELETE as well as in the ranking, so a group of two protected rows ranks them one and two without the second being deleted.

Verified by running the changeset's own SQL on a throwaway CockroachDB v26.2.4 against a seeded duplicate set: a tied-timestamp pair collapses to one row, a three-row group keeps the oldest, a group whose newer row is `SCHEDULED` keeps that row and drops the untouched one, a group whose newer row has a check item does the same, a group of two worked-on rows is left whole for the precondition to report, and rows on another project, another tenant, or with a null rule reference are untouched. The index changeset carries a precondition with `onFail="CONTINUE"`, so a duplicate a human has to resolve reports the query that lists it and leaves the changeset unapplied to run again on the next startup, rather than failing the deploy or being silently marked ran.

Audited on IITM staging before writing it: 14 inspections, 8 with a rule reference, no duplicate group at all, so the cleanup is a no-op there.

**How the constraint and the retry path cooperate.** The rejection cannot be caught per rule and skipped. Calling `save` does not send the insert: Hibernate holds it until it next has to flush, which is the following rule's existence query or the commit, so by the time the constraint speaks the loop has moved on from the rule it is about. And wherever the failure lands, a failed statement leaves the transaction unusable, so there is nothing left to continue into either. The write phase instead runs through `TransactionRetryTemplate` with the unique violation (SQLSTATE `23505`) nominated as retryable. The whole phase restarts, and the second attempt's existence check reads the row the winner committed and skips it, which was the intended outcome. The request answers 200 with what this run genuinely created and the user never learns there was a race. Only a run that keeps losing until its attempts are gone surfaces a 409, which is honest at that point.

`persist` was already safe to run again from the start (it holds no state across attempts and re-reads what exists); the one visible cost is a gap in the `INSP` number series from an abandoned attempt, which the series tolerates because it is an identifier and not a count.

`TransactionRetryTemplate` gains an overload taking that nomination as a `Predicate`. It is per call site rather than built in, because a duplicate key is usually a permanent error and retrying every one would only delay the failure and then report it as a concurrency conflict instead of as itself. `SqlStateDetector` holds the SQLSTATE chain walk that `SerializationFailureDetector` already did, so both use one implementation.

## #509: truncated responses reported success with zero results

Past some rule count the answer is cut off at the token cap. The parser sliced from the first `[` to the **last** `]` in the text, which in a truncated answer closes some element's inner `resolutionOptions` array rather than the outer one, so the slice ends mid-object. Jackson threw, the throw was swallowed, and the run reported success having created nothing. The symptom (a clean empty result) points at rule curation rather than at truncation.

**Detection, with no token measurement.** `ComplianceResponseReader` refuses the answer on three signals, none of which needs to know where the ceiling falls:

1. **The provider's stop reason.** `choices[0].finish_reason` of `length` or `max_tokens` (also read as `stop_reason`, which some gateways use). This was read by nothing at all.
2. **The shape of the JSON.** An array that opens and never closes, or one that closes and does not parse. The bracket scan matches the opening bracket rather than taking the last one in the text, which is what makes a mid-element stop visible instead of plausible. Brackets inside string literals are skipped, so a rationale citing "section 3[b]" cannot end the array early.
3. **Coverage.** The prompt asks for one element per candidate rule, so a rule that comes back unassessed means the answer stopped early even when it happened to stop on a valid bracket and the provider reported no stop reason. A rule assessed more than once is refused too, for a different reason: counting distinct codes would let an answer that says a rule does not apply and then that it does satisfy coverage, and the generation service stops at the first element it can use, so it would create an inspection off one half of a contradiction.

Codes are put back onto the candidate's spelling before either check, so a code echoed as `" tn-1 "` neither fails coverage as a missing rule nor sails through it and then gets dropped without a word by the generation service's exact-match lookup. Every `[` in the text is tried in turn rather than just the first, because prose wrapping the answer can cite a bracket of its own.

Each refusal quotes `compliance.ai.max-tokens` and the reported `usage.completion_tokens`, so the per-rule token cost falls out of a real failure rather than needing a separate run.

**Empty now means what it says.** The service stays fail-soft only about being switched off (disabled, no key, no candidate rules). Everything else raises `ComplianceAiException`, answered as 502 with `retryable: true` and the message saying which of the failures it was. A model that assessed every rule and found none applicable still returns one element per rule with `applies: false`, never an empty array, so nothing legitimate is lost by treating an empty or short answer as a failure. `ComplianceGenerationListener` already catches and logs, so project approval still succeeds.

## Behaviour change worth watching on the first live run

The coverage check makes generation fail where it previously half-succeeded. If the model drops a rule for its own reasons rather than because of truncation, the run now returns 502 instead of creating compliances for the rules it did assess. That is the intended trade (a partial answer silently dropping a compliance the project needs is the failure this issue is about), and the prompt now states the exact element count to make it less likely, but it is worth eyeballing the first live run on `echno.in` against the 6 curated Tamil Nadu residential rules before assuming it is settled. Project approval is unaffected either way: `ComplianceGenerationListener` catches and logs.

## Deliberately not here

- **Chunking the catalogue into batches.** It is the optimisation, not the detection, and it belongs with the background-job work in #482. Detection has to land first either way, because chunking without it just moves the silent failure.
- **Measuring the exact token ceiling.** It needs an Anthropic-style API key that is not configured yet, and none of the three checks above depends on the number. Worth doing as a follow-up on #482 to size `compliance.ai.max-tokens` and the batch size, but nothing here waits on it. The error messages now carry the two numbers the measurement would produce.
- **Anything in #482's execution model.** Generation still runs inside the request.

## Failing-test table

Each fix was reverted in an isolated copy and the new tests re-run against the pre-fix behaviour.

| Reverted | Test | Without the fix |
|---|---|---|
| Reader: no stop-reason check, slice to the last `]`, swallow the parse failure, no coverage check | `refusesAnAnswerTheProviderSaysItCutOffAtTheTokenLimit` | FAILED |
| " | `readsStopReasonWhenTheProviderNamesTheFieldThatWayInstead` | FAILED |
| " | `refusesAnArrayThatStopsMidElement` | FAILED |
| " | `refusesAnArrayThatClosesButDoesNotParse` | FAILED |
| " | `refusesAnAnswerThatLeavesCandidateRulesUnassessed` | FAILED |
| " | `namesOnlyTheFirstFewMissingRulesAndCountsTheRest` | FAILED |
| " | `refusesAnEmptyArrayRatherThanReadingItAsNothingApplies` | FAILED |
| " | `refusesAnAnswerWithNoArrayInItAtAll` | FAILED |
| " | `refusesAnEmptyAssistantMessage` | FAILED |
| " | `readsEveryAssessmentOutOfACompleteAnswer`, `acceptsAnAnswerInWhichNothingApplies`, `doesNotEndTheArrayOnABracketInsideAString`, `stillToleratesTheModelWrappingItsArrayInProseAndAFence`, `ignoresCodesTheModelInventedAsLongAsEveryCandidateWasAssessed` | PASSED (regression guards, correctly unaffected) |
| Service: write phase back on the two-argument `execute` | `losingTheRaceToAConcurrentRunSkipsTheRuleInsteadOfFailingTheRequest` | FAILED |
| " | `restartingTheWritePhaseDoesNotCallTheModelAgain` | FAILED |
| " | `givesUpAsAConflictWhenTheDuplicateNeverResolves` | FAILED |
| " | `createsTheInspectionWhenNothingRacesIt`, `skipsARuleThatAlreadyHasAnInspection`, `doesNotRestartOnAnIntegrityFailureThatIsNotADuplicate` | PASSED (regression guards) |
| Template: nominating overload ignores its predicate | `restartsAConflictTheCallerNominatesAsRetryable` | FAILED |
| " | the other ten `TransactionRetryTemplateTest` cases | PASSED |
| Migration: `060` not included in the master changelog | `theDatabaseRefusesASecondInspectionForTheSameRuleOnTheSameProject` | FAILED |
| Reader at the pre-review-fix revision (single `[` anchor, distinct-code coverage, no canonicalisation) | `findsTheArrayWhenTheProseBeforeItContainsABracketOfItsOwn` | FAILED |
| " | `refusesAnAnswerThatAssessesTheSameRuleTwice` | FAILED |
| " | `putsARuleCodeReturnedInADifferentCaseBackOnTheCandidateSpelling` | FAILED |
| " | the other sixteen `ComplianceResponseReaderTest` cases | PASSED |

With every fix in place all of the above pass. The migration was exercised end to end: `ComplianceGenerationServiceIT` runs against a real CockroachDB, so `060` is applied by Liquibase in the test and the index is what rejects the raw duplicate insert.

Tests are plain JUnit and Mockito except the existing integration test, so no new Spring context enters the shared test JVM.
