### PR TITLE
Address the object-store bucket in the path, from one shared setting

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/SpacesConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/SpacesConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -12,56 +13,84 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
 
+/**
+ * Object-store clients.
+ *
+ * <p>Two clients talk to the same store: {@link S3Client} for server-side calls and
+ * {@link S3Presigner} for URLs handed to the browser. They differ only in the endpoint
+ * they address, because the browser cannot reach the internal one. Everything else,
+ * credentials, region and above all the addressing style, comes from the single
+ * {@link #objectStoreServiceConfiguration()} bean below, so the two clients cannot end
+ * up disagreeing about how a bucket is addressed.
+ */
 @Configuration
 public class SpacesConfig {
 
+    /** Internal endpoint used for server-side calls. */
     @Value("${digital-ocean.uri}")
     private String spaces;
 
+    /** Public endpoint presigned URLs are signed against, since the browser resolves that one. */
     @Value("${digital-ocean.presign-endpoint}")
     private String presignEndpoint;
 
     @Value("${digital-ocean.access-key-id}")
-    private String access_key_id;
+    private String accessKeyId;
 
     @Value("${digital-ocean.secret-access-key}")
-    private String secret_access_key;
+    private String secretAccessKey;
+
+    /**
+     * Where the bucket name goes in a request URL. Path-style puts it in the path
+     * ({@code http://host/bucket/key}); the alternative, virtual-host style, puts it in the
+     * hostname ({@code http://bucket.host/key}).
+     *
+     * <p>Default true, because it is the setting that works on every store we deploy against.
+     * Self-hosted MinIO serves path-style only, so virtual-host style resolves the bucket into
+     * a hostname that does not exist. DigitalOcean Spaces and AWS S3 both still serve path-style,
+     * so the same default is correct there. Set {@code digital-ocean.path-style-access=false}
+     * only for a store that refuses path-style, and be aware that a bucket name containing dots
+     * then breaks TLS certificate matching.
+     */
+    @Value("${digital-ocean.path-style-access:true}")
+    private boolean pathStyleAccess;
+
+    /**
+     * The one addressing decision, shared by every client below. Both beans take it as an
+     * argument rather than building their own, which is what stops them drifting apart:
+     * a client that wants a different style has to change this bean, and changing it moves
+     * both clients together.
+     */
+    @Bean
+    public S3Configuration objectStoreServiceConfiguration() {
+        return S3Configuration.builder()
+                .pathStyleAccessEnabled(pathStyleAccess)
+                .build();
+    }
 
     @Bean
-    public S3Client s3Client() {
+    public S3Client s3Client(S3Configuration objectStoreServiceConfiguration) {
         return S3Client.builder()
                 .endpointOverride(URI.create(spaces))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(
-                                        access_key_id,
-                                        secret_access_key
-                                )
-                        )
-                )
+                .serviceConfiguration(objectStoreServiceConfiguration)
+                .credentialsProvider(objectStoreCredentials())
                 .region(Region.US_EAST_1)
                 .build();
     }
 
-    // Presigned URLs are handed to the browser, so they must be signed against the
-    // public object-store endpoint (which may differ from the internal endpoint the
-    // s3Client above uses for server-side ops). Path-style addressing is required for
-    // MinIO, which puts the bucket in the path rather than the host.
     @Bean
-    public S3Presigner s3Presigner() {
+    public S3Presigner s3Presigner(S3Configuration objectStoreServiceConfiguration) {
         return S3Presigner.builder()
                 .endpointOverride(URI.create(presignEndpoint))
-                .serviceConfiguration(
-                        S3Configuration.builder()
-                                .pathStyleAccessEnabled(true)
-                                .build()
-                )
+                .serviceConfiguration(objectStoreServiceConfiguration)
+                .credentialsProvider(objectStoreCredentials())
                 .region(Region.US_EAST_1)
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(access_key_id, secret_access_key)
-                        )
-                )
                 .build();
+    }
+
+    private AwsCredentialsProvider objectStoreCredentials() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ jwt:
 digital-ocean:
   uri: ${DIGITAL_OCEAN_SPACES_URI}
   presign-endpoint: ${OBJECT_STORE_PUBLIC_ENDPOINT:${DIGITAL_OCEAN_SPACES_URI}}
+  path-style-access: ${DIGITAL_OCEAN_SPACES_PATH_STYLE:true}
   access-key-id: ${DIGITAL_OCEAN_SPACES_KEY_ID}
   secret-access-key: ${DIGITAL_OCEAN_SPACES_KEY_SECRET}
   bucket-name: ${DIGITAL_OCEAN_SPACES_BUCKET_NAME}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/SpacesConfigAddressingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/SpacesConfigAddressingTest.java
@@ -1,0 +1,111 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URI;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins how the object-store clients address a bucket.
+ *
+ * <p>The server-side client and the presigner used to be built independently, and only the
+ * presigner was given path-style addressing. The client therefore folded the bucket into the
+ * hostname and every server-side call died on {@code UnknownHostException:
+ * echno-objects.echno-minio}, because MinIO answers to one name and serves buckets from the
+ * path. These tests fail if either client goes back to bucket-in-host, and fail if the two
+ * ever stop agreeing.
+ */
+class SpacesConfigAddressingTest {
+
+    private static final String INTERNAL_ENDPOINT = "http://echno-minio:9000";
+    private static final String PUBLIC_ENDPOINT = "https://storage.echno.test";
+    private static final String BUCKET = "echno-objects";
+    private static final String KEY = "issue/site-photo.png";
+
+    @Test
+    void serverSideClientPutsTheBucketInThePathNotTheHost() {
+        SpacesConfig config = configWith(true);
+
+        try (S3Client client = config.s3Client(config.objectStoreServiceConfiguration())) {
+            URI url = urlFor(client);
+
+            assertThat(url.getHost()).isEqualTo("echno-minio");
+            assertThat(url.getPath()).isEqualTo("/" + BUCKET + "/" + KEY);
+            assertThat(url.getHost()).doesNotContain(BUCKET);
+        }
+    }
+
+    @Test
+    void presignerPutsTheBucketInThePathNotTheHost() {
+        SpacesConfig config = configWith(true);
+
+        try (S3Presigner presigner = config.s3Presigner(config.objectStoreServiceConfiguration())) {
+            URI url = presignedUrlFor(presigner);
+
+            assertThat(url.getHost()).isEqualTo("storage.echno.test");
+            assertThat(url.getPath()).isEqualTo("/" + BUCKET + "/" + KEY);
+        }
+    }
+
+    @Test
+    void bothClientsAddressTheBucketTheSameWay() {
+        SpacesConfig config = configWith(true);
+        S3Configuration shared = config.objectStoreServiceConfiguration();
+
+        try (S3Client client = config.s3Client(shared);
+             S3Presigner presigner = config.s3Presigner(shared)) {
+
+            // Endpoints differ by design, the addressing style must not.
+            assertThat(urlFor(client).getPath()).isEqualTo(presignedUrlFor(presigner).getPath());
+        }
+    }
+
+    @Test
+    void virtualHostStyleIsAvailableForStoresThatRequireIt() {
+        SpacesConfig config = configWith(false);
+        S3Configuration shared = config.objectStoreServiceConfiguration();
+
+        try (S3Client client = config.s3Client(shared);
+             S3Presigner presigner = config.s3Presigner(shared)) {
+
+            // Both flip together, which is the point of the shared configuration.
+            assertThat(urlFor(client).getHost()).isEqualTo(BUCKET + ".echno-minio");
+            assertThat(presignedUrlFor(presigner).getHost()).isEqualTo(BUCKET + ".storage.echno.test");
+        }
+    }
+
+    private static SpacesConfig configWith(boolean pathStyleAccess) {
+        SpacesConfig config = new SpacesConfig();
+        ReflectionTestUtils.setField(config, "spaces", INTERNAL_ENDPOINT);
+        ReflectionTestUtils.setField(config, "presignEndpoint", PUBLIC_ENDPOINT);
+        ReflectionTestUtils.setField(config, "accessKeyId", "test-key-id");
+        ReflectionTestUtils.setField(config, "secretAccessKey", "test-secret-key");
+        ReflectionTestUtils.setField(config, "pathStyleAccess", pathStyleAccess);
+        return config;
+    }
+
+    /** The URL the client would call for an object, resolved offline through the SDK's own rules. */
+    private static URI urlFor(S3Client client) {
+        return URI.create(client.utilities()
+                .getUrl(GetUrlRequest.builder().bucket(BUCKET).key(KEY).build())
+                .toString());
+    }
+
+    private static URI presignedUrlFor(S3Presigner presigner) {
+        return URI.create(presigner.presignPutObject(PutObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(15))
+                        .putObjectRequest(PutObjectRequest.builder().bucket(BUCKET).key(KEY).build())
+                        .build())
+                .url()
+                .toString());
+    }
+}


### PR DESCRIPTION
Fixes #532. Live defect on `echno.in`: attaching a file to an Issue fails with "Unexpected error occurred", and the staging log shows `UnknownHostException: echno-objects.echno-minio` three times on 28 Aug. ClickUp `86d45v7nt`.

## What was wrong

`SpacesConfig` builds two clients against the same store. `s3Presigner()` set `pathStyleAccessEnabled(true)`; `s3Client()` had no `serviceConfiguration` at all. So the server-side client put the bucket in the hostname, and MinIO answers to `echno-minio` only. The presigned browser path kept working, which is why the failure looked screen-dependent.

## What changed

The defect is the two clients disagreeing, so a one-line paste would leave the same trap in place. Addressing is now a single `S3Configuration` bean, and both `s3Client(S3Configuration)` and `s3Presigner(S3Configuration)` take it as an argument instead of building their own. Changing the style now moves both clients together. The credentials provider was duplicated in the same way and is built once too.

The two clients still differ in exactly one thing, the endpoint, which is deliberate: presigned URLs go to the browser and have to be signed against the public endpoint.

## MinIO and Spaces

Path-style is the default (`digital-ocean.path-style-access`, env `DIGITAL_OCEAN_SPACES_PATH_STYLE`, defaulting to `true`), because it is the one setting correct on every store we deploy against:

- Compose staging, self-hosted MinIO at `storage.echno.in`: serves path-style only.
- DigitalOcean Spaces (production plan) and AWS S3: serve both, so path-style is fine there.

It is configurable rather than hardcoded so a store that refuses path-style can be pointed at virtual-host style without editing the class, and the switch then applies to both clients at once. No environment needs to set it today.

## Test

`SpacesConfigAddressingTest`, plain JUnit, no Spring context. It resolves the URL each client would actually use, offline, through the SDK's own endpoint rules (`S3Client.utilities().getUrl` and a real presign), then asserts the bucket lands in the path and that both clients agree.

Run against the previous asymmetry, three of the four fail, with the exact hostname from the production stack trace:

```
serverSideClientPutsTheBucketInThePathNotTheHost -> expected: "echno-minio" but was: "echno-objects.echno-minio"
bothClientsAddressTheBucketTheSameWay           -> expected: "/echno-objects/issue/site-photo.png" but was: "/issue/site-photo.png"
virtualHostStyleIsAvailableForStoresThatRequireIt -> expected: "echno-objects.storage.echno.test" but was: "storage.echno.test"
presignerPutsTheBucketInThePathNotTheHost       -> PASSED (the presigner was already correct)
```

All four pass on this branch, and the full `./gradlew test` suite is green.

## Checked and left out

`SpacesConfig` is the only place in the repo that builds an S3 client or presigner, so nothing else needed the same treatment.

Items 2 and 3 from the issue are not in here and want their own change: the backend still surfaces an object-store failure as a generic unknown error, and the web upload path leaves the user with a saved Issue and a lost file rather than a retry.