### PR TITLE
Check consumption against the balance row it writes, and give stock adjustments a way to correct one

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
@@ -88,13 +88,17 @@ public class InventoryEventListener {
         MaterialConsumption consumption = event.getMaterialConsumption();
         logger.info("Handling material consumed event for consumption ID: {}", consumption.getId());
 
+        // Read the balance this movement actually draws down. With no storage location that
+        // is the project's unlocated row, not the project total: the total would put an
+        // opening and closing figure on the ledger entry that the row it moves never held.
         Double openingStock;
         if (consumption.getStorageLocation() != null) {
             openingStock = inventoryService.getStockAtLocation(
                     consumption.getMaterial().getId(), consumption.getProject().getId(),
                     consumption.getStorageLocation().getId());
         } else {
-            openingStock = inventoryService.getCurrentStock(consumption.getMaterial().getId(), consumption.getProject().getId());
+            openingStock = inventoryService.findUnlocatedStock(
+                    consumption.getMaterial().getId(), consumption.getProject().getId()).orElse(0.0);
         }
         Double quantityChanged = -consumption.getQuantity().doubleValue();
         Double closingStock = openingStock + quantityChanged;

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
@@ -73,6 +73,10 @@ public class InventoryService {
     /**
      * Returns current stock for a material at one storage location within a project.
      *
+     * <p>Flattens a missing balance row to zero. Use {@link #findStockAtLocation} where the
+     * difference matters: a material that has never been stocked at a location and a location
+     * that has genuinely run out are different situations and deserve different messages.
+     *
      * @param materialId The material to look up.
      * @param projectId The project the location belongs to.
      * @param storageLocationId The storage location to read.
@@ -80,10 +84,43 @@ public class InventoryService {
      */
     @Transactional(readOnly = true)
     public Double getStockAtLocation(Long materialId, Long projectId, Long storageLocationId) {
+        return findStockAtLocation(materialId, projectId, storageLocationId).orElse(0.0);
+    }
+
+    /**
+     * Returns the balance for a material at one storage location, empty when no row exists.
+     *
+     * <p>The empty result means "this material has never been stocked here", which reads the
+     * same as a zero balance once flattened but is a different fact about the data.
+     *
+     * @param materialId The material to look up.
+     * @param projectId The project the location belongs to.
+     * @param storageLocationId The storage location to read.
+     * @return The quantity on hand, or empty when the balance row does not exist.
+     */
+    @Transactional(readOnly = true)
+    public Optional<Double> findStockAtLocation(Long materialId, Long projectId, Long storageLocationId) {
         return currentStockRepository
                 .findByMaterialIdAndProjectIdAndStorageLocationId(materialId, projectId, storageLocationId)
-                .map(CurrentStock::getCurrentQuantity)
-                .orElse(0.0);
+                .map(CurrentStock::getCurrentQuantity);
+    }
+
+    /**
+     * Returns the project balance held against no storage location, empty when no row exists.
+     *
+     * <p>This is the row a movement with no storage location reads and writes. It is not the
+     * project total: stock booked into a storage location lives in its own row and is not
+     * reachable from here.
+     *
+     * @param materialId The material to look up.
+     * @param projectId The project to read.
+     * @return The unlocated quantity on hand, or empty when the balance row does not exist.
+     */
+    @Transactional(readOnly = true)
+    public Optional<Double> findUnlocatedStock(Long materialId, Long projectId) {
+        return currentStockRepository
+                .findByMaterialIdAndProjectIdAndStorageLocationIsNull(materialId, projectId)
+                .map(CurrentStock::getCurrentQuantity);
     }
 
     /**
@@ -123,18 +160,64 @@ public class InventoryService {
     /**
      * Checks that a storage location holds at least the required quantity of a material.
      *
+     * <p>A balance row that does not exist is reported separately from a row that has run
+     * down to zero. Both leave nothing to draw on, but only the second is a stock-out; the
+     * first means the material has never been received into that location, which is a
+     * different thing to tell the user and a different thing for them to fix.
+     *
      * @param materialId The material to check.
      * @param projectId The project the location belongs to.
      * @param storageLocationId The storage location to check.
      * @param requiredQuantity The quantity that must be available.
-     * @throws InsufficientStockException if the quantity on hand at the location is below the required amount.
+     * @throws InsufficientStockException if no balance exists at the location, or the quantity on hand is below the required amount.
      */
     public void validateSufficientStockAtLocation(Long materialId, Long projectId, Long storageLocationId, Double requiredQuantity) {
-        Double currentStock = getStockAtLocation(materialId, projectId, storageLocationId);
+        Optional<Double> balance = findStockAtLocation(materialId, projectId, storageLocationId);
+        if (balance.isEmpty() && requiredQuantity > 0) {
+            throw new InsufficientStockException(
+                String.format("No stock of material ID %d has ever been held at project ID %d, storage location ID %d, "
+                        + "so there is none to draw on. Required: %.2f. Receive the material into this location with a "
+                        + "goods receipt or a transfer in, or record a stock adjustment, before drawing from it.",
+                    materialId, projectId, storageLocationId, requiredQuantity)
+            );
+        }
+        Double currentStock = balance.orElse(0.0);
         if (currentStock < requiredQuantity) {
             throw new InsufficientStockException(
                 String.format("Insufficient stock for material ID %d at project ID %d, storage location ID %d. Required: %.2f, Available: %.2f",
                     materialId, projectId, storageLocationId, requiredQuantity, currentStock)
+            );
+        }
+    }
+
+    /**
+     * Checks the project balance held against no storage location.
+     *
+     * <p>This is the check for a movement that names no location, because that is the row the
+     * movement goes on to write. {@link #validateSufficientStock} is deliberately not used
+     * here: it sums every row on the project, so it passes on stock sitting in storage
+     * locations that the unlocated write will never touch, and the balance goes negative.
+     *
+     * @param materialId The material to check.
+     * @param projectId The project to check within.
+     * @param requiredQuantity The quantity that must be available.
+     * @throws InsufficientStockException if no unlocated balance exists, or it is below the required amount.
+     */
+    public void validateSufficientUnlocatedStock(Long materialId, Long projectId, Double requiredQuantity) {
+        Optional<Double> balance = findUnlocatedStock(materialId, projectId);
+        if (balance.isEmpty() && requiredQuantity > 0) {
+            throw new InsufficientStockException(
+                String.format("Material ID %d holds no stock at project ID %d outside a storage location. Required: %.2f. "
+                        + "Any stock the project holds sits in its storage locations, so name the location to draw from.",
+                    materialId, projectId, requiredQuantity)
+            );
+        }
+        Double currentStock = balance.orElse(0.0);
+        if (currentStock < requiredQuantity) {
+            throw new InsufficientStockException(
+                String.format("Insufficient stock for material ID %d at project ID %d outside a storage location. "
+                        + "Required: %.2f, Available: %.2f",
+                    materialId, projectId, requiredQuantity, currentStock)
             );
         }
     }
@@ -155,8 +238,16 @@ public class InventoryService {
         for (Map.Entry<Long, Double> entry : requiredQuantities.entrySet()) {
             Long materialId = entry.getKey();
             Double required = entry.getValue();
-            Double available = getStockAtLocation(materialId, projectId, storageLocationId);
+            Optional<Double> balance = findStockAtLocation(materialId, projectId, storageLocationId);
 
+            if (balance.isEmpty() && required > 0) {
+                insufficientItems.add(
+                    String.format("Material ID %d: Required %.2f, never stocked at this location",
+                        materialId, required)
+                );
+                continue;
+            }
+            Double available = balance.orElse(0.0);
             if (available < required) {
                 insufficientItems.add(
                     String.format("Material ID %d: Required %.2f, Available %.2f",

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
@@ -23,6 +23,7 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
@@ -122,6 +123,9 @@ public class MaterialService {
                                 creationDto.getStorageLocationId(), TenantContext.getCurrentOrgId())
                         .orElseThrow(() -> new ResourceNotFoundException(
                                 "Storage location with ID " + creationDto.getStorageLocationId() + " was not found in this organization"));
+                // The project and the location were resolved independently, so an opening
+                // balance could be seeded onto a location belonging to another project.
+                StorageLocationScope.requireUsableFromProject(storageLocation, project.getId());
             }
 
             Double quantity = creationDto.getOpeningStock().doubleValue();

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionService.java
@@ -24,6 +24,7 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.task.Task;
 import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.User;
@@ -36,10 +37,14 @@ import java.util.stream.Collectors;
 /**
  * Records material consumption and exposes queries over past consumption.
  *
- * <p>Recording a consumption first checks that enough stock is available (at the storage
- * location when one is given, otherwise across the project), then persists the record and
- * publishes a {@link MaterialConsumedEvent} so the inventory ledger draws the stock down in
- * the same transaction.
+ * <p>Recording a consumption first checks that enough stock is available on the balance row
+ * the draw-down will write: the storage location's row when a location is given, otherwise
+ * the project's unlocated row. It then persists the record and publishes a
+ * {@link MaterialConsumedEvent} so the inventory ledger draws the stock down.
+ *
+ * <p>A storage location on another project is refused, and an organisation-level location
+ * (one that names no project) is accepted from any project. See
+ * {@link org.tornotron.echno_backend.storageLocation.StorageLocationScope}.
  */
 @Service
 public class MaterialConsumptionService {
@@ -80,15 +85,17 @@ public class MaterialConsumptionService {
     /**
      * Records a material consumption after checking stock, and triggers the stock decrease.
      *
-     * <p>Resolves the material, creator, and project, then validates sufficient stock at the
-     * storage location when one is supplied or across the project otherwise. An optional task
-     * must belong to the same project. After saving, a {@link MaterialConsumedEvent} is
-     * published so inventory is reduced.
+     * <p>Resolves the material, creator, project and storage location, checks that the
+     * location may be used from that project, then validates sufficient stock on the balance
+     * row the draw-down will write: the location's row when a location is supplied, the
+     * project's unlocated row otherwise. An optional task must belong to the same project.
+     * After saving, a {@link MaterialConsumedEvent} is published so inventory is reduced.
      *
      * @param creationDto The consumption details, including material, quantity, project, and optional storage location and task.
      * @return The created consumption record as a DTO.
      * @throws ResourceNotFoundException if the material, creator, project, storage location, or task is not found in this organization.
-     * @throws InsufficientStockException if the available stock is below the consumed quantity.
+     * @throws org.tornotron.echno_backend.common.exception.InvalidRequestException if the storage location belongs to a different project.
+     * @throws InsufficientStockException if there is no balance to draw on, or it is below the consumed quantity.
      * @throws IllegalArgumentException if the given task does not belong to the given project.
      */
     @Transactional
@@ -104,14 +111,31 @@ public class MaterialConsumptionService {
         Project project = projectRepository.findByIdAndOrganization_Id(creationDto.getProjectId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Project with ID " + creationDto.getProjectId() + " was not found in this organization"));
 
-        // CRITICAL: Validate sufficient stock before consumption
-        // Use storage-location-level validation when a storage location is specified
+        // Resolve the storage location before the stock check, because the location decides
+        // which balance row the check has to read: the consumption draws down exactly one row
+        // and the check has to be asked about that same row.
+        StorageLocation storageLocation = null;
         if (creationDto.getStorageLocationId() != null) {
+            storageLocation = storageLocationRepository.findByIdAndOrganization_Id(
+                            creationDto.getStorageLocationId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Storage location with ID " + creationDto.getStorageLocationId() + " was not found in this organization"));
+            // Nothing used to check the location against the project, so a location on another
+            // project (or none) could be booked here and the balance row could never exist.
+            StorageLocationScope.requireUsableFromProject(storageLocation, project.getId());
+        }
+
+        // CRITICAL: Validate sufficient stock before consumption, against the row the
+        // consumption will write. With no location that is the project's unlocated row, not
+        // the project total, which would pass on stock held in locations this write cannot
+        // reach and drive the unlocated balance negative.
+        if (storageLocation != null) {
             inventoryService.validateSufficientStockAtLocation(
-                    creationDto.getMaterialId(), project.getId(),
-                    creationDto.getStorageLocationId(), creationDto.getQuantity().doubleValue());
+                    material.getId(), project.getId(),
+                    storageLocation.getId(), creationDto.getQuantity().doubleValue());
         } else {
-            inventoryService.validateSufficientStock(creationDto.getMaterialId(), project.getId(), creationDto.getQuantity().doubleValue());
+            inventoryService.validateSufficientUnlocatedStock(
+                    material.getId(), project.getId(), creationDto.getQuantity().doubleValue());
         }
 
         // Create material consumption
@@ -124,14 +148,7 @@ public class MaterialConsumptionService {
         consumption.setCreatedBy(createdBy);
         consumption.setProject(project);
 
-        // Validate and set storage location (optional)
-        if (creationDto.getStorageLocationId() != null) {
-            StorageLocation storageLocation = storageLocationRepository.findByIdAndOrganization_Id(
-                            creationDto.getStorageLocationId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "Storage location with ID " + creationDto.getStorageLocationId() + " was not found in this organization"));
-            consumption.setStorageLocation(storageLocation);
-        }
+        consumption.setStorageLocation(storageLocation);
 
         // Validate and set task (optional)
         if (creationDto.getTaskId() != null) {

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
@@ -24,8 +24,10 @@ import java.util.List;
  * values (e.g. {@code write_off}, {@code physical_count}) that are not valid Java enum
  * identifiers; the frontend validates them.
  *
- * <p>MVP scope: this document is persisted only. It does not mutate {@code CurrentStock}
- * or post inventory transactions; that integration is deferred.
+ * <p>The document is a draft until it is approved. Approval posts each line to the stock
+ * ledger and moves the balance, and stamps {@code processedAt}, which is what marks the
+ * document as posted: a posted document cannot be posted again, edited, or deleted. See
+ * {@link StockAdjustmentService#approve}.
  */
 @Entity
 @Table(name = "stock_adjustment")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -23,9 +23,12 @@ import java.util.List;
         name = "Stock Adjustments (Web)",
         description = "Documents that correct the recorded on-hand quantity of materials at a storage "
                 + "location against a physical count, capturing the variance, its reason and justification "
-                + "per line item. Endpoints cover creating, updating, browsing and deleting stock "
-                + "adjustment documents for the caller's current tenant. Read endpoints require tenant "
-                + "membership; write endpoints require the system-admin or project-manager role."
+                + "per line item. This is the controlled way to set or correct a stock balance: approving "
+                + "a document posts its lines to the inventory ledger and moves the balance, so the "
+                + "resulting figure stays explainable. Endpoints cover creating, updating, browsing, "
+                + "approving and deleting stock adjustment documents for the caller's current tenant. "
+                + "Read endpoints require tenant membership; write and approval endpoints require the "
+                + "system-admin or project-manager role."
 )
 public class StockAdjustmentControllerWeb {
 
@@ -88,9 +91,8 @@ public class StockAdjustmentControllerWeb {
     @Operation(
             summary = "Create a stock adjustment",
             description = "Records a stock adjustment document capturing the counted and system quantities, "
-                    + "variance and justification for one or more materials at a location. In the current "
-                    + "scope the document is persisted as a record only; it does not yet post inventory "
-                    + "transactions or change the current stock balance."
+                    + "variance and justification for one or more materials at a location. The document is "
+                    + "created as a draft: it does not change any stock balance until it is approved."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Stock adjustment created"),
@@ -107,7 +109,8 @@ public class StockAdjustmentControllerWeb {
     @Operation(
             summary = "Update a stock adjustment",
             description = "Replaces the header fields and line items of an existing stock adjustment with "
-                    + "the given values."
+                    + "the given values. Refused once the adjustment has been approved and posted, since "
+                    + "the ledger entries would then describe a document that no longer exists."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment updated"),
@@ -120,11 +123,37 @@ public class StockAdjustmentControllerWeb {
         return new ResponseEntity<>(stockAdjustmentService.update(id, creationDto), HttpStatus.OK);
     }
 
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Approve a stock adjustment and post it to the stock ledger",
+            description = "Approves the adjustment and posts each of its lines as an inventory "
+                    + "transaction, then moves the balance for that material, project and storage "
+                    + "location. A line carrying a counted physical quantity is posted as the movement "
+                    + "needed to reach that count from the balance as it stands at approval; a line "
+                    + "without one uses its signed adjustment quantity. Every line must carry a reason, "
+                    + "or the document must give a primary reason to fall back on, because the reason is "
+                    + "what the resulting balance is explained by. This is the only path that sets or "
+                    + "corrects a balance, and it is restricted to the system-admin and project-manager "
+                    + "roles. It runs once: an approved document is frozen against further posting, "
+                    + "editing and deletion, and a mistake is corrected by raising another adjustment."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment approved and posted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The adjustment is already posted, names no project, has no lines, or a line is missing a material, a reason or a quantity, or would take a balance below zero"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
+    })
+    public ResponseEntity<StockAdjustmentDto> approveStockAdjustment(@PathVariable Long id) {
+        return new ResponseEntity<>(stockAdjustmentService.approve(id), HttpStatus.OK);
+    }
+
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Delete a stock adjustment",
-            description = "Deletes the stock adjustment with the given id."
+            description = "Deletes the stock adjustment with the given id. Refused once the adjustment "
+                    + "has been approved and posted; raise a further adjustment instead."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment deleted"),

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -86,6 +86,13 @@ public class StockAdjustmentService {
     /** Status a document carries once its movements are on the ledger. */
     static final String POSTED_STATUS = "processed";
 
+    /**
+     * Below this, a line's movement is treated as none at all. A count matching the balance
+     * to the last decimal place can still leave floating-point residue, and a ledger entry
+     * for a movement of 1e-16 is a phantom row claiming stock moved when it did not.
+     */
+    private static final double NO_MOVEMENT = 1e-9;
+
     @Transactional
     public StockAdjustmentDto create(StockAdjustmentCreationDto creationDto) {
         Organization organization = tenantEntityHelper.resolveCurrentOrganization();
@@ -241,7 +248,8 @@ public class StockAdjustmentService {
             line.setSystemQuantity(balance);
             line.setAdjustmentQuantity(movement);
 
-            if (movement == 0.0) {
+            if (Math.abs(movement) < NO_MOVEMENT) {
+                line.setAdjustmentQuantity(0.0);
                 continue;
             }
             double closing = balance + movement;

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -6,9 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.organization.Organization;
@@ -20,14 +25,30 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCr
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
+import org.tornotron.echno_backend.user.UserContextService;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * CRUD + list for stock-adjustment documents. MVP scope: the document is persisted
- * only; this service does NOT touch {@code CurrentStock} or post inventory
- * transactions. That integration is deferred.
+ * Stock-adjustment documents: draft, browse, edit, and post to the stock ledger.
+ *
+ * <p>A stock adjustment is the only way to set or correct a balance once a material
+ * exists. Everything else that moves stock (a goods receipt, a consumption, a site
+ * transfer) records a business event, so a balance that is simply wrong, or a
+ * (material, project, location) row that no receipt ever created, had no route back to
+ * the truth. It is deliberately not a direct edit of {@code CurrentStock}: {@link #approve}
+ * writes an {@link InventoryTransaction} carrying the signed movement and its reason and
+ * then moves the balance, so the resulting figure stays explainable from the ledger like
+ * every other movement.
+ *
+ * <p>{@link #create} and {@link #update} persist the document only. Posting happens once,
+ * through {@link #approve}, and a posted document is then frozen: edits and deletes are
+ * refused, because changing the lines afterwards would leave the ledger describing a
+ * document that no longer exists.
  */
 @Service
 public class StockAdjustmentService {
@@ -38,20 +59,32 @@ public class StockAdjustmentService {
     private final MaterialRepository materialRepository;
     private final StorageLocationRepository storageLocationRepository;
     private final ProjectRepository projectRepository;
+    private final InventoryService inventoryService;
+    private final InventoryTransactionRepository inventoryTransactionRepository;
+    private final UserContextService userContextService;
 
     public StockAdjustmentService(StockAdjustmentRepository stockAdjustmentRepository,
                                   StockAdjustmentMapper stockAdjustmentMapper,
                                   TenantEntityHelper tenantEntityHelper,
                                   MaterialRepository materialRepository,
                                   StorageLocationRepository storageLocationRepository,
-                                  ProjectRepository projectRepository) {
+                                  ProjectRepository projectRepository,
+                                  InventoryService inventoryService,
+                                  InventoryTransactionRepository inventoryTransactionRepository,
+                                  UserContextService userContextService) {
         this.stockAdjustmentRepository = stockAdjustmentRepository;
         this.stockAdjustmentMapper = stockAdjustmentMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.materialRepository = materialRepository;
         this.storageLocationRepository = storageLocationRepository;
         this.projectRepository = projectRepository;
+        this.inventoryService = inventoryService;
+        this.inventoryTransactionRepository = inventoryTransactionRepository;
+        this.userContextService = userContextService;
     }
+
+    /** Status a document carries once its movements are on the ledger. */
+    static final String POSTED_STATUS = "processed";
 
     @Transactional
     public StockAdjustmentDto create(StockAdjustmentCreationDto creationDto) {
@@ -87,12 +120,22 @@ public class StockAdjustmentService {
                 .map(stockAdjustmentMapper::toDto);
     }
 
+    /**
+     * Replaces the header fields and line items of a document that has not been posted.
+     *
+     * @param id The document to update.
+     * @param creationDto The replacement header and lines.
+     * @return The updated document as a DTO.
+     * @throws ResourceNotFoundException if the document, or anything it references, is not in this organization.
+     * @throws InvalidRequestException if the document has already been posted to the stock ledger.
+     */
     @Transactional
     public StockAdjustmentDto update(Long id, StockAdjustmentCreationDto creationDto) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
                 .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
+        requireNotPosted(stockAdjustment, "edited");
         Organization organization = stockAdjustment.getOrganization();
 
         applyHeaderFields(stockAdjustment, creationDto);
@@ -108,13 +151,192 @@ public class StockAdjustmentService {
         return stockAdjustmentMapper.toDto(saved);
     }
 
+    /**
+     * Deletes a document that has not been posted.
+     *
+     * @param id The document to delete.
+     * @throws ResourceNotFoundException if no such document exists in this organization.
+     * @throws InvalidRequestException if the document has already been posted to the stock ledger.
+     */
     @Transactional
     public void delete(Long id) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
                 .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
+        requireNotPosted(stockAdjustment, "deleted");
         stockAdjustmentRepository.delete(stockAdjustment);
+    }
+
+    /**
+     * Approves a stock adjustment and posts its lines to the stock ledger.
+     *
+     * <p>This is the controlled way to set or correct a balance. Each line resolves the
+     * balance row it applies to, from the line's own storage location or the document's,
+     * and the movement it needs to reach the counted figure. A line carrying a physical
+     * count is posted as the difference between that count and the balance <em>as it stands
+     * now</em>, not the {@code systemQuantity} recorded when the count sheet was written, so
+     * the balance ends at exactly the counted figure even if stock moved in between; the
+     * line is rewritten with the figures actually posted. A line with no count falls back to
+     * its signed {@code adjustmentQuantity}. Lines that come out at no movement are skipped
+     * rather than writing a ledger row that changes nothing.
+     *
+     * <p>Every posted line writes an {@code ADJUST} {@link InventoryTransaction} whose
+     * remarks carry the reason, so the balance stays explainable, and only then moves the
+     * balance. Both happen in this transaction: an approval that recorded no movement is the
+     * failure this whole path exists to remove. Posting is refused a second time, and the
+     * document is frozen against edits afterwards.
+     *
+     * @param id The document to approve and post.
+     * @return The posted document as a DTO.
+     * @throws ResourceNotFoundException if no such document exists in this organization.
+     * @throws InvalidRequestException if the document is already posted, names no project, has no lines, or a line is missing a material, a reason, or a quantity, or would drive a balance negative.
+     */
+    @Transactional
+    public StockAdjustmentDto approve(Long id) {
+        StockAdjustment stockAdjustment = stockAdjustmentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Stock adjustment with ID " + id + " was not found in this organization"));
+        requireNotPosted(stockAdjustment, "posted again");
+
+        Project project = stockAdjustment.getProject();
+        if (project == null) {
+            throw new InvalidRequestException("Stock adjustment with ID " + id
+                    + " names no project, so there is no balance for it to correct");
+        }
+        if (stockAdjustment.getLineItems().isEmpty()) {
+            throw new InvalidRequestException("Stock adjustment with ID " + id
+                    + " has no line items, so there is nothing to post");
+        }
+
+        Organization organization = stockAdjustment.getOrganization();
+        LocalDateTime postedAt = LocalDateTime.now();
+        LocalDateTime transactionDate = stockAdjustment.getEffectiveDate() != null
+                ? stockAdjustment.getEffectiveDate().atStartOfDay()
+                : postedAt;
+        String referenceNumber = referenceNumber(stockAdjustment);
+        double totalVariance = 0.0;
+
+        for (StockAdjustmentLineItem line : stockAdjustment.getLineItems()) {
+            Material material = line.getMaterial();
+            if (material == null) {
+                throw new InvalidRequestException("Every line on stock adjustment with ID " + id
+                        + " must name the material it adjusts");
+            }
+            String reason = resolveReason(line, stockAdjustment, material);
+
+            StorageLocation location = line.getLocation() != null
+                    ? line.getLocation()
+                    : stockAdjustment.getLocation();
+            StorageLocationScope.requireUsableFromProject(location, project.getId());
+
+            Double balance = (location != null
+                    ? inventoryService.findStockAtLocation(material.getId(), project.getId(), location.getId())
+                    : inventoryService.findUnlocatedStock(material.getId(), project.getId()))
+                    .orElse(0.0);
+            Double movement = resolveMovement(line, balance, material, id);
+
+            // Record what was actually posted, so the document and the ledger agree.
+            line.setSystemQuantity(balance);
+            line.setAdjustmentQuantity(movement);
+
+            if (movement == 0.0) {
+                continue;
+            }
+            double closing = balance + movement;
+            if (closing < 0) {
+                throw new InvalidRequestException(String.format(
+                        "Adjusting material ID %d by %.2f would leave %.2f on hand at project ID %d. "
+                                + "An adjustment corrects a balance to a counted figure and cannot take it below zero.",
+                        material.getId(), movement, closing, project.getId()));
+            }
+
+            BigDecimal unitCost = line.getUnitValue() != null
+                    ? line.getUnitValue()
+                    : inventoryService.getAverageCost(material.getId(), project.getId(),
+                            location != null ? location.getId() : null);
+
+            InventoryTransaction transaction = new InventoryTransaction();
+            transaction.setTransactionDate(transactionDate);
+            transaction.setMaterial(material);
+            transaction.setOpeningStock(balance);
+            transaction.setQuantityChanged(movement);
+            transaction.setClosingStock(closing);
+            transaction.setTransactionType(InventoryTransactionType.ADJUST);
+            transaction.setReferenceNumber(referenceNumber);
+            transaction.setRemarks("Stock adjustment - " + reason);
+            transaction.setProject(project);
+            transaction.setStorageLocation(location);
+            transaction.setOrganization(organization);
+            transaction.setUnitCost(unitCost);
+            inventoryTransactionRepository.save(transaction);
+
+            inventoryService.updateCurrentStock(material, project, location, organization,
+                    movement, movement > 0 ? unitCost : null);
+
+            totalVariance += movement;
+        }
+
+        Long approver = userContextService.getCurrentUserId();
+        stockAdjustment.setTotalVarianceQuantity(totalVariance);
+        stockAdjustment.setStatus(POSTED_STATUS);
+        stockAdjustment.setApprovedBy(approver);
+        stockAdjustment.setApprovedAt(postedAt);
+        stockAdjustment.setProcessedBy(approver);
+        stockAdjustment.setProcessedAt(postedAt);
+
+        StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
+        return stockAdjustmentMapper.toDto(saved);
+    }
+
+    /** Refuses to change a document whose movements are already on the ledger. */
+    private void requireNotPosted(StockAdjustment stockAdjustment, String action) {
+        if (stockAdjustment.getProcessedAt() != null) {
+            throw new InvalidRequestException("Stock adjustment with ID " + stockAdjustment.getId()
+                    + " was posted to the stock ledger on " + stockAdjustment.getProcessedAt()
+                    + " and cannot be " + action + ". Raise a further adjustment to correct it.");
+        }
+    }
+
+    /**
+     * The reason recorded against the ledger entry. A stock movement with no stated reason
+     * is the thing that makes a balance unexplainable, so one is required: the line's own
+     * reason, else the document's primary reason, else the request is refused.
+     */
+    private String resolveReason(StockAdjustmentLineItem line, StockAdjustment stockAdjustment, Material material) {
+        String reason = hasText(line.getReason()) ? line.getReason() : stockAdjustment.getPrimaryReason();
+        if (!hasText(reason)) {
+            throw new InvalidRequestException("The line adjusting material ID " + material.getId()
+                    + " has no reason, and stock adjustment with ID " + stockAdjustment.getId()
+                    + " gives no primary reason to fall back on. Every stock movement must say why it happened.");
+        }
+        String detail = hasText(line.getReasonDetails()) ? ": " + line.getReasonDetails() : "";
+        return reason + detail;
+    }
+
+    /** The signed movement a line posts: to the counted figure where there is one, else the stated delta. */
+    private Double resolveMovement(StockAdjustmentLineItem line, Double balance, Material material, Long id) {
+        if (line.getPhysicalQuantity() != null) {
+            return line.getPhysicalQuantity() - balance;
+        }
+        if (line.getAdjustmentQuantity() != null) {
+            return line.getAdjustmentQuantity();
+        }
+        throw new InvalidRequestException("The line adjusting material ID " + material.getId()
+                + " on stock adjustment with ID " + id + " carries neither a counted physical quantity "
+                + "nor an adjustment quantity, so there is nothing to post");
+    }
+
+    /** The ledger reference for the document, falling back to its id when it carries no number. */
+    private String referenceNumber(StockAdjustment stockAdjustment) {
+        return hasText(stockAdjustment.getAdjustmentNumber())
+                ? stockAdjustment.getAdjustmentNumber()
+                : "SA-" + stockAdjustment.getId();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     /** Copies the header scalars from the creation DTO, resolving the location and project. */

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationScope.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationScope.java
@@ -1,0 +1,60 @@
+package org.tornotron.echno_backend.storageLocation;
+
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+
+/**
+ * The rule deciding which projects a storage location may be booked against.
+ *
+ * <p><strong>A location with no project is an organisation-level store</strong>: a central
+ * yard or warehouse that every project draws from, so it is selectable from all of them.
+ * A location that names a project belongs to that project alone and may not be used from
+ * any other. Where such a row ought to be owned by a project, the fix is to populate its
+ * project, not to make the row unusable.
+ *
+ * <p>Nothing used to check this at all, so a consumption could be booked against a
+ * (project, location) pair whose stock row could never exist, and the request was refused
+ * with a bare "Available: 0.00". Every path that books a movement against a project and a
+ * location goes through {@link #requireUsableFromProject} so the rule is stated once.
+ *
+ * <p>The web client applies the same rule when it fills the location dropdown
+ * ({@code features/material-consumptions/storage-location-scope.ts}), so a change here
+ * has to be made there too.
+ */
+public final class StorageLocationScope {
+
+    private StorageLocationScope() {
+    }
+
+    /**
+     * Says whether a location may hold stock for the given project.
+     *
+     * @param location The storage location, or null when no location is named.
+     * @param projectId The project the movement is booked against.
+     * @return True when the location is organisation-level or belongs to this project.
+     */
+    public static boolean isUsableFromProject(StorageLocation location, Long projectId) {
+        if (location == null || location.getProject() == null) {
+            return true;
+        }
+        return location.getProject().getId().equals(projectId);
+    }
+
+    /**
+     * Refuses a location that belongs to a different project.
+     *
+     * @param location The storage location, or null when no location is named.
+     * @param projectId The project the movement is booked against.
+     * @throws InvalidRequestException if the location belongs to another project.
+     */
+    public static void requireUsableFromProject(StorageLocation location, Long projectId) {
+        if (isUsableFromProject(location, projectId)) {
+            return;
+        }
+        throw new InvalidRequestException(String.format(
+                "Storage location with ID %d belongs to project with ID %d and cannot be used from "
+                        + "project with ID %d. Choose a location on this project, or an "
+                        + "organisation-level location, which belongs to no project and is available "
+                        + "from every one.",
+                location.getId(), location.getProject().getId(), projectId));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerConsumptionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerConsumptionTest.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.common.events.listeners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.events.MaterialConsumedEvent;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.materialConsumption.MaterialConsumption;
+import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The ledger entry a consumption writes has to describe the balance row the consumption
+ * moves. With no storage location that row is the project's unlocated balance, so reading
+ * the project total instead would stamp an opening and closing figure on the entry that
+ * the row it moved never held.
+ */
+@ExtendWith(MockitoExtension.class)
+class InventoryEventListenerConsumptionTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 2L;
+    private static final Long PROJECT = 3L;
+    private static final Long LOCATION = 14L;
+
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private InventoryService inventoryService;
+
+    private InventoryEventListener listener;
+    private Material material;
+    private Project project;
+    private Organization organization;
+
+    @BeforeEach
+    void setUp() {
+        listener = new InventoryEventListener(inventoryTransactionRepository, inventoryService);
+        material = new Material();
+        material.setId(MATERIAL);
+        project = new Project();
+        project.setId(PROJECT);
+        organization = new Organization();
+        organization.setId(ORG);
+    }
+
+    private MaterialConsumption consumption(StorageLocation location) {
+        MaterialConsumption consumption = new MaterialConsumption();
+        consumption.setId(31L);
+        consumption.setConsumptionDate(LocalDateTime.now());
+        consumption.setMaterial(material);
+        consumption.setProject(project);
+        consumption.setOrganization(organization);
+        consumption.setStorageLocation(location);
+        consumption.setQuantity(4);
+        consumption.setConsumptionType(MaterialConsumptionType.USED_FROM_STOCK);
+        return consumption;
+    }
+
+    @Test
+    void aConsumptionWithNoLocationOpensFromTheProjectsUnlocatedBalance() {
+        when(inventoryService.findUnlocatedStock(MATERIAL, PROJECT)).thenReturn(Optional.of(10.0));
+
+        listener.handleMaterialConsumed(new MaterialConsumedEvent(this, consumption(null)));
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getOpeningStock()).isEqualTo(10.0);
+        assertThat(captor.getValue().getQuantityChanged()).isEqualTo(-4.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(6.0);
+        verify(inventoryService, never()).getCurrentStock(any(), any());
+    }
+
+    @Test
+    void aConsumptionAtALocationOpensFromThatLocationsBalance() {
+        StorageLocation location = new StorageLocation();
+        location.setId(LOCATION);
+        when(inventoryService.getStockAtLocation(MATERIAL, PROJECT, LOCATION)).thenReturn(10.0);
+
+        listener.handleMaterialConsumed(new MaterialConsumedEvent(this, consumption(location)));
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getOpeningStock()).isEqualTo(10.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(6.0);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionServiceTest.java
@@ -139,12 +139,15 @@ class MaterialConsumptionServiceTest {
     }
 
     @Test
-    void create_withoutStorageLocation_usesProjectScopedStockCheck() {
+    void create_withoutStorageLocation_checksTheProjectsUnlocatedBalance() {
         stubMasterLookups();
 
         service.createMaterialConsumption(baseDto());
 
-        verify(inventoryService).validateSufficientStock(MATERIAL, PROJECT, 5.0);
+        // The unlocated row, not the project total: the draw-down writes that row, so summing
+        // every row on the project would pass on stock this write cannot reach.
+        verify(inventoryService).validateSufficientUnlocatedStock(MATERIAL, PROJECT, 5.0);
+        verify(inventoryService, never()).validateSufficientStock(anyLong(), anyLong(), anyDouble());
         verify(inventoryService, never()).validateSufficientStockAtLocation(anyLong(), anyLong(), anyLong(), anyDouble());
     }
 

--- a/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionStockScopeTest.java
@@ -1,0 +1,207 @@
+package org.tornotron.echno_backend.materialConsumption;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.exception.InsufficientStockException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStock;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionCreationDto;
+import org.tornotron.echno_backend.materialConsumption.mapper.MaterialConsumptionMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The consumption path against a real {@link InventoryService} over a mocked stock
+ * repository, so the balance row the check reads is the thing under test rather than a
+ * mock's say-so. This is the shape of Anand's QA report: a form showing 60 MT, an API
+ * refusing 1 MT, and a storage location paired with a project it does not belong to.
+ */
+@ExtendWith(MockitoExtension.class)
+class MaterialConsumptionStockScopeTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 2L;
+    private static final Long EMPLOYEE = 7L;
+    private static final Long PROJECT = 3L;
+    private static final Long LOCATION = 14L;
+    private static final Long OTHER_PROJECT = 9L;
+
+    @Mock private MaterialConsumptionRepository materialConsumptionRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private CurrentStockRepository currentStockRepository;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private MaterialConsumptionMapper materialConsumptionMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private TaskRepository taskRepository;
+
+    private MaterialConsumptionService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        InventoryService inventoryService = new InventoryService(currentStockRepository,
+                inventoryTransactionRepository, materialRepository, storageLocationRepository);
+        service = new MaterialConsumptionService(materialConsumptionRepository, materialRepository,
+                inventoryService, eventPublisher, materialConsumptionMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository, taskRepository);
+
+        Material material = new Material();
+        material.setId(MATERIAL);
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE);
+        Project project = new Project();
+        project.setId(PROJECT);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG)).thenReturn(Optional.of(material));
+        lenient().when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(PROJECT, ORG)).thenReturn(Optional.of(project));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(materialConsumptionRepository.save(any(MaterialConsumption.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private MaterialConsumptionCreationDto dto(Long storageLocationId) {
+        MaterialConsumptionCreationDto dto = new MaterialConsumptionCreationDto();
+        dto.setConsumptionDate(LocalDateTime.now());
+        dto.setMaterialId(MATERIAL);
+        dto.setQuantity(1);
+        dto.setConsumptionType("USED_FROM_STOCK");
+        dto.setProjectId(PROJECT);
+        dto.setCreatedBy(EMPLOYEE);
+        dto.setStorageLocationId(storageLocationId);
+        return dto;
+    }
+
+    private StorageLocation location(Long id, Long owningProjectId) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        if (owningProjectId != null) {
+            Project owner = new Project();
+            owner.setId(owningProjectId);
+            location.setProject(owner);
+        }
+        when(storageLocationRepository.findByIdAndOrganization_Id(id, ORG)).thenReturn(Optional.of(location));
+        return location;
+    }
+
+    private CurrentStock stockRow(double quantity) {
+        CurrentStock row = new CurrentStock();
+        row.setCurrentQuantity(quantity);
+        return row;
+    }
+
+    @Test
+    void aLocationThatHasNeverHeldTheMaterialIsNamedAsSuchRatherThanReportedAsZero() {
+        location(LOCATION, PROJECT);
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationId(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createMaterialConsumption(dto(LOCATION)))
+                .withMessageContaining("has ever been held")
+                .withMessageContaining("goods receipt");
+
+        verify(materialConsumptionRepository, never()).save(any());
+    }
+
+    @Test
+    void aLocationThatHasRunDownToZeroIsStillReportedAsAStockOut() {
+        location(LOCATION, PROJECT);
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationId(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(stockRow(0.0)));
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createMaterialConsumption(dto(LOCATION)))
+                .withMessageContaining("Insufficient stock")
+                .withMessageContaining("Available: 0.00");
+    }
+
+    @Test
+    void aStorageLocationBelongingToAnotherProjectIsRefused() {
+        location(LOCATION, OTHER_PROJECT);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createMaterialConsumption(dto(LOCATION)))
+                .withMessageContaining("belongs to project with ID 9");
+
+        verify(materialConsumptionRepository, never()).save(any());
+    }
+
+    @Test
+    void anOrganisationLevelLocationIsAcceptedFromAnyProject() {
+        location(LOCATION, null);
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationId(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(stockRow(60.0)));
+
+        assertThatCode(() -> service.createMaterialConsumption(dto(LOCATION))).doesNotThrowAnyException();
+
+        verify(materialConsumptionRepository).save(any());
+    }
+
+    @Test
+    void aConsumptionWithNoLocationIsRefusedWhenTheProjectHoldsItsStockInsideLocations() {
+        // The project total is 60, all of it inside storage locations. The draw-down writes
+        // the project's unlocated row, which holds nothing, so passing the project total here
+        // is what took row 15 on staging to -30.
+        lenient().when(currentStockRepository.sumCurrentQuantityByMaterialAndProject(MATERIAL, PROJECT))
+                .thenReturn(60.0);
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, PROJECT))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createMaterialConsumption(dto(null)))
+                .withMessageContaining("outside a storage location")
+                .withMessageContaining("name the location");
+
+        verify(materialConsumptionRepository, never()).save(any());
+    }
+
+    @Test
+    void aConsumptionWithNoLocationIsAllowedAgainstTheUnlocatedBalance() {
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, PROJECT))
+                .thenReturn(Optional.of(stockRow(4.0)));
+
+        assertThatCode(() -> service.createMaterialConsumption(dto(null))).doesNotThrowAnyException();
+
+        verify(materialConsumptionRepository).save(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -1,0 +1,287 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Approving a stock adjustment is the only way to set or correct a balance, so this covers
+ * what that has to guarantee: a ledger entry carrying the reason is written before the
+ * balance moves, a physical count lands the balance on the counted figure, a movement with
+ * no stated reason is refused, an adjustment cannot be posted twice or edited afterwards,
+ * and it cannot be used to book stock onto a location belonging to another project or to
+ * push a balance below zero.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentApprovalTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ADJUSTMENT = 5L;
+    private static final Long MATERIAL = 8L;
+    private static final Long PROJECT = 7L;
+    private static final Long LOCATION = 14L;
+    private static final Long OTHER_PROJECT = 9L;
+    private static final Long APPROVER = 42L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+
+    private StockAdjustmentService service;
+    private Organization organization;
+    private Project project;
+    private Material material;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService);
+
+        organization = new Organization();
+        organization.setId(ORG);
+        project = new Project();
+        project.setId(PROJECT);
+        material = new Material();
+        material.setId(MATERIAL);
+
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(APPROVER);
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(inventoryService.getAverageCost(any(), any(), any())).thenReturn(BigDecimal.ZERO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private StorageLocation location(Long id, Long owningProjectId) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        if (owningProjectId != null) {
+            Project owner = new Project();
+            owner.setId(owningProjectId);
+            location.setProject(owner);
+        }
+        return location;
+    }
+
+    private StockAdjustment adjustment(StorageLocation headerLocation) {
+        StockAdjustment adjustment = new StockAdjustment();
+        adjustment.setId(ADJUSTMENT);
+        adjustment.setAdjustmentNumber("SA-2026-0005");
+        adjustment.setOrganization(organization);
+        adjustment.setProject(project);
+        adjustment.setLocation(headerLocation);
+        adjustment.setPrimaryReason("physical_count");
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(ADJUSTMENT, ORG))
+                .thenReturn(Optional.of(adjustment));
+        return adjustment;
+    }
+
+    private StockAdjustmentLineItem line(StockAdjustment adjustment, Double physical, Double delta, String reason) {
+        StockAdjustmentLineItem line = new StockAdjustmentLineItem();
+        line.setMaterial(material);
+        line.setPhysicalQuantity(physical);
+        line.setAdjustmentQuantity(delta);
+        line.setReason(reason);
+        line.setOrganization(organization);
+        adjustment.addLineItem(line);
+        return line;
+    }
+
+    private void balanceAtLocation(double quantity) {
+        when(inventoryService.findStockAtLocation(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(quantity));
+    }
+
+    @Test
+    void aCountedLineWritesALedgerEntryCarryingItsReasonAndLandsTheBalanceOnTheCount() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
+        line.setReasonDetails("bags damaged by moisture");
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        InventoryTransaction posted = captor.getValue();
+        assertThat(posted.getTransactionType()).isEqualTo(InventoryTransactionType.ADJUST);
+        assertThat(posted.getReferenceNumber()).isEqualTo("SA-2026-0005");
+        assertThat(posted.getOpeningStock()).isEqualTo(48.0);
+        assertThat(posted.getQuantityChanged()).isEqualTo(-2.0);
+        assertThat(posted.getClosingStock()).isEqualTo(46.0);
+        assertThat(posted.getRemarks()).contains("damage").contains("bags damaged by moisture");
+        assertThat(posted.getProject()).isSameAs(project);
+
+        verify(inventoryService).updateCurrentStock(eq(material), eq(project), any(StorageLocation.class),
+                eq(organization), eq(-2.0), isNull());
+        assertThat(line.getSystemQuantity()).isEqualTo(48.0);
+        assertThat(line.getAdjustmentQuantity()).isEqualTo(-2.0);
+        assertThat(adjustment.getTotalVarianceQuantity()).isEqualTo(-2.0);
+        assertThat(adjustment.getStatus()).isEqualTo("processed");
+        assertThat(adjustment.getApprovedBy()).isEqualTo(APPROVER);
+        assertThat(adjustment.getProcessedBy()).isEqualTo(APPROVER);
+        assertThat(adjustment.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    void aCountIsPostedAgainstTheBalanceAsItStandsNotTheSystemQuantityOnTheCountSheet() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
+        // The count sheet was written when the system said 48; a receipt has since taken it to 50.
+        line.setSystemQuantity(48.0);
+        balanceAtLocation(50.0);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getQuantityChanged()).isEqualTo(-4.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(46.0);
+    }
+
+    @Test
+    void aNegativeBalanceCanBeCorrectedBackToZero() {
+        // Row 15 on staging: material 8, project 7, no storage location, quantity -30.
+        StockAdjustment adjustment = adjustment(null);
+        line(adjustment, 0.0, null, "correcting a negative balance");
+        when(inventoryService.findUnlocatedStock(MATERIAL, PROJECT)).thenReturn(Optional.of(-30.0));
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getQuantityChanged()).isEqualTo(30.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(0.0);
+        verify(inventoryService).updateCurrentStock(eq(material), eq(project), isNull(), eq(organization),
+                eq(30.0), any(BigDecimal.class));
+    }
+
+    @Test
+    void aMovementWithNoReasonAnywhereIsRefused() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setPrimaryReason(null);
+        line(adjustment, null, -5.0, null);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("must say why it happened");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void aLineOnALocationBelongingToAnotherProjectIsRefused() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, OTHER_PROJECT));
+        line(adjustment, null, -5.0, "damage");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("belongs to project with ID 9");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+    }
+
+    @Test
+    void anAdjustmentThatWouldTakeABalanceBelowZeroIsRefused() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        line(adjustment, null, -20.0, "write off");
+        balanceAtLocation(5.0);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("cannot take it below zero");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+    }
+
+    @Test
+    void aLineThatComesOutAtNoMovementWritesNoLedgerEntry() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        line(adjustment, 48.0, null, "physical count");
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+        assertThat(adjustment.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    void anAdjustmentWithNoProjectHasNoBalanceToCorrect() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setProject(null);
+        line(adjustment, null, -5.0, "damage");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("names no project");
+    }
+
+    @Test
+    void aPostedAdjustmentCannotBePostedEditedOrDeletedAgain() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        line(adjustment, null, -5.0, "damage");
+        adjustment.setProcessedAt(LocalDateTime.now());
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("posted again");
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(ADJUSTMENT, new StockAdjustmentCreationDto()))
+                .withMessageContaining("cannot be edited");
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.delete(ADJUSTMENT))
+                .withMessageContaining("cannot be deleted");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(stockAdjustmentRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
@@ -22,6 +22,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -29,8 +30,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * the guard: any member of the current tenant may read, but only a system-admin or
  * project-manager may write. This pins both halves and, crucially, that a plain member
  * who holds neither role is refused a write. If the write guard were ever loosened to
- * membership, the member-without-role delete test fails. @orgSecurity is mocked so each
- * branch is exercised independently.
+ * membership, the member-without-role delete test fails. Approving is held to the same
+ * bar: it is the action that moves a stock balance, so a plain member must not reach it.
+ * @orgSecurity is mocked so each branch is exercised independently.
  */
 @WebMvcTest(StockAdjustmentControllerWeb.class)
 @Import(StockAdjustmentControllerWebAuthzTest.TestSecurityConfig.class)
@@ -86,6 +88,25 @@ class StockAdjustmentControllerWebAuthzTest {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
 
         mockMvc.perform(delete("/api/v1/stock-adjustments/web/1").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void approve_isOk_forAnElevatedRoleHolder() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/stock-adjustments/web/1/approve").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void approve_isForbidden_forAPlainMemberWithoutAnElevatedRole() throws Exception {
+        // Approving posts to the stock ledger and moves a balance. Letting any member do that
+        // silently is the governance hole this endpoint exists to close, not to open.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/stock-adjustments/web/1/approve").with(jwt()).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -10,6 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
 import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.organization.Organization;
@@ -20,6 +22,7 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCr
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,13 +36,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for StockAdjustmentService. The MVP service persists the document only (it
- * does not yet move stock), so the logic worth pinning is the reference resolution it
- * owns: an id that names nothing in the current tenant is rejected, a null id resolves to
- * no association rather than an error, line items are wired to their parent and stamped
- * with the organization, and an update replaces the whole line-item collection. The
- * repositories, mapper, and tenant helper are mocked; assertions read the entity captured
- * on saveAndFlush.
+ * Unit tests for the drafting half of StockAdjustmentService: an id that names nothing in
+ * the current tenant is rejected, a null id resolves to no association rather than an
+ * error, line items are wired to their parent and stamped with the organization, and an
+ * update replaces the whole line-item collection. The repositories, mapper, and tenant
+ * helper are mocked; assertions read the entity captured on saveAndFlush. Posting to the
+ * stock ledger is covered by {@link StockAdjustmentApprovalTest}.
  */
 @ExtendWith(MockitoExtension.class)
 class StockAdjustmentServiceTest {
@@ -55,6 +57,9 @@ class StockAdjustmentServiceTest {
     @Mock private MaterialRepository materialRepository;
     @Mock private StorageLocationRepository storageLocationRepository;
     @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
 
     private StockAdjustmentService service;
 
@@ -62,7 +67,8 @@ class StockAdjustmentServiceTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
-                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository);
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
             Organization org = new Organization();
             org.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationScopeTest.java
@@ -1,0 +1,71 @@
+package org.tornotron.echno_backend.storageLocation;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.project.Project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Pins the decision about what a storage location with no project means, so that changing
+ * it is a deliberate edit to one file rather than a drift between the paths that book
+ * stock. The rule: no project means an organisation-level store, usable from every
+ * project; a named project means that project alone. The web client holds the same rule
+ * in {@code features/material-consumptions/storage-location-scope.ts}.
+ */
+class StorageLocationScopeTest {
+
+    private static final Long PROJECT = 3L;
+    private static final Long OTHER_PROJECT = 9L;
+
+    private StorageLocation location(Long id, Long projectId) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        if (projectId != null) {
+            Project project = new Project();
+            project.setId(projectId);
+            location.setProject(project);
+        }
+        return location;
+    }
+
+    @Test
+    void aLocationWithNoProjectIsOrganisationLevelAndUsableFromEveryProject() {
+        StorageLocation central = location(14L, null);
+
+        assertThat(StorageLocationScope.isUsableFromProject(central, PROJECT)).isTrue();
+        assertThat(StorageLocationScope.isUsableFromProject(central, OTHER_PROJECT)).isTrue();
+        assertThatCode(() -> StorageLocationScope.requireUsableFromProject(central, PROJECT))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aLocationIsUsableFromTheProjectItBelongsTo() {
+        StorageLocation site = location(7L, PROJECT);
+
+        assertThat(StorageLocationScope.isUsableFromProject(site, PROJECT)).isTrue();
+        assertThatCode(() -> StorageLocationScope.requireUsableFromProject(site, PROJECT))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aLocationOnAnotherProjectIsRefusedAndTheMessageNamesBothProjects() {
+        StorageLocation site = location(7L, OTHER_PROJECT);
+
+        assertThat(StorageLocationScope.isUsableFromProject(site, PROJECT)).isFalse();
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> StorageLocationScope.requireUsableFromProject(site, PROJECT))
+                .withMessageContaining("Storage location with ID 7")
+                .withMessageContaining("belongs to project with ID 9")
+                .withMessageContaining("project with ID 3");
+    }
+
+    @Test
+    void noLocationAtAllIsNotSomethingToRefuse() {
+        assertThat(StorageLocationScope.isUsableFromProject(null, PROJECT)).isTrue();
+        assertThatCode(() -> StorageLocationScope.requireUsableFromProject(null, PROJECT))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Closes #530
Closes #531

## What was wrong

Two issues from Anand's 28 Aug QA pass on `echno.in`, both on the procurement screens.

**#530.** The browser invented `transferNumber` and `poNumber` and sent them; the server only checked what it was handed. So every create after the first collided on `000001`, and no amount of frontend cleverness could fix it, because two tabs compute the same next number from the same list. On top of that the unique constraint was **global** while every service check was **per organization** (harmless with one tenant, a bug the second client triggers on their first document), and `GlobalExceptionHandler` threw `ex.getMessage()` away, so `PO-2026-000001 already exists` reached the user as "Data already exists". That last part is why this was first reported as a double-submit bug.

**#531.** `status` on the purchase order create payload was a free `String` resolved with `valueOf`, so a PO could be created already `APPROVED` and approval was bypassed entirely. `unitPrice` had no `@NotNull` and no `@Positive*`, was coerced from null to zero, and orders saved with a total of nothing.

## Allocation, and why it is correct under concurrency

Numbers now come from a counter row per `(organization, document type, year)` in a new `document_number_sequence` table. `DocumentNumberAllocator` takes one:

```sql
INSERT INTO document_number_sequence
    (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
VALUES (?, ?, ?, 1, current_timestamp, current_timestamp)
ON CONFLICT (organization_id, document_type, sequence_year)
DO UPDATE SET last_allocated = document_number_sequence.last_allocated + 1,
              updated_at = current_timestamp
RETURNING last_allocated
```

**One statement is the whole point.** Read-then-write is wrong however it is ordered, because two transactions can read the same counter before either writes, and `max + 1` has the same fault with an extra table scan. As a single statement the counter row *is* the point of conflict:

- The first transaction to touch it leaves a write intent. The second blocks on that intent rather than reading around it, and only proceeds once the first has committed or aborted, incrementing whatever the first left.
- If waiting pushes the second's timestamp past something it has already read, CockroachDB aborts it with SQLSTATE `40001` rather than let it commit on a stale snapshot. `TransactionRetryTemplate` then runs the whole unit of work again, and the fresh attempt allocates the number after the winner's.

Two committed transactions cannot come away with the same number: that would need both to have read the same counter value and both to have committed, which is what SERIALIZABLE forbids.

The four create paths also nominate `23505` as retryable, following #528's pattern, so a number that somehow did collide (a counter seeded behind the rows already in the table, say) is re-allocated on the next attempt instead of surfacing as a 500 for a duplicate the user never chose. That is a backstop, not the mechanism.

**The trade.** Allocation runs inside the create transaction, so the number is spent only if the create commits and a rolled back create leaves no gap. The cost is that the counter row stays locked until commit, which serialises concurrent creates of one document type within one tenant. At the rate these documents are raised that is the right side of the trade, and it is why the allocation is taken as late in the create flow as it can be.

**Proven, not argued.** `DocumentNumberAllocatorConcurrencyIT` runs eight threads at once against a real CockroachDB and asserts they come away with exactly `000001` through `000008`. Swapped for a read-then-write implementation it fails immediately:

```
DuplicateKeyException: duplicate key value violates unique constraint "uk_document_number_sequence"
  Detail: Key (organization_id, document_type, sequence_year)=(3, 'PURCHASE_ORDER', 2026) already exists.
```

## Four of four, not two of four

`generateIndentNumber` and `generateGrnNumber` have exactly the shape of the two that broke, so indents and GRNs are allocated server-side too rather than left to break next. `lib/utils/document-number-utils.ts` can go entirely.

While there: indent create never checked its number for a duplicate at all, and GRN create checked `existsByGrnNumber` with no organization at all, so one tenant's GRN number blocked another's. Both are moot now that the server issues the number, and the constraint underneath each is per-tenant.

## API contract for the frontend unwind

This is what echno-web PR #312's four steps should be written against.

**1. Stop sending the number.** `transferNumber`, `poNumber`, `indentNumber` and `grnNumber` are **gone from the four creation DTOs**. Unknown properties are ignored on deserialization, so the currently deployed frontend keeps working unchanged until it is updated; the field is simply discarded. Nothing needs to be coordinated on deploy order.

| Endpoint | Field removed from the request |
|---|---|
| `POST /api/v1/site-transfers` (and `/web`) | `transferNumber` |
| `POST /api/v1/purchase-orders` (and `/web`) | `poNumber` |
| `POST /api/v1/indents` (and `/web`) | `indentNumber` |
| `POST /api/v1/goods-received-notes` (and `/web`) | `grnNumber` |

**2. Show it from the response.** The number is on the created resource exactly as before: `SiteTransferDto.transferNumber`, `PurchaseOrderDto.poNumber`, `IndentDto.indentNumber`, `GoodsReceivedNoteDto.grnNumber`. Nothing on the read side changed. Format is unchanged too, `PREFIX-YYYY-NNNNNN` with the same `TRF` / `PO` / `IND` / `GRN` prefixes and the same six-digit padding, so a "will be assigned on save" placeholder followed by the real value from the 201 body is all that is needed.

**3. Drop the client `required()` check.** There is nothing left for the user to supply. The PO number field was editable; it should become read-only or disappear, since a typed number is now ignored rather than honoured.

**4. Duplicate messages now arrive intact.** A 409 from `DuplicateResourceException` carries the service's own sentence in `detail` (and in the legacy `message` property), for example `Purchase Order with PO number PO-2026-000001 already exists`. The generic string survives only as a fallback for an exception with no message.

**Also for #531, on the same screens:**

- `status` on `POST /purchase-orders` is now the `PurchaseOrderStatus` enum, **optional**, and **`DRAFT` is the only accepted value**. Omitting it means `DRAFT`. Anything else is a 400 naming the status that was refused. The status select should come off the create form; approval goes through `PATCH /purchase-orders/{id}/status`, which already exists.
- `unitPrice` on a purchase order line is now **required** and must be **zero or positive**. Zero is still allowed, for a line genuinely supplied free of charge, but it has to be sent deliberately rather than fall out of an empty field. `validateForm()` should mirror that so the user finds out before submitting.
- `totalAmount` on the create payload and `totalPrice` on a line are ignored, and always were: the server computes both. Their schema descriptions now say so.

## Schema

`db/changelog/v4.0/061-document-number-sequences.xml`, four changesets:

1. Create `document_number_sequence` with a unique `(organization_id, document_type, sequence_year)` and an FK to `organization`.
2. **Seed it above the numbers already in each table**, so the first server-issued number cannot collide with a browser-issued one. Only rows in the canonical `PREFIX-YYYY-NNNNNN` shape are counted, which is exactly the right set: a number in any other shape can never be produced by the allocator, so it cannot be collided with. The year is read out of the number rather than off `created_at`, because the number is what has to stay unique. Positions are fixed rather than a capture group, since CockroachDB's `substring` with a regex returns the whole match rather than the group.
3. Add `(organization_id, <number>)` unique constraints on all four tables.
4. Drop the global ones. `DROP INDEX ... CASCADE` rather than `DROP CONSTRAINT`, because CockroachDB backs a `UNIQUE` column constraint with an index of the same name. `uk_intend_number` is dropped alongside `uk_indent_number`: that is the name the constraint carries on databases built from the v1, v2 or v3 baselines, before the intend-to-indent rename.

New constraints are added before the old ones are dropped, so the numbers are never unconstrained in between. The whole file is exercised on a real CockroachDB v26.2.4 by every integration test in the suite.

Also `echno.document-number.zone` (default `Asia/Kolkata`), because the year stamped on a document should not flip a day early on a server running UTC.

## Tests

Every new test was run against the fix removed. Nothing here passes vacuously.

| Test | Fix removed | Result without it |
|---|---|---|
| `DocumentNumberAllocatorConcurrencyIT.concurrentAllocations_eachGetTheirOwnNumber` | single upsert replaced by read-then-write | **FAILED** &mdash; `DuplicateKeyException` on `uk_document_number_sequence`, two callers computed the same next value |
| `DocumentNumberAllocatorTest.allocate_readsAndWritesTheCounterInASingleUpsert` | same | **FAILED** |
| `DocumentNumberAllocatorTest.allocate_formatsThePrefixYearAndPaddedSequence` | same | **FAILED** |
| `DocumentNumberAllocatorTest.allocate_padsToSixDigitsButDoesNotTruncateBeyondThem` | same | **FAILED** |
| `DocumentNumberAllocatorTest.allocate_usesEachTypesOwnPrefix` | same | **FAILED** |
| `DocumentNumberAllocatorTest.allocate_readsTheYearInTheConfiguredZoneNotTheContainers` | same | **FAILED** |
| `PurchaseOrderServiceTest.createPurchaseOrder_takesItsNumberFromTheServerNotTheCaller` | allocator call replaced by a literal | **FAILED** |
| `SiteTransferServiceTest.create_takesItsNumberFromTheServerNotTheCaller` | same | **FAILED** |
| `IndentServiceTest.addIndent_takesItsNumberFromTheServerNotTheCaller` | same | **FAILED** |
| `GoodsReceivedNoteServiceTest.create_takesItsNumberFromTheServerNotTheCaller` | same | **FAILED** |
| `GoodsReceivedNoteServiceTest.create_buildsItemsSavesThemAndPublishesEvent` | same | **FAILED** (it asserts the published number) |
| `PurchaseOrderServiceTest.createPurchaseOrder_asApproved_isRefused` | guard removed, `setStatus(dto.getStatus())` restored | **FAILED** |
| `PurchaseOrderServiceTest.createPurchaseOrder_asAnyOtherLaterState_isRefused` | same | **FAILED** |
| `PurchaseOrderServiceTest.createPurchaseOrder_withNoStatus_startsAsDraft` | same | **FAILED** |
| `PurchaseOrderItemCreationDtoValidationTest.missingUnitPrice_isRejected` | `@NotNull` / `@PositiveOrZero` removed | **FAILED** |
| `PurchaseOrderItemCreationDtoValidationTest.negativeUnitPrice_isRejected` | same | **FAILED** |
| `GlobalExceptionHandlerTest.duplicateResource_reportsTheDuplicateItActuallyFound` | handler restored to the fixed string | **FAILED** |

Two tests pass under those reverts and are honestly not part of the red demonstration: `DocumentNumberAllocatorConcurrencyIT.countersAreSeparatePerOrganizationAndPerType`, which covers the per-tenant scoping rather than the concurrency, and `GlobalExceptionHandlerTest.duplicateResource_withNoMessage_stillSaysSomethingUseful`, which pins the fallback.

Full suite green on the lab box against real CockroachDB.

## Not addressed

`existsByPoNumberAndOrganization_Id` and `existsByTransferNumberAndOrganization_Id` are now unused. They are left in place deliberately: #473 is in flight across the repository interfaces and a one-line deletion there is not worth the conflict. Worth sweeping once that lands.
