### PR TITLE
Allocate document numbers on the server, and scope their uniqueness to the tenant

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocator.java
+++ b/src/main/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocator.java
@@ -1,0 +1,100 @@
+package org.tornotron.echno_backend.common.documentnumber;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * Hands out the next document number for a tenant, a document family and a year.
+ *
+ * <p>Numbers used to be invented by the browser from the list it happened to have loaded, so
+ * two people on the New Purchase Order screen at the same moment proposed the same number and
+ * the second save was rejected. The number is issued here instead, from a counter row per
+ * {@code (organization, document type, year)} in {@code document_number_sequence}.
+ *
+ * <h2>Why one statement</h2>
+ *
+ * <p>The allocation is a single {@code INSERT ... ON CONFLICT ... DO UPDATE ... RETURNING}.
+ * Read-then-write would be wrong here whatever isolation the database ran at, because two
+ * transactions can read the same counter before either writes. As one statement, the row is
+ * the point of conflict:
+ *
+ * <ul>
+ *   <li>The first transaction to touch the counter row leaves a write intent on it. The second
+ *       blocks on that intent rather than reading around it, and only proceeds once the first
+ *       has committed or aborted, at which point it increments the value the first left.</li>
+ *   <li>If waiting pushes the second transaction's timestamp past something it has already
+ *       read, CockroachDB aborts it with SQLSTATE 40001 rather than let it commit on a stale
+ *       snapshot. The whole unit of work then runs again through
+ *       {@link org.tornotron.echno_backend.common.retry.TransactionRetryTemplate}, which
+ *       re-reads the counter and allocates the next number after the winner's.</li>
+ * </ul>
+ *
+ * <p>Either way, two committed transactions cannot come away with the same number: that would
+ * require both to have read the same counter value and both to have committed, which is exactly
+ * what SERIALIZABLE forbids.
+ *
+ * <h2>What the caller still owes</h2>
+ *
+ * <p>This runs in the caller's transaction, so the counter advances only if the create commits;
+ * a rolled back create returns its number to the pool rather than leaving a gap. The cost is
+ * that the counter row stays locked until the caller commits, which serialises concurrent
+ * creates of the same document type within one tenant. That is the intended trade at the volume
+ * these documents are raised, and it is why the lock is taken as late as the create flow allows.
+ *
+ * <p>The per-organization unique index on the number column is the backstop, not the mechanism.
+ * If a number ever were issued twice (a counter seeded behind the rows already in the table, say)
+ * the insert is rejected with SQLSTATE 23505, and the callers nominate that as a retryable
+ * conflict so the next attempt allocates a fresh number instead of answering the user with a 500.
+ */
+@Component
+public class DocumentNumberAllocator {
+
+    /**
+     * Allocates and formats in one round trip. {@code last_allocated} holds the highest number
+     * issued so far, so a first allocation inserts 1 and every later one returns the value it
+     * has just written.
+     */
+    private static final String ALLOCATE_SQL = """
+            INSERT INTO document_number_sequence
+                (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
+            VALUES (?, ?, ?, 1, current_timestamp, current_timestamp)
+            ON CONFLICT (organization_id, document_type, sequence_year)
+            DO UPDATE SET last_allocated = document_number_sequence.last_allocated + 1,
+                          updated_at = current_timestamp
+            RETURNING last_allocated
+            """;
+
+    /** Matches the six-digit padding the browser used, so old and new numbers sort together. */
+    private static final String NUMBER_FORMAT = "%s-%d-%06d";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ZoneId zone;
+
+    public DocumentNumberAllocator(
+            JdbcTemplate jdbcTemplate,
+            @Value("${echno.document-number.zone:Asia/Kolkata}") String zone) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.zone = ZoneId.of(zone);
+    }
+
+    /**
+     * Issues the next number of {@code type} for {@code organizationId} in the current year.
+     *
+     * <p>Must be called inside a transaction, and inside the same one that saves the document:
+     * the number is only spent if that transaction commits.
+     *
+     * @param type           the document family, which decides the prefix and the counter row
+     * @param organizationId the tenant the counter belongs to
+     * @return the formatted number, for example {@code PO-2026-000007}
+     */
+    public String allocate(DocumentNumberType type, Long organizationId) {
+        int year = LocalDate.now(zone).getYear();
+        Long sequence = jdbcTemplate.queryForObject(
+                ALLOCATE_SQL, Long.class, organizationId, type.name(), year);
+        return NUMBER_FORMAT.formatted(type.getPrefix(), year, sequence);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberType.java
+++ b/src/main/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberType.java
@@ -1,0 +1,36 @@
+package org.tornotron.echno_backend.common.documentnumber;
+
+/**
+ * The document families that carry a server-allocated number, and the prefix each one wears.
+ *
+ * <p>The name of the constant is what goes into the {@code document_type} column of
+ * {@code document_number_sequence}, so renaming one orphans that tenant's counter and starts
+ * its numbering again from one. Add constants, do not rename them.
+ *
+ * <p>The prefixes are the ones the browser used to generate, kept identical so numbers issued
+ * before and after the move to server-side allocation sort and read the same way.
+ */
+public enum DocumentNumberType {
+
+    /** Site transfers, {@code TRF-2026-000001}. */
+    SITE_TRANSFER("TRF"),
+
+    /** Purchase orders, {@code PO-2026-000001}. */
+    PURCHASE_ORDER("PO"),
+
+    /** Material indents, {@code IND-2026-000001}. */
+    INDENT("IND"),
+
+    /** Goods received notes, {@code GRN-2026-000001}. */
+    GOODS_RECEIVED_NOTE("GRN");
+
+    private final String prefix;
+
+    DocumentNumberType(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -196,12 +196,27 @@ public class GlobalExceptionHandler {
                 "Database operation failed, Data Integrity violation", request);
     }
 
+    /**
+     * Reports the duplicate the service actually found.
+     *
+     * <p>This used to answer "Database operation failed, Data already exists" and throw
+     * {@code ex.getMessage()} away, which cost a QA pass on staging: the backend knew it had
+     * been handed a purchase order number it already held, said so in the exception, and the
+     * user was told only that something was a duplicate. It was reported as a double-submit
+     * bug rather than the numbering fault it was.
+     *
+     * <p>Every message this exception carries names the field and the value that clashed and is
+     * already written for a person to read, so passing it through leaks nothing a caller who
+     * just sent that value does not have.
+     */
     @ExceptionHandler(DuplicateResourceException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ProblemDetail handleDuplicateResourceException(DuplicateResourceException ex, WebRequest request) {
         logger.error("Duplicate resource: ", ex);
-        return problem(HttpStatus.CONFLICT, "Duplicate Resource",
-                "Database operation failed, Data already exists", request);
+        String detail = (ex.getMessage() == null || ex.getMessage().isBlank())
+                ? "Database operation failed, Data already exists"
+                : ex.getMessage();
+        return problem(HttpStatus.CONFLICT, "Duplicate Resource", detail, request);
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
@@ -37,7 +37,12 @@ public class GoodsReceivedNote implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "grn_number", nullable = false, unique = true)
+    /**
+     * Allocated by the server, never by the client. Unique per organization rather than
+     * globally: the constraint that enforces it is {@code uk_grn_org_number} in the schema, and it
+     * is composite, so it cannot be declared here as a column-level unique.
+     */
+    @Column(name = "grn_number", nullable = false)
     private String grnNumber;
 
     @Column(name = "received_on", nullable = false)

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
@@ -11,8 +11,11 @@ import org.tornotron.echno_backend.goodsReceivedNote.mapper.GoodsReceivedNoteMap
 import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
@@ -61,6 +64,8 @@ public class GoodsReceivedNoteService {
     private final ProjectRepository projectRepository;
     private final StorageLocationRepository storageLocationRepository;
     private final PurchaseOrderRepository purchaseOrderRepository;
+    private final DocumentNumberAllocator documentNumberAllocator;
+    private final TransactionRetryTemplate retryTemplate;
 
     public GoodsReceivedNoteService(GoodsReceivedNoteRepository goodsReceivedNoteRepository,
                                     GrnItemRepository grnItemRepository,
@@ -72,7 +77,10 @@ public class GoodsReceivedNoteService {
                                     TenantEntityHelper tenantEntityHelper,
                                     EmployeeRepository employeeRepository,
                                     ProjectRepository projectRepository,
-                                    StorageLocationRepository storageLocationRepository, PurchaseOrderRepository purchaseOrderRepository) {
+                                    StorageLocationRepository storageLocationRepository,
+                                    PurchaseOrderRepository purchaseOrderRepository,
+                                    DocumentNumberAllocator documentNumberAllocator,
+                                    TransactionRetryTemplate retryTemplate) {
         this.goodsReceivedNoteRepository = goodsReceivedNoteRepository;
         this.grnItemRepository = grnItemRepository;
         this.vendorRepository = vendorRepository;
@@ -84,29 +92,36 @@ public class GoodsReceivedNoteService {
         this.projectRepository = projectRepository;
         this.storageLocationRepository = storageLocationRepository;
         this.purchaseOrderRepository = purchaseOrderRepository;
+        this.documentNumberAllocator = documentNumberAllocator;
+        this.retryTemplate = retryTemplate;
     }
 
     /**
      * Creates a Goods Received Note with its line items and triggers the stock increase.
      *
-     * <p>Rejects a duplicate GRN number, resolves the vendor, receiving employee, project,
-     * and purchase order (plus an optional storage location) within the current tenant, and
+     * <p>Allocates the GRN number, resolves the vendor, receiving employee, project, and
+     * purchase order (plus an optional storage location) within the current tenant, and
      * resolves each line's material. After saving, a {@link GrnCreatedEvent} is published so
      * inventory is updated for the received goods.
      *
+     * <p>The transaction is restarted on a serialization abort, and also on a unique
+     * violation: the counter behind the GRN number is the row two concurrent creates contend
+     * on, and a fresh attempt allocates the next number rather than reporting a collision the
+     * user did not cause. The inventory listener runs after commit, so only the attempt that
+     * commits raises stock.
+     *
      * @param creationDto The GRN header fields and the list of received line items.
      * @return The created GRN as a DTO.
-     * @throws DuplicateResourceException if the GRN number is already used in this organization.
      * @throws ResourceNotFoundException if any referenced vendor, employee, project, purchase order, storage location, or material is not found in this organization.
      */
-    @Transactional
     public GoodsReceivedNoteDto createGoodsReceivedNote(GoodsReceivedNoteCreationDto creationDto) {
-        // Check for duplicate GRN number
-        if (goodsReceivedNoteRepository.existsByGrnNumber(creationDto.getGrnNumber())) {
-            throw new DuplicateResourceException("GRN number '" + creationDto.getGrnNumber() + "' is already in use in this organization");
-        }
+        return retryTemplate.execute(
+                "GoodsReceivedNoteService.createGoodsReceivedNote",
+                failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
+                () -> createGoodsReceivedNoteInTransaction(creationDto));
+    }
 
-
+    private GoodsReceivedNoteDto createGoodsReceivedNoteInTransaction(GoodsReceivedNoteCreationDto creationDto) {
         // Validate vendor
         Vendor vendor = vendorRepository.findByIdAndOrganization_Id(creationDto.getVendorId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Vendor with ID " + creationDto.getVendorId() + " was not found in this organization"));
@@ -123,7 +138,8 @@ public class GoodsReceivedNoteService {
 
         // Create GRN
         GoodsReceivedNote grn = new GoodsReceivedNote();
-        grn.setGrnNumber(creationDto.getGrnNumber());
+        grn.setGrnNumber(
+                documentNumberAllocator.allocate(DocumentNumberType.GOODS_RECEIVED_NOTE, TenantContext.getCurrentOrgId()));
         grn.setReceivedOn(creationDto.getReceivedOn());
         grn.setReceivedBy(receivedBy);
         grn.setVendor(vendor);

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
@@ -2,7 +2,6 @@ package org.tornotron.echno_backend.goodsReceivedNote.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -13,13 +12,9 @@ import java.util.List;
 
 @Data
 @Schema(description = "Payload to record a goods received note. The received quantities on the items are "
-        + "posted into stock at the given storage location.")
+        + "posted into stock at the given storage location. The GRN number is allocated by the server "
+        + "and returned on the created note; it is not part of this payload.")
 public class GoodsReceivedNoteCreationDto {
-
-    @Schema(description = "Goods received note number, unique within the tenant.", example = "GRN-2026-0042")
-    @NotBlank(message = "GRN number is required")
-    @Size(min = 1, max = 50, message = "GRN number must be between 1 and 50 characters")
-    private String grnNumber;
 
     @Schema(description = "When the goods were received.", example = "2026-08-01T10:30:00")
     @NotNull(message = "received on date is required")

--- a/src/main/java/org/tornotron/echno_backend/indent/Indent.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/Indent.java
@@ -36,7 +36,12 @@ public class Indent implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "indent_number", nullable = false, unique = true)
+    /**
+     * Allocated by the server, never by the client. Unique per organization rather than
+     * globally: the constraint that enforces it is {@code uk_indent_org_number} in the schema, and it
+     * is composite, so it cannot be declared here as a column-level unique.
+     */
+    @Column(name = "indent_number", nullable = false)
     private String indentNumber;
 
     @CreationTimestamp

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
@@ -8,7 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
 import org.tornotron.echno_backend.indent.mapper.IndentMapper;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -50,11 +54,15 @@ public class IndentService {
     private final EmployeeRepository employeeRepository;
     private final ProjectRepository projectRepository;
     private final IndentItemMapper indentItemMapper;
+    private final DocumentNumberAllocator documentNumberAllocator;
+    private final TransactionRetryTemplate retryTemplate;
 
     public IndentService(IndentRepository indentRepository, IndentItemRepository indentItemRepository,
                          MaterialRepository materialRepository, IndentMapper indentMapper,
                          TenantEntityHelper tenantEntityHelper, EmployeeRepository employeeRepository,
-                         ProjectRepository projectRepository, IndentItemMapper indentItemMapper) {
+                         ProjectRepository projectRepository, IndentItemMapper indentItemMapper,
+                         DocumentNumberAllocator documentNumberAllocator,
+                         TransactionRetryTemplate retryTemplate) {
         this.indentRepository = indentRepository;
         this.indentItemRepository = indentItemRepository;
         this.materialRepository = materialRepository;
@@ -63,6 +71,8 @@ public class IndentService {
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
         this.indentItemMapper = indentItemMapper;
+        this.documentNumberAllocator = documentNumberAllocator;
+        this.retryTemplate = retryTemplate;
     }
 
     // ==================== Indent CRUD ====================
@@ -121,15 +131,26 @@ public class IndentService {
     /**
      * Creates an indent with any nested line items.
      *
-     * <p>Resolves the creating employee and project, sets the header fields, and attaches
-     * each supplied item, resolving its material.
+     * <p>Allocates the indent number, resolves the creating employee and project, sets the
+     * header fields, and attaches each supplied item, resolving its material.
+     *
+     * <p>The transaction is restarted on a serialization abort, and also on a unique
+     * violation: the counter behind the indent number is the row two concurrent creates
+     * contend on, and a fresh attempt allocates the next number rather than reporting a
+     * collision the user did not cause.
      *
      * @param indentCreationDto The indent header fields and optional list of items.
      * @return The created indent as a DTO.
      * @throws ResourceNotFoundException if the creator, project, or a line's material is not found in this organization.
      */
-    @Transactional
     public IndentDto addIndent(IndentCreationDto indentCreationDto) {
+        return retryTemplate.execute(
+                "IndentService.addIndent",
+                failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
+                () -> addIndentInTransaction(indentCreationDto));
+    }
+
+    private IndentDto addIndentInTransaction(IndentCreationDto indentCreationDto) {
         Indent indent = new Indent();
         Employee employee = employeeRepository.findByIdAndOrganizationId(indentCreationDto.getCreatedByEmployeeId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee with ID " + indentCreationDto.getCreatedByEmployeeId() + " was not found in this organization"));
@@ -139,7 +160,8 @@ public class IndentService {
 
         indent.setCreatedBy(employee);
         indent.setProject(project);
-        indent.setIndentNumber(indentCreationDto.getIndentNumber());
+        indent.setIndentNumber(
+                documentNumberAllocator.allocate(DocumentNumberType.INDENT, TenantContext.getCurrentOrgId()));
         indent.setStatus(IndentStatus.valueOf(indentCreationDto.getStatus()));
         indent.setExpectedOn(indentCreationDto.getExpectedOn());
         indent.setRemarks(indentCreationDto.getRemarks());

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentCreationDto.java
@@ -4,21 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Schema(description = "Payload to raise a material indent on a project, with its requested items.")
+@Schema(description = "Payload to raise a material indent on a project, with its requested items. "
+        + "The indent number is allocated by the server and returned on the created indent; it is "
+        + "not part of this payload.")
 @Data
 public class IndentCreationDto {
-
-    @Schema(description = "Indent number, unique per organization.", example = "IND-2026-0015")
-    @NotBlank(message = "indentNumber is required(type: String)")
-    @Size(min = 1, max = 50, message = "indentNumber must be between 1 and 50 characters")
-    private String indentNumber;
 
     @Schema(description = "Id of the project the indent is raised for.", example = "3")
     @NotNull(message = "project ID is required")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrder.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrder.java
@@ -40,7 +40,12 @@ public class PurchaseOrder implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "po_number", nullable = false, unique = true)
+    /**
+     * Allocated by the server, never by the client. Unique per organization rather than
+     * globally: the constraint that enforces it is {@code uk_purchase_order_org_number} in the schema, and it
+     * is composite, so it cannot be declared here as a column-level unique.
+     */
+    @Column(name = "po_number", nullable = false)
     private String poNumber;
 
     @ManyToOne

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
@@ -7,10 +7,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.indent.Indent;
@@ -28,6 +32,7 @@ import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
 import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
 import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
+import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.vendor.Vendor;
 import org.tornotron.echno_backend.vendor.VendorRepository;
 
@@ -38,10 +43,16 @@ import java.util.stream.Collectors;
 /**
  * CRUD, status changes, and total maintenance for purchase orders.
  *
- * <p>Creating a purchase order validates the vendor, creator, project, and optional indent,
- * builds its line items, and sums their line totals into the order total. When an item is
- * raised from an indent item, that indent item is flagged as converted to a purchase order.
- * The total can be recomputed from the persisted lines after they change.
+ * <p>Creating a purchase order allocates its PO number, validates the vendor, creator,
+ * project, and optional indent, builds its line items, and sums their line totals into the
+ * order total. When an item is raised from an indent item, that indent item is flagged as
+ * converted to a purchase order. The total can be recomputed from the persisted lines after
+ * they change.
+ *
+ * <p>An order is always created in {@link PurchaseOrderStatus#DRAFT}. Approving it, sending it
+ * to the vendor and every later state change go through the status endpoint, so that approval
+ * is a separate act on an order that already exists rather than a value the create form can
+ * choose for itself.
  */
 @Service
 public class PurchaseOrderService {
@@ -56,6 +67,8 @@ public class PurchaseOrderService {
     private final PurchaseOrderItemRepository purchaseOrderItemRepository;
     private final MaterialRepository materialRepository;
     private final IndentItemRepository indentItemRepository;
+    private final DocumentNumberAllocator documentNumberAllocator;
+    private final TransactionRetryTemplate retryTemplate;
 
     public PurchaseOrderService(PurchaseOrderRepository purchaseOrderRepository,
                                 VendorRepository vendorRepository,
@@ -66,7 +79,9 @@ public class PurchaseOrderService {
                                 ProjectRepository projectRepository,
                                 PurchaseOrderItemRepository purchaseOrderItemRepository,
                                 MaterialRepository materialRepository,
-                                IndentItemRepository indentItemRepository) {
+                                IndentItemRepository indentItemRepository,
+                                DocumentNumberAllocator documentNumberAllocator,
+                                TransactionRetryTemplate retryTemplate) {
         this.purchaseOrderRepository = purchaseOrderRepository;
         this.vendorRepository = vendorRepository;
         this.indentRepository = indentRepository;
@@ -77,26 +92,42 @@ public class PurchaseOrderService {
         this.purchaseOrderItemRepository = purchaseOrderItemRepository;
         this.materialRepository = materialRepository;
         this.indentItemRepository = indentItemRepository;
+        this.documentNumberAllocator = documentNumberAllocator;
+        this.retryTemplate = retryTemplate;
     }
 
     /**
      * Creates a purchase order with its line items and computed total.
      *
-     * <p>Rejects a duplicate PO number and resolves the vendor, creator, project, and
-     * optional indent. Each supplied item is built, its line total added to the order total,
-     * and any linked indent item is marked as converted to a purchase order.
+     * <p>Allocates the PO number and resolves the vendor, creator, project, and optional
+     * indent. Each supplied item is built, its line total added to the order total, and any
+     * linked indent item is marked as converted to a purchase order.
+     *
+     * <p>The transaction is restarted on a serialization abort, and also on a unique
+     * violation: the counter behind the PO number is the row two concurrent creates contend
+     * on, and a fresh attempt allocates the next number rather than reporting a collision the
+     * user did not cause. See {@link DocumentNumberAllocator} for why that is enough.
      *
      * @param creationDto The order header fields and the list of line items.
      * @return The created purchase order as a DTO.
-     * @throws DuplicateResourceException if the PO number already exists in this organization.
+     * @throws InvalidRequestException if a status other than DRAFT is asked for on create.
      * @throws ResourceNotFoundException if the vendor, creator, project, indent, or a line's material or indent item is not found in this organization.
      */
-    @Transactional
     public PurchaseOrderDto createPurchaseOrder(PurchaseOrderCreationDto creationDto) {
-        if (purchaseOrderRepository.existsByPoNumberAndOrganization_Id(creationDto.getPoNumber(),TenantContext.getCurrentOrgId())) {
-            throw new DuplicateResourceException("Purchase Order with PO number " + creationDto.getPoNumber() + " already exists");
+        if (creationDto.getStatus() != null && creationDto.getStatus() != PurchaseOrderStatus.DRAFT) {
+            throw new InvalidRequestException(
+                    "A purchase order is created as " + PurchaseOrderStatus.DRAFT + " and cannot be "
+                            + "created as " + creationDto.getStatus() + ". Create it first, then move "
+                            + "it with the purchase order status endpoint.");
         }
 
+        return retryTemplate.execute(
+                "PurchaseOrderService.createPurchaseOrder",
+                failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
+                () -> createPurchaseOrderInTransaction(creationDto));
+    }
+
+    private PurchaseOrderDto createPurchaseOrderInTransaction(PurchaseOrderCreationDto creationDto) {
         Vendor vendor = vendorRepository.findByIdAndOrganization_Id(creationDto.getVendorId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Vendor with ID " + creationDto.getVendorId() + " was not found in this organization"));
 
@@ -112,17 +143,20 @@ public class PurchaseOrderService {
                     .orElseThrow(() -> new ResourceNotFoundException("Indent with ID " + creationDto.getIndentId() + " was not found in this organization"));
         }
 
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
+
         PurchaseOrder purchaseOrder = new PurchaseOrder();
-        purchaseOrder.setPoNumber(creationDto.getPoNumber());
+        purchaseOrder.setPoNumber(
+                documentNumberAllocator.allocate(DocumentNumberType.PURCHASE_ORDER, TenantContext.getCurrentOrgId()));
         purchaseOrder.setVendor(vendor);
         purchaseOrder.setIndent(indent);
-        purchaseOrder.setStatus(PurchaseOrderStatus.valueOf(creationDto.getStatus()));
+        purchaseOrder.setStatus(PurchaseOrderStatus.DRAFT);
         purchaseOrder.setCreatedBy(createdBy);
         purchaseOrder.setProject(project);
         purchaseOrder.setExpectedDeliveryDate(creationDto.getExpectedDeliveryDate());
         purchaseOrder.setRemarks(creationDto.getRemarks());
         purchaseOrder.setTotalAmount(BigDecimal.ZERO);
-        purchaseOrder.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        purchaseOrder.setOrganization(organization);
 
         // Add nested purchase order items if provided
         if (creationDto.getItems() != null) {

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderCreationDto.java
@@ -2,24 +2,20 @@ package org.tornotron.echno_backend.purchaseOrder.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Schema(description = "Payload to raise a purchase order against a vendor, with its line items.")
+@Schema(description = "Payload to raise a purchase order against a vendor, with its line items. "
+        + "The PO number is allocated by the server and returned on the created order; it is not "
+        + "part of this payload.")
 @Data
 public class PurchaseOrderCreationDto {
-
-    @Schema(description = "Purchase order number, unique per organization.", example = "PO-2026-0042")
-    @NotBlank(message = "PO number is required")
-    @Size(min = 1, max = 50, message = "PO number must be between 1 and 50 characters")
-    private String poNumber;
 
     @Schema(description = "Id of the vendor the order is raised against.", example = "12")
     @NotNull(message = "vendor ID is required")
@@ -28,9 +24,12 @@ public class PurchaseOrderCreationDto {
     @Schema(description = "Id of the indent this order was converted from, if any.", example = "7")
     private Long indentId;
 
-    @Schema(description = "Lifecycle status of the purchase order.", example = "DRAFT")
-    @NotBlank(message = "status is required")
-    private String status;
+    @Schema(description = "Status the order starts in. Optional, and DRAFT is the only value "
+            + "accepted, so leaving it out is the same as sending DRAFT. Approval and every later "
+            + "state change go through PATCH /purchase-orders/{id}/status, which is what makes "
+            + "approving an order a deliberate act rather than a field on the create form.",
+            example = "DRAFT", allowableValues = {"DRAFT"})
+    private PurchaseOrderStatus status;
 
     @Schema(description = "Id of the project the materials are for.", example = "3")
     @NotNull(message = "project ID is required")
@@ -46,7 +45,8 @@ public class PurchaseOrderCreationDto {
     @Schema(description = "Free-text remarks on the order.", example = "Deliver to Perumbavoor site, second gate")
     private String remarks;
 
-    @Schema(description = "Total value of the purchase order in INR.", example = "485000.00")
+    @Schema(description = "Total value of the purchase order in INR. Ignored on create: the total "
+            + "is the sum of the line totals the server computes.", example = "485000.00")
     private BigDecimal totalAmount;
 
     @Schema(description = "Line items being ordered.")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemCreationDto.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.purchaseOrderItem.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -26,10 +27,16 @@ public class PurchaseOrderItemCreationDto {
     @Min(value = 1, message = "Ordered quantity must be at least 1")
     private Integer orderedQuantity;
 
-    @Schema(description = "Unit price in INR.", example = "62.50")
+    @Schema(description = "Unit price in INR. Required. Zero is allowed, for a line supplied free "
+            + "of charge, but it has to be sent deliberately: an empty price field is rejected "
+            + "rather than treated as zero, which is how orders were being saved with a total of "
+            + "nothing.", example = "62.50")
+    @NotNull(message = "Unit price is required")
+    @PositiveOrZero(message = "Unit price cannot be negative")
     private BigDecimal unitPrice;
 
-    @Schema(description = "Total price for this line in INR.", example = "31250.00")
+    @Schema(description = "Total price for this line in INR. Ignored: the server computes it as "
+            + "unit price times ordered quantity.", example = "31250.00")
     private BigDecimal totalPrice;
 
     @Schema(description = "Free-text remarks on this line item.", example = "IS 1786 grade, mill test certificate required")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransfer.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransfer.java
@@ -34,7 +34,12 @@ public class SiteTransfer implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "transfer_number", nullable = false, unique = true)
+    /**
+     * Allocated by the server, never by the client. Unique per organization rather than
+     * globally: the constraint that enforces it is {@code uk_site_transfer_org_number} in the schema, and it
+     * is composite, so it cannot be declared here as a column-level unique.
+     */
+    @Column(name = "transfer_number", nullable = false)
     private String transferNumber;
 
     @Column(name = "issue_date")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -11,8 +11,11 @@ import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
@@ -61,6 +64,8 @@ public class SiteTransferService {
     private final EmployeeRepository employeeRepository;
     private final ProjectRepository projectRepository;
     private final StorageLocationRepository storageLocationRepository;
+    private final DocumentNumberAllocator documentNumberAllocator;
+    private final TransactionRetryTemplate retryTemplate;
 
     public SiteTransferService(SiteTransferRepository siteTransferRepository,
                                SiteTransferItemRepository siteTransferItemRepository,
@@ -72,7 +77,9 @@ public class SiteTransferService {
                                TenantEntityHelper tenantEntityHelper,
                                EmployeeRepository employeeRepository,
                                ProjectRepository projectRepository,
-                               StorageLocationRepository storageLocationRepository) {
+                               StorageLocationRepository storageLocationRepository,
+                               DocumentNumberAllocator documentNumberAllocator,
+                               TransactionRetryTemplate retryTemplate) {
         this.siteTransferRepository = siteTransferRepository;
         this.siteTransferItemRepository = siteTransferItemRepository;
         this.userRepository = userRepository;
@@ -84,29 +91,37 @@ public class SiteTransferService {
         this.employeeRepository = employeeRepository;
         this.projectRepository = projectRepository;
         this.storageLocationRepository = storageLocationRepository;
+        this.documentNumberAllocator = documentNumberAllocator;
+        this.retryTemplate = retryTemplate;
     }
 
     /**
      * Creates a site transfer with its items after checking sending-side stock.
      *
-     * <p>Rejects a duplicate transfer number and resolves the sending person and the sending
-     * and receiving projects (plus optional storage locations). Requested quantities are
-     * totalled per material and validated against the sending side. After saving the transfer
-     * and its items, a {@link SiteTransferCreatedEvent} is published so inventory moves.
+     * <p>Allocates the transfer number and resolves the sending person and the sending and
+     * receiving projects (plus optional storage locations). Requested quantities are totalled
+     * per material and validated against the sending side. After saving the transfer and its
+     * items, a {@link SiteTransferCreatedEvent} is published so inventory moves.
+     *
+     * <p>The transaction is restarted on a serialization abort, and also on a unique
+     * violation: the counter behind the transfer number is the row two concurrent creates
+     * contend on, and a fresh attempt allocates the next number rather than reporting a
+     * collision the user did not cause. The inventory listener runs after commit, so only the
+     * attempt that commits moves stock.
      *
      * @param creationDto The transfer header fields and the list of items to move.
      * @return The created site transfer as a DTO.
-     * @throws DuplicateResourceException if the transfer number already exists in this organization.
      * @throws ResourceNotFoundException if the sending person, either project, a storage location, or a line's material is not found in this organization.
      * @throws org.tornotron.echno_backend.common.exception.InsufficientStockException if the sending side does not hold enough of any requested material.
      */
-    @Transactional
     public SiteTransferDto createSiteTransfer(SiteTransferCreationDto creationDto) {
-        // Check for duplicate transfer number
-        if (siteTransferRepository.existsByTransferNumberAndOrganization_Id(creationDto.getTransferNumber(),TenantContext.getCurrentOrgId())) {
-            throw new DuplicateResourceException("Site transfer with number " + creationDto.getTransferNumber() + " already exists");
-        }
+        return retryTemplate.execute(
+                "SiteTransferService.createSiteTransfer",
+                failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
+                () -> createSiteTransferInTransaction(creationDto));
+    }
 
+    private SiteTransferDto createSiteTransferInTransaction(SiteTransferCreationDto creationDto) {
         Employee sendingPerson = employeeRepository.findByIdAndOrganizationId(creationDto.getSendingPerson(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Sending person (employee) with ID " + creationDto.getSendingPerson() + " was not found in this organization"));
 
@@ -133,7 +148,8 @@ public class SiteTransferService {
 
         // Create site transfer
         SiteTransfer transfer = new SiteTransfer();
-        transfer.setTransferNumber(creationDto.getTransferNumber());
+        transfer.setTransferNumber(
+                documentNumberAllocator.allocate(DocumentNumberType.SITE_TRANSFER, TenantContext.getCurrentOrgId()));
         transfer.setIssueDate(creationDto.getIssueDate());
         transfer.setSendingPerson(sendingPerson);
         transfer.setSendingProject(sendingProject);

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
@@ -5,20 +5,16 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Schema(description = "Payload to create a site transfer moving materials from a sending project to a receiving project.")
+@Schema(description = "Payload to create a site transfer moving materials from a sending project "
+        + "to a receiving project. The transfer number is allocated by the server and returned on "
+        + "the created transfer; it is not part of this payload.")
 @Data
 public class SiteTransferCreationDto {
-
-    @Schema(description = "Unique transfer document number.", example = "ST-2026-0031")
-    @NotBlank(message = "transfer number is required")
-    @Size(min = 1, max = 50, message = "transfer number must be between 1 and 50 characters")
-    private String transferNumber;
 
     @Schema(description = "Date and time the transfer was issued.", example = "2026-01-15T09:30:00")
     @NotNull(message = "issue date is required")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -173,6 +173,12 @@ echno:
       # which can differ from the internal URL the backend dials, so list every URL
       # the same realm may present.
       accepted-issuers: ${ECHNO_JWT_ACCEPTED_ISSUERS:}
+  document-number:
+    # Site transfer, purchase order, indent and GRN numbers carry the year they were issued in,
+    # and the counter behind them resets with it. The year is read in this zone rather than the
+    # container's, so a document raised at eight in the morning in Kerala is not stamped with
+    # the previous year because the server happens to run on UTC.
+    zone: ${ECHNO_DOCUMENT_NUMBER_ZONE:Asia/Kolkata}
   transaction:
     retry:
       # CockroachDB runs SERIALIZABLE and aborts one side of a read-write conflict with

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -316,4 +316,7 @@
     <!-- v4.0 - Compliance: one inspection per rule per project, enforced in the schema -->
     <include file="db/changelog/v4.0/060-compliance-inspection-rule-ref-unique.xml"/>
 
+    <!-- v4.0 - Server-allocated document numbers, and per-tenant uniqueness for them -->
+    <include file="db/changelog/v4.0/061-document-number-sequences.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/061-document-number-sequences.xml
+++ b/src/main/resources/db/changelog/v4.0/061-document-number-sequences.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="061-create-document-number-sequence" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="document_number_sequence"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            One counter row per tenant, document family and year. Site transfer, purchase order,
+            indent and GRN numbers were invented by the browser from the list it happened to have
+            loaded, so two people on the same screen proposed the same number and the second save
+            was rejected. The server issues them from here instead.
+
+            last_allocated holds the highest number handed out so far, so the allocator's single
+            INSERT ... ON CONFLICT DO UPDATE ... RETURNING statement inserts 1 for a new counter
+            and returns the value it has just written for an existing one.
+        </comment>
+
+        <createTable tableName="document_number_sequence">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="document_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="sequence_year" type="INT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="last_allocated" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="document_number_sequence"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_document_number_sequence_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addUniqueConstraint tableName="document_number_sequence"
+                             columnNames="organization_id, document_type, sequence_year"
+                             constraintName="uk_document_number_sequence"/>
+
+        <rollback>
+            <dropTable tableName="document_number_sequence"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="061-seed-document-number-sequence" author="echno">
+        <comment>
+            Starts each counter above the numbers already in the table, so the first number the
+            server issues cannot collide with one the browser issued before it.
+
+            Only rows whose number is in the canonical PREFIX-YYYY-NNNNNN shape are counted, and
+            that is exactly the right set: a number in any other shape can never be produced by
+            the allocator, so it cannot be collided with. The year is read out of the number
+            rather than off created_at, because the number is what has to stay unique.
+
+            The positions are fixed rather than a capture group: CockroachDB's substring with a
+            regular expression returns the whole match, not the group, so the guard is the ~ test
+            and the extraction is by offset. PO- is three characters, TRF-, IND- and GRN- are
+            four, which is the only difference between the four statements.
+
+            ON CONFLICT DO NOTHING makes this re-runnable and keeps it from disturbing a counter
+            the running application has already advanced.
+        </comment>
+
+        <sql>
+            INSERT INTO document_number_sequence
+                (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
+            SELECT organization_id,
+                   'PURCHASE_ORDER',
+                   CAST(substring(po_number, 4, 4) AS INT),
+                   MAX(CAST(substring(po_number, 9) AS INT)),
+                   current_timestamp, current_timestamp
+            FROM purchase_order
+            WHERE organization_id IS NOT NULL
+              AND po_number ~ '^PO-[0-9]{4}-[0-9]+$'
+            GROUP BY organization_id, CAST(substring(po_number, 4, 4) AS INT)
+            ON CONFLICT DO NOTHING;
+        </sql>
+
+        <sql>
+            INSERT INTO document_number_sequence
+                (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
+            SELECT organization_id,
+                   'SITE_TRANSFER',
+                   CAST(substring(transfer_number, 5, 4) AS INT),
+                   MAX(CAST(substring(transfer_number, 10) AS INT)),
+                   current_timestamp, current_timestamp
+            FROM site_transfer
+            WHERE organization_id IS NOT NULL
+              AND transfer_number ~ '^TRF-[0-9]{4}-[0-9]+$'
+            GROUP BY organization_id, CAST(substring(transfer_number, 5, 4) AS INT)
+            ON CONFLICT DO NOTHING;
+        </sql>
+
+        <sql>
+            INSERT INTO document_number_sequence
+                (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
+            SELECT organization_id,
+                   'INDENT',
+                   CAST(substring(indent_number, 5, 4) AS INT),
+                   MAX(CAST(substring(indent_number, 10) AS INT)),
+                   current_timestamp, current_timestamp
+            FROM indent
+            WHERE organization_id IS NOT NULL
+              AND indent_number ~ '^IND-[0-9]{4}-[0-9]+$'
+            GROUP BY organization_id, CAST(substring(indent_number, 5, 4) AS INT)
+            ON CONFLICT DO NOTHING;
+        </sql>
+
+        <sql>
+            INSERT INTO document_number_sequence
+                (organization_id, document_type, sequence_year, last_allocated, created_at, updated_at)
+            SELECT organization_id,
+                   'GOODS_RECEIVED_NOTE',
+                   CAST(substring(grn_number, 5, 4) AS INT),
+                   MAX(CAST(substring(grn_number, 10) AS INT)),
+                   current_timestamp, current_timestamp
+            FROM goods_received_note
+            WHERE organization_id IS NOT NULL
+              AND grn_number ~ '^GRN-[0-9]{4}-[0-9]+$'
+            GROUP BY organization_id, CAST(substring(grn_number, 5, 4) AS INT)
+            ON CONFLICT DO NOTHING;
+        </sql>
+
+        <rollback>
+            DELETE FROM document_number_sequence;
+        </rollback>
+    </changeSet>
+
+    <changeSet id="061-add-per-org-document-number-uniqueness" author="echno">
+        <comment>
+            The application has always checked these numbers for a duplicate within the
+            organization while the schema enforced uniqueness across every organization at once.
+            With one tenant on staging the disagreement is invisible. With two it is a bug that
+            only the second client can trigger: their PO-2026-000001 passes the service check and
+            is then rejected by a constraint they share with a tenant they cannot see.
+
+            These constraints are what the service check has always meant. They are added before
+            the global ones are dropped, so the numbers are never unconstrained in between.
+        </comment>
+
+        <addUniqueConstraint tableName="purchase_order"
+                             columnNames="organization_id, po_number"
+                             constraintName="uk_purchase_order_org_number"/>
+
+        <addUniqueConstraint tableName="site_transfer"
+                             columnNames="organization_id, transfer_number"
+                             constraintName="uk_site_transfer_org_number"/>
+
+        <addUniqueConstraint tableName="indent"
+                             columnNames="organization_id, indent_number"
+                             constraintName="uk_indent_org_number"/>
+
+        <addUniqueConstraint tableName="goods_received_note"
+                             columnNames="organization_id, grn_number"
+                             constraintName="uk_grn_org_number"/>
+
+        <rollback>
+            <dropUniqueConstraint tableName="purchase_order" constraintName="uk_purchase_order_org_number"/>
+            <dropUniqueConstraint tableName="site_transfer" constraintName="uk_site_transfer_org_number"/>
+            <dropUniqueConstraint tableName="indent" constraintName="uk_indent_org_number"/>
+            <dropUniqueConstraint tableName="goods_received_note" constraintName="uk_grn_org_number"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="061-drop-global-document-number-uniqueness" author="echno">
+        <comment>
+            Removes the cross-tenant constraints now that the per-tenant ones above stand in their
+            place. DROP INDEX rather than DROP CONSTRAINT because CockroachDB backs a UNIQUE column
+            constraint with an index of the same name and that is how it is removed.
+
+            uk_intend_number is the name the constraint carried on databases built from the v1, v2
+            or v3 baselines, before the intend to indent rename; IF EXISTS covers whichever of the
+            two a given database has.
+        </comment>
+
+        <sql>
+            DROP INDEX IF EXISTS purchase_order@uk_purchase_order_number CASCADE;
+            DROP INDEX IF EXISTS site_transfer@uk_site_transfer_number CASCADE;
+            DROP INDEX IF EXISTS indent@uk_indent_number CASCADE;
+            DROP INDEX IF EXISTS indent@uk_intend_number CASCADE;
+            DROP INDEX IF EXISTS goods_received_note@uk_grn_number CASCADE;
+        </sql>
+
+        <rollback>
+            <comment>
+                Restoring a global unique constraint would fail on any data that has since made
+                use of the per-tenant scope, so the rollback does not pretend it can.
+            </comment>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocatorConcurrencyIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocatorConcurrencyIT.java
@@ -1,0 +1,148 @@
+package org.tornotron.echno_backend.common.documentnumber;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the allocation against a real CockroachDB, which is the only place the claim can be
+ * tested: what stops two callers taking the same number is the engine's own conflict handling
+ * on the counter row, and no in-memory stand-in reproduces that.
+ *
+ * <p>Eight threads allocate at once for one organization and one document type. The assertion
+ * is not merely that the numbers differ but that they are exactly the first eight, so a run
+ * that quietly skipped or repeated one fails. Replace the single upsert with a read followed
+ * by a write and this test reports duplicates.
+ *
+ * <p>Each caller goes through {@link TransactionRetryTemplate} the way the services do, since
+ * restarting an aborted transaction is half of what makes the allocation correct: under
+ * SERIALIZABLE the loser of a conflict is told to run again rather than made to wait forever.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({DocumentNumberAllocator.class, TransactionRetryTemplate.class,
+        TransactionalWorkRunner.class, SimpleMeterRegistry.class})
+@TestPropertySource(properties = {
+        "echno.transaction.retry.initial-backoff-millis=0",
+        "echno.transaction.retry.max-backoff-millis=5",
+        "echno.transaction.retry.max-attempts=20"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DocumentNumberAllocatorConcurrencyIT extends AbstractIntegrationTest {
+
+    private static final int CALLERS = 8;
+
+    @Autowired
+    private DocumentNumberAllocator allocator;
+
+    @Autowired
+    private TransactionRetryTemplate retryTemplate;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentAllocations_eachGetTheirOwnNumber() throws Exception {
+        Long orgId = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Allocator Org");
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail("allocator@example.test");
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+            entityManager.flush();
+            return org.getId();
+        });
+
+        CountDownLatch startLine = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(CALLERS);
+        List<Future<String>> results = new ArrayList<>();
+        try {
+            for (int caller = 0; caller < CALLERS; caller++) {
+                Callable<String> allocateOnce = () -> {
+                    startLine.await();
+                    return retryTemplate.execute("test.allocate",
+                            () -> allocator.allocate(DocumentNumberType.PURCHASE_ORDER, orgId));
+                };
+                results.add(pool.submit(allocateOnce));
+            }
+            startLine.countDown();
+
+            List<String> numbers = new ArrayList<>();
+            for (Future<String> result : results) {
+                numbers.add(result.get(60, TimeUnit.SECONDS));
+            }
+
+            assertThat(numbers).doesNotHaveDuplicates();
+            assertThat(numbers).allSatisfy(number -> assertThat(number).startsWith("PO-"));
+            assertThat(numbers.stream().map(n -> n.substring(n.lastIndexOf('-') + 1)).sorted().toList())
+                    .containsExactly("000001", "000002", "000003", "000004",
+                            "000005", "000006", "000007", "000008");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void countersAreSeparatePerOrganizationAndPerType() {
+        Long first = newOrganization("counter-a@example.test");
+        Long second = newOrganization("counter-b@example.test");
+
+        String firstPo = retryTemplate.execute("test.allocate",
+                () -> allocator.allocate(DocumentNumberType.PURCHASE_ORDER, first));
+        String secondPo = retryTemplate.execute("test.allocate",
+                () -> allocator.allocate(DocumentNumberType.PURCHASE_ORDER, second));
+        String firstIndent = retryTemplate.execute("test.allocate",
+                () -> allocator.allocate(DocumentNumberType.INDENT, first));
+
+        // A second tenant starts at one of its own, which is the whole point of scoping the
+        // constraint to the organization: their PO-YYYY-000001 is not a collision with ours.
+        assertThat(firstPo).endsWith("-000001");
+        assertThat(secondPo).endsWith("-000001");
+        assertThat(firstIndent).endsWith("-000001").startsWith("IND-");
+    }
+
+    private Long newOrganization(String email) {
+        return new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Org " + email);
+            org.setOrganizationAddress("addr");
+            org.setOrganizationEmail(email);
+            org.setOrganizationPhone("0000000000");
+            entityManager.persist(org);
+            entityManager.flush();
+            return org.getId();
+        });
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocatorTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/documentnumber/DocumentNumberAllocatorTest.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.common.documentnumber;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the shape of the allocation: the number the caller gets back, and the one
+ * statement it is allowed to take to get there. The concurrency behaviour that statement buys
+ * is proven against a real database in {@link DocumentNumberAllocatorConcurrencyIT}.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentNumberAllocatorTest {
+
+    private static final String ZONE = "Asia/Kolkata";
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private int currentYear() {
+        return LocalDate.now(ZoneId.of(ZONE)).getYear();
+    }
+
+    @Test
+    void allocate_formatsThePrefixYearAndPaddedSequence() {
+        DocumentNumberAllocator allocator = new DocumentNumberAllocator(jdbcTemplate, ZONE);
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(Object[].class)))
+                .thenReturn(7L);
+
+        assertThat(allocator.allocate(DocumentNumberType.PURCHASE_ORDER, 42L))
+                .isEqualTo("PO-" + currentYear() + "-000007");
+    }
+
+    @Test
+    void allocate_padsToSixDigitsButDoesNotTruncateBeyondThem() {
+        DocumentNumberAllocator allocator = new DocumentNumberAllocator(jdbcTemplate, ZONE);
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(Object[].class)))
+                .thenReturn(1234567L);
+
+        assertThat(allocator.allocate(DocumentNumberType.SITE_TRANSFER, 42L))
+                .isEqualTo("TRF-" + currentYear() + "-1234567");
+    }
+
+    @Test
+    void allocate_usesEachTypesOwnPrefix() {
+        DocumentNumberAllocator allocator = new DocumentNumberAllocator(jdbcTemplate, ZONE);
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(Object[].class)))
+                .thenReturn(1L);
+
+        assertThat(allocator.allocate(DocumentNumberType.INDENT, 1L)).startsWith("IND-");
+        assertThat(allocator.allocate(DocumentNumberType.GOODS_RECEIVED_NOTE, 1L)).startsWith("GRN-");
+    }
+
+    /**
+     * The counter has to be read and written by one statement. Two statements, however they are
+     * ordered, let two transactions read the same value before either writes, which is the fault
+     * this whole change exists to remove.
+     */
+    @Test
+    void allocate_readsAndWritesTheCounterInASingleUpsert() {
+        DocumentNumberAllocator allocator = new DocumentNumberAllocator(jdbcTemplate, ZONE);
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(Object[].class)))
+                .thenReturn(3L);
+
+        allocator.allocate(DocumentNumberType.PURCHASE_ORDER, 42L);
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> args = ArgumentCaptor.forClass(Object.class);
+        verify(jdbcTemplate).queryForObject(sql.capture(), eq(Long.class),
+                args.capture(), args.capture(), args.capture());
+
+        String statement = sql.getValue().toUpperCase();
+        assertThat(statement).contains("INSERT INTO DOCUMENT_NUMBER_SEQUENCE");
+        assertThat(statement).contains("ON CONFLICT");
+        assertThat(statement).contains("DO UPDATE SET LAST_ALLOCATED = DOCUMENT_NUMBER_SEQUENCE.LAST_ALLOCATED + 1");
+        assertThat(statement).contains("RETURNING LAST_ALLOCATED");
+
+        assertThat(args.getAllValues())
+                .containsExactly(42L, DocumentNumberType.PURCHASE_ORDER.name(), currentYear());
+    }
+
+    @Test
+    void allocate_readsTheYearInTheConfiguredZoneNotTheContainers() {
+        // A zone whose calendar date is a day ahead of UTC for part of every day. The assertion
+        // is that the allocator asks the zone rather than the JVM default, which on the servers
+        // is UTC.
+        String zone = "Pacific/Kiritimati";
+        DocumentNumberAllocator allocator = new DocumentNumberAllocator(jdbcTemplate, zone);
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(Object[].class)))
+                .thenReturn(1L);
+
+        allocator.allocate(DocumentNumberType.PURCHASE_ORDER, 42L);
+
+        ArgumentCaptor<Object> args = ArgumentCaptor.forClass(Object.class);
+        verify(jdbcTemplate).queryForObject(anyString(), eq(Long.class),
+                args.capture(), args.capture(), args.capture());
+        assertThat(args.getAllValues().get(2)).isEqualTo(LocalDate.now(ZoneId.of(zone)).getYear());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
@@ -95,6 +95,28 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void duplicateResource_reportsTheDuplicateItActuallyFound() {
+        ProblemDetail pd = handler.handleDuplicateResourceException(
+                new DuplicateResourceException("Purchase Order with PO number PO-2026-000001 already exists"),
+                requestWithPath("uri=/api/v1/purchase-orders"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getTitle()).isEqualTo("Duplicate Resource");
+        assertThat(pd.getDetail()).isEqualTo("Purchase Order with PO number PO-2026-000001 already exists");
+        assertThat(pd.getProperties())
+                .containsEntry("message", "Purchase Order with PO number PO-2026-000001 already exists");
+    }
+
+    @Test
+    void duplicateResource_withNoMessage_stillSaysSomethingUseful() {
+        ProblemDetail pd = handler.handleDuplicateResourceException(
+                new DuplicateResourceException(null), requestWithPath("uri=/api/v1/purchase-orders"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getDetail()).isEqualTo("Database operation failed, Data already exists");
+    }
+
+    @Test
     void unknownException_isA500Problem() {
         ProblemDetail pd = handler.handleAllUncaughtException(
                 new RuntimeException("boom"), requestWithPath("uri=/api/v1/x"));

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -24,6 +23,9 @@ import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
@@ -36,10 +38,13 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,16 +76,23 @@ class GoodsReceivedNoteServiceTest {
     @Mock private ProjectRepository projectRepository;
     @Mock private StorageLocationRepository storageLocationRepository;
     @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
 
     private GoodsReceivedNoteService service;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new GoodsReceivedNoteService(goodsReceivedNoteRepository, grnItemRepository,
                 vendorRepository, userRepository, materialRepository, eventPublisher,
                 goodsReceivedNoteMapper, tenantEntityHelper, employeeRepository, projectRepository,
-                storageLocationRepository, purchaseOrderRepository);
+                storageLocationRepository, purchaseOrderRepository,
+                documentNumberAllocator, retryTemplate);
+        // The template's own behaviour is covered by its own tests; here it just runs the work.
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }
 
     @AfterEach
@@ -106,6 +118,8 @@ class GoodsReceivedNoteServiceTest {
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
         lenient().when(goodsReceivedNoteRepository.save(any(GoodsReceivedNote.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.GOODS_RECEIVED_NOTE, ORG))
+                .thenReturn("GRN-2026-000042");
     }
 
     private GrnItemDto itemDto(Long materialId, int ordered, int received, String unitCost) {
@@ -119,7 +133,6 @@ class GoodsReceivedNoteServiceTest {
 
     private GoodsReceivedNoteCreationDto baseDto() {
         GoodsReceivedNoteCreationDto dto = new GoodsReceivedNoteCreationDto();
-        dto.setGrnNumber("GRN-001");
         dto.setReceivedOn(LocalDateTime.of(2026, 8, 3, 10, 0));
         dto.setReceivedByEmployeeId(7L);
         dto.setVendorId(5L);
@@ -136,19 +149,20 @@ class GoodsReceivedNoteServiceTest {
     }
 
     @Test
-    void create_duplicateGrnNumber_throws() {
-        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(true);
+    void create_takesItsNumberFromTheServerNotTheCaller() {
+        stubMasterLookups();
+        when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
 
-        assertThatThrownBy(() -> service.createGoodsReceivedNote(baseDto()))
-                .isInstanceOf(DuplicateResourceException.class);
+        service.createGoodsReceivedNote(baseDto());
 
-        verify(goodsReceivedNoteRepository, never()).save(any());
-        verify(eventPublisher, never()).publishEvent(any());
+        ArgumentCaptor<GoodsReceivedNote> captor = ArgumentCaptor.forClass(GoodsReceivedNote.class);
+        verify(goodsReceivedNoteRepository).save(captor.capture());
+        assertThat(captor.getValue().getGrnNumber()).isEqualTo("GRN-2026-000042");
+        verify(documentNumberAllocator).allocate(DocumentNumberType.GOODS_RECEIVED_NOTE, ORG);
     }
 
     @Test
     void create_unknownPurchaseOrder_throwsNotFound() {
-        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
         Vendor vendor = new Vendor();
         vendor.setId(5L);
         Employee employee = new Employee();
@@ -168,7 +182,6 @@ class GoodsReceivedNoteServiceTest {
 
     @Test
     void create_buildsItemsSavesThemAndPublishesEvent() {
-        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
         stubMasterLookups();
         when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
 
@@ -191,14 +204,13 @@ class GoodsReceivedNoteServiceTest {
         ArgumentCaptor<GrnCreatedEvent> eventCaptor = ArgumentCaptor.forClass(GrnCreatedEvent.class);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
         GoodsReceivedNote published = eventCaptor.getValue().getGoodsReceivedNote();
-        assertThat(published.getGrnNumber()).isEqualTo("GRN-001");
+        assertThat(published.getGrnNumber()).isEqualTo("GRN-2026-000042");
         assertThat(published.getItems()).hasSize(1);
         assertThat(published.getVendor().getId()).isEqualTo(5L);
     }
 
     @Test
     void create_unknownStorageLocation_throwsNotFound() {
-        when(goodsReceivedNoteRepository.existsByGrnNumber("GRN-001")).thenReturn(false);
         stubMasterLookups();
         when(storageLocationRepository.findByIdAndOrganization_Id(88L, ORG)).thenReturn(Optional.empty());
 

--- a/src/test/java/org/tornotron/echno_backend/indent/IndentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/indent/IndentServiceTest.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.indent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
+import org.tornotron.echno_backend.indent.mapper.IndentMapper;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the part of indent creation this change owns: the indent number comes from
+ * the server, not from whatever the browser worked out from the list it had loaded.
+ */
+@ExtendWith(MockitoExtension.class)
+class IndentServiceTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private IndentRepository indentRepository;
+    @Mock private IndentItemRepository indentItemRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private IndentMapper indentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private IndentItemMapper indentItemMapper;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+
+    private IndentService service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new IndentService(indentRepository, indentItemRepository, materialRepository,
+                indentMapper, tenantEntityHelper, employeeRepository, projectRepository,
+                indentItemMapper, documentNumberAllocator, retryTemplate);
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void addIndent_takesItsNumberFromTheServerNotTheCaller() {
+        Employee employee = new Employee();
+        employee.setId(7L);
+        Project project = new Project();
+        project.setId(9L);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(employeeRepository.findByIdAndOrganizationId(7L, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(9L, ORG)).thenReturn(Optional.of(project));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(indentRepository.save(any(Indent.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.INDENT, ORG))
+                .thenReturn("IND-2026-000042");
+
+        IndentCreationDto dto = new IndentCreationDto();
+        dto.setCreatedByEmployeeId(7L);
+        dto.setProjectId(9L);
+        dto.setStatus(IndentStatus.PENDING.name());
+
+        service.addIndent(dto);
+
+        ArgumentCaptor<Indent> captor = ArgumentCaptor.forClass(Indent.class);
+        verify(indentRepository).save(captor.capture());
+        assertThat(captor.getValue().getIndentNumber()).isEqualTo("IND-2026-000042");
+        verify(documentNumberAllocator).allocate(DocumentNumberType.INDENT, ORG);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.employee.Employee;
@@ -33,10 +36,13 @@ import org.tornotron.echno_backend.vendor.VendorRepository;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -64,15 +70,22 @@ class PurchaseOrderServiceTest {
     @Mock private PurchaseOrderItemRepository purchaseOrderItemRepository;
     @Mock private MaterialRepository materialRepository;
     @Mock private IndentItemRepository indentItemRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
 
     private PurchaseOrderService service;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new PurchaseOrderService(purchaseOrderRepository, vendorRepository, indentRepository,
                 purchaseOrderMapper, tenantEntityHelper, employeeRepository, projectRepository,
-                purchaseOrderItemRepository, materialRepository, indentItemRepository);
+                purchaseOrderItemRepository, materialRepository, indentItemRepository,
+                documentNumberAllocator, retryTemplate);
+        // The template's own behaviour is covered by its own tests; here it just runs the work.
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }
 
     @AfterEach
@@ -95,15 +108,16 @@ class PurchaseOrderServiceTest {
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
         lenient().when(purchaseOrderRepository.save(any(PurchaseOrder.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.PURCHASE_ORDER, ORG))
+                .thenReturn("PO-2026-000042");
     }
 
     private PurchaseOrderCreationDto baseDto() {
         PurchaseOrderCreationDto dto = new PurchaseOrderCreationDto();
-        dto.setPoNumber("PO-001");
         dto.setVendorId(5L);
         dto.setCreatedBy(7L);
         dto.setProjectId(9L);
-        dto.setStatus("DRAFT");
+        dto.setStatus(PurchaseOrderStatus.DRAFT);
         return dto;
     }
 
@@ -122,18 +136,60 @@ class PurchaseOrderServiceTest {
     }
 
     @Test
-    void createPurchaseOrder_duplicatePoNumber_throws() {
-        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(true);
+    void createPurchaseOrder_takesItsNumberFromTheServerNotTheCaller() {
+        stubMasterLookups();
 
-        assertThatThrownBy(() -> service.createPurchaseOrder(baseDto()))
-                .isInstanceOf(DuplicateResourceException.class);
+        service.createPurchaseOrder(baseDto());
 
+        ArgumentCaptor<PurchaseOrder> captor = ArgumentCaptor.forClass(PurchaseOrder.class);
+        verify(purchaseOrderRepository).save(captor.capture());
+        assertThat(captor.getValue().getPoNumber()).isEqualTo("PO-2026-000042");
+        verify(documentNumberAllocator).allocate(DocumentNumberType.PURCHASE_ORDER, ORG);
+    }
+
+    @Test
+    void createPurchaseOrder_asApproved_isRefused() {
+        PurchaseOrderCreationDto dto = baseDto();
+        dto.setStatus(PurchaseOrderStatus.APPROVED);
+
+        assertThatThrownBy(() -> service.createPurchaseOrder(dto))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("APPROVED");
+
+        verify(purchaseOrderRepository, never()).save(any());
+        verify(documentNumberAllocator, never()).allocate(any(), any());
+    }
+
+    @Test
+    void createPurchaseOrder_asAnyOtherLaterState_isRefused() {
+        for (PurchaseOrderStatus status : PurchaseOrderStatus.values()) {
+            if (status == PurchaseOrderStatus.DRAFT) {
+                continue;
+            }
+            PurchaseOrderCreationDto dto = baseDto();
+            dto.setStatus(status);
+            assertThatThrownBy(() -> service.createPurchaseOrder(dto))
+                    .as("creating a purchase order as %s", status)
+                    .isInstanceOf(InvalidRequestException.class);
+        }
         verify(purchaseOrderRepository, never()).save(any());
     }
 
     @Test
+    void createPurchaseOrder_withNoStatus_startsAsDraft() {
+        stubMasterLookups();
+        PurchaseOrderCreationDto dto = baseDto();
+        dto.setStatus(null);
+
+        service.createPurchaseOrder(dto);
+
+        ArgumentCaptor<PurchaseOrder> captor = ArgumentCaptor.forClass(PurchaseOrder.class);
+        verify(purchaseOrderRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(PurchaseOrderStatus.DRAFT);
+    }
+
+    @Test
     void createPurchaseOrder_unknownVendor_throwsNotFound() {
-        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
         when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.createPurchaseOrder(baseDto()))
@@ -142,7 +198,6 @@ class PurchaseOrderServiceTest {
 
     @Test
     void createPurchaseOrder_withoutItems_totalIsZero() {
-        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
         stubMasterLookups();
 
         service.createPurchaseOrder(baseDto());
@@ -157,7 +212,6 @@ class PurchaseOrderServiceTest {
 
     @Test
     void createPurchaseOrder_withItems_computesLineAndOrderTotals() {
-        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
         stubMasterLookups();
         when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
         when(materialRepository.findByIdAndOrganization_Id(12L, ORG)).thenReturn(Optional.of(material(12L)));
@@ -183,7 +237,6 @@ class PurchaseOrderServiceTest {
 
     @Test
     void createPurchaseOrder_itemFromIndentItem_marksItConverted() {
-        when(purchaseOrderRepository.existsByPoNumberAndOrganization_Id("PO-001", ORG)).thenReturn(false);
         stubMasterLookups();
         when(materialRepository.findByIdAndOrganization_Id(11L, ORG)).thenReturn(Optional.of(material(11L)));
         IndentItem indentItem = new IndentItem();

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemCreationDtoValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemCreationDtoValidationTest.java
@@ -1,0 +1,75 @@
+package org.tornotron.echno_backend.purchaseOrderItem;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Bean validation on a purchase order line.
+ *
+ * <p>An unpriced line used to be accepted and then coerced to zero, so an order raised from a
+ * form whose price fields were never filled in saved with a total of nothing and looked, on the
+ * screen, like a rendering fault. The price is now required in its own right: a line genuinely
+ * supplied free of charge sends a zero, which is a decision someone made rather than a field
+ * nobody touched.
+ */
+class PurchaseOrderItemCreationDtoValidationTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void openValidator() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        factory.close();
+    }
+
+    private PurchaseOrderItemCreationDto line(BigDecimal unitPrice) {
+        PurchaseOrderItemCreationDto dto = new PurchaseOrderItemCreationDto();
+        dto.setMaterialId(11L);
+        dto.setOrderedQuantity(5);
+        dto.setUnitPrice(unitPrice);
+        return dto;
+    }
+
+    @Test
+    void missingUnitPrice_isRejected() {
+        assertThat(validator.validate(line(null)))
+                .singleElement()
+                .satisfies(violation -> {
+                    assertThat(violation.getPropertyPath()).hasToString("unitPrice");
+                    assertThat(violation.getMessage()).isEqualTo("Unit price is required");
+                });
+    }
+
+    @Test
+    void negativeUnitPrice_isRejected() {
+        assertThat(validator.validate(line(new BigDecimal("-1.00"))))
+                .singleElement()
+                .satisfies(violation ->
+                        assertThat(violation.getPropertyPath()).hasToString("unitPrice"));
+    }
+
+    @Test
+    void zeroUnitPrice_isAllowedBecauseSendingItIsADecision() {
+        assertThat(validator.validate(line(BigDecimal.ZERO))).isEmpty();
+    }
+
+    @Test
+    void aPricedLine_passes() {
+        assertThat(validator.validate(line(new BigDecimal("62.50")))).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
-import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -23,6 +22,9 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
@@ -35,11 +37,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -75,15 +80,22 @@ class SiteTransferServiceTest {
     @Mock private EmployeeRepository employeeRepository;
     @Mock private ProjectRepository projectRepository;
     @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
 
     private SiteTransferService service;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
                 materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
-                employeeRepository, projectRepository, storageLocationRepository);
+                employeeRepository, projectRepository, storageLocationRepository,
+                documentNumberAllocator, retryTemplate);
+        // The template's own behaviour is covered by its own tests; here it just runs the work.
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }
 
     @AfterEach
@@ -100,7 +112,8 @@ class SiteTransferServiceTest {
         receiving.setId(RECEIVING_PROJECT);
         Organization org = new Organization();
         org.setId(ORG);
-        lenient().when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(false);
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.SITE_TRANSFER, ORG))
+                .thenReturn("TRF-2026-000042");
         lenient().when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG)).thenReturn(Optional.of(sender));
         lenient().when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.of(sending));
         lenient().when(projectRepository.findByIdAndOrganization_Id(RECEIVING_PROJECT, ORG)).thenReturn(Optional.of(receiving));
@@ -123,7 +136,6 @@ class SiteTransferServiceTest {
 
     private SiteTransferCreationDto baseDto() {
         SiteTransferCreationDto dto = new SiteTransferCreationDto();
-        dto.setTransferNumber("ST-001");
         dto.setIssueDate(LocalDateTime.now());
         dto.setSendingPerson(SENDER);
         dto.setSendingProjectId(SENDING_PROJECT);
@@ -134,18 +146,19 @@ class SiteTransferServiceTest {
     }
 
     @Test
-    void create_duplicateTransferNumber_throws() {
-        when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(true);
+    void create_takesItsNumberFromTheServerNotTheCaller() {
+        stubMasterLookups();
 
-        assertThatExceptionOfType(DuplicateResourceException.class)
-                .isThrownBy(() -> service.createSiteTransfer(baseDto()));
+        service.createSiteTransfer(baseDto());
 
-        verify(siteTransferRepository, never()).save(any());
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getTransferNumber()).isEqualTo("TRF-2026-000042");
+        verify(documentNumberAllocator).allocate(DocumentNumberType.SITE_TRANSFER, ORG);
     }
 
     @Test
     void create_unknownSendingProject_throwsNotFound() {
-        when(siteTransferRepository.existsByTransferNumberAndOrganization_Id("ST-001", ORG)).thenReturn(false);
         when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG))
                 .thenReturn(Optional.of(new Employee()));
         when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.empty());


### PR DESCRIPTION
Closes #482.

#514 took the model call out of the transaction and #528 made a cut-short answer fail loudly instead of writing nothing. Both left the run itself on the request thread, where it dies at the sixty-second edge timeout no matter how well it behaves. This moves it off, and splits the rule catalogue so no single call has to carry all of it.

## The token ceiling, measured

This was recorded as blocked on a key. It was not: the key is configured on staging, and the numbers below come from real calls to the configured endpoint (`llama-4-maverick` on DigitalOcean Gradient) through the lab proxy, using a prompt built exactly the way `buildUserPrompt` builds it, over the seeded rule catalogue extended to the sizes shown.

| Rules | prompt tokens | completion tokens | tokens/rule | elapsed | finish_reason | elements parsed |
|---|---|---|---|---|---|---|
| 6 | 695 | 339 | 56.5 | 13.2 s | stop | 6 |
| 8 | 825 | 451 | 56.4 | 20.3 s | stop | 8 |
| 10 | 958 | 573 | 57.3 | 17.2 s | stop | 10 |
| 12 | 1096 | 701 | 58.4 | 23.4 s | stop | 12 |
| 21 | 1710 | 1209 | 57.6 | 38.4 s | stop | 21 |
| 40 | 3048 | 2376 | 59.4 | 58.3 s | stop | 40 |
| 60 | 4444 | 3187 | 53.1 | 108.5 s | stop | 60 |
| **72** | 5286 | **4096 (capped)** | - | 257.7 s | **length** | **none: the array never closes** |

**About 57 completion tokens per rule.** The 72-rule run is the ceiling landing exactly where that predicts: `finish_reason: length`, the budget spent to the token, and a response whose array never closes, which is precisely the second of #528's three truncation checks firing on live data. Two things worth noting beyond the headline:

- **Wall clock is the tighter limit, and it bites first.** At about 1.7 s per rule, 40 rules already takes 58 s. So the sixty-second ceiling arrives at roughly 40 rules and the token ceiling at roughly 72. The issue estimated both at 30 to 35; the shape of the argument was right and the numbers were pessimistic.
- **The model gets terser as it approaches the cap** (53.1 tokens/rule at 60 against 57 to 59 below it), so answer quality degrades before truncation does. That is a further argument for a batch size nowhere near the cap.

**Batch size: 10.** Ten rules costs about 600 completion tokens, under a sixth of the 4096 budget, and takes about 20 seconds against a 60-second read timeout. Twenty would still fit the token budget but would sit at roughly two thirds of the read timeout, which is not enough margin for one slow call. Both numbers are configuration (`compliance.ai.batch-size`), because the figure that has to hold is not the average rule but the worst rule in someone's catalogue.

**The batches run concurrently, also on evidence.** The issue asked whether chunked calls serialise per API key. They do not: four simultaneous ten-rule calls finished in 22 s where the same four run one after another took 91. So a 70-rule catalogue costs roughly one batch of wall clock rather than seven. `compliance.ai.batch-concurrency` defaults to 4, and setting it to 1 is the right move for an endpoint that rate-limits per key.

## The queue

New table `compliance_generation_jobs` (changelog 061). `POST /compliance/jobs?projectId=` inserts a row and answers with it; `GET /compliance/jobs/{id}` is the poll; `GET /compliance/jobs?projectId=` returns the latest run for a project, which is how a page that was reloaded mid-run finds what it was watching.

**Status model.** Five states, because a caller has five things to show and no fewer:

| status | means |
|---|---|
| `queued` | accepted, waiting for a worker |
| `running` | a worker has it; the progress counters move here |
| `succeeded` | every rule assessed, compliances created |
| `nothing-to-report` | every rule assessed, nothing to create (none applied, or all already existed) |
| `failed` | did not cover every rule; nothing created |

Splitting `succeeded` from `nothing-to-report` is the whole point of the set. Before #528, "the answer was cut short and we lost it" and "there is nothing outstanding for this project" both reached the user as an empty list. A job that recorded both as one success state would have put that ambiguity straight back, one layer further from anyone who could notice. `failed` is the third of the three, and it never carries a count.

**Progress.** `batchesDone/batchesTotal` and `rulesAssessed/rulesTotal`, written after each batch in their own short transaction. They are progress and never a partial result: a run that stops at batch three has assessed some rules and produced nothing.

**Preconditions stay at accept time.** No project, no project type, no recognisable state, no rules for the jurisdiction, AI not configured: all decidable from the database and configuration, so they are raised on the request as the 400 or 404 they have always been. Only failures that genuinely need the model come back later as a failed job.

**One job per project.** A partial unique index on `(organization_id, project_id) WHERE status IN ('QUEUED','RUNNING')`. A second click joins the run in flight rather than starting a second one, and the loser of an insert race reads back the winner and hands that to its caller. This is #510's race closed one step earlier, where it matters more, because a duplicate run spends a minute of inference before it gets far enough to collide.

**Which replica.** Every replica polls every two seconds; a claim is `UPDATE ... SET status='RUNNING' WHERE id=? AND status='QUEUED'` and only one can win. No leader (a replica that wrongly believes it is one is a failure mode this design cannot have), no advisory locks (CockroachDB has none), no broker (Redis is optional and off by default here, so a Redis-only queue would be a second configuration axis for every environment). The claim writes a lease that the worker pushes forward as it finishes each batch, so progress and liveness are the same signal and cannot get out of step. A dead replica's lease goes stale and the next poll on any replica returns the row to the queue, or fails it if its attempts are gone. The attempt is counted by the claim, so a job that kills its worker before the worker writes anything still stops eventually.

**Tenancy.** The poller cannot have a tenant, since its job is to find out which tenant to become, so its queries are native and return bare scalars, never entities: a Hibernate `@Filter` does not apply to native SQL, so the intent is in the query rather than in ambient thread state a later edit could widen. Everything after the claim runs inside `TenantScopedJobRunner`, which refuses a null org id rather than running unscoped.

**Approval queues too.** `ComplianceGenerationListener` inserts a job instead of running generation on an `@Async` thread. That thread was watched by nothing and outlived by nothing: a replica restarted mid-run left an approved project with no compliances and no record that generation had ever been attempted.

## Partial batch failure

**A failed batch fails the whole run and creates nothing.** Batch 3 of 5 failing means the run has no opinion at all about the rules in batches 3 to 5. Handing back batches 1 and 2 would create their compliances and show the user a finished result silently missing three fifths of the jurisdiction, which is the exact failure this module exists to prevent, and is #528's rule applied one level up. The job goes to `failed`, or back to `queued` if it has attempts left, with the reason on the row either way so a caller polling through a retry is told what is going wrong. Re-running is cheap and idempotent per rule, which is what makes throwing the work away affordable.

## `POST /compliance/regenerate` is still there

Unchanged, still synchronous, still 200/409/502, so `echno-web` #315 keeps working. It is marked in the OpenAPI description as the shape to move off, and should be deleted once the web client is on the job endpoints. Batching pushes its ceiling out (a 70-rule catalogue now runs in about the time one batch takes) but does not remove it, and it will not survive a big enough catalogue.

## Tests

Every new test was run against the code without its fix to confirm it fails for the reason it claims. See the failing-test table in the review notes.

`ComplianceGenerationServiceIT` gained the job-table cases rather than getting a sibling IT, so the suite keeps one cached Spring context instead of two. Those are the cases only a real CockroachDB can settle: that the partial index predicate holds, that finished jobs do not block a new run, that two claims cannot both win, and that lease recovery moves a row the way it is supposed to. Everything else is plain JUnit and Mockito with no context at all.

## Not done here

- **The web client.** Nothing in `echno-web` uses the job endpoints yet; that is its own change, and until it lands the button still goes through `regenerate`.
- **The nightly sweep.** When Anand's catalogue lands, every already-approved project in an affected jurisdiction is silently missing compliances and nothing regenerates them. That needs a change timestamp on `ComplianceRule` and is a separate piece of work.
- **The hardcoded 60 s read timeout** in `requestFactory()`. It is no longer the binding constraint at a batch size of ten, but it is still a constant where the rest of this is configuration.

## Seed verified against the real staging data

The integration tests exercise the migration on a real CockroachDB v26.2.4, but they start from an empty database, so the seed statements run against zero rows there. The arithmetic that matters is the arithmetic on rows that already exist, so it was checked read-only against the live `echno.in` database:

| Document | org | rows | matching the canonical shape | max sequence | year read |
|---|---|---|---|---|---|
| Purchase order | 2 | 1 | 1 | 1 | 2026 |
| Site transfer | 2 | 1 | 1 | 1 | 2026 |
| Indent | 2 | 5 | 5 | 5 | 2026 |
| GRN | 2 | 5 | 5 | 5 | 2026 |

Every existing row is in the canonical shape, and the offsets pull the year and the sequence out of all of them. The counters therefore start at 1, 1, 5 and 5, and the first numbers the server issues are `PO-2026-000002`, `TRF-2026-000002`, `IND-2026-000006` and `GRN-2026-000006`. None collides with a row already there, which was the one thing that could have made the first create after deploy fail.

## Not mine, and pre-existing: the mapper's aggregate queries

`MaterialMapper.fillStock` runs two aggregate queries per material in an `@AfterMapping` hook, and `IndentItemMapper` declares `uses = MaterialMapper`, so any indent DTO pays two queries per line. The create response built here goes through that mapper, exactly as it did before this change. It is #522's to fix, not this PR's, and the cost is unchanged either way. Noting it so the next person profiling an indent create does not attribute it to the numbering work. Purchase orders are not affected by that particular path: `PurchaseOrderMapper` uses only `EmployeeMapper`.

## Review

No CodeRabbit review ran on this PR. The bot's check reports `pass` with "Review rate limited", and three separate `@coderabbitai review` requests across an hour, including one after the stated reset window, were each refused with the free-OSS quota notice. Merged on green CI plus my own reading, and logged on ClickUp `86d45heqm` for the retro review pass once the quota resets.
