### PR TITLE
Bound the last sixteen web listings that read a whole table

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
 import org.tornotron.echno_backend.asset.dto.AssetDto;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -38,14 +39,14 @@ public class AssetControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all assets",
-            description = "Returns every asset in the caller's current tenant organization, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Assets returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<List<AssetDto>> readAllAssets() {
-        return new ResponseEntity<>(assetService.getAllAssets(), HttpStatus.OK);
+        return UnpagedResultCap.respond(assetService.getAllAssets(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
@@ -17,8 +17,6 @@ import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.vendor.Vendor;
 import org.tornotron.echno_backend.vendor.VendorRepository;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class AssetService {
@@ -56,12 +54,6 @@ public class AssetService {
         return assetMapper.toDto(asset);
     }
 
-    @Transactional(readOnly = true)
-    public List<AssetDto> getAllAssets() {
-        return assetRepository.findAll().stream()
-                .map(asset -> assetMapper.toDto(asset))
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<AssetDto> getAllAssets(int pageNo, int pageSize) {

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -11,6 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
@@ -95,28 +96,34 @@ public class EmployeeControllerWeb {
     @Operation(
             summary = "List employees for pickers",
             description = "Returns a minimal, non-sensitive list of employees (id and name) for "
-                    + "populating selection widgets. Readable by any tenant member."
+                    + "populating selection widgets. Narrow the feed with search, which matches "
+                    + "name, email, phone or the employee id, and size it with limit, which is "
+                    + "capped at 500. X-Total-Count carries the true match count and "
+                    + "X-Result-Capped is set when rows were left out. Readable by any tenant member."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<EmployeeLookupDto>> lookupEmployees() {
-        return new ResponseEntity<>(employeeService.lookupEmployees(), HttpStatus.OK);
+    public ResponseEntity<List<EmployeeLookupDto>> lookupEmployees(
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "500") int limit) {
+        return UnpagedResultCap.respond(employeeService.lookupEmployees(search, limit));
     }
 
     @GetMapping
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List all employees",
-            description = "Returns every employee in the current tenant, with their full details."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Employees returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<EmployeeDto>> readAllEmployees() {
-        return new ResponseEntity<>(employeeService.displayAllEmployees(), HttpStatus.OK);
+        return UnpagedResultCap.respond(employeeService.displayAllEmployees(
+                0, UnpagedResultCap.MAX_ROWS, null, null, null));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -97,7 +97,7 @@ public class EmployeeControllerWeb {
             summary = "List employees for pickers",
             description = "Returns a minimal, non-sensitive list of employees (id and name) for "
                     + "populating selection widgets. Narrow the feed with search, which matches "
-                    + "name, email, phone or the employee id, and size it with limit, which is "
+                    + "the employee name or the employee id, and size it with limit, which is "
                     + "capped at 500. X-Total-Count carries the true match count and "
                     + "X-Result-Capped is set when rows were left out. Readable by any tenant member."
     )

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -109,4 +109,23 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
             @Param("status") EmployeeStatus status,
             @Param("department") String department,
             Pageable pageable);
+
+    /**
+     * Paginated employee search for the picker feed, which any tenant member may
+     * read. Deliberately narrower than {@link #search}: it matches only the two
+     * fields a picker displays, the employee name and the human-facing employee
+     * id, and not the email or phone number. Matching a contact detail would let
+     * any member confirm a guessed address or number against a returned identity,
+     * which is a lookup the picker has no use for. The caller passes {@code search}
+     * already lower-cased and wrapped in {@code %} wildcards (or null); see
+     * {@link #search} for why the pattern is built in Java. The tenant orgFilter
+     * still applies.
+     */
+    @Query("""
+            SELECT e FROM Employee e WHERE
+              (:search IS NULL
+                 OR LOWER(e.employeeName) LIKE :search
+                 OR LOWER(e.employeeId) LIKE :search)
+            """)
+    Page<Employee> searchForLookup(@Param("search") String search, Pageable pageable);
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.KeycloakGroupService;
 import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -217,33 +218,35 @@ public class EmployeeService {
 
 
     /**
-     * Retrieves a list of all employees.
+     * Retrieves employees as a minimal, non-sensitive lookup projection for pickers.
+     * Unlike {@link #displayAllEmployees(int, int, String, String, String)} this exposes
+     * no contact details, salary or personal data, so it can be read by any tenant member.
      *
-     * @return A list of all employee DTOs.
+     * <p>A picker feed is a search-and-limit read rather than a whole-table read: the
+     * caller narrows with {@code search} and takes only as many rows as the widget can
+     * show. The limit is clamped to {@link UnpagedResultCap#MAX_ROWS} so no caller can
+     * ask for the whole table by passing a large number.
+     *
+     * @param search Case-insensitive substring matched against name, email, phone or the
+     *               human-facing employee id, or null for no filter.
+     * @param limit  Most rows to return, clamped to at least one and at most
+     *               {@link UnpagedResultCap#MAX_ROWS}.
+     * @return A single page of lookup projections ordered by name, carrying the true
+     *         match count so a caller can tell it narrowed too little.
      */
     @Transactional(readOnly = true)
-    public List<EmployeeDto> displayAllEmployees() {
-        return employeeRepository.findAll().stream()
-                .map(employee -> employeeMapper.toDto(employee))
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieves every employee as a minimal, non-sensitive lookup projection for
-     * dropdowns. Unlike {@link #displayAllEmployees()} this exposes no contact
-     * details, salary or personal data, so it can be read by any tenant member.
-     */
-    @Transactional(readOnly = true)
-    public List<EmployeeLookupDto> lookupEmployees() {
-        return employeeRepository.findAll().stream()
+    public Page<EmployeeLookupDto> lookupEmployees(String search, int limit) {
+        int size = Math.min(Math.max(limit, 1), UnpagedResultCap.MAX_ROWS);
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "employeeName"));
+        String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
+        return employeeRepository.search(searchTerm, null, null, pageable)
                 .map(employee -> new EmployeeLookupDto(
                         employee.getId(),
                         employee.getEmployeeId(),
                         employee.getEmployeeName(),
                         employee.getDesignation(),
                         employee.getStatus(),
-                        employee.getOrganization() != null ? employee.getOrganization().getId() : null))
-                .collect(Collectors.toList());
+                        employee.getOrganization() != null ? employee.getOrganization().getId() : null));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -227,7 +227,12 @@ public class EmployeeService {
      * show. The limit is clamped to {@link UnpagedResultCap#MAX_ROWS} so no caller can
      * ask for the whole table by passing a large number.
      *
-     * @param search Case-insensitive substring matched against name, email, phone or the
+     * <p>The search matches only what the picker displays, the name and the human-facing
+     * employee id. It deliberately does not match email or phone, which the restricted
+     * listing does: matching a contact detail would turn a feed any member may read into
+     * a way of confirming a guessed address or number against a returned identity.
+     *
+     * @param search Case-insensitive substring matched against the employee name or the
      *               human-facing employee id, or null for no filter.
      * @param limit  Most rows to return, clamped to at least one and at most
      *               {@link UnpagedResultCap#MAX_ROWS}.
@@ -239,7 +244,7 @@ public class EmployeeService {
         int size = Math.min(Math.max(limit, 1), UnpagedResultCap.MAX_ROWS);
         Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "employeeName"));
         String searchTerm = (search == null || search.isBlank()) ? null : "%" + search.trim().toLowerCase() + "%";
-        return employeeRepository.search(searchTerm, null, null, pageable)
+        return employeeRepository.searchForLookup(searchTerm, pageable)
                 .map(employee -> new EmployeeLookupDto(
                         employee.getId(),
                         employee.getEmployeeId(),

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.expense.dto.ExpenseCreationDto;
 import org.tornotron.echno_backend.expense.dto.ExpenseDto;
 import org.tornotron.echno_backend.expense.dto.ExpenseUpdateDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -39,14 +40,15 @@ public class ExpenseControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all expenses",
-            description = "Returns every expense for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Expenses returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<ExpenseDto>> readAllExpenses() {
-        return new ResponseEntity<>(expenseService.getAll(), HttpStatus.OK);
+        return UnpagedResultCap.respond(expenseService.getPaginated(
+                0, UnpagedResultCap.MAX_ROWS, null, null));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseService.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseService.java
@@ -16,8 +16,6 @@ import org.tornotron.echno_backend.expense.dto.ExpenseUpdateDto;
 import org.tornotron.echno_backend.expense.mapper.ExpenseMapper;
 import org.tornotron.echno_backend.organization.Organization;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CRUD + list for expenses. The expense is a flat header scoped to the current tenant;
@@ -70,12 +68,6 @@ public class ExpenseService {
         return expenseMapper.toDto(expense);
     }
 
-    @Transactional(readOnly = true)
-    public List<ExpenseDto> getAll() {
-        return expenseRepository.findAll().stream()
-                .map(expenseMapper::toDto)
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<ExpenseDto> getPaginated(int pageNo, int pageSize, String search, String status) {

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteUpdateDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -72,15 +73,14 @@ public class GoodsReceivedNoteControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List goods received notes",
-            description = "Returns every GRN in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Goods received notes returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<GoodsReceivedNoteDto>> getAllGrns() {
-        List<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns();
-        return ResponseEntity.ok(grns);
+        return UnpagedResultCap.respond(goodsReceivedNoteService.getAllGrns(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
@@ -237,12 +237,6 @@ public class GoodsReceivedNoteService {
         return goodsReceivedNoteMapper.toDto(grn);
     }
 
-    @Transactional(readOnly = true)
-    public List<GoodsReceivedNoteDto> getAllGrns() {
-        return goodsReceivedNoteRepository.findAll().stream()
-                .map(grn -> goodsReceivedNoteMapper.toDto(grn))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Retrieves GRNs one page at a time, newest received first.

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemUpdateDto;
 import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -72,14 +73,14 @@ public class IndentControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all indents",
-            description = "Returns every indent for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Indents returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<IndentDto>> getAllIndents() {
-        return new ResponseEntity<>(indentService.getAllIndents(), HttpStatus.OK);
+        return UnpagedResultCap.respond(indentService.getAllIndents(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
@@ -171,12 +171,6 @@ public class IndentService {
                 .map(indent -> indentMapper.toDto(indent));
     }
 
-    @Transactional(readOnly = true)
-    public List<IndentDto> getAllIndents() {
-        return indentRepository.findAll().stream()
-                .map(indent -> indentMapper.toDto(indent))
-                .toList();
-    }
 
     /**
      * Retrieves a single indent by its id within the current tenant.

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.issue.dto.IssueDto;
 import org.tornotron.echno_backend.issue.dto.IssueSimpleDto;
 import org.tornotron.echno_backend.issue.dto.IssueStatsDto;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 import java.util.Map;
@@ -47,15 +48,15 @@ public class IssueControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all issues",
-            description = "Returns every issue in the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Issues returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<IssueDto>> readAllIssues() {
-        List<IssueDto> issues = issueService.getAllIssues();
-        return new ResponseEntity<>(issues, HttpStatus.OK);
+        return UnpagedResultCap.respond(issueService.getAllIssuesPaginated(
+                0, UnpagedResultCap.MAX_ROWS, null, null, null, null, null, null));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -108,12 +108,6 @@ public class IssueService {
         return issueMapper.toSimpleDto(savedIssue);
     }
 
-    @Transactional(readOnly = true)
-    public List<IssueDto> getAllIssues() {
-        return issueRepository.findAll().stream()
-                .map(issue -> issueMapper.toDto(issue))
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<IssueDto> getAllIssuesPaginated(int pageNo, int pageSize, Long projectId, String search, String status, String type, Long assigneeId, Long creatorId) {

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
 import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -80,15 +81,14 @@ public class MaterialControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all materials",
-            description = "Returns every material in the organization's catalogue, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Materials returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<MaterialDto>> getAllMaterials() {
-        List<MaterialDto> materials = materialService.getAllMaterials();
-        return ResponseEntity.ok(materials);
+        return UnpagedResultCap.respond(materialService.getAllMaterials(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
@@ -165,12 +165,6 @@ public class MaterialService {
         return materialMapper.toDto(material);
     }
 
-    @Transactional(readOnly = true)
-    public List<MaterialDto> getAllMaterials() {
-        return materialRepository.findAll().stream()
-                .map(material -> materialMapper.toDto(material))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Retrieves materials one page at a time, ordered by name.

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionCreationDto;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionDto;
 import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -79,15 +80,15 @@ public class MaterialConsumptionControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all material consumptions",
-            description = "Returns every material consumption record in the organization, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Consumptions returned"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<MaterialConsumptionDto>> getAllMaterialConsumptions() {
-        List<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions();
-        return ResponseEntity.ok(consumptions);
+        return UnpagedResultCap.respond(
+                materialConsumptionService.getAllMaterialConsumptions(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionService.java
@@ -169,12 +169,6 @@ public class MaterialConsumptionService {
         return materialConsumptionMapper.toDto(consumption);
     }
 
-    @Transactional(readOnly = true)
-    public List<MaterialConsumptionDto> getAllMaterialConsumptions() {
-        return materialConsumptionRepository.findAll().stream()
-                .map(consumption -> materialConsumptionMapper.toDto(consumption))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Retrieves consumption records one page at a time, newest first.

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderUpdateDto;
 import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -72,15 +73,15 @@ public class PurchaseOrderControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all purchase orders",
-            description = "Returns every purchase order for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase orders returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<PurchaseOrderDto>> getAllPurchaseOrders() {
-        List<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders();
-        return ResponseEntity.ok(purchaseOrders);
+        return UnpagedResultCap.respond(
+                purchaseOrderService.getAllPurchaseOrders(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
@@ -178,12 +178,6 @@ public class PurchaseOrderService {
         return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
-    @Transactional(readOnly = true)
-    public List<PurchaseOrderDto> getAllPurchaseOrders() {
-        return purchaseOrderRepository.findAll().stream()
-                .map(po -> purchaseOrderMapper.toDto(po))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Retrieves purchase orders one page at a time, newest first.

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.receipt.dto.ReceiptCreationDto;
 import org.tornotron.echno_backend.receipt.dto.ReceiptDto;
 import org.tornotron.echno_backend.receipt.dto.ReceiptUpdateDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -39,14 +40,15 @@ public class ReceiptControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all receipts",
-            description = "Returns every receipt for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Receipts returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<ReceiptDto>> readAllReceipts() {
-        return new ResponseEntity<>(receiptService.getAll(), HttpStatus.OK);
+        return UnpagedResultCap.respond(receiptService.getPaginated(
+                0, UnpagedResultCap.MAX_ROWS, null, null));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptService.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptService.java
@@ -18,8 +18,6 @@ import org.tornotron.echno_backend.receipt.mapper.ReceiptMapper;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CRUD + list for receipts. The receipt is a flat header scoped to the current tenant;
@@ -74,12 +72,6 @@ public class ReceiptService {
         return receiptMapper.toDto(receipt);
     }
 
-    @Transactional(readOnly = true)
-    public List<ReceiptDto> getAll() {
-        return receiptRepository.findAll().stream()
-                .map(receiptMapper::toDto)
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<ReceiptDto> getPaginated(int pageNo, int pageSize, String search, String status) {

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -77,15 +78,15 @@ public class SiteTransferControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all site transfers",
-            description = "Returns every site transfer in the organization, without pagination."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfers returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<SiteTransferDto>> getAllSiteTransfers() {
-        List<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers();
-        return ResponseEntity.ok(transfers);
+        return UnpagedResultCap.respond(
+                siteTransferService.getAllSiteTransfers(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -200,12 +200,6 @@ public class SiteTransferService {
         return siteTransferMapper.toDto(transfer);
     }
 
-    @Transactional(readOnly = true)
-    public List<SiteTransferDto> getAllSiteTransfers() {
-        return siteTransferRepository.findAll().stream()
-                .map(transfer -> siteTransferMapper.toDto(transfer))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Retrieves site transfers one page at a time, newest first.

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -39,15 +40,14 @@ public class StockAdjustmentControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all stock adjustments",
-            description = "Returns every stock adjustment document recorded for the organization, without "
-                    + "pagination."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustments returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<List<StockAdjustmentDto>> readAllStockAdjustments() {
-        return new ResponseEntity<>(stockAdjustmentService.getAll(), HttpStatus.OK);
+        return UnpagedResultCap.respond(stockAdjustmentService.getAll(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -22,7 +22,6 @@ import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CRUD + list for stock-adjustment documents. MVP scope: the document is persisted
@@ -73,12 +72,6 @@ public class StockAdjustmentService {
         return stockAdjustmentMapper.toDto(stockAdjustment);
     }
 
-    @Transactional(readOnly = true)
-    public List<StockAdjustmentDto> getAll() {
-        return stockAdjustmentRepository.findAll().stream()
-                .map(stockAdjustmentMapper::toDto)
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<StockAdjustmentDto> getAll(int pageNo, int pageSize) {

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.storageLocation.dto.StorageLocationCreationDt
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationUpdateDto;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -77,15 +78,15 @@ public class StorageLocationControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List all storage locations",
-            description = "Returns every storage location in the caller's organization, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Storage locations returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<StorageLocationDto>> getAllStorageLocations() {
-        List<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations();
-        return ResponseEntity.ok(storageLocations);
+        return UnpagedResultCap.respond(
+                storageLocationService.getAllStorageLocations(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
@@ -77,12 +77,6 @@ public class StorageLocationService {
         return storageLocationMapper.toDto(storageLocation);
     }
 
-    @Transactional(readOnly = true)
-    public List<StorageLocationDto> getAllStorageLocations() {
-        return storageLocationRepository.findAll().stream()
-                .map(storageLocation -> storageLocationMapper.toDto(storageLocation))
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<StorageLocationDto> getAllStorageLocations(int pageNo, int pageSize) {

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.subcontract.dto.SubContractCreationDto;
 import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -38,14 +39,15 @@ public class SubContractControllerWeb {
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all subcontracts",
-            description = "Returns every subcontract for the current tenant, unpaginated."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subcontracts returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<SubContractDto>> readAllSubContracts() {
-        return new ResponseEntity<>(subContractService.getAll(), HttpStatus.OK);
+        return UnpagedResultCap.respond(subContractService.getPaginated(
+                0, UnpagedResultCap.MAX_ROWS, null, null, null));
     }
 
     @GetMapping("/paginated")

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractService.java
@@ -16,7 +16,6 @@ import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
 import org.tornotron.echno_backend.subcontract.mapper.SubContractMapper;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CRUD + list for subcontracts. The subcontract is a header plus a list of
@@ -58,12 +57,6 @@ public class SubContractService {
         return subContractMapper.toDto(subContract);
     }
 
-    @Transactional(readOnly = true)
-    public List<SubContractDto> getAll() {
-        return subContractRepository.findAll().stream()
-                .map(subContractMapper::toDto)
-                .collect(Collectors.toList());
-    }
 
     @Transactional(readOnly = true)
     public Page<SubContractDto> getPaginated(int pageNo, int pageSize, String search, String status, String type) {

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.vendor.dto.*;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -74,15 +75,14 @@ public class VendorControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "List vendors",
-            description = "Returns every vendor in the current tenant."
+            description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendors returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<VendorDto>> getAllVendors() {
-        List<VendorDto> vendors = vendorService.getAllVendors();
-        return ResponseEntity.ok(vendors);
+        return UnpagedResultCap.respond(vendorService.getAllVendors(0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/all")

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorService.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorService.java
@@ -114,17 +114,6 @@ public class VendorService {
         return vendorMapper.toDto(vendor);
     }
 
-    /**
-     * Returns every vendor visible to the current organization.
-     *
-     * @return The list of vendor DTOs.
-     */
-    @Transactional(readOnly = true)
-    public List<VendorDto> getAllVendors() {
-        return vendorRepository.findAll().stream()
-                .map(vendor -> vendorMapper.toDto(vendor))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Returns a page of vendors ordered by name.

--- a/src/test/java/org/tornotron/echno_backend/architecture/UnboundedRepositoryReadTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/UnboundedRepositoryReadTest.java
@@ -45,7 +45,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * what they read, and the temporary ones are simply not fixed yet. Row counts today are not a
  * reason for either. On a per-client production model one tenant's small reference table is
  * another's long tail, so an entry earns the permanent half only when the ceiling comes from what
- * the table <em>is</em>.
+ * the table <em>is</em>. The temporary half is currently empty: every read that grew with a
+ * tenant's site activity was bounded under issue #473, so what is left is reference data.
  *
  * <p>Runs under {@code @AnalyzeClasses} rather than importing the class graph itself. ArchUnit
  * holds a graph of this size in memory, and the test JVM is capped at 1 GB while already caching
@@ -83,27 +84,13 @@ class UnboundedRepositoryReadTest {
             "FeatureService",
             // Leave types a tenant defines (annual, sick, casual): bounded by policy design, not by
             // headcount and not by elapsed time.
-            "LeavePolicyService",
+            "LeavePolicyService"
 
-            // --- Temporary. Genuinely unbounded, waiting on the client work that moves each caller
-            // onto the paginated endpoint that already exists. Tracked by issue #473. Every entry
-            // here is a table that grows with a tenant's site activity and never shrinks.
-
-            "AssetService",
-            "EmployeeService",
-            "ExpenseService",
-            "GoodsReceivedNoteService",
-            "IndentService",
-            "IssueService",
-            "MaterialConsumptionService",
-            "MaterialService",
-            "PurchaseOrderService",
-            "ReceiptService",
-            "SiteTransferService",
-            "StockAdjustmentService",
-            "StorageLocationService",
-            "SubContractService",
-            "VendorService"
+            // --- Temporary. Empty. The fifteen services that grew with a tenant's site activity
+            // were closed out under issue #473: each web listing now reads a single capped page
+            // through UnpagedResultCap and the unbounded service method behind it is gone. An
+            // entry belongs here only while a genuinely unbounded read is waiting on client work,
+            // and it comes out the moment that read is bounded.
     );
 
     private static final DescribedPredicate<JavaClass> NOT_ALLOWED =

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
@@ -1,0 +1,261 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.asset.AssetControllerWeb;
+import org.tornotron.echno_backend.asset.AssetService;
+import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.employee.EmployeeControllerWeb;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.expense.ExpenseControllerWeb;
+import org.tornotron.echno_backend.expense.ExpenseService;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteControllerWeb;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNoteService;
+import org.tornotron.echno_backend.indent.IndentControllerWeb;
+import org.tornotron.echno_backend.indent.IndentService;
+import org.tornotron.echno_backend.issue.IssueControllerWeb;
+import org.tornotron.echno_backend.issue.IssueService;
+import org.tornotron.echno_backend.material.MaterialControllerWeb;
+import org.tornotron.echno_backend.material.MaterialService;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionControllerWeb;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumptionService;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderControllerWeb;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderService;
+import org.tornotron.echno_backend.receipt.ReceiptControllerWeb;
+import org.tornotron.echno_backend.receipt.ReceiptService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferControllerWeb;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferService;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentControllerWeb;
+import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentService;
+import org.tornotron.echno_backend.storageLocation.StorageLocationControllerWeb;
+import org.tornotron.echno_backend.storageLocation.StorageLocationService;
+import org.tornotron.echno_backend.subcontract.SubContractControllerWeb;
+import org.tornotron.echno_backend.subcontract.SubContractService;
+import org.tornotron.echno_backend.vendor.VendorControllerWeb;
+import org.tornotron.echno_backend.vendor.VendorService;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Every bare web listing that answers with a JSON array now reads exactly one capped page.
+ *
+ * <p>This is the regression these tests exist for, and it has already been shipped twice: a bare
+ * listing that reads {@code page.getContent()} from a page it sized with a defaulted
+ * {@code pageSize} of ten silently answers with the first ten rows, which is worse than an
+ * unbounded read because nothing about the response says it is incomplete. The listings here take
+ * no page parameters at all, so the only defensible read is page zero at the cap.
+ *
+ * <p>Each case pins the two halves that can drift apart: the page the controller asks the service
+ * for, and that the response carries the true total rather than the returned size. The
+ * architecture ratchet in {@code UnboundedRepositoryReadTest} stops the underlying read going back
+ * to a whole-table {@code findAll}; it cannot see what page number a controller asks for.
+ */
+@ExtendWith(MockitoExtension.class)
+class CappedWebListingTest {
+
+    @Mock private AssetService assetService;
+    @Mock private EmployeeService employeeService;
+    @Mock private ExpenseService expenseService;
+    @Mock private GoodsReceivedNoteService goodsReceivedNoteService;
+    @Mock private IndentService indentService;
+    @Mock private IssueService issueService;
+    @Mock private MaterialConsumptionService materialConsumptionService;
+    @Mock private MaterialService materialService;
+    @Mock private PurchaseOrderService purchaseOrderService;
+    @Mock private ReceiptService receiptService;
+    @Mock private SiteTransferService siteTransferService;
+    @Mock private StockAdjustmentService stockAdjustmentService;
+    @Mock private StorageLocationService storageLocationService;
+    @Mock private SubContractService subContractService;
+    @Mock private VendorService vendorService;
+
+    @Test
+    void assetsReadTheFirstCappedPage() {
+        when(assetService.getAllAssets(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AssetControllerWeb(assetService).readAllAssets();
+
+        verify(assetService).getAllAssets(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void employeesReadTheFirstCappedPageWithNoFilters() {
+        when(employeeService.displayAllEmployees(anyInt(), anyInt(), any(), any(), any()))
+                .thenReturn(Page.empty());
+
+        new EmployeeControllerWeb(employeeService).readAllEmployees();
+
+        verify(employeeService).displayAllEmployees(
+                eq(0), eq(UnpagedResultCap.MAX_ROWS), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void theEmployeePickerPassesItsSearchAndLimitThrough() {
+        when(employeeService.lookupEmployees(any(), anyInt())).thenReturn(Page.empty());
+
+        new EmployeeControllerWeb(employeeService).lookupEmployees("mason", 25);
+
+        verify(employeeService).lookupEmployees("mason", 25);
+    }
+
+    @Test
+    void expensesReadTheFirstCappedPageWithNoFilters() {
+        when(expenseService.getPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
+
+        new ExpenseControllerWeb(expenseService).readAllExpenses();
+
+        verify(expenseService).getPaginated(eq(0), eq(UnpagedResultCap.MAX_ROWS), isNull(), isNull());
+    }
+
+    @Test
+    void goodsReceivedNotesReadTheFirstCappedPage() {
+        when(goodsReceivedNoteService.getAllGrns(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new GoodsReceivedNoteControllerWeb(goodsReceivedNoteService).getAllGrns();
+
+        verify(goodsReceivedNoteService).getAllGrns(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void indentsReadTheFirstCappedPage() {
+        when(indentService.getAllIndents(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new IndentControllerWeb(indentService).getAllIndents();
+
+        verify(indentService).getAllIndents(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void issuesReadTheFirstCappedPageWithNoFilters() {
+        when(issueService.getAllIssuesPaginated(
+                anyInt(), anyInt(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Page.empty());
+
+        new IssueControllerWeb(issueService, null).readAllIssues();
+
+        verify(issueService).getAllIssuesPaginated(
+                eq(0), eq(UnpagedResultCap.MAX_ROWS),
+                isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void materialsReadTheFirstCappedPage() {
+        when(materialService.getAllMaterials(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new MaterialControllerWeb(materialService, null).getAllMaterials();
+
+        verify(materialService).getAllMaterials(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void materialConsumptionsReadTheFirstCappedPage() {
+        when(materialConsumptionService.getAllMaterialConsumptions(anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new MaterialConsumptionControllerWeb(materialConsumptionService).getAllMaterialConsumptions();
+
+        verify(materialConsumptionService).getAllMaterialConsumptions(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void purchaseOrdersReadTheFirstCappedPage() {
+        when(purchaseOrderService.getAllPurchaseOrders(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new PurchaseOrderControllerWeb(purchaseOrderService).getAllPurchaseOrders();
+
+        verify(purchaseOrderService).getAllPurchaseOrders(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void receiptsReadTheFirstCappedPageWithNoFilters() {
+        when(receiptService.getPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
+
+        new ReceiptControllerWeb(receiptService).readAllReceipts();
+
+        verify(receiptService).getPaginated(eq(0), eq(UnpagedResultCap.MAX_ROWS), isNull(), isNull());
+    }
+
+    @Test
+    void siteTransfersReadTheFirstCappedPage() {
+        when(siteTransferService.getAllSiteTransfers(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new SiteTransferControllerWeb(siteTransferService).getAllSiteTransfers();
+
+        verify(siteTransferService).getAllSiteTransfers(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void stockAdjustmentsReadTheFirstCappedPage() {
+        when(stockAdjustmentService.getAll(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new StockAdjustmentControllerWeb(stockAdjustmentService).readAllStockAdjustments();
+
+        verify(stockAdjustmentService).getAll(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void storageLocationsReadTheFirstCappedPage() {
+        when(storageLocationService.getAllStorageLocations(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new StorageLocationControllerWeb(storageLocationService).getAllStorageLocations();
+
+        verify(storageLocationService).getAllStorageLocations(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void subContractsReadTheFirstCappedPageWithNoFilters() {
+        when(subContractService.getPaginated(anyInt(), anyInt(), any(), any(), any()))
+                .thenReturn(Page.empty());
+
+        new SubContractControllerWeb(subContractService).readAllSubContracts();
+
+        verify(subContractService).getPaginated(
+                eq(0), eq(UnpagedResultCap.MAX_ROWS), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void vendorsReadTheFirstCappedPage() {
+        when(vendorService.getAllVendors(anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new VendorControllerWeb(vendorService, null).getAllVendors();
+
+        verify(vendorService).getAllVendors(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    /**
+     * A truncated listing says so. Without this a caller cannot distinguish a tenant with exactly
+     * the cap's worth of rows from one whose result was cut, which is how a silent truncation goes
+     * unnoticed in the first place.
+     */
+    @Test
+    void aTruncatedListingCarriesTheTrueTotalAndTheCappedFlag() {
+        List<AssetDto> rows = IntStream.range(0, UnpagedResultCap.MAX_ROWS)
+                .mapToObj(i -> new AssetDto())
+                .toList();
+        when(assetService.getAllAssets(anyInt(), anyInt())).thenReturn(new PageImpl<>(
+                rows, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), UnpagedResultCap.MAX_ROWS + 7));
+
+        ResponseEntity<List<AssetDto>> response =
+                new AssetControllerWeb(assetService).readAllAssets();
+
+        assertThat(response.getBody()).hasSize(UnpagedResultCap.MAX_ROWS);
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.TOTAL_HEADER))
+                .isEqualTo(Long.toString(UnpagedResultCap.MAX_ROWS + 7L));
+        assertThat(response.getHeaders().getFirst(UnpagedResultCap.CAPPED_HEADER)).isEqualTo("true");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/security/ReadWriteGuardSymmetryTest.java
@@ -36,9 +36,9 @@ import org.tornotron.echno_backend.subcontract.SubContractService;
 import org.tornotron.echno_backend.task.TaskControllerWeb;
 import org.tornotron.echno_backend.task.TaskService;
 
-import java.util.List;
 import java.util.stream.Stream;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -119,12 +119,13 @@ class ReadWriteGuardSymmetryTest {
     @BeforeEach
     void stubEmptyResults() {
         // The handlers that page call getContent() on the result, so these cannot be left null.
-        when(assetService.getAllAssets()).thenReturn(List.of());
-        when(expenseService.getAll()).thenReturn(List.of());
-        when(receiptService.getAll()).thenReturn(List.of());
-        when(subContractService.getAll()).thenReturn(List.of());
-        when(stockAdjustmentService.getAll()).thenReturn(List.of());
-        when(issueService.getAllIssues()).thenReturn(List.of());
+        when(assetService.getAllAssets(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(expenseService.getPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
+        when(receiptService.getPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
+        when(subContractService.getPaginated(anyInt(), anyInt(), any(), any(), any())).thenReturn(Page.empty());
+        when(stockAdjustmentService.getAll(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(issueService.getAllIssuesPaginated(anyInt(), anyInt(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Page.empty());
         when(categoryService.getAllCategories(anyInt(), anyInt())).thenReturn(Page.empty());
         when(taskService.getAllTasks(anyInt(), anyInt())).thenReturn(Page.empty());
         when(issueCommentService.getAllIssueComments(anyInt(), anyInt())).thenReturn(Page.empty());

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
@@ -1,0 +1,130 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The picker feed behind {@code GET /api/v1/employee/web/lookup}.
+ *
+ * <p>It used to read the whole employee table and map every row, which is the one shape a
+ * dropdown never needs: the widget shows a handful of entries and the user narrows by typing.
+ * It is now a search-and-limit read, and the two things worth pinning are that a caller cannot
+ * talk it back into a whole-table read with a large {@code limit}, and that a blank search means
+ * no filter rather than a filter on an empty string.
+ *
+ * <p>Only the collaborators this path touches are mocked. Mockito passes null for the rest of the
+ * constructor, which is accurate: nothing else is reachable from the method under test.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmployeeLookupTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    private EmployeeService service() {
+        return new EmployeeService(employeeRepository, null, null, null, null, null, null);
+    }
+
+    private Pageable capturePageable() {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(employeeRepository).search(any(), any(), any(), pageable.capture());
+        return pageable.getValue();
+    }
+
+    private String captureSearchPattern() {
+        ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
+        verify(employeeRepository).search(pattern.capture(), any(), any(), any());
+        return pattern.getValue();
+    }
+
+    @Test
+    void aLimitAboveTheCapIsClampedToIt() {
+        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees(null, 100_000);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void aLimitBelowOneIsRaisedToOne() {
+        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees(null, 0);
+
+        assertThat(capturePageable().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    void theFeedAlwaysReadsTheFirstPage() {
+        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees("mason", 25);
+
+        Pageable pageable = capturePageable();
+        assertThat(pageable.getPageNumber()).isZero();
+        assertThat(pageable.getPageSize()).isEqualTo(25);
+    }
+
+    @Test
+    void aBlankSearchLeavesTheFilterOff() {
+        when(employeeRepository.search(isNull(), any(), any(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees("   ", 50);
+
+        assertThat(captureSearchPattern()).isNull();
+    }
+
+    @Test
+    void aSearchTermIsLowercasedAndWrapped() {
+        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees("  Mason  ", 50);
+
+        assertThat(captureSearchPattern()).isEqualTo("%mason%");
+    }
+
+    @Test
+    void theStatusAndDepartmentFiltersStayOff() {
+        when(employeeRepository.search(any(), isNull(), isNull(), any())).thenReturn(Page.empty());
+
+        service().lookupEmployees("mason", 50);
+
+        verify(employeeRepository).search(any(), isNull(), isNull(), any());
+    }
+
+    @Test
+    void aRowIsProjectedWithoutContactOrSalaryDetail() {
+        Employee employee = new Employee();
+        employee.setId(7L);
+        employee.setEmployeeId("EMP-007");
+        employee.setEmployeeName("Mason");
+        employee.setDesignation("Site engineer");
+        when(employeeRepository.search(any(), any(), any(), any()))
+                .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(employee)));
+
+        Page<EmployeeLookupDto> page = service().lookupEmployees(null, 50);
+
+        assertThat(page.getContent()).singleElement().satisfies(dto -> {
+            assertThat(dto.id()).isEqualTo(7L);
+            assertThat(dto.employeeId()).isEqualTo("EMP-007");
+            assertThat(dto.employeeName()).isEqualTo("Mason");
+            assertThat(dto.organizationId()).isNull();
+        });
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeLookupTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,19 +43,19 @@ class EmployeeLookupTest {
 
     private Pageable capturePageable() {
         ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
-        verify(employeeRepository).search(any(), any(), any(), pageable.capture());
+        verify(employeeRepository).searchForLookup(any(), pageable.capture());
         return pageable.getValue();
     }
 
     private String captureSearchPattern() {
         ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
-        verify(employeeRepository).search(pattern.capture(), any(), any(), any());
+        verify(employeeRepository).searchForLookup(pattern.capture(), any());
         return pattern.getValue();
     }
 
     @Test
     void aLimitAboveTheCapIsClampedToIt() {
-        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+        when(employeeRepository.searchForLookup(any(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees(null, 100_000);
 
@@ -63,7 +64,7 @@ class EmployeeLookupTest {
 
     @Test
     void aLimitBelowOneIsRaisedToOne() {
-        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+        when(employeeRepository.searchForLookup(any(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees(null, 0);
 
@@ -72,7 +73,7 @@ class EmployeeLookupTest {
 
     @Test
     void theFeedAlwaysReadsTheFirstPage() {
-        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+        when(employeeRepository.searchForLookup(any(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees("mason", 25);
 
@@ -83,7 +84,7 @@ class EmployeeLookupTest {
 
     @Test
     void aBlankSearchLeavesTheFilterOff() {
-        when(employeeRepository.search(isNull(), any(), any(), any())).thenReturn(Page.empty());
+        when(employeeRepository.searchForLookup(isNull(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees("   ", 50);
 
@@ -92,7 +93,7 @@ class EmployeeLookupTest {
 
     @Test
     void aSearchTermIsLowercasedAndWrapped() {
-        when(employeeRepository.search(any(), any(), any(), any())).thenReturn(Page.empty());
+        when(employeeRepository.searchForLookup(any(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees("  Mason  ", 50);
 
@@ -100,12 +101,15 @@ class EmployeeLookupTest {
     }
 
     @Test
-    void theStatusAndDepartmentFiltersStayOff() {
-        when(employeeRepository.search(any(), isNull(), isNull(), any())).thenReturn(Page.empty());
+    void theFeedDoesNotSearchContactDetails() {
+        when(employeeRepository.searchForLookup(any(), any())).thenReturn(Page.empty());
 
         service().lookupEmployees("mason", 50);
 
-        verify(employeeRepository).search(any(), isNull(), isNull(), any());
+        // The restricted listing's search also matches email and phone. This feed is
+        // readable by any tenant member, so it must not become a way of confirming a
+        // guessed contact detail against a returned identity.
+        verify(employeeRepository, never()).search(any(), any(), any(), any());
     }
 
     @Test
@@ -115,7 +119,7 @@ class EmployeeLookupTest {
         employee.setEmployeeId("EMP-007");
         employee.setEmployeeName("Mason");
         employee.setDesignation("Site engineer");
-        when(employeeRepository.search(any(), any(), any(), any()))
+        when(employeeRepository.searchForLookup(any(), any()))
                 .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(employee)));
 
         Page<EmployeeLookupDto> page = service().lookupEmployees(null, 50);

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,8 +16,8 @@ import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationSer
 import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
-import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -55,7 +56,7 @@ class SiteTransferControllerWebAuthzTest {
     @Test
     void readAll_isOk_forASystemAdmin() throws Exception {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
-        when(siteTransferService.getAllSiteTransfers()).thenReturn(List.of());
+        when(siteTransferService.getAllSiteTransfers(anyInt(), anyInt())).thenReturn(Page.empty());
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
                 .andExpect(status().isOk());

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,8 +16,8 @@ import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationSer
 import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
-import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -57,7 +58,7 @@ class StockAdjustmentControllerWebAuthzTest {
     @Test
     void read_isOk_forAnyMember() throws Exception {
         when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
-        when(stockAdjustmentService.getAll()).thenReturn(List.of());
+        when(stockAdjustmentService.getAll(anyInt(), anyInt())).thenReturn(Page.empty());
 
         mockMvc.perform(get("/api/v1/stock-adjustments/web").with(jwt()))
                 .andExpect(status().isOk());


### PR DESCRIPTION
Closes #473.

## The real count

The issue title says 26. That figure was accurate when it was written and is no longer. PR #483 capped 17 reads (the mobile twins and the endpoints no client used), PR #489 turned the finding into a ratchet with a shrinking allowlist, and #494 and #504 took the task and project listings. Re-surveying `development` at `3eeeb34`:

| | Unbounded repository reads | Classes making them |
|---|---|---|
| Before this PR | 24 | 21 |
| After this PR | 8 | 6 |

The 24 are every `findAll()` and `findAll(Sort)` reaching a repository, which is what the ratchet actually bans; the `findAll(Sort)` variant is why this is 24 rather than the 21 a naive grep returns. Sixteen of them were genuinely unbounded and are fixed here. The remaining eight are the six reference-data services already recorded as deliberate, and they stay.

The allowlist's temporary half is now empty. Every entry left is permanent.

## What was done to each read, and why

The shape of the problem made the decision for most of them: **fifteen of the sixteen already had a paginated sibling on the same controller**, so the bare `@GetMapping` was the only unbounded one. Capping it bounds the read without changing the response, and a client that wants a complete result moves to the sibling that already exists. The unbounded service method behind each is deleted, which is what takes the class off the allowlist.

| Endpoint | Read | Decision | Why |
|---|---|---|---|
| `GET /assets/web` | `AssetService.getAllAssets()` | capped | `/paginated` sibling exists |
| `GET /employee/web` | `EmployeeService.displayAllEmployees()` | capped | `/paginated` sibling exists |
| `GET /employee/web/lookup` | `EmployeeService.lookupEmployees()` | **search-and-limit** | picker feed, see below |
| `GET /expenses/web` | `ExpenseService.getAll()` | capped | `/paginated` sibling exists |
| `GET /grns/web` | `GoodsReceivedNoteService.getAllGrns()` | capped | `/paginated` sibling exists |
| `GET /indents/web` | `IndentService.getAllIndents()` | capped | `/all` sibling exists |
| `GET /issues/web` | `IssueService.getAllIssues()` | capped | `/paginated` sibling exists; this one sits in the app shell, so it is on every route |
| `GET /material-consumptions/web` | `MaterialConsumptionService.getAllMaterialConsumptions()` | capped | `/paginated` sibling exists |
| `GET /materials/web` | `MaterialService.getAllMaterials()` | capped | `/paginated` sibling exists |
| `GET /purchase-orders/web` | `PurchaseOrderService.getAllPurchaseOrders()` | capped | `/paginated` sibling exists |
| `GET /receipts/web` | `ReceiptService.getAll()` | capped | `/paginated` sibling exists |
| `GET /site-transfers/web` | `SiteTransferService.getAllSiteTransfers()` | capped | `/paginated` sibling exists |
| `GET /stock-adjustments/web` | `StockAdjustmentService.getAll()` | capped | `/paginated` sibling exists |
| `GET /storage-locations/web` | `StorageLocationService.getAllStorageLocations()` | capped | `/paginated` sibling exists |
| `GET /sub-contracts/web` | `SubContractService.getAll()` | capped | `/paginated` sibling exists |
| `GET /vendors/web` | `VendorService.getAllVendors()` | capped | `/all` sibling exists |

Capped means the handler reads page zero at `UnpagedResultCap.MAX_ROWS` (500) and responds through `UnpagedResultCap.respond`, so the body stays an array and gains `X-Total-Count` with the true row count plus `X-Result-Capped` when rows were left out. A capped response is never silently truncated, which is the failure mode that hit the task and project listings in #478.

### The one that is not a cap

`GET /employee/web/lookup` feeds pickers, and a dropdown never wants the whole table: the widget shows a handful and the user narrows by typing. It becomes a search-and-limit read backed by the repository's existing paged `search`:

- `search` (optional): case-insensitive substring matched against the employee name or the human-facing employee id.
- `limit` (optional, default 500): clamped to at least one and at most 500, so no caller can ask for the whole table by passing a large number.

Both parameters default to the previous behaviour, so an existing caller sees no difference until it starts narrowing.

The feed gets its own repository query rather than reusing the one behind the restricted listing, which also matches email and phone. This endpoint is readable by any tenant member, so matching a contact detail would have let a member confirm a guessed address or number against the identity the feed returns. The old whole-table read did not offer that, and neither does this one.

## Four of these are only half-fixed, and the rest is #522

Pagination caps the number of rows a response carries. It does nothing about what each row costs, and for four of these listings that cost is a database round trip hidden inside the MapStruct mapper's `@AfterMapping` hook, invisible at the call site because the mapper reads as a pure conversion. `hibernate.default_batch_fetch_size` does not help: these are explicit repository calls, not lazy association loads.

| Listing | Per-row cost | What a 500-row page actually costs |
|---|---|---|
| `GET /materials/web` | `MaterialMapper.fillStock`, 2 SUM queries per material | ~1,000 extra queries |
| `GET /storage-locations/web` | `StorageLocationMapper.fillItemsCount`, 1 COUNT per row | ~500 extra queries |
| `GET /indents/web` | `IndentMapper` uses `IndentItemMapper` uses `MaterialMapper`, so it multiplies by the line count | 2 queries per indent line |
| `GET /issues/web` | `IssueMapper` uses `AttachmentMapper`, 1 SigV4 presign per attachment | 1 presign per attachment |

`GET /employee/web` composes `AttachmentMapper` the same way. The picker feed does not: it projects its rows by hand and touches no mapper.

Capping these is still strictly better than not capping them, because before this change the multiplier applied to the whole table rather than to 500 rows. But calling them done would be wrong. The mapper side is proposed separately on #522, whose recommendation is to ban I/O from `@AfterMapping` and enforce that with the existing ArchUnit suite. `MaterialMapper.toWithStockDto` already shows the target shape, taking the stock as an argument instead of fetching it, and it measures zero extra reads.

### Left alone, on purpose

The six permanent allowlist entries keep their unbounded reads, and their reasons are already written into `UnboundedRepositoryReadTest`: `AccountService` and `AccountCsvService` (the chart of accounts, where a partial extract would misreport every total and the volume lives in the paged journal entries), `CompanyBankAccountService`, `CostCategoryService`, `FeatureService` (a fixed catalogue shipped with the product) and `LeavePolicyService`. Each is bounded by what the table is rather than by how many rows it holds today, which is the bar the allowlist sets. Nothing was added to the allowlist in this PR.

## Breaking for `echno-web`?

**No response shape changes.** Every endpoint above still returns the same JSON array it returned before, with the same element type. This was deliberate: turning an array into a page object would have forced a backend, core release, web sequence across sixteen endpoints at once, and there was no need for it when a paginated sibling already existed on every controller.

Two behaviour changes the frontend should still know about, neither of which needs a code change to keep working:

1. **A tenant with more than 500 rows now gets 500 rows and a header, instead of all of them.** Any page that renders one of these listings and needs completeness should move to the paginated sibling. `X-Result-Capped` on the response is the signal that it matters for that tenant.
2. **`/employee/web/lookup` gained two optional query parameters.** Existing calls are unaffected. Pickers should start passing `search` as the user types, and a small `limit`.

## Tests

- `CappedWebListingTest`: every capped listing asks for page zero at the cap, and a truncated response carries the true total and the capped flag. This pins the defect from #478 (a bare listing reading `getContent()` off a page sized by a defaulted `pageSize`), which the architecture ratchet cannot see because it only looks at the repository call.
- `EmployeeLookupTest`: the limit clamps at both ends, a blank search leaves the filter off rather than filtering on an empty string, the feed never reaches the wider search that matches contact details, and the row projection still carries no contact or salary detail.
- Both are plain JUnit and Mockito with no Spring context, so they add nothing to the test JVM's context cache.
- `UnboundedRepositoryReadTest` allowlist shrinks from 21 entries to 6. Its `theAllowlistHasNoStaleEntries` check is what makes that a ratchet rather than an edit: an entry that no longer makes the call fails the build.
- Full suite green on the lab build box.
