### PR TITLE
Run compliance generation as a queued job, a batch of rules at a time

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListener.java
@@ -10,14 +10,24 @@ import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
-import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
 
 /**
- * Runs AI compliance generation when a project is approved. It fires only AFTER the
+ * Queues AI compliance generation when a project is approved. It fires only AFTER the
  * approving transaction commits (so the project row is durable) and on a separate
- * async thread (so the slow AI call never blocks the approving request). That async
- * thread has no tenant context, so the organization id is read from the event and
- * established for the duration of the work by {@link TenantScopedJobRunner}.
+ * async thread. That async thread has no tenant context, so the organization id is read
+ * from the event and established for the duration of the work by
+ * {@link TenantScopedJobRunner}.
+ *
+ * <h2>Why it queues rather than generates</h2>
+ *
+ * <p>It used to call generation directly, which meant the approval path carried the whole
+ * model call on an {@code @Async} thread. Nothing was watching that thread and nothing
+ * outlived it: a replica restarted mid-run left the approved project with no compliances,
+ * no record that generation had been attempted, and nobody any the wiser. Approval now
+ * inserts a job instead, so the work survives a restart, so a second approval of the same
+ * project cannot start a second run against it, and so the same progress a project manager
+ * sees on the manual path is available for this one.
  *
  * <h2>Why this listener owns no transaction</h2>
  *
@@ -34,18 +44,18 @@ import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
  * have failed open on had it stopped holding.
  *
  * <p>The transaction also spanned the external model call, so the approval path pinned a
- * pool connection for its full 34 to 47 seconds. Being {@code @Async} moved the wait off
+ * pool connection for the model call's full length. Being {@code @Async} moved the wait off
  * the request thread; it did nothing about the connection.
  *
- * <p>So the listener now does what a listener should: establish the tenant, delegate, and
- * let {@link ComplianceGenerationService} own its own transaction boundaries.
+ * <p>So the listener now does what a listener should: establish the tenant and delegate,
+ * leaving the transaction boundaries to whoever owns the work.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ComplianceGenerationListener {
 
-    private final ComplianceGenerationService complianceGenerationService;
+    private final ComplianceGenerationJobService complianceGenerationJobService;
     private final TenantScopedJobRunner tenantScopedJobRunner;
 
     @Async
@@ -59,17 +69,18 @@ public class ComplianceGenerationListener {
             return;
         }
 
-        log.info("Project {} approved; generating compliance inspections for organization {}", projectId, orgId);
+        log.info("Project {} approved; queueing compliance generation for organization {}", projectId, orgId);
         try {
             tenantScopedJobRunner.runForTenant(orgId,
-                    () -> complianceGenerationService.generateForProject(projectId, orgId));
+                    () -> complianceGenerationJobService.submit(projectId, orgId));
         } catch (InvalidRequestException | ResourceNotFoundException e) {
             // Expected on auto-approval: a project approved without a state in its address, or
             // before any rules exist for its jurisdiction, is normal. Log quietly and move on;
-            // a project manager can regenerate once the precondition is met.
+            // a project manager can regenerate once the precondition is met. Those checks now
+            // happen at accept time, so they still surface here rather than inside a worker.
             log.info("Compliance auto-generation skipped for project {}: {}", projectId, e.getMessage());
         } catch (Exception e) {
-            log.error("Compliance generation failed for project {} in organization {}: {}",
+            log.error("Compliance generation could not be queued for project {} in organization {}: {}",
                     projectId, orgId, e.getMessage(), e);
         }
     }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationProgress.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationProgress.java
@@ -1,0 +1,32 @@
+package org.tornotron.echno_backend.compliance;
+
+/**
+ * Told how far a generation run has got, once per completed batch.
+ *
+ * <p>It exists so the slow part of generation can report on itself without knowing anything
+ * about jobs, rows or HTTP. The synchronous endpoint passes {@link #NONE} and the numbers go
+ * nowhere; the queue passes an implementation that writes them to the job row so a polling
+ * caller sees the run advance.
+ *
+ * <p>What it reports is progress and nothing else. A run that stops at batch three of five
+ * has moved this counter three times and still has no result, so nothing downstream may read
+ * these numbers as a partial answer. The result is the return of the generation call, and
+ * there is no such thing as a partial one.
+ */
+@FunctionalInterface
+public interface ComplianceGenerationProgress {
+
+    /** Reports progress that goes nowhere, for callers that are watching the call itself. */
+    ComplianceGenerationProgress NONE = (batchesDone, batchesTotal, rulesAssessed, rulesTotal) -> {
+    };
+
+    /**
+     * One batch of candidate rules has been assessed.
+     *
+     * @param batchesDone   batches finished, 1-based and counting up to {@code batchesTotal}
+     * @param batchesTotal  batches this run was split into
+     * @param rulesAssessed candidate rules covered so far
+     * @param rulesTotal    candidate rules in the run
+     */
+    void batchCompleted(int batchesDone, int batchesTotal, int rulesAssessed, int rulesTotal);
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -74,12 +74,23 @@ import java.util.stream.Collectors;
  *
  * <h2>Why this class owns no transaction of its own</h2>
  *
- * <p>The model call takes 34 to 47 seconds today and grows with the size of the curated
- * rule set. Running it inside a transaction pinned one of twenty pool connections for
- * that whole time while doing nothing but waiting on a third party, so a handful of
- * concurrent users could exhaust the pool. {@link #generateForProject} is therefore
- * three phases: read the inputs in one transaction, call the model with no transaction
- * and no connection held, then persist in a second transaction.
+ * <p>The model call costs roughly 1.7 seconds a rule, measured against the configured
+ * endpoint, so it is tens of seconds for a jurisdiction of any size. Running it inside a
+ * transaction pinned one of twenty pool connections for that whole time while doing
+ * nothing but waiting on a third party, so a handful of concurrent users could exhaust
+ * the pool. {@link #generateForProject} is therefore three phases: read the inputs in one
+ * transaction, call the model with no transaction and no connection held, then persist in
+ * a second transaction.
+ *
+ * <h2>Who calls this, and why not from a request</h2>
+ *
+ * <p>Splitting the transaction removed the connection pin. It did nothing about the wall
+ * clock, and could not: a request that waits for the whole run dies at the sixty-second edge
+ * timeout once a jurisdiction has about forty rules, whatever this class does with its
+ * transactions. So the caller that matters is {@code ComplianceGenerationJobWorker}, running
+ * a queued job with nobody waiting on a socket, and it passes a
+ * {@link ComplianceGenerationProgress} so the run can be watched while it happens. The
+ * synchronous endpoint still calls in, and is still subject to that ceiling.
  *
  * <p>Both transactions are opened by calling {@link TransactionRetryTemplate}, which opens
  * them through {@code TransactionalWorkRunner}, and that choice is load bearing rather
@@ -140,13 +151,55 @@ public class ComplianceGenerationService {
      * @param orgId     the owning organization; must match the current tenant context
      */
     public List<InspectionDto> generateForProject(Long projectId, Long orgId) {
+        return generateForProject(projectId, orgId, ComplianceGenerationProgress.NONE);
+    }
+
+    /**
+     * Checks everything that can be checked without calling the model, and reports how much
+     * work a run would be.
+     *
+     * <p>This is what lets the queue answer straight away and still answer usefully. The four
+     * precondition failures (no project, no project type, no recognisable state, no rules for
+     * the jurisdiction) plus an unconfigured AI service are all decidable from the database
+     * and configuration, so they are raised at accept time as the 404 or 400 they have always
+     * been, rather than being discovered by a worker a minute later and delivered as a failed
+     * job the user has to go and read. Only failures that genuinely need the model reach the
+     * caller as a failed job.
+     *
+     * @return how many candidate rules a run would assess
+     */
+    public int validateAndCountCandidateRules(Long projectId, Long orgId) {
+        GenerationInputs inputs = retryTemplate.execute(
+                "ComplianceGenerationService.loadInputs", () -> loadInputs(projectId, orgId));
+        if (!complianceAiService.isConfigured()) {
+            throw new InvalidRequestException(
+                    "The compliance AI service is not configured, so suggestions cannot be "
+                            + "generated. Set the compliance AI key and try again.");
+        }
+        return inputs.candidateRules().size();
+    }
+
+    /** How many model calls a run over {@code ruleCount} rules takes at the configured batch size. */
+    public int batchCount(int ruleCount) {
+        return complianceAiService.batchCount(ruleCount);
+    }
+
+    /**
+     * As {@link #generateForProject(Long, Long)}, reporting each finished batch of the model
+     * call to {@code progress} so a caller that is not holding the request open can show the
+     * run advancing.
+     */
+    public List<InspectionDto> generateForProject(Long projectId,
+                                                  Long orgId,
+                                                  ComplianceGenerationProgress progress) {
         GenerationInputs inputs = retryTemplate.execute(
                 "ComplianceGenerationService.loadInputs", () -> loadInputs(projectId, orgId));
 
-        // Outside any transaction: this is the 34 to 47 second call, and it must not be
-        // holding a pool connection while it waits.
+        // Outside any transaction: this is the slow part, and it must not be holding a pool
+        // connection while it waits. It is now a batch of calls rather than one, which is
+        // what keeps its cost per call flat as the rule catalogue grows.
         List<ComplianceSuggestion> suggestions = complianceAiService.suggestCompliances(
-                inputs.project(), inputs.state(), inputs.candidateRules());
+                inputs.project(), inputs.state(), inputs.candidateRules(), progress);
 
         // An empty list now means only "there was nothing to ask": the AI service raises a
         // ComplianceAiException for a call that failed or answered with something unusable,

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
@@ -34,6 +34,32 @@ public class ComplianceAiProperties {
     /** Upper bound on tokens generated in the response. */
     private int maxTokens = 4096;
 
+    /**
+     * How many candidate rules to ask about in one call. Zero or less asks about the whole
+     * catalogue in a single call, which is what the code did before batching and is kept
+     * only as an escape hatch.
+     *
+     * <p>Ten comes from measuring the configured endpoint rather than from taste. The answer
+     * costs about 57 completion tokens per rule, so ten rules spends roughly 600 of the 4096
+     * available and a run does not approach the cap until about 72 rules in one call, which is
+     * where a measured run was in fact cut off. Ten rules also takes about 20 seconds against
+     * a 60-second read timeout. Both margins are deliberately large, because the number that
+     * has to hold is not the average rule but the worst rule in someone's catalogue.
+     */
+    private int batchSize = 10;
+
+    /**
+     * How many batches of one run may be in flight at once. One runs them strictly in
+     * sequence.
+     *
+     * <p>Four, because the endpoint was measured serving four simultaneous calls in about the
+     * time it served one, so the run costs roughly one batch instead of the sum of them. It is
+     * configuration rather than a constant because that is a property of the endpoint and its
+     * key, not of this application: an endpoint that rate-limits per key, or a self-hosted
+     * gateway with one GPU, wants this set to one and should not need a build to get it.
+     */
+    private int batchConcurrency = 4;
+
     /** Sampling temperature; kept low for deterministic structured output. */
     private double temperature = 0.2;
 

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -9,13 +9,23 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.tornotron.echno_backend.common.exception.ComplianceAiException;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationProgress;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.project.Project;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Wraps the OpenAI-compatible chat-completions call that decides which candidate
@@ -42,6 +52,48 @@ import java.util.List;
  *
  * <p>{@link ComplianceResponseReader} holds the checks that decide this, and its javadoc
  * explains how a truncated answer is recognised from the response alone.
+ *
+ * <h2>Why the rules are asked about a batch at a time</h2>
+ *
+ * <p>One call for the whole catalogue does not scale, and both of its limits have now been
+ * measured against the configured endpoint rather than estimated. The answer costs about 57
+ * completion tokens per rule (53 to 59 across runs of 6 to 60 rules), so a single call runs
+ * out of the 4096-token budget at about 72 rules, which a 72-rule run confirmed by coming
+ * back with {@code finish_reason: length}, exactly 4096 completion tokens and an array that
+ * never closes. Wall clock is the tighter of the two: about 1.7 seconds a rule, so 40 rules
+ * already takes 58 seconds and 60 takes 108.
+ *
+ * <p>Splitting the catalogue into batches removes both. Each call asks about a fixed number
+ * of rules, so per-call output and per-call wall clock stop growing with the catalogue and
+ * the whole thing scales by doing more calls rather than one bigger one. It also gives the
+ * run something to report between calls, which is what makes progress on a queued job real
+ * rather than a guess.
+ *
+ * <p>The batches run concurrently, which was worth checking before relying on: four
+ * simultaneous ten-rule calls against the configured endpoint finished in 22 seconds, where
+ * the same four run one after another took 91. So the endpoint does not queue calls behind a
+ * single key, and the whole run costs roughly one batch rather than the sum of them. Without
+ * that measurement the sensible default would have been to run them one at a time, since
+ * concurrency against a serialising endpoint buys nothing and only makes the failure modes
+ * harder.
+ *
+ * <p>The batch size is configuration, and the default of ten is chosen from those numbers
+ * with room on both sides: ten rules costs about 600 completion tokens, under a sixth of the
+ * budget, and takes about 20 seconds, a third of the read timeout. A batch of twenty would
+ * still fit the token budget but would sit at roughly two thirds of the read timeout, which
+ * is not enough margin for one slow call.
+ *
+ * <h2>What happens when one batch fails</h2>
+ *
+ * <p>The whole call fails and nothing is returned. That is not a shortcut around combining
+ * partial results; it is the same rule the truncation checks exist to enforce, applied one
+ * level up. A run that assessed batches one and two and lost batch three has no opinion at
+ * all about the rules in batches three to five, and a caller handed the first two batches
+ * would create compliances from them and show the user a finished result that quietly omits
+ * two fifths of the jurisdiction. Missing compliances that nobody knows are missing is the
+ * failure this module exists to prevent, so an incomplete run reports itself as a failure
+ * and creates nothing. Re-running is cheap and idempotent, which is what makes that
+ * affordable.
  */
 @Slf4j
 @Service
@@ -72,12 +124,28 @@ public class OpenAiCompatibleComplianceService {
      * <p>Returns an empty list only when there was nothing to ask: the AI is disabled or
      * unconfigured, or there are no candidate rules.
      *
-     * @throws ComplianceAiException when the call failed, or the answer was cut short,
-     *                               unparseable, or did not cover every candidate rule
+     * @throws ComplianceAiException when a call failed, or an answer was cut short,
+     *                               unparseable, or did not cover every rule it was sent
      */
     public List<ComplianceSuggestion> suggestCompliances(Project project,
                                                          String state,
                                                          List<ComplianceRule> candidateRules) {
+        return suggestCompliances(project, state, candidateRules, ComplianceGenerationProgress.NONE);
+    }
+
+    /**
+     * As {@link #suggestCompliances(Project, String, List)}, reporting each finished batch to
+     * {@code progress}.
+     *
+     * <p>The batches partition the candidate rules, so every rule is in exactly one batch and
+     * each batch's answer is checked for full coverage of its own rules before it is
+     * accepted. Coverage of the whole run therefore follows from the batches, and there is no
+     * separate whole-run check that could disagree with the per-batch ones.
+     */
+    public List<ComplianceSuggestion> suggestCompliances(Project project,
+                                                         String state,
+                                                         List<ComplianceRule> candidateRules,
+                                                         ComplianceGenerationProgress progress) {
         if (!isConfigured()) {
             log.info("Compliance AI disabled or API key not configured; skipping AI suggestion for project {}",
                     project.getId());
@@ -87,8 +155,134 @@ public class OpenAiCompatibleComplianceService {
             return List.of();
         }
 
-        String responseJson = callModel(project, state, candidateRules);
-        return responseReader.read(responseJson, candidateRules);
+        List<List<ComplianceRule>> batches = batch(candidateRules, props.getBatchSize());
+        if (batches.size() == 1) {
+            return runBatches(project, state, candidateRules, batches, progress, null);
+        }
+
+        // One pool per run rather than a shared bean. A run lasts tens of seconds and there is
+        // at most one per project, so the cost of creating threads is nothing against the cost
+        // of the calls they make, and in exchange an idle application holds no threads open and
+        // one tenant's oversized catalogue cannot starve another tenant's run of a shared pool.
+        ExecutorService pool = Executors.newFixedThreadPool(
+                Math.min(effectiveConcurrency(), batches.size()), batchThreadFactory());
+        try {
+            return runBatches(project, state, candidateRules, batches, progress, pool);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * Runs the batches and concatenates their answers in batch order.
+     *
+     * <p>With a pool the calls overlap, which is worth doing because the configured endpoint
+     * was measured serving four simultaneous calls in the time it took to serve one (22
+     * seconds against 91 sequential), so it does not queue them behind a single key. Without a
+     * pool, for the single-batch case, the call happens inline on this thread.
+     *
+     * <p>Results are collected in batch order even though they arrive out of order, so the
+     * output does not depend on which call happened to finish first. Progress is reported from
+     * this thread as each batch in order becomes available, which keeps the counter monotonic
+     * and single-threaded, and means a caller writing it to a row needs no locking. It also
+     * makes the reported progress a lower bound rather than an optimistic one, since a later
+     * batch that has already finished is not counted until the ones before it have.
+     */
+    private List<ComplianceSuggestion> runBatches(Project project,
+                                                  String state,
+                                                  List<ComplianceRule> candidateRules,
+                                                  List<List<ComplianceRule>> batches,
+                                                  ComplianceGenerationProgress progress,
+                                                  ExecutorService pool) {
+        List<Future<List<ComplianceSuggestion>>> futures = new ArrayList<>(batches.size());
+        for (List<ComplianceRule> batchRules : batches) {
+            Callable<List<ComplianceSuggestion>> call =
+                    () -> responseReader.read(callModel(project, state, batchRules), batchRules);
+            futures.add(pool == null ? runInline(call) : pool.submit(call));
+        }
+
+        List<ComplianceSuggestion> suggestions = new ArrayList<>(candidateRules.size());
+        for (int i = 0; i < futures.size(); i++) {
+            try {
+                suggestions.addAll(futures.get(i).get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ComplianceAiException(
+                        "Compliance generation was interrupted before it finished, so no "
+                                + "compliances were generated.", e);
+            } catch (ExecutionException e) {
+                // Said plainly, because the honest thing to tell someone waiting is how far it
+                // got and that the answer is being thrown away rather than shown half-finished.
+                Throwable cause = e.getCause() == null ? e : e.getCause();
+                throw new ComplianceAiException(
+                        "Batch " + (i + 1) + " of " + batches.size() + " failed, so the assessment "
+                                + "of " + candidateRules.size() + " rule(s) is incomplete and no "
+                                + "compliances were generated. " + cause.getMessage(), cause);
+            }
+            progress.batchCompleted(i + 1, batches.size(), suggestions.size(), candidateRules.size());
+        }
+        return List.copyOf(suggestions);
+    }
+
+    /**
+     * Runs a batch on the calling thread and hands back its outcome as an already-completed
+     * future, so the single-batch case takes the same collection path as the concurrent one
+     * rather than a second path that could drift away from it.
+     */
+    private static Future<List<ComplianceSuggestion>> runInline(Callable<List<ComplianceSuggestion>> call) {
+        CompletableFuture<List<ComplianceSuggestion>> done = new CompletableFuture<>();
+        try {
+            done.complete(call.call());
+        } catch (Exception e) {
+            done.completeExceptionally(e);
+        }
+        return done;
+    }
+
+    private static ThreadFactory batchThreadFactory() {
+        AtomicInteger seq = new AtomicInteger();
+        return runnable -> {
+            Thread thread = new Thread(runnable, "compliance-ai-batch-" + seq.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+
+    /** Simultaneous model calls per run, floored at one so a misconfiguration cannot stall a run. */
+    private int effectiveConcurrency() {
+        return Math.max(1, props.getBatchConcurrency());
+    }
+
+    /**
+     * How many model calls a run of {@code ruleCount} rules will take, so a job can say what
+     * it is going to do before it starts doing it.
+     */
+    public int batchCount(int ruleCount) {
+        if (ruleCount <= 0) {
+            return 0;
+        }
+        int size = props.getBatchSize();
+        if (size <= 0 || size >= ruleCount) {
+            return 1;
+        }
+        return (ruleCount + size - 1) / size;
+    }
+
+    /**
+     * Splits the rules into consecutive groups of at most {@code batchSize}.
+     *
+     * <p>Consecutive rather than interleaved because the rules arrive from the repository in
+     * a stable order and keeping neighbours together keeps a batch's rules related, which
+     * gives the model a coherent slice of one jurisdiction to reason over instead of an
+     * arbitrary scattering of it.
+     */
+    private static List<List<ComplianceRule>> batch(List<ComplianceRule> rules, int batchSize) {
+        int size = batchSize <= 0 ? rules.size() : batchSize;
+        List<List<ComplianceRule>> batches = new ArrayList<>();
+        for (int from = 0; from < rules.size(); from += size) {
+            batches.add(rules.subList(from, Math.min(from + size, rules.size())));
+        }
+        return batches;
     }
 
     /**
@@ -96,8 +290,14 @@ public class OpenAiCompatibleComplianceService {
      * itself can fail (a connect or read timeout, a proxy refusing, a 4xx or 5xx from the
      * endpoint) arrives here and leaves as a {@link ComplianceAiException}, so the caller
      * is told the run failed instead of being handed an empty result to interpret.
+     *
+     * <p>Package-private rather than private so a test can substitute canned responses for
+     * the network. That is the only seam in this class, and it is the right one: everything
+     * batching does (how the rules are split, what order the answers come back in, what
+     * happens when one call of five fails) is decided around this method and is otherwise
+     * only observable by making real calls with a rule catalogue large enough to break.
      */
-    private String callModel(Project project, String state, List<ComplianceRule> candidateRules) {
+    String callModel(Project project, String state, List<ComplianceRule> candidateRules) {
         try {
             String systemPrompt = buildSystemPrompt();
             String userPrompt = buildUserPrompt(project, state, candidateRules);

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJob.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJob.java
@@ -1,0 +1,157 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * One request to generate compliance inspections for a project, held durably so the work
+ * can happen after the request that asked for it has been answered.
+ *
+ * <h2>Why the work needs a row at all</h2>
+ *
+ * <p>The model call runs at roughly two seconds a rule and the whole catalogue is the unit
+ * of work, so a request that waits for it dies at the edge timeout once a jurisdiction has
+ * a few dozen rules. Handing the work to an {@code @Async} method would move the wait off
+ * the request thread but would leave it in a thread pool that a restart empties without a
+ * trace: the user would be told the work had started and nothing would ever finish it. The
+ * row is what makes the promise keepable. It also gives the caller something to read while
+ * the work runs, which an in-memory future does not, since the replica answering the poll
+ * is not necessarily the one doing the work.
+ *
+ * <h2>One active job per project</h2>
+ *
+ * <p>{@code (organization_id, project_id)} is unique over the rows in a non-terminal state
+ * (changelog {@code 062}), so a second click while a run is in flight cannot start a second
+ * run. The insert is rejected and the submitting code hands back the job already running,
+ * which is what the user meant. That closes the same duplicate-inspection race the
+ * inspection-level unique index closes, one step earlier and without the losing run having
+ * to do the whole model call first to find out.
+ *
+ * <h2>Claiming, and what happens when a worker dies</h2>
+ *
+ * <p>There is no queue broker. Every replica polls, and a claim is a conditional update
+ * ({@code SET status='RUNNING' WHERE id=? AND status='QUEUED'}) which exactly one replica
+ * can win. The winner writes {@link #leaseExpiresAt} ahead of itself and pushes it forward
+ * as it finishes each batch. A replica that dies stops pushing, the lease goes stale, and
+ * the next poll on any replica puts the row back to {@code QUEUED}. Re-running is safe
+ * because generation is idempotent per rule, so the recovered attempt creates only what the
+ * dead one had not got to.
+ *
+ * <h2>Progress</h2>
+ *
+ * <p>{@link #batchesDone} / {@link #batchesTotal} and {@link #rulesAssessed} /
+ * {@link #rulesTotal} are written after each batch, in their own short transaction, so the
+ * polling caller sees the run advance rather than a spinner with nothing behind it. They
+ * are progress, not a result: a run that stops at batch three of five has assessed some
+ * rules and produced nothing, and its status says {@code FAILED} rather than reporting the
+ * rules it did get through as though they were the answer.
+ */
+@Entity
+@Table(name = "compliance_generation_jobs",
+        indexes = {
+                @Index(name = "idx_compliance_job_project", columnList = "organization_id, project_id"),
+                @Index(name = "idx_compliance_job_status", columnList = "status")
+        })
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ComplianceGenerationJob implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    /** Scalar project reference, as inspections themselves carry. */
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private ComplianceJobStatus status = ComplianceJobStatus.QUEUED;
+
+    /** Candidate rules for the project's jurisdiction, counted when the job was accepted. */
+    @Column(name = "rules_total", nullable = false)
+    private int rulesTotal;
+
+    /** Rules the model has come back on so far. Only ever moves forward within an attempt. */
+    @Column(name = "rules_assessed", nullable = false)
+    private int rulesAssessed;
+
+    /** How many model calls the run is split into, from the configured batch size. */
+    @Column(name = "batches_total", nullable = false)
+    private int batchesTotal;
+
+    @Column(name = "batches_done", nullable = false)
+    private int batchesDone;
+
+    /** Compliance inspections this run created. Zero is a real answer; see {@link ComplianceJobStatus}. */
+    @Column(name = "created_count", nullable = false)
+    private int createdCount;
+
+    /**
+     * Why the last attempt did not finish, in the words the user should read. Set while the
+     * job is still being retried as well as on final failure, so a caller polling through a
+     * retry is told what is going wrong rather than watching an unexplained pause.
+     */
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    /** Attempts started, incremented by the claim itself so a crash still counts. */
+    @Column(name = "attempt", nullable = false)
+    private int attempt;
+
+    /** Copied from configuration at accept time so a config change cannot strand a running job. */
+    @Column(name = "max_attempts", nullable = false)
+    private int maxAttempts;
+
+    /**
+     * When the current claim goes stale. Null while queued. A worker pushes it forward after
+     * each batch; a lease in the past means the worker holding it is gone.
+     */
+    @Column(name = "lease_expires_at")
+    private LocalDateTime leaseExpiresAt;
+
+    /** Which replica holds the claim. Diagnostic only: correctness rests on the conditional update. */
+    @Column(name = "claimed_by", length = 120)
+    private String claimedBy;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDispatcher.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDispatcher.java
@@ -1,0 +1,235 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Finds queued compliance generation work and takes it. What happens to a job once taken is
+ * {@link ComplianceGenerationJobWorker}'s business.
+ *
+ * <h2>Every replica polls, and the database decides</h2>
+ *
+ * <p>There is no leader and no broker. Each replica asks every couple of seconds for the
+ * oldest queued jobs and tries to take one with a conditional update
+ * ({@code SET status='RUNNING' WHERE id=? AND status='QUEUED'}). Exactly one replica's
+ * statement can move a given row out of {@code QUEUED}, so exactly one gets it and the
+ * others get a row count of zero and move on. Two replicas reading the same shortlist is
+ * expected, not a bug to design around.
+ *
+ * <p>That is deliberately the least machinery that works. CockroachDB has no advisory locks,
+ * {@code SKIP LOCKED} would be a heavier tool for the same job, and a leader election would
+ * add a failure mode this design cannot have, namely a replica that believes it is the leader
+ * and is not. A queue broker was rejected for a plainer reason: Redis is optional here and off
+ * by default, so a queue that only worked on the Redis profile would become a second
+ * configuration axis for every environment.
+ *
+ * <h2>What happens when a replica dies mid-run</h2>
+ *
+ * <p>The claim carries a lease, which the worker pushes forward as it finishes each batch. A
+ * replica that is killed stops pushing. Once the lease is in the past, the next poll on any
+ * replica returns the row to {@code QUEUED}, or fails it outright if it has no attempts left.
+ * Re-running is safe because generation skips the compliances that already exist, so the
+ * recovered attempt does the part the dead one had not got to.
+ *
+ * <p>The attempt is counted by the claim rather than by the worker, so a job that reliably
+ * kills its worker before the worker can write anything still exhausts its attempts and stops,
+ * instead of cycling for ever.
+ *
+ * <h2>Tenancy</h2>
+ *
+ * <p>The poller cannot have a tenant, since its whole purpose is to find out which tenant to
+ * become. So its queries are native and read scalars only, never entities, and the moment a
+ * job is claimed it is handed to the worker, which establishes the tenant through
+ * {@link TenantScopedJobRunner} before touching anything.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "compliance.job.enabled", havingValue = "true", matchIfMissing = true)
+public class ComplianceGenerationJobDispatcher {
+
+    private final ComplianceGenerationJobRepository jobRepository;
+    private final ComplianceGenerationJobWorker worker;
+    private final TransactionRetryTemplate retryTemplate;
+    private final ComplianceJobProperties properties;
+
+    /** This replica's name on the rows it claims. Diagnostic, and the guard on stale writes. */
+    private final String nodeId;
+
+    /**
+     * Its own pool rather than the shared {@code applicationTaskExecutor}. A generation run
+     * occupies its thread for minutes at a time, so putting these on the executor that also
+     * serves the ordinary short {@code @Async} work would let a queue of compliance runs delay
+     * everything else in the application.
+     */
+    private final ExecutorService workers;
+
+    /** Free worker slots. Held from before the claim until the run ends, so no claim lacks one. */
+    private final Semaphore freeSlots;
+
+    public ComplianceGenerationJobDispatcher(ComplianceGenerationJobRepository jobRepository,
+                                             ComplianceGenerationJobWorker worker,
+                                             TransactionRetryTemplate retryTemplate,
+                                             ComplianceJobProperties properties) {
+        this.jobRepository = jobRepository;
+        this.worker = worker;
+        this.retryTemplate = retryTemplate;
+        this.properties = properties;
+        this.nodeId = resolveNodeId();
+
+        int slots = Math.max(1, properties.getMaxInFlight());
+        this.freeSlots = new Semaphore(slots);
+        AtomicInteger seq = new AtomicInteger();
+        this.workers = Executors.newFixedThreadPool(slots, runnable -> {
+            Thread thread = new Thread(runnable, "compliance-job-" + seq.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+        log.info("Compliance generation dispatcher active as '{}' with {} worker slot(s)", nodeId, slots);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        // Not awaited. A run in flight loses its lease and is picked up again, which is the
+        // recovery path that has to work anyway, and waiting minutes for a model call to finish
+        // would turn every deployment into a slow one.
+        workers.shutdownNow();
+    }
+
+    /**
+     * One pass: recover jobs whose worker is gone, then take as much new work as there are free
+     * slots for.
+     *
+     * <p>Everything here is short and non-blocking, because it runs on the application's single
+     * shared scheduler thread and must not hold it. The claim is a one-row update; the work
+     * itself goes to the worker pool.
+     */
+    @Scheduled(fixedDelayString = "${compliance.job.poll-interval-millis:2000}")
+    @WithoutTenant("The queue poller belongs to no organization: it exists to find out which "
+            + "organization to become, reads scalars only, and hands the claimed job to the "
+            + "worker, which pins the tenant before any entity is touched")
+    public void poll() {
+        poll(workers);
+    }
+
+    /**
+     * The pass itself, with the executor named rather than assumed.
+     *
+     * <p>Package-private and parameterised so a test can run a pass on the calling thread and
+     * assert on what it did, instead of racing a thread pool. Nothing in production calls it
+     * with anything but the pool above.
+     */
+    void poll(Executor executor) {
+        try {
+            recoverExpiredLeases();
+            takeWork(executor);
+        } catch (Exception e) {
+            // Never let a bad pass kill the schedule: Spring stops rescheduling a @Scheduled
+            // method that throws, and a queue that silently stops draining is exactly the
+            // failure this whole change exists to remove.
+            log.error("Compliance generation poll failed: {}", e.getMessage(), e);
+        }
+    }
+
+    private void recoverExpiredLeases() {
+        LocalDateTime now = LocalDateTime.now();
+        int requeued = retryTemplate.execute("ComplianceGenerationJobDispatcher.requeue", () ->
+                jobRepository.requeueExpiredLeases(
+                        "The worker running this job stopped responding, so it was queued again.", now));
+        if (requeued > 0) {
+            log.warn("Returned {} compliance generation job(s) to the queue after their lease expired",
+                    requeued);
+        }
+
+        int failed = retryTemplate.execute("ComplianceGenerationJobDispatcher.failExpired", () ->
+                jobRepository.failExpiredLeasesOutOfAttempts(
+                        "The worker running this job stopped responding and no attempts were left, "
+                                + "so nothing was generated. Try again.", now));
+        if (failed > 0) {
+            log.error("Gave up on {} compliance generation job(s) whose worker stopped responding", failed);
+        }
+    }
+
+    private void takeWork(Executor executor) {
+        int slots = freeSlots.availablePermits();
+        if (slots == 0) {
+            return;
+        }
+
+        List<UUID> queued = retryTemplate.execute("ComplianceGenerationJobDispatcher.findQueued",
+                () -> jobRepository.findQueuedIds(slots));
+        for (UUID jobId : queued) {
+            if (!freeSlots.tryAcquire()) {
+                return;
+            }
+            boolean handedOff = false;
+            try {
+                if (claim(jobId)) {
+                    executor.execute(() -> runAndRelease(jobId));
+                    handedOff = true;
+                }
+            } finally {
+                if (!handedOff) {
+                    freeSlots.release();
+                }
+            }
+        }
+    }
+
+    private boolean claim(UUID jobId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime leaseUntil = now.plus(properties.getLeaseDuration());
+        int claimed = retryTemplate.execute("ComplianceGenerationJobDispatcher.claim",
+                () -> jobRepository.claim(jobId, nodeId, leaseUntil, now));
+        return claimed == 1;
+    }
+
+    /**
+     * Runs a claimed job and gives its slot back. The worker records every ending on the row
+     * itself, so anything thrown here is a fault in the recording rather than in the run, and
+     * has nowhere to go but the log.
+     */
+    private void runAndRelease(UUID jobId) {
+        try {
+            worker.run(jobId, nodeId);
+        } catch (Exception e) {
+            log.error("Compliance generation job {} could not be run: {}", jobId, e.getMessage(), e);
+        } finally {
+            freeSlots.release();
+        }
+    }
+
+    /** This replica's name on the rows it claims. */
+    String nodeId() {
+        return nodeId;
+    }
+
+    /**
+     * A name for this replica. The hostname where the platform gives one, since that is what
+     * someone reading the row will want, and a random suffix regardless, because containers
+     * routinely report a hostname their neighbours also report and two replicas must hold
+     * distinguishable claims.
+     */
+    private static String resolveNodeId() {
+        String host = System.getenv("HOSTNAME");
+        if (host == null || host.isBlank()) {
+            host = "unknown";
+        }
+        String id = host + "-" + UUID.randomUUID().toString().substring(0, 8);
+        return id.length() <= 120 ? id : id.substring(id.length() - 120);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDto.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDto.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * One compliance generation job as the caller sees it: what it is doing, how far it has got,
+ * and what came of it.
+ *
+ * <p>The three counts are there so a caller can show something truthful at every point in the
+ * run. {@code batchesDone} over {@code batchesTotal} is the progress bar; {@code rulesAssessed}
+ * over {@code rulesTotal} is the same thing in the units the user thinks in;
+ * {@code createdCount} is meaningful only once {@code status} is terminal, and is zero on a
+ * failure by construction, since a run that did not cover every rule creates nothing.
+ */
+@Schema(description = "A compliance generation run: its state, its progress and its outcome.")
+public record ComplianceGenerationJobDto(
+
+        @Schema(description = "Job id; poll this job with GET /compliance/jobs/{id}.")
+        UUID id,
+
+        @Schema(description = "The project the compliances are being generated for.")
+        Long projectId,
+
+        @Schema(description = "queued and running are in flight. succeeded finished and created "
+                + "compliances; nothing-to-report finished having assessed every rule and found "
+                + "nothing to create, which is a result and not a failure; failed did not cover "
+                + "every rule and created nothing.")
+        ComplianceJobStatus status,
+
+        @Schema(description = "Candidate rules for this project's jurisdiction.")
+        int rulesTotal,
+
+        @Schema(description = "Rules assessed so far. Progress only: it is not a partial result.")
+        int rulesAssessed,
+
+        @Schema(description = "Model calls the run is split into.")
+        int batchesTotal,
+
+        @Schema(description = "Model calls completed so far.")
+        int batchesDone,
+
+        @Schema(description = "Compliance inspections created. Meaningful once the status is terminal.")
+        int createdCount,
+
+        @Schema(description = "Why the last attempt did not finish, in plain words. Present while a "
+                + "job is being retried as well as on final failure.")
+        String errorMessage,
+
+        @Schema(description = "Attempts started so far.")
+        int attempt,
+
+        @Schema(description = "Attempts before the job gives up.")
+        int maxAttempts,
+
+        LocalDateTime createdAt,
+        LocalDateTime startedAt,
+        LocalDateTime finishedAt) {
+
+    static ComplianceGenerationJobDto from(ComplianceGenerationJob job) {
+        return new ComplianceGenerationJobDto(
+                job.getId(),
+                job.getProjectId(),
+                job.getStatus(),
+                job.getRulesTotal(),
+                job.getRulesAssessed(),
+                job.getBatchesTotal(),
+                job.getBatchesDone(),
+                job.getCreatedCount(),
+                job.getErrorMessage(),
+                job.getAttempt(),
+                job.getMaxAttempts(),
+                job.getCreatedAt(),
+                job.getStartedAt(),
+                job.getFinishedAt());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
@@ -1,0 +1,196 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Reads and writes over {@link ComplianceGenerationJob}.
+ *
+ * <h2>Two kinds of query, and why they are written differently</h2>
+ *
+ * <p>The caller-facing queries are JPQL and rely on {@code orgFilter} being enabled by the
+ * transaction the service opens, exactly like every other tenant-scoped repository here.
+ * They also name the organization explicitly, so a path that somehow reached them without a
+ * tenant context would still return nothing rather than another tenant's rows. Note the
+ * house rule this follows: never {@code findById} on a tenant entity, because the filter
+ * does not apply to a load by primary key.
+ *
+ * <p>The dispatcher's queries are native and deliberately unscoped, because a poller cannot
+ * be scoped: it has to see queued work across every tenant to find out which tenant to
+ * become. Making them native rather than reaching for the bypass flag is what keeps that
+ * blast radius small. A Hibernate {@code @Filter} is not applied to native SQL at all, so
+ * the intent is in the query itself rather than in ambient thread state that a later edit
+ * could widen by accident. Each returns bare scalars, never a managed entity, so
+ * {@code TenantIsolationLoadListener} has nothing to check and no entity crosses a tenant
+ * boundary. The organization id comes back as data, and the worker then runs the actual
+ * work under it through {@code TenantScopedJobRunner}.
+ */
+@Repository
+public interface ComplianceGenerationJobRepository extends JpaRepository<ComplianceGenerationJob, UUID> {
+
+    @Query("SELECT j FROM ComplianceGenerationJob j "
+            + "WHERE j.id = :id AND j.organization.id = :orgId")
+    Optional<ComplianceGenerationJob> findByIdScoped(@Param("id") UUID id, @Param("orgId") Long orgId);
+
+    /**
+     * The job that currently owns the project, if there is one. At most one row can match,
+     * because the partial unique index in changelog {@code 062} allows only one non-terminal
+     * row per project.
+     */
+    @Query("SELECT j FROM ComplianceGenerationJob j "
+            + "WHERE j.organization.id = :orgId AND j.projectId = :projectId "
+            + "AND j.status IN (org.tornotron.echno_backend.compliance.job.ComplianceJobStatus.QUEUED, "
+            + "org.tornotron.echno_backend.compliance.job.ComplianceJobStatus.RUNNING)")
+    Optional<ComplianceGenerationJob> findActiveForProject(@Param("orgId") Long orgId,
+                                                           @Param("projectId") Long projectId);
+
+    /** The newest job for a project whatever its state, so a reloaded page can find what it was watching. */
+    @Query("SELECT j FROM ComplianceGenerationJob j "
+            + "WHERE j.organization.id = :orgId AND j.projectId = :projectId "
+            + "ORDER BY j.createdAt DESC, j.id DESC")
+    List<ComplianceGenerationJob> findLatestForProject(@Param("orgId") Long orgId,
+                                                       @Param("projectId") Long projectId,
+                                                       org.springframework.data.domain.Pageable pageable);
+
+    // ---------------------------------------------------------------------------------
+    // Dispatcher queries. Cross-tenant by necessity, scalars only, never entities.
+    // ---------------------------------------------------------------------------------
+
+    /**
+     * Ids of the oldest queued jobs, across every tenant. Only a shortlist is read; the
+     * claim below is what decides who actually gets each one, so two replicas reading the
+     * same shortlist is expected and harmless.
+     */
+    @Query(value = "SELECT id FROM compliance_generation_jobs "
+            + "WHERE status = 'QUEUED' ORDER BY created_at LIMIT :limit", nativeQuery = true)
+    List<UUID> findQueuedIds(@Param("limit") int limit);
+
+    /**
+     * Takes a queued job for this replica, or does not.
+     *
+     * <p>This is the whole of the mutual exclusion. The {@code AND status = 'QUEUED'} makes
+     * the update a compare-and-set: whichever replica's statement lands first moves the row
+     * out of {@code QUEUED} and every other replica's statement then matches no row and
+     * returns zero. No leader election, no advisory lock (CockroachDB has none) and no
+     * {@code SKIP LOCKED} is needed for that, and none of them would be as easy to reason
+     * about. The caller proceeds only on a return of 1.
+     *
+     * <p>The attempt counter is incremented here rather than by the worker so that an attempt
+     * which dies before it can write anything still counts against {@code max_attempts}. A
+     * job that crashes the worker every time therefore gives up rather than cycling forever.
+     */
+    @Modifying
+    @Query(value = "UPDATE compliance_generation_jobs SET "
+            + "status = 'RUNNING', "
+            + "attempt = attempt + 1, "
+            + "claimed_by = :claimedBy, "
+            + "lease_expires_at = :leaseExpiresAt, "
+            + "started_at = COALESCE(started_at, :now), "
+            + "updated_at = :now "
+            + "WHERE id = :id AND status = 'QUEUED'", nativeQuery = true)
+    int claim(@Param("id") UUID id,
+              @Param("claimedBy") String claimedBy,
+              @Param("leaseExpiresAt") LocalDateTime leaseExpiresAt,
+              @Param("now") LocalDateTime now);
+
+    /**
+     * Pushes the claim forward and records how far the run has got. Conditional on the row
+     * still being this worker's: a worker whose lease expired and was taken back must not
+     * overwrite the progress of whoever picked the job up after it.
+     *
+     * <p>The condition names the attempt as well as the replica, because the replica name is
+     * not a per-claim token: a job whose lease expired can be requeued and then re-claimed by
+     * the same replica, and the first, superseded run would otherwise still match on
+     * {@code claimed_by} alone. The attempt is incremented by every claim, so it is the value
+     * that tells the two runs apart.
+     */
+    @Modifying
+    @Query(value = "UPDATE compliance_generation_jobs SET "
+            + "batches_done = :batchesDone, "
+            + "rules_assessed = :rulesAssessed, "
+            + "lease_expires_at = :leaseExpiresAt, "
+            + "updated_at = :now "
+            + "WHERE id = :id AND status = 'RUNNING' AND claimed_by = :claimedBy "
+            + "AND attempt = :attempt", nativeQuery = true)
+    int recordProgress(@Param("id") UUID id,
+                       @Param("claimedBy") String claimedBy,
+                       @Param("attempt") int attempt,
+                       @Param("batchesDone") int batchesDone,
+                       @Param("rulesAssessed") int rulesAssessed,
+                       @Param("leaseExpiresAt") LocalDateTime leaseExpiresAt,
+                       @Param("now") LocalDateTime now);
+
+    /**
+     * Returns jobs whose worker stopped extending the lease to the queue.
+     *
+     * <p>A pod that is killed mid-run leaves its row saying {@code RUNNING} for ever
+     * otherwise, and the user watching it would wait for a worker that no longer exists.
+     * The attempt counter is not touched here, because the attempt was already counted when
+     * it was claimed.
+     */
+    @Modifying
+    @Query(value = "UPDATE compliance_generation_jobs SET "
+            + "status = 'QUEUED', "
+            + "lease_expires_at = NULL, "
+            + "claimed_by = NULL, "
+            + "error_message = :message, "
+            + "updated_at = :now "
+            + "WHERE status = 'RUNNING' AND lease_expires_at IS NOT NULL AND lease_expires_at < :now "
+            + "AND attempt < max_attempts", nativeQuery = true)
+    int requeueExpiredLeases(@Param("message") String message, @Param("now") LocalDateTime now);
+
+    /**
+     * Fails a job whose worker died and which has no attempts left. Separate from the requeue
+     * above so an exhausted job reaches a terminal state instead of sitting {@code RUNNING}
+     * behind a lease nothing will ever extend.
+     */
+    @Modifying
+    @Query(value = "UPDATE compliance_generation_jobs SET "
+            + "status = 'FAILED', "
+            + "lease_expires_at = NULL, "
+            + "finished_at = :now, "
+            + "error_message = :message, "
+            + "updated_at = :now "
+            + "WHERE status = 'RUNNING' AND lease_expires_at IS NOT NULL AND lease_expires_at < :now "
+            + "AND attempt >= max_attempts", nativeQuery = true)
+    int failExpiredLeasesOutOfAttempts(@Param("message") String message, @Param("now") LocalDateTime now);
+
+    /**
+     * The tenant and project a claimed job belongs to, plus the counters the worker needs.
+     * Scalars only, so no tenant-scoped entity is loaded on a thread that has no tenant.
+     *
+     * <p>The aliases are double-quoted because CockroachDB folds an unquoted identifier to
+     * lower case, and the projection is matched to the result labels by name.
+     */
+    @Query(value = "SELECT organization_id AS \"organizationId\", "
+            + "project_id AS \"projectId\", "
+            + "attempt AS \"attempt\", "
+            + "max_attempts AS \"maxAttempts\", "
+            + "rules_total AS \"rulesTotal\", "
+            + "batches_total AS \"batchesTotal\" "
+            + "FROM compliance_generation_jobs WHERE id = :id", nativeQuery = true)
+    Optional<DispatchRow> findDispatchRow(@Param("id") UUID id);
+
+    /** What a worker needs off a claimed row before it can establish the tenant and start. */
+    interface DispatchRow {
+        Long getOrganizationId();
+
+        Long getProjectId();
+
+        int getAttempt();
+
+        int getMaxAttempts();
+
+        int getRulesTotal();
+
+        int getBatchesTotal();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobService.java
@@ -1,0 +1,146 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.SqlStateDetector;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Accepts compliance generation work and reports on it. The work itself is done later, by
+ * {@link ComplianceGenerationJobDispatcher} on whichever replica claims the row.
+ *
+ * <h2>What "accept" costs</h2>
+ *
+ * <p>A precondition check and an insert. The preconditions are checked here, on the request
+ * thread, on purpose: a project with no type, no recognisable state, no rules for its
+ * jurisdiction, or an unconfigured AI service is a fault the user can fix and should be told
+ * about immediately, as the 400 or 404 it has always been. Deferring those to the worker
+ * would have turned a clear error message into a job the user has to poll before finding out
+ * that nothing was ever going to work. Only failures that genuinely need the model, which is
+ * to say the ones nobody can predict, come back later as a failed job.
+ *
+ * <h2>Clicking twice</h2>
+ *
+ * <p>The second click joins the first run rather than starting a second. That is not
+ * politeness: two runs for one project both spend a minute of inference and then race to
+ * insert the same inspections, which is the duplicate the inspection-level unique index had
+ * to be added to catch. Here the partial unique index on the job table stops the second run
+ * from ever starting, and the loser of the insert reads back the winner's row and returns it,
+ * so both callers watch one run. The user sees the run they asked for either way.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ComplianceGenerationJobService {
+
+    private final ComplianceGenerationJobRepository jobRepository;
+    private final ComplianceGenerationService complianceGenerationService;
+    private final ComplianceJobProperties jobProperties;
+    private final TenantEntityHelper tenantEntityHelper;
+    private final TransactionRetryTemplate retryTemplate;
+
+    /** What {@link #submit} did, so the controller can answer 202 for new work and 200 for a join. */
+    public record Accepted(ComplianceGenerationJobDto job, boolean created) {}
+
+    /**
+     * Accepts a generation request for a project, or hands back the run already in flight
+     * for it.
+     *
+     * @throws org.tornotron.echno_backend.common.exception.ResourceNotFoundException no such
+     *         project in this tenant
+     * @throws org.tornotron.echno_backend.common.exception.InvalidRequestException the project
+     *         or the configuration cannot support a run, with the fix in the message
+     */
+    public Accepted submit(Long projectId, Long orgId) {
+        int ruleCount = complianceGenerationService.validateAndCountCandidateRules(projectId, orgId);
+        int batches = complianceGenerationService.batchCount(ruleCount);
+
+        Optional<ComplianceGenerationJob> running = retryTemplate.execute(
+                "ComplianceGenerationJobService.findActive",
+                () -> jobRepository.findActiveForProject(orgId, projectId));
+        if (running.isPresent()) {
+            return new Accepted(ComplianceGenerationJobDto.from(running.get()), false);
+        }
+
+        try {
+            ComplianceGenerationJob job = retryTemplate.execute(
+                    "ComplianceGenerationJobService.submit",
+                    () -> insert(projectId, ruleCount, batches));
+            log.info("Accepted compliance generation job {} for project {} in organization {} "
+                            + "({} rule(s) over {} batch(es))",
+                    job.getId(), projectId, orgId, ruleCount, batches);
+            return new Accepted(ComplianceGenerationJobDto.from(job), true);
+        } catch (RuntimeException e) {
+            if (!SqlStateDetector.carriesSqlState(e, SqlStateDetector.UNIQUE_VIOLATION)) {
+                throw e;
+            }
+            // Another request inserted between the read above and this insert. Its row is the
+            // run, so return that rather than reporting a conflict the caller cannot act on.
+            return new Accepted(ComplianceGenerationJobDto.from(
+                    reloadAfterLostRace(projectId, orgId)), false);
+        }
+    }
+
+    /** One job, or 404. Scoped to the tenant, so another organization's job id reads as absent. */
+    public ComplianceGenerationJobDto find(UUID jobId, Long orgId) {
+        ComplianceGenerationJob job = retryTemplate.execute(
+                "ComplianceGenerationJobService.find",
+                () -> jobRepository.findByIdScoped(jobId, orgId).orElseThrow(() ->
+                        new ResourceNotFoundException(
+                                "No compliance generation job with id " + jobId
+                                        + " was found in this organization.")));
+        return ComplianceGenerationJobDto.from(job);
+    }
+
+    /**
+     * The most recent job for a project, if it has ever had one. This is what a page that was
+     * reloaded mid-run polls to find what it was watching, since the job id it held is gone
+     * with the tab.
+     */
+    public Optional<ComplianceGenerationJobDto> findLatestForProject(Long projectId, Long orgId) {
+        List<ComplianceGenerationJob> latest = retryTemplate.execute(
+                "ComplianceGenerationJobService.findLatest",
+                () -> jobRepository.findLatestForProject(orgId, projectId, PageRequest.of(0, 1)));
+        return latest.stream().findFirst().map(ComplianceGenerationJobDto::from);
+    }
+
+    private ComplianceGenerationJob insert(Long projectId, int ruleCount, int batches) {
+        ComplianceGenerationJob job = new ComplianceGenerationJob();
+        job.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        job.setProjectId(projectId);
+        job.setStatus(ComplianceJobStatus.QUEUED);
+        job.setRulesTotal(ruleCount);
+        job.setBatchesTotal(batches);
+        job.setMaxAttempts(Math.max(1, jobProperties.getMaxAttempts()));
+        return jobRepository.save(job);
+    }
+
+    /**
+     * Reads back the job that won the insert race.
+     *
+     * <p>It can legitimately be gone by the time we look: a very short run could have finished
+     * and left the active state between the constraint rejecting our insert and this read.
+     * That is not an error, so the newest job for the project is returned instead, which is
+     * the one the caller wanted to know about either way.
+     */
+    private ComplianceGenerationJob reloadAfterLostRace(Long projectId, Long orgId) {
+        return retryTemplate.execute("ComplianceGenerationJobService.reload", () ->
+                jobRepository.findActiveForProject(orgId, projectId)
+                        .or(() -> jobRepository
+                                .findLatestForProject(orgId, projectId, PageRequest.of(0, 1))
+                                .stream().findFirst())
+                        .orElseThrow(() -> new IllegalStateException(
+                                "A compliance generation job for project " + projectId
+                                        + " was rejected as a duplicate but no job for that project "
+                                        + "can be found")));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobWorker.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobWorker.java
@@ -1,0 +1,259 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationProgress;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Runs one claimed compliance generation job to a conclusion, and writes down which
+ * conclusion it was.
+ *
+ * <p>Separate from {@link ComplianceGenerationJobDispatcher} because the two do genuinely
+ * different things and fail in different ways. The dispatcher is about threads, timing and
+ * who gets which row; this is about what a run means. Keeping them apart also means the
+ * part with all the judgement in it, which outcome a given ending is, can be exercised
+ * without a thread pool anywhere near it.
+ *
+ * <h2>Tenancy</h2>
+ *
+ * <p>It is handed an organization id read off the claimed row, never one inferred from the
+ * thread, and everything it does happens inside {@link TenantScopedJobRunner}, which refuses
+ * a null org id rather than running unscoped. Both tenant-isolation mechanisms fail open on
+ * a missing context, so a worker that forgot this would read every organization's rows and
+ * look perfectly healthy doing it.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ComplianceGenerationJobWorker {
+
+    private final ComplianceGenerationJobRepository jobRepository;
+    private final ComplianceGenerationService complianceGenerationService;
+    private final TenantScopedJobRunner tenantScopedJobRunner;
+    private final TransactionRetryTemplate retryTemplate;
+    private final ComplianceJobProperties properties;
+
+    /**
+     * Runs the job with this id, which the caller has already claimed for {@code nodeId}.
+     *
+     * <p>Throws nothing: every ending is recorded on the row, which is the whole point of
+     * there being a row.
+     *
+     * <p>Declared unscoped for the dispatch-row read alone, which is scalars by design: the
+     * organization id is what that read is for. {@link TenantScopedJobRunner} then withdraws
+     * the declaration and pins the tenant for everything that follows.
+     */
+    @WithoutTenant("Reading which organization a claimed job belongs to is the step that "
+            + "establishes the tenant, so it cannot itself run under one")
+    public void run(UUID jobId, String nodeId) {
+        Optional<ComplianceGenerationJobRepository.DispatchRow> found = retryTemplate.execute(
+                "ComplianceGenerationJobWorker.dispatchRow", () -> jobRepository.findDispatchRow(jobId));
+        if (found.isEmpty()) {
+            log.warn("Compliance generation job {} vanished between being claimed and being run", jobId);
+            return;
+        }
+
+        ComplianceGenerationJobRepository.DispatchRow row = found.get();
+        Long orgId = row.getOrganizationId();
+        Long projectId = row.getProjectId();
+        log.info("Running compliance generation job {} for project {} in organization {} (attempt {} of {})",
+                jobId, projectId, orgId, row.getAttempt(), row.getMaxAttempts());
+
+        tenantScopedJobRunner.runForTenant(orgId, () -> {
+            try {
+                // Revalidated here, not only at accept time, because the row outlives the
+                // configuration it was accepted under. A restart that lost the AI key would
+                // otherwise reach the generation call, be handed the empty list an unconfigured
+                // service answers with, and record NOTHING_TO_REPORT for a run that asked
+                // nothing, which is precisely the ambiguity the status split exists to remove.
+                complianceGenerationService.validateAndCountCandidateRules(projectId, orgId);
+                List<InspectionDto> created = complianceGenerationService.generateForProject(
+                        projectId, orgId, progressFor(jobId, nodeId, row.getAttempt()));
+                finish(jobId, orgId, nodeId, row.getAttempt(), created.size());
+            } catch (Exception e) {
+                recordFailure(jobId, orgId, nodeId, row, e);
+            }
+        });
+    }
+
+    /**
+     * Writes progress as each batch lands, and pushes the lease forward with it.
+     *
+     * <p>Progress and the lease travel together on purpose. Finishing a batch is the only
+     * evidence that this worker is alive and making headway, so it is exactly the moment the
+     * claim deserves extending, and a worker that has stopped making headway stops extending
+     * it. That removes the need for a separate heartbeat timer and makes the two impossible to
+     * get out of step.
+     *
+     * <p>The update is conditional on this claim still being the row's current one, so a
+     * worker whose lease expired and whose job was picked up again cannot write over the new
+     * owner's progress. The claim is named by replica and attempt together, not by the
+     * replica alone: the requeued job may be re-claimed by this same replica, and only the
+     * attempt, which every claim increments, tells the superseded run from the current one.
+     */
+    private ComplianceGenerationProgress progressFor(UUID jobId, String nodeId, int attempt) {
+        return (batchesDone, batchesTotal, rulesAssessed, rulesTotal) -> {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime leaseUntil = now.plus(properties.getLeaseDuration());
+            int updated = retryTemplate.execute("ComplianceGenerationJobWorker.progress", () ->
+                    jobRepository.recordProgress(jobId, nodeId, attempt, batchesDone, rulesAssessed,
+                            leaseUntil, now));
+            if (updated == 0) {
+                log.warn("Compliance generation job {} is no longer claimed by {}; its progress "
+                        + "({} of {} batches) was not recorded", jobId, nodeId, batchesDone, batchesTotal);
+            }
+        };
+    }
+
+    /**
+     * Records a finished run.
+     *
+     * <p>A run that created nothing is {@code NOTHING_TO_REPORT} rather than a success with a
+     * zero count, because the two need different words in front of a user: one says the
+     * jurisdiction has nothing outstanding for this project, the other would leave them
+     * wondering whether the feature had worked at all. Neither is a failure, and neither may
+     * be confused with one. That distinction is the reason the truncation checks were written;
+     * losing it here would put the same ambiguity back one layer further away from anyone who
+     * could notice.
+     */
+    private void finish(UUID jobId, Long orgId, String nodeId, int attempt, int createdCount) {
+        ComplianceJobStatus status = createdCount > 0
+                ? ComplianceJobStatus.SUCCEEDED
+                : ComplianceJobStatus.NOTHING_TO_REPORT;
+        if (writeTerminal(jobId, orgId, nodeId, attempt, status, createdCount, null)) {
+            log.info("Compliance generation job {} finished as {} with {} inspection(s) created",
+                    jobId, status.getValue(), createdCount);
+        }
+    }
+
+    /**
+     * Records a run that did not finish, and decides whether it gets another go.
+     *
+     * <p>A precondition failure is terminal at once. Those are decided from the project row and
+     * the configuration, so a second attempt would read the same rows and fail the same way,
+     * and retrying would only delay telling the user what to fix. Everything else, which is
+     * everything involving the model or the network, is retried until the attempts run out,
+     * because those are the failures a second try genuinely fixes.
+     *
+     * <p>The message is written on every attempt rather than only the last, so a caller polling
+     * through a retry is told what is going wrong instead of watching an unexplained pause.
+     * Nothing was created either way: a run that did not cover every rule creates nothing, so a
+     * retry has no partial state to reconcile with.
+     */
+    private void recordFailure(UUID jobId,
+                               Long orgId,
+                               String nodeId,
+                               ComplianceGenerationJobRepository.DispatchRow row,
+                               Exception failure) {
+        boolean deterministic = failure instanceof InvalidRequestException
+                || failure instanceof ResourceNotFoundException;
+        boolean attemptsLeft = row.getAttempt() < row.getMaxAttempts();
+        String message = failure.getMessage() == null
+                ? failure.getClass().getSimpleName()
+                : failure.getMessage();
+
+        if (deterministic || !attemptsLeft) {
+            log.error("Compliance generation job {} failed for project {}: {}",
+                    jobId, row.getProjectId(), message, failure);
+            writeTerminal(jobId, orgId, nodeId, row.getAttempt(), ComplianceJobStatus.FAILED, 0, message);
+            return;
+        }
+
+        log.warn("Compliance generation job {} failed on attempt {} of {} and will be tried again: {}",
+                jobId, row.getAttempt(), row.getMaxAttempts(), message);
+        requeue(jobId, orgId, nodeId, row.getAttempt(),
+                "Attempt " + row.getAttempt() + " of " + row.getMaxAttempts()
+                + " did not finish, and it is being tried again. " + message);
+    }
+
+    /**
+     * Moves a job to a final state, if this replica still owns it.
+     *
+     * @return whether the write happened
+     */
+    private boolean writeTerminal(UUID jobId,
+                                  Long orgId,
+                                  String nodeId,
+                                  int attempt,
+                                  ComplianceJobStatus status,
+                                  int createdCount,
+                                  String errorMessage) {
+        return retryTemplate.execute("ComplianceGenerationJobWorker.finish", () -> {
+            Optional<ComplianceGenerationJob> found = jobRepository.findByIdScoped(jobId, orgId);
+            if (found.isEmpty() || !stillOurs(found.get(), jobId, nodeId, attempt)) {
+                return false;
+            }
+            ComplianceGenerationJob job = found.get();
+            job.setStatus(status);
+            job.setCreatedCount(createdCount);
+            job.setErrorMessage(truncate(errorMessage));
+            job.setFinishedAt(LocalDateTime.now());
+            job.setLeaseExpiresAt(null);
+            jobRepository.save(job);
+            return true;
+        });
+    }
+
+    private void requeue(UUID jobId, Long orgId, String nodeId, int attempt, String errorMessage) {
+        retryTemplate.executeWithoutResult("ComplianceGenerationJobWorker.retry", () -> {
+            Optional<ComplianceGenerationJob> found = jobRepository.findByIdScoped(jobId, orgId);
+            if (found.isEmpty() || !stillOurs(found.get(), jobId, nodeId, attempt)) {
+                return;
+            }
+            ComplianceGenerationJob job = found.get();
+            job.setStatus(ComplianceJobStatus.QUEUED);
+            job.setErrorMessage(truncate(errorMessage));
+            job.setClaimedBy(null);
+            job.setLeaseExpiresAt(null);
+            job.setBatchesDone(0);
+            job.setRulesAssessed(0);
+            jobRepository.save(job);
+        });
+    }
+
+    /**
+     * Whether the claim this run started under is still the row's current one.
+     *
+     * <p>A worker whose lease expired while it was working has had its job taken by someone
+     * else, and must not write over what the new owner is doing. Its own work is not wasted:
+     * generation is idempotent, so whatever it created is what the new owner finds already
+     * there and skips.
+     *
+     * <p>The attempt is compared as well as the replica name because the name alone does not
+     * identify a claim: the new owner can be this very replica, having re-claimed the job
+     * after the lease lapsed, and then the name matches while the run does not. Every claim
+     * increments the attempt, so it is the part that cannot collide.
+     */
+    private boolean stillOurs(ComplianceGenerationJob job, UUID jobId, String nodeId, int attempt) {
+        boolean ours = job.getStatus() == ComplianceJobStatus.RUNNING
+                && nodeId.equals(job.getClaimedBy())
+                && job.getAttempt() == attempt;
+        if (!ours) {
+            log.warn("Compliance generation job {} is no longer claimed by {} on attempt {} "
+                            + "(status {}, holder {}, attempt {}); leaving it to its current owner",
+                    jobId, nodeId, attempt, job.getStatus(), job.getClaimedBy(), job.getAttempt());
+        }
+        return ours;
+    }
+
+    /** Keeps a long provider message inside the column rather than failing the write that reports it. */
+    private static String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        return message.length() <= 1000 ? message : message.substring(0, 997) + "...";
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceJobProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceJobProperties.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * How the compliance generation queue behaves. Bound from the {@code compliance.job.*}
+ * block in application.yml.
+ *
+ * <p>Every value here is deliberately overridable per environment, because the two that
+ * matter most, {@link #maxInFlight} and {@link #leaseDuration}, are really statements about
+ * the inference endpoint and the replica rather than about the application. An environment
+ * pointed at a slower endpoint, or one with a per-key concurrency limit, wants a different
+ * pair of numbers and should not need a build to get them.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "compliance.job")
+public class ComplianceJobProperties {
+
+    /**
+     * Master switch for the dispatcher. When false the queue still accepts jobs and they
+     * stay {@code QUEUED}, which is the right behaviour for a replica that should serve
+     * requests without doing background work.
+     */
+    private boolean enabled = true;
+
+    /**
+     * How often each replica looks for work, in milliseconds.
+     *
+     * <p>Milliseconds rather than a {@link Duration} because this one value is also read
+     * straight out of configuration by {@code @Scheduled(fixedDelayString)}, and that
+     * annotation accepts a plain number or ISO-8601, not the {@code 2s} shorthand the rest of
+     * Spring Boot's binding takes. A property that binds one way here and another way there
+     * would be a trap for whoever next tries to change it.
+     */
+    private long pollIntervalMillis = 2000;
+
+    /**
+     * How many jobs one replica runs at once. Two rather than one because a single stuck
+     * job should not stop every tenant's queue, and not many more because each in-flight
+     * job is an open connection to the inference endpoint for minutes at a time.
+     */
+    private int maxInFlight = 2;
+
+    /**
+     * How far ahead a worker holds its claim. It is pushed forward after every batch, so
+     * this only has to outlast one batch by a comfortable margin, not the whole run. Too
+     * short and a slow batch gets its job taken away underneath it; too long and a dead
+     * replica's work sits unrecovered for that long.
+     */
+    private Duration leaseDuration = Duration.ofMinutes(5);
+
+    /**
+     * Attempts before a job is given up on. Counted at claim time, so a worker that dies
+     * without writing anything still uses one up.
+     */
+    private int maxAttempts = 3;
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceJobStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceJobStatus.java
@@ -1,0 +1,74 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Where one compliance generation job has got to.
+ *
+ * <p>The set is chosen so a caller can tell apart the five outcomes it has to show
+ * differently, and no fewer:
+ *
+ * <ul>
+ *   <li>{@link #QUEUED} accepted and waiting for a worker. The user sees "queued".</li>
+ *   <li>{@link #RUNNING} a worker has it and is working through the batches. This is the
+ *       state the progress counters move in.</li>
+ *   <li>{@link #SUCCEEDED} finished, every candidate rule was assessed, and at least one
+ *       compliance inspection was created.</li>
+ *   <li>{@link #NOTHING_TO_REPORT} finished, every candidate rule was assessed, and
+ *       nothing was created. That is a real answer, not a non-answer: either the model
+ *       found no rule applicable to this project, or every applicable compliance already
+ *       existed from an earlier run.</li>
+ *   <li>{@link #FAILED} the run did not cover every rule, so it has no result to show.
+ *       Nothing was created.</li>
+ * </ul>
+ *
+ * <p>Splitting {@link #SUCCEEDED} from {@link #NOTHING_TO_REPORT} rather than leaving the
+ * caller to read a zero count is the point of the whole set. Before the truncation checks
+ * landed, "the model was cut off by its token limit" and "nothing applied" both reached
+ * the user as an empty list, and the first one is a failure that has to be fixed while the
+ * second needs no action at all. A job that recorded both as one success state would have
+ * put that ambiguity straight back, one layer further from anyone who could notice it.
+ *
+ * <p>Database representation is the constant name; the JSON wire form is the hyphenated
+ * lowercase value, as elsewhere in the codebase.
+ */
+public enum ComplianceJobStatus {
+
+    QUEUED("queued"),
+    RUNNING("running"),
+    SUCCEEDED("succeeded"),
+    NOTHING_TO_REPORT("nothing-to-report"),
+    FAILED("failed");
+
+    private final String value;
+
+    ComplianceJobStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ComplianceJobStatus fromValue(String value) {
+        for (ComplianceJobStatus status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown compliance job status: " + value);
+    }
+
+    /** Whether the job is finished and its row will not change again. */
+    public boolean isTerminal() {
+        return this == SUCCEEDED || this == NOTHING_TO_REPORT || this == FAILED;
+    }
+
+    /** Whether the job still owns the project, so a second request joins it instead of starting another. */
+    public boolean isActive() {
+        return this == QUEUED || this == RUNNING;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/web/ComplianceControllerWeb.java
@@ -5,24 +5,44 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.exception.TenantIdMissingException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobDto;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
 import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Manual entry point for AI compliance generation. The automatic path runs on project
  * approval through {@code ComplianceGenerationListener}; this lets a project manager
  * re-run generation on demand (for example after the AI key is configured, or after
  * new rules are added). Generation is idempotent, so a re-run only adds compliances
- * that do not already exist. Runs synchronously and returns the rows it created.
+ * that do not already exist.
+ *
+ * <h2>Two shapes, for as long as it takes to move</h2>
+ *
+ * <p>{@code POST /jobs} is the shape that works: it accepts the request, answers in the
+ * time an insert takes, and hands back a job to poll. It is the one to build against.
+ *
+ * <p>{@code POST /regenerate} is the original synchronous call. It holds the request open
+ * for the whole run, so it dies at the sixty-second edge timeout once a jurisdiction has
+ * about forty rules, and no client budget can change that. Batching the model calls has
+ * pushed that boundary out, and it has not moved it far enough to keep. It stays only so
+ * that the web client keeps working while it moves to the job endpoints, and it should be
+ * deleted once it has.
  */
 @RestController
 @RequestMapping("/api/v1/inspections/web/compliance")
@@ -37,14 +57,84 @@ import java.util.List;
 public class ComplianceControllerWeb {
 
     private final ComplianceGenerationService complianceGenerationService;
+    private final ComplianceGenerationJobService complianceGenerationJobService;
+
+    @PostMapping("/jobs")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Start compliance generation for a project",
+            description = "Accepts the work and returns a job to poll with GET /compliance/jobs/{jobId}. "
+                    + "Everything decidable without the model is checked before accepting, so a project "
+                    + "that cannot be generated for still fails immediately with the reason. A request "
+                    + "made while a run for the same project is already in flight joins that run rather "
+                    + "than starting a second one, and answers 200 with it instead of 202."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "Accepted; the body is the queued job"),
+            @ApiResponse(responseCode = "200", description = "A run for this project was already in flight; the body is that job"),
+            @ApiResponse(responseCode = "400", description = "No organization context set (the X-Organization-Id header is required), or a precondition is unmet: the project has no type, its address carries no recognisable state, no rules are registered for its jurisdiction, or the AI service is not configured. The detail message states what to fix."),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No project with the given id in the current tenant")
+    })
+    public ResponseEntity<ComplianceGenerationJobDto> startGeneration(@RequestParam Long projectId) {
+        ComplianceGenerationJobService.Accepted accepted =
+                complianceGenerationJobService.submit(projectId, requireOrgId());
+        return ResponseEntity
+                .status(accepted.created() ? HttpStatus.ACCEPTED : HttpStatus.OK)
+                .body(accepted.job());
+    }
+
+    @GetMapping("/jobs/{jobId}")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Read one compliance generation job",
+            description = "Status, progress and outcome of a single run. Poll this while the status is "
+                    + "queued or running. The terminal states are distinct on purpose: succeeded created "
+                    + "compliances, nothing-to-report assessed every rule and found nothing to create, "
+                    + "and failed did not cover every rule and created nothing."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The job"),
+            @ApiResponse(responseCode = "400", description = "No organization context set (the X-Organization-Id header is required)"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No job with the given id in the current tenant")
+    })
+    public ComplianceGenerationJobDto readJob(@PathVariable UUID jobId) {
+        return complianceGenerationJobService.find(jobId, requireOrgId());
+    }
+
+    @GetMapping("/jobs")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Read the most recent compliance generation job for a project",
+            description = "The latest run for a project, whatever state it is in, or 404 if it has never "
+                    + "had one. This is how a page that was reloaded during a run finds the run again, "
+                    + "since the job id it was holding went with the tab."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The most recent job for the project"),
+            @ApiResponse(responseCode = "400", description = "No organization context set (the X-Organization-Id header is required)"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "This project has never had a generation job")
+    })
+    public ComplianceGenerationJobDto readLatestJob(@RequestParam Long projectId) {
+        Long orgId = requireOrgId();
+        return complianceGenerationJobService.findLatestForProject(projectId, orgId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No compliance generation has ever been run for project " + projectId + "."));
+    }
 
     @PostMapping("/regenerate")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
     @Operation(
-            summary = "Regenerate compliance inspections for a project",
+            summary = "Regenerate compliance inspections for a project (superseded by POST /compliance/jobs)",
             description = "Runs compliance generation for the given project synchronously and returns the "
                     + "compliance inspections it created. Idempotent: inspections that already exist for a "
-                    + "matched rule are not duplicated."
+                    + "matched rule are not duplicated. Superseded: this call holds the request open for the "
+                    + "whole run, so it stops working once a jurisdiction has enough rules for the run to "
+                    + "outlast the sixty-second edge timeout. Use POST /compliance/jobs, which accepts the "
+                    + "work and returns a job to poll.",
+            deprecated = true
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Generation ran; the created inspections are returned (possibly empty when nothing new applied)"),
@@ -55,10 +145,14 @@ public class ComplianceControllerWeb {
             @ApiResponse(responseCode = "502", description = "The compliance AI endpoint could not be reached, returned an error, or returned an answer that was cut short by its token limit and so did not cover every candidate rule. Nothing was created; the detail message says which")
     })
     public List<InspectionDto> regenerate(@RequestParam Long projectId) {
+        return complianceGenerationService.generateForProject(projectId, requireOrgId());
+    }
+
+    private static Long requireOrgId() {
         Long orgId = TenantContext.getCurrentOrgId();
         if (orgId == null) {
             throw new TenantIdMissingException("No organization context set; the X-Organization-Id header is required");
         }
-        return complianceGenerationService.generateForProject(projectId, orgId);
+        return orgId;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,10 +52,28 @@ compliance:
     max-tokens: 4096
     temperature: 0.2
     enabled: ${COMPLIANCE_AI_ENABLED:true}
+    # Candidate rules per model call, and how many of those calls may overlap.
+    # Measured against the configured endpoint: the answer costs about 57 completion
+    # tokens per rule, so one call for 72 rules exhausts max-tokens (a 72-rule run came
+    # back cut off at exactly 4096), and wall clock runs about 1.7 s per rule. Ten rules
+    # is therefore ~600 tokens and ~20 s, well inside both limits. Four in flight because
+    # the endpoint served four simultaneous calls in the time it served one; set it to 1
+    # for an endpoint that rate-limits per key. batch-size 0 disables batching.
+    batch-size: ${COMPLIANCE_AI_BATCH_SIZE:10}
+    batch-concurrency: ${COMPLIANCE_AI_BATCH_CONCURRENCY:4}
     # Optional forward proxy for egress (unset = direct, the DO production behaviour).
     # Set both when the backend has no direct internet, e.g. the IITM lab host proxy.
     proxy-host: ${COMPLIANCE_AI_PROXY_HOST:}
     proxy-port: ${COMPLIANCE_AI_PROXY_PORT:3128}
+  # The generation queue. Every replica polls and claims with a conditional update, so
+  # there is no leader. enabled: false still accepts jobs but runs none, which is what a
+  # replica that should serve requests and do no background work wants.
+  job:
+    enabled: ${COMPLIANCE_JOB_ENABLED:true}
+    poll-interval-millis: 2000
+    max-in-flight: ${COMPLIANCE_JOB_MAX_IN_FLIGHT:2}
+    lease-duration: 5m
+    max-attempts: 3
 
 
 # Chart-of-accounts auto numbering. level-steps is the gap between sibling codes

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -319,6 +319,9 @@
     <!-- v4.0 - Server-allocated document numbers, and per-tenant uniqueness for them -->
     <include file="db/changelog/v4.0/061-document-number-sequences.xml"/>
 
+    <!-- v4.0 - Compliance: the generation queue, so the model call happens off the request -->
+    <include file="db/changelog/v4.0/062-create-compliance-generation-jobs.xml"/>
+
     <!-- v4.0 - Assets: the project an asset is deployed on becomes a reference, keeping the old text -->
     <include file="db/changelog/v4.0/063-add-asset-assigned-project-ref.xml"/>
 

--- a/src/main/resources/db/changelog/v4.0/062-create-compliance-generation-jobs.xml
+++ b/src/main/resources/db/changelog/v4.0/062-create-compliance-generation-jobs.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="062-01-create-compliance-generation-jobs" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="compliance_generation_jobs"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The queue behind AI compliance generation. Each row is one request to generate the
+            compliance inspections for a project, and it exists so the work can outlive the
+            request that asked for it.
+
+            The work is a sequence of calls to an inference endpoint that costs roughly two
+            seconds a rule, so a request that waits for it dies at the edge timeout once a
+            jurisdiction has a few dozen curated rules. Moving the work to a thread pool alone
+            would not have been enough: a pool is emptied by a restart without a trace, so the
+            user would be promised a run that nothing was left to finish. Durability is the
+            point of the table, and being able to read progress off it while the run is
+            happening is the second point, since the replica answering the poll is not
+            necessarily the replica doing the work.
+
+            status is the five outcomes a caller has to be able to tell apart: QUEUED and
+            RUNNING are in flight, SUCCEEDED finished and created compliances,
+            NOTHING_TO_REPORT finished having assessed every rule and found nothing to create,
+            and FAILED did not cover every rule and created nothing. SUCCEEDED and
+            NOTHING_TO_REPORT are separate states rather than one state with a count, because
+            "the model was cut short and we lost the answer" and "there is nothing outstanding
+            for this project" used to arrive as the same empty list, and telling them apart is
+            what the truncation checks were added for. Collapsing them here would have put the
+            same ambiguity back one layer further from anyone who could notice it.
+
+            project_id is a plain scalar with no foreign key, as inspections themselves refer
+            to projects. batches_done, rules_assessed and the counters beside them are
+            progress, never a partial result: a run that stops halfway creates nothing, so
+            there is no half-finished set of inspections for those numbers to describe.
+
+            attempt is incremented by the claim rather than by the worker, so a job that kills
+            its worker before the worker writes anything still uses up an attempt and
+            eventually stops instead of cycling for ever. lease_expires_at and claimed_by are
+            how a dead replica's work is recovered: the holder pushes the lease forward as it
+            finishes each batch, and a lease left in the past is the signal that nobody is
+            working on the row any more.
+        </comment>
+
+        <createTable tableName="compliance_generation_jobs">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(40)" defaultValue="QUEUED">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rules_total" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rules_assessed" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="batches_total" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="batches_done" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_count" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="error_message" type="VARCHAR(1000)"/>
+            <column name="attempt" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_attempts" type="INT" defaultValueNumeric="3">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lease_expires_at" type="TIMESTAMP"/>
+            <column name="claimed_by" type="VARCHAR(120)"/>
+            <column name="started_at" type="TIMESTAMP"/>
+            <column name="finished_at" type="TIMESTAMP"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="compliance_generation_jobs"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_compliance_job_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="compliance_generation_jobs" indexName="idx_compliance_job_project">
+            <column name="organization_id"/>
+            <column name="project_id"/>
+        </createIndex>
+        <createIndex tableName="compliance_generation_jobs" indexName="idx_compliance_job_status">
+            <column name="status"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="062-02-compliance-job-one-active-per-project" author="echno">
+        <comment>
+            One in-flight job per project, enforced in the schema rather than by the code that
+            reads before it writes.
+
+            The service does check for a running job before inserting, and that check is a
+            read, so it cannot be the guarantee: two clicks arriving together both see no
+            active job and both insert. They do not conflict in the database's eyes either,
+            because each inserts its own row with its own id, so SERIALIZABLE has nothing to
+            abort. That is the same shape as the duplicate-inspection race changelog 060 was
+            written to close, one step earlier in the flow, and it matters more here because
+            each duplicate run spends a minute of inference before it gets far enough to
+            collide.
+
+            With this index the second insert is rejected, and the submitting code reads back
+            the row that won and returns it, so both callers end up watching the same run.
+
+            The predicate is over the non-terminal states only. A project may have any number
+            of finished jobs, which is the history a user scrolls back through; it may have at
+            most one that is still going. Expressed as a partial unique index because that is
+            the only way to say "unique among some rows", and it is written as raw SQL because
+            the structured Liquibase tags cannot express a WHERE clause on an index.
+        </comment>
+
+        <sql>
+            CREATE UNIQUE INDEX IF NOT EXISTS uk_compliance_job_active
+            ON compliance_generation_jobs (organization_id, project_id)
+            WHERE status IN ('QUEUED', 'RUNNING');
+        </sql>
+
+        <rollback>
+            DROP INDEX IF EXISTS compliance_generation_jobs@uk_compliance_job_active;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListenerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/events/listeners/ComplianceGenerationListenerTest.java
@@ -12,7 +12,9 @@ import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
-import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobDto;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
+import org.tornotron.echno_backend.compliance.job.ComplianceJobStatus;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,7 +32,8 @@ import static org.mockito.Mockito.when;
 /**
  * The approval path runs on a pooled async thread with no request behind it, so what
  * matters here is that the tenant is established from the event before any work happens,
- * and that the listener owns no transaction of its own.
+ * that the work is queued rather than run on that thread, and that the listener owns no
+ * transaction of its own.
  */
 @ExtendWith(MockitoExtension.class)
 class ComplianceGenerationListenerTest {
@@ -39,7 +42,7 @@ class ComplianceGenerationListenerTest {
     private static final Long ORG_ID = 7L;
 
     @Mock
-    private ComplianceGenerationService complianceGenerationService;
+    private ComplianceGenerationJobService complianceGenerationJobService;
     @Mock
     private TenantScopedJobRunner tenantScopedJobRunner;
 
@@ -61,39 +64,61 @@ class ComplianceGenerationListenerTest {
     }
 
     @Test
-    void establishesTheTenantFromTheEventBeforeGenerating() {
+    void establishesTheTenantFromTheEventBeforeQueueing() {
         runInline();
         AtomicReference<Long> tenantDuringWork = new AtomicReference<>();
-        when(complianceGenerationService.generateForProject(PROJECT_ID, ORG_ID))
+        when(complianceGenerationJobService.submit(PROJECT_ID, ORG_ID))
                 .thenAnswer(invocation -> {
                     tenantDuringWork.set(TenantContext.getCurrentOrgId());
-                    return java.util.List.of();
+                    return accepted();
                 });
 
         listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, ORG_ID));
 
         verify(tenantScopedJobRunner).runForTenant(eq(ORG_ID), any(Runnable.class));
         assertThat(tenantDuringWork.get())
-                .as("generation must run with the event's organization on the thread")
+                .as("the job must be inserted with the event's organization on the thread")
                 .isEqualTo(ORG_ID);
     }
 
+    /**
+     * Approval must hand the work to the queue, not do it. Running it inline on the async
+     * thread is what left an approved project with no compliances and no record of the
+     * attempt whenever a replica restarted mid-run.
+     */
     @Test
-    void eventWithNoOrganization_generatesNothing() {
+    void queuesTheWorkRatherThanRunningItOnTheApprovalThread() {
+        runInline();
+        when(complianceGenerationJobService.submit(PROJECT_ID, ORG_ID)).thenReturn(accepted());
+
+        listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, ORG_ID));
+
+        verify(complianceGenerationJobService).submit(PROJECT_ID, ORG_ID);
+    }
+
+    @Test
+    void eventWithNoOrganization_queuesNothing() {
         listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, null));
 
-        verify(complianceGenerationService, never()).generateForProject(anyLong(), any());
+        verify(complianceGenerationJobService, never()).submit(anyLong(), any());
         verify(tenantScopedJobRunner, never()).runForTenant(any(), any(Runnable.class));
     }
 
     @Test
     void unmetPrecondition_isSwallowedSoApprovalIsNotDisturbed() {
         runInline();
-        when(complianceGenerationService.generateForProject(PROJECT_ID, ORG_ID))
+        when(complianceGenerationJobService.submit(PROJECT_ID, ORG_ID))
                 .thenThrow(new InvalidRequestException("no rules for this jurisdiction yet"));
 
         assertThatCode(() -> listener.onProjectApproved(new ProjectApprovedEvent(this, PROJECT_ID, ORG_ID)))
                 .doesNotThrowAnyException();
+    }
+
+    private static ComplianceGenerationJobService.Accepted accepted() {
+        return new ComplianceGenerationJobService.Accepted(
+                new ComplianceGenerationJobDto(java.util.UUID.randomUUID(), PROJECT_ID,
+                        ComplianceJobStatus.QUEUED, 6, 0, 1, 0, 0, null, 0, 3, null, null, null),
+                true);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationConcurrencyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationConcurrencyTest.java
@@ -93,7 +93,7 @@ class ComplianceGenerationConcurrencyTest {
                 .thenReturn(Optional.of(project));
         when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
                 .thenReturn(List.of(rule()));
-        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any(), any()))
                 .thenReturn(List.of(suggestion()));
         when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
         when(numberGen.next(anyString())).thenReturn("INSP-0001");
@@ -221,7 +221,7 @@ class ComplianceGenerationConcurrencyTest {
 
     /**
      * The model call sits between the two transactions and must not be repeated by a restart
-     * of the write phase. It is the 34 to 47 second part of the run and, unlike the write, it
+     * of the write phase. It is the slow part of the run and, unlike the write, it
      * is not free to run again.
      */
     @Test
@@ -235,6 +235,6 @@ class ComplianceGenerationConcurrencyTest {
         service.generateForProject(PROJECT_ID, ORG_ID);
 
         verify(complianceAiService, times(1))
-                .suggestCompliances(any(Project.class), eq("Tamil Nadu"), any());
+                .suggestCompliances(any(Project.class), eq("Tamil Nadu"), any(), any());
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -24,6 +24,8 @@ import org.tornotron.echno_backend.common.retry.SqlStateDetector;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
+import org.tornotron.echno_backend.compliance.job.ComplianceJobStatus;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
@@ -37,7 +39,9 @@ import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.enums.ProjectType;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -88,6 +92,9 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     @Autowired
     private PlatformTransactionManager txManager;
 
+    @Autowired
+    private ComplianceGenerationJobRepository jobRepository;
+
     private Long orgAId;
     private Long projectId;
 
@@ -111,7 +118,8 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
         });
 
         // The stub applies two of the six seeded TN residential rules and rejects the rest.
-        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+        when(complianceAiService.suggestCompliances(
+                any(Project.class), anyString(), any(), any(ComplianceGenerationProgress.class)))
                 .thenReturn(List.of(
                         new ComplianceSuggestion(RULE_POST, true, "critical",
                                 List.of("Apply for the occupancy certificate"), "Required before handover",
@@ -135,6 +143,9 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
         // Committed seed rows survive the rollback; remove them by hand. The global
         // compliance_rules seed is left intact (it is shared reference data).
         inCommittedTx(() -> {
+            entityManager.createNativeQuery(
+                            "DELETE FROM compliance_generation_jobs WHERE organization_id = :org")
+                    .setParameter("org", orgAId).executeUpdate();
             entityManager.createNativeQuery(
                             "DELETE FROM inspections WHERE organization_id = :org")
                     .setParameter("org", orgAId).executeUpdate();
@@ -217,6 +228,167 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
                 SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION))
                 .as("the insert must be rejected by a unique violation (SQLSTATE 23505)")
                 .isTrue());
+    }
+
+    /**
+     * The queue's own version of the same guarantee, one step earlier in the flow.
+     *
+     * <p>The service does look for a job in flight before inserting, and that look is a read,
+     * so two requests arriving together both see none and both insert. Nothing about the two
+     * inserts conflicts in the database's eyes either, since each carries its own id, so
+     * SERIALIZABLE has nothing to abort. Only the partial index stops it, and only if its
+     * predicate really does hold on CockroachDB, which is what this asserts.
+     *
+     * <p>It matters more here than at the inspection level, because a duplicate job spends a
+     * minute of inference before it gets far enough to collide.
+     */
+    @Test
+    void theDatabaseRefusesASecondJobForAProjectThatAlreadyHasOneInFlight() {
+        insertJob(ComplianceJobStatus.QUEUED);
+
+        assertThatThrownBy(() -> insertJob(ComplianceJobStatus.RUNNING))
+                .satisfies(failure -> assertThat(
+                        SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION))
+                        .as("a second non-terminal job must be rejected by a unique violation")
+                        .isTrue());
+    }
+
+    /**
+     * And the other half of the predicate: finished jobs are history, and a project may have
+     * as many of those as it has ever had runs. An index over all rows rather than the
+     * non-terminal ones would have made the second run of a project's life impossible.
+     */
+    @Test
+    void aProjectMayHaveManyFinishedJobsAndStillStartANewOne() {
+        insertJob(ComplianceJobStatus.SUCCEEDED);
+        insertJob(ComplianceJobStatus.NOTHING_TO_REPORT);
+        insertJob(ComplianceJobStatus.FAILED);
+
+        UUID fresh = insertJob(ComplianceJobStatus.QUEUED);
+
+        assertThat(fresh).isNotNull();
+    }
+
+    /**
+     * The whole of the mutual exclusion between replicas, against a real database. The second
+     * claim must match no row, because the first one moved it out of QUEUED.
+     */
+    @Test
+    void onlyOneClaimOfTwoCanWin() {
+        UUID jobId = insertJob(ComplianceJobStatus.QUEUED);
+        LocalDateTime now = LocalDateTime.now();
+
+        int first = jobRepository.claim(jobId, "replica-a", now.plusMinutes(5), now);
+        int second = jobRepository.claim(jobId, "replica-b", now.plusMinutes(5), now);
+
+        assertThat(first).isEqualTo(1);
+        assertThat(second)
+                .as("the losing replica must be told it got nothing, not silently share the job")
+                .isZero();
+    }
+
+    /**
+     * A claim is named by replica and attempt together. When a lease lapses, the job is
+     * requeued and the SAME replica may claim it again, so its name is back on the row and a
+     * write guarded by the name alone would let the superseded run overwrite the new one.
+     * The attempt moved on with the second claim, and that is what shuts the old run out.
+     */
+    @Test
+    void aSupersededRunOnTheSameReplicaCannotWriteProgress() {
+        UUID jobId = insertJob(ComplianceJobStatus.QUEUED);
+        LocalDateTime past = LocalDateTime.now().minusMinutes(10);
+        jobRepository.claim(jobId, "replica-a", past, past);              // attempt 1, stalls
+        jobRepository.requeueExpiredLeases("worker gone", LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        jobRepository.claim(jobId, "replica-a", now.plusMinutes(5), now); // attempt 2, same name
+
+        int staleWrite = jobRepository.recordProgress(
+                jobId, "replica-a", 1, 2, 20, now.plusMinutes(5), now);
+
+        assertThat(staleWrite)
+                .as("the run claimed as attempt 1 no longer owns the row and must match nothing")
+                .isZero();
+        int currentWrite = jobRepository.recordProgress(
+                jobId, "replica-a", 2, 2, 20, now.plusMinutes(5), now);
+        assertThat(currentWrite).isEqualTo(1);
+    }
+
+    /** The claim counts the attempt, so a worker that dies before writing still uses one up. */
+    @Test
+    void theClaimItselfCountsTheAttempt() {
+        UUID jobId = insertJob(ComplianceJobStatus.QUEUED);
+        LocalDateTime now = LocalDateTime.now();
+
+        jobRepository.claim(jobId, "replica-a", now.plusMinutes(5), now);
+
+        assertThat(attemptOf(jobId)).isEqualTo(1);
+    }
+
+    /**
+     * Recovery, which is the reason for the lease at all. A row left RUNNING behind a lease
+     * nobody is extending has to become someone else's problem, or the user waits for a
+     * worker that no longer exists.
+     */
+    @Test
+    void aJobWhoseLeaseHasExpiredGoesBackToTheQueueWhileAttemptsRemain() {
+        UUID jobId = insertJob(ComplianceJobStatus.QUEUED);
+        LocalDateTime past = LocalDateTime.now().minusMinutes(10);
+        jobRepository.claim(jobId, "replica-a", past, past);
+
+        int requeued = jobRepository.requeueExpiredLeases("worker gone", LocalDateTime.now());
+
+        assertThat(requeued).isEqualTo(1);
+        assertThat(statusOf(jobId)).isEqualTo("QUEUED");
+    }
+
+    /**
+     * And when there are none left it is failed outright rather than left RUNNING for ever
+     * behind a lease nothing will extend.
+     */
+    @Test
+    void aJobWhoseLeaseHasExpiredWithNoAttemptsLeftIsFailed() {
+        UUID jobId = insertJob(ComplianceJobStatus.QUEUED);
+        LocalDateTime past = LocalDateTime.now().minusMinutes(10);
+        jobRepository.claim(jobId, "replica-a", past, past);
+        jobRepository.requeueExpiredLeases("worker gone", LocalDateTime.now());
+        jobRepository.claim(jobId, "replica-a", past, past);
+        jobRepository.requeueExpiredLeases("worker gone", LocalDateTime.now());
+        jobRepository.claim(jobId, "replica-a", past, past);
+
+        int failed = jobRepository.failExpiredLeasesOutOfAttempts("gave up", LocalDateTime.now());
+
+        assertThat(failed).isEqualTo(1);
+        assertThat(statusOf(jobId)).isEqualTo("FAILED");
+    }
+
+    /** Inserts a job row directly, so what is under test is the schema and not the service. */
+    private UUID insertJob(ComplianceJobStatus status) {
+        UUID id = UUID.randomUUID();
+        entityManager.createNativeQuery(
+                        "INSERT INTO compliance_generation_jobs (id, organization_id, project_id, "
+                                + "status, rules_total, rules_assessed, batches_total, batches_done, "
+                                + "created_count, attempt, max_attempts, created_at, updated_at) VALUES "
+                                + "(:id, :org, :project, :status, 6, 0, 1, 0, 0, 0, 3, "
+                                + "now()::timestamp, now()::timestamp)")
+                .setParameter("id", id)
+                .setParameter("org", orgAId)
+                .setParameter("project", projectId)
+                .setParameter("status", status.name())
+                .executeUpdate();
+        entityManager.flush();
+        return id;
+    }
+
+    private String statusOf(UUID jobId) {
+        return (String) entityManager.createNativeQuery(
+                        "SELECT status FROM compliance_generation_jobs WHERE id = :id")
+                .setParameter("id", jobId).getSingleResult();
+    }
+
+    private int attemptOf(UUID jobId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "SELECT attempt FROM compliance_generation_jobs WHERE id = :id")
+                .setParameter("id", jobId).getSingleResult()).intValue();
     }
 
     private void inCommittedTx(Runnable work) {

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceTest.java
@@ -171,7 +171,7 @@ class ComplianceGenerationServiceTest {
                 .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai, Tamil Nadu")));
         when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
                 .thenReturn(List.of(new org.tornotron.echno_backend.compliance.domain.ComplianceRule()));
-        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any(), any()))
                 .thenReturn(List.of());
         when(complianceAiService.isConfigured()).thenReturn(false);
 
@@ -182,18 +182,25 @@ class ComplianceGenerationServiceTest {
 
     /**
      * The orchestrator must hold no transaction of its own, because its middle phase is an
-     * external model call measured at 34 to 47 seconds. A {@code @Transactional} here would
-     * put that call back inside a transaction and pin one of twenty pool connections for
-     * its duration. The two transactions belong to the read and write phases, which reach
-     * them through {@code TransactionRetryTemplate}.
+     * external model call, which runs at roughly 1.7 seconds a rule. A {@code @Transactional}
+     * here would put that call back inside a transaction and pin one of twenty pool
+     * connections for its duration. The two transactions belong to the read and write phases,
+     * which reach them through {@code TransactionRetryTemplate}.
+     *
+     * <p>Both overloads are checked, because the one that does the work is the one taking a
+     * progress sink and an annotation on it would be just as wrong and much easier to miss.
      */
     @Test
     @MockitoSettings(strictness = Strictness.LENIENT)
     void orchestratorOwnsNoTransaction() throws Exception {
-        Method method = ComplianceGenerationService.class
+        Method twoArg = ComplianceGenerationService.class
                 .getMethod("generateForProject", Long.class, Long.class);
+        Method withProgress = ComplianceGenerationService.class
+                .getMethod("generateForProject", Long.class, Long.class,
+                        ComplianceGenerationProgress.class);
 
-        assertThat(method.getAnnotation(Transactional.class)).isNull();
+        assertThat(twoArg.getAnnotation(Transactional.class)).isNull();
+        assertThat(withProgress.getAnnotation(Transactional.class)).isNull();
     }
 
     @Test
@@ -202,7 +209,7 @@ class ComplianceGenerationServiceTest {
                 .thenReturn(Optional.of(project(ProjectType.RESIDENTIAL, "12 Mount Road, Chennai, Tamil Nadu")));
         when(ruleRepository.findByStateIgnoreCaseAndProjectTypeAndActiveTrue(anyString(), any()))
                 .thenReturn(List.of(new org.tornotron.echno_backend.compliance.domain.ComplianceRule()));
-        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any()))
+        when(complianceAiService.suggestCompliances(any(Project.class), anyString(), any(), any()))
                 .thenReturn(List.of());
         when(complianceAiService.isConfigured()).thenReturn(true);
 

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceBatchingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/ComplianceBatchingTest.java
@@ -1,0 +1,259 @@
+package org.tornotron.echno_backend.compliance.ai;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
+import org.tornotron.echno_backend.compliance.CompliancePhase;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Batching, without a network.
+ *
+ * <p>The one seam is {@code callModel}, which is overridden here to return canned response
+ * bodies. Everything else is the real service, the real splitting and the real
+ * {@link ComplianceResponseReader}, because the behaviour worth pinning down is precisely
+ * what happens around those calls: how the catalogue is divided, what order the answers are
+ * put back in when they arrive out of order, and what a run does when one call of five
+ * fails. All of that is otherwise only observable by making real calls against a rule
+ * catalogue large enough to break, which is how the token ceiling stayed unmeasured for as
+ * long as it did.
+ */
+class ComplianceBatchingTest {
+
+    /** Records what each call was asked about, so the split itself can be asserted on. */
+    private final List<List<String>> callsMade = new CopyOnWriteArrayList<>();
+
+    private final List<Progress> progressReports = new ArrayList<>();
+
+    /** One progress callback, as a value so a test can compare it. */
+    private record Progress(int batchesDone, int batchesTotal, int rulesAssessed, int rulesTotal) {}
+
+    @Test
+    void splitsTheCatalogueIntoBatchesOfTheConfiguredSize() {
+        OpenAiCompatibleComplianceService service = service(10, 4, batch -> answerFor(batch));
+
+        service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record);
+
+        assertThat(callsMade).hasSize(3);
+        assertThat(callsMade.stream().map(List::size)).containsExactlyInAnyOrder(10, 10, 5);
+        assertThat(callsMade.stream().flatMap(List::stream).sorted().toList())
+                .as("every rule must be asked about exactly once")
+                .isEqualTo(rules(25).stream().map(ComplianceRule::getCode).sorted().toList());
+    }
+
+    @Test
+    void asksInOneCallWhenBatchingIsSwitchedOff() {
+        OpenAiCompatibleComplianceService service = service(0, 4, batch -> answerFor(batch));
+
+        service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record);
+
+        assertThat(callsMade).hasSize(1);
+        assertThat(callsMade.get(0)).hasSize(25);
+    }
+
+    /**
+     * With the calls overlapping, the last batch can and does finish first. The answer must
+     * not depend on that, or the order of the generated compliances would change from run to
+     * run for no reason the user could see.
+     */
+    @Test
+    void returnsAnswersInBatchOrderEvenWhenTheCallsFinishOutOfOrder() {
+        OpenAiCompatibleComplianceService service = service(10, 4, batch -> {
+            // The first batch is the slowest, so completion order is the reverse of batch order.
+            sleepQuietly(batch.get(0).getCode().equals("RULE-00") ? 120 : 10);
+            return answerFor(batch);
+        });
+
+        List<ComplianceSuggestion> suggestions =
+                service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record);
+
+        assertThat(suggestions.stream().map(ComplianceSuggestion::ruleCode).toList())
+                .isEqualTo(rules(25).stream().map(ComplianceRule::getCode).toList());
+    }
+
+    @Test
+    void reportsProgressAfterEachBatch() {
+        OpenAiCompatibleComplianceService service = service(10, 4, batch -> answerFor(batch));
+
+        service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record);
+
+        assertThat(progressReports).containsExactly(
+                new Progress(1, 3, 10, 25),
+                new Progress(2, 3, 20, 25),
+                new Progress(3, 3, 25, 25));
+    }
+
+    /**
+     * The rule from the truncation work, one level up: a run that did not cover every rule
+     * has no result, and must not present the batches it did get through as one.
+     *
+     * <p>Batch three of five fails. Batches one and two have perfectly good answers in hand,
+     * covering ten of twenty-five rules. Handing those back would create ten compliances and
+     * show the user a finished result silently missing three fifths of the jurisdiction,
+     * which is the exact failure the compliance module exists to prevent.
+     */
+    @Test
+    void oneFailedBatchFailsTheWholeRunAndReturnsNothing() {
+        OpenAiCompatibleComplianceService service = service(5, 1, batch -> {
+            if (batch.get(0).getCode().equals("RULE-10")) {
+                throw new ComplianceAiException("the endpoint returned 503");
+            }
+            return answerFor(batch);
+        });
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> service.suggestCompliances(
+                        project(), "Tamil Nadu", rules(25), this::record))
+                .withMessageContaining("Batch 3 of 5")
+                .withMessageContaining("25 rule(s) is incomplete")
+                .withMessageContaining("no compliances were generated");
+    }
+
+    /**
+     * Progress stops where the run stopped. A counter that ran on past the failed batch would
+     * be the same lie as returning the partial answer, told in numbers instead.
+     */
+    @Test
+    void progressStopsAtTheFailedBatch() {
+        OpenAiCompatibleComplianceService service = service(5, 4, batch -> {
+            if (batch.get(0).getCode().equals("RULE-10")) {
+                sleepQuietly(80);
+                throw new ComplianceAiException("the endpoint returned 503");
+            }
+            return answerFor(batch);
+        });
+
+        assertThatExceptionOfType(ComplianceAiException.class).isThrownBy(() ->
+                service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record));
+
+        assertThat(progressReports)
+                .as("only the batches before the failure are progress that happened")
+                .hasSize(2);
+        assertThat(progressReports.get(1)).isEqualTo(new Progress(2, 5, 10, 25));
+    }
+
+    /**
+     * A batch whose answer is short is refused by the reader exactly as a whole-catalogue
+     * answer would be, so batching does not open a way around the coverage check.
+     */
+    @Test
+    void aBatchThatComesBackShortIsRefused() {
+        OpenAiCompatibleComplianceService service = service(10, 4, batch ->
+                batch.get(0).getCode().equals("RULE-10")
+                        ? answerFor(batch.subList(0, batch.size() - 1))
+                        : answerFor(batch));
+
+        assertThatExceptionOfType(ComplianceAiException.class)
+                .isThrownBy(() -> service.suggestCompliances(
+                        project(), "Tamil Nadu", rules(25), this::record))
+                .withMessageContaining("Batch 2 of 3")
+                .withMessageContaining("unassessed");
+    }
+
+    @Test
+    void batchCountMatchesTheNumberOfCallsMade() {
+        OpenAiCompatibleComplianceService service = service(10, 4, batch -> answerFor(batch));
+
+        assertThat(service.batchCount(25)).isEqualTo(3);
+        assertThat(service.batchCount(10)).isEqualTo(1);
+        assertThat(service.batchCount(0)).isZero();
+
+        service.suggestCompliances(project(), "Tamil Nadu", rules(25), this::record);
+        assertThat(callsMade).hasSize(service.batchCount(25));
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    /** What one call does with the rules it was given. */
+    private interface CannedEndpoint {
+        String answer(List<ComplianceRule> batch);
+    }
+
+    private OpenAiCompatibleComplianceService service(int batchSize,
+                                                      int concurrency,
+                                                      CannedEndpoint endpoint) {
+        ComplianceAiProperties props = new ComplianceAiProperties();
+        props.setApiKey("test-key");
+        props.setBatchSize(batchSize);
+        props.setBatchConcurrency(concurrency);
+        return new OpenAiCompatibleComplianceService(props) {
+            @Override
+            String callModel(Project project, String state, List<ComplianceRule> candidateRules) {
+                callsMade.add(candidateRules.stream().map(ComplianceRule::getCode).toList());
+                return endpoint.answer(candidateRules);
+            }
+        };
+    }
+
+    private void record(int batchesDone, int batchesTotal, int rulesAssessed, int rulesTotal) {
+        progressReports.add(new Progress(batchesDone, batchesTotal, rulesAssessed, rulesTotal));
+    }
+
+    /**
+     * A complete, well-formed chat-completions body assessing exactly the rules given, built
+     * with Jackson so the escaping is the provider's rather than this test's guess at it.
+     */
+    private static String answerFor(List<ComplianceRule> batch) {
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode assessments = mapper.createArrayNode();
+        for (ComplianceRule rule : batch) {
+            ObjectNode element = assessments.addObject();
+            element.put("ruleCode", rule.getCode());
+            element.put("applies", true);
+            element.put("riskLevel", "high");
+            element.putArray("resolutionOptions").add("Apply to the authority");
+            element.put("rationale", "Applies to a residential project of this size.");
+            element.put("phase", "pre-construction");
+        }
+
+        ObjectNode root = mapper.createObjectNode();
+        ObjectNode choice = root.putArray("choices").addObject();
+        choice.put("finish_reason", "stop");
+        choice.putObject("message").put("content", assessments.toString());
+        root.putObject("usage").put("completion_tokens", batch.size() * 57);
+        return root.toString();
+    }
+
+    private static List<ComplianceRule> rules(int count) {
+        return IntStream.range(0, count).mapToObj(i -> {
+            ComplianceRule rule = new ComplianceRule();
+            rule.setCode(String.format("RULE-%02d", i));
+            rule.setName("Rule " + i);
+            rule.setDescription("Something that must be obtained.");
+            rule.setAuthority("Some Authority");
+            rule.setPhase(CompliancePhase.PRE_CONSTRUCTION);
+            rule.setDefaultRiskLevel(ComplianceRiskLevel.HIGH);
+            return rule;
+        }).toList();
+    }
+
+    private static Project project() {
+        Project project = new Project();
+        project.setProjectName("Anna Nagar Residency");
+        project.setProjectType(ProjectType.RESIDENTIAL);
+        project.setProjectAddress("14 Second Avenue, Anna Nagar, Chennai");
+        return project;
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDispatcherTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobDispatcherTest.java
@@ -1,0 +1,191 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Claiming, and only claiming.
+ *
+ * <p>The pass is driven with a same-thread executor, so what a poll did is a fact rather than
+ * something to wait for. That is the whole reason the worker is a separate bean: the timing
+ * lives here and the judgement lives there, and neither test has to carry the other's
+ * apparatus.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceGenerationJobDispatcherTest {
+
+    private static final UUID JOB_ID = UUID.fromString("11111111-2222-3333-4444-555555555555");
+    private static final UUID OTHER_JOB_ID = UUID.fromString("66666666-7777-8888-9999-000000000000");
+
+    /** Runs the handed-off work where it stands, so a pass is finished when poll() returns. */
+    private static final Executor SAME_THREAD = Runnable::run;
+
+    @Mock
+    private ComplianceGenerationJobRepository jobRepository;
+    @Mock
+    private ComplianceGenerationJobWorker worker;
+    @Mock
+    private TransactionRetryTemplate retryTemplate;
+
+    private ComplianceGenerationJobDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        lenient().doAnswer(invocation -> invocation.getArgument(1, Supplier.class).get())
+                .when(retryTemplate).execute(anyString(), any(Supplier.class));
+
+        ComplianceJobProperties properties = new ComplianceJobProperties();
+        properties.setMaxInFlight(2);
+        dispatcher = new ComplianceGenerationJobDispatcher(
+                jobRepository, worker, retryTemplate, properties);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dispatcher.shutdown();
+    }
+
+    /**
+     * The conditional update is the whole of the mutual exclusion. Losing it means another
+     * replica already has the job, and the loser must not go on to run it as well.
+     */
+    @Test
+    void doesNotRunAJobWhoseClaimAnotherReplicaWon() {
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(0);
+
+        dispatcher.poll(SAME_THREAD);
+
+        verify(worker, never()).run(any(), anyString());
+    }
+
+    @Test
+    void runsAJobWhoseClaimItWon() {
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(1);
+
+        dispatcher.poll(SAME_THREAD);
+
+        verify(worker).run(JOB_ID, dispatcher.nodeId());
+    }
+
+    /**
+     * The claim writes this replica's name and a lease ahead of itself. Both are what makes
+     * recovery possible: the name is how a superseded worker knows to stop writing, and the
+     * lease is how any replica knows the holder is gone.
+     */
+    @Test
+    void theClaimCarriesThisReplicasNameAndALeaseInTheFuture() {
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(1);
+
+        dispatcher.poll(SAME_THREAD);
+
+        verify(jobRepository).claim(
+                org.mockito.ArgumentMatchers.eq(JOB_ID),
+                org.mockito.ArgumentMatchers.eq(dispatcher.nodeId()),
+                org.mockito.ArgumentMatchers.argThat(lease -> lease.isAfter(LocalDateTime.now())),
+                any());
+    }
+
+    /**
+     * Slots are held from before the claim until the run ends, so a replica configured for two
+     * cannot end up holding three claims it has nowhere to run.
+     */
+    @Test
+    void takesNoMoreWorkThanItHasSlotsFor() {
+        UUID third = UUID.randomUUID();
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID, OTHER_JOB_ID, third));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(1);
+
+        // Never returns, so both slots stay occupied for the duration of the pass.
+        Executor neverFinishing = runnable -> { };
+        dispatcher.poll(neverFinishing);
+
+        verify(jobRepository, times(2)).claim(any(), anyString(), any(), any());
+    }
+
+    @Test
+    void freesTheSlotWhenTheClaimIsLostSoTheNextPassCanUseIt() {
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(0);
+
+        dispatcher.poll(SAME_THREAD);
+        dispatcher.poll(SAME_THREAD);
+
+        verify(jobRepository, times(2)).findQueuedIds(2);
+    }
+
+    /** Recovery runs before new work is taken, so a freed job is available in the same pass. */
+    @Test
+    void returnsJobsWithAnExpiredLeaseToTheQueue() {
+        when(jobRepository.requeueExpiredLeases(anyString(), any())).thenReturn(1);
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of());
+
+        dispatcher.poll(SAME_THREAD);
+
+        verify(jobRepository).requeueExpiredLeases(anyString(), any());
+        verify(jobRepository).failExpiredLeasesOutOfAttempts(anyString(), any());
+    }
+
+    /**
+     * Spring stops rescheduling a {@code @Scheduled} method that throws, and a queue that
+     * silently stops draining is the failure this whole change exists to remove. So a bad pass
+     * has to be survivable, which means it has to be swallowed here.
+     */
+    @Test
+    void aFailedPassDoesNotEscapeAndCancelTheSchedule() {
+        when(jobRepository.requeueExpiredLeases(anyString(), any()))
+                .thenThrow(new IllegalStateException("the database is unreachable"));
+
+        assertThatCode(() -> dispatcher.poll(SAME_THREAD)).doesNotThrowAnyException();
+
+        // And the next pass still happens. Restubbed with doReturn because when() would call the
+        // mock, and this one is currently set to throw.
+        doReturn(0).when(jobRepository).requeueExpiredLeases(anyString(), any());
+        doReturn(List.of()).when(jobRepository).findQueuedIds(anyInt());
+        dispatcher.poll(SAME_THREAD);
+        verify(jobRepository, times(2)).requeueExpiredLeases(anyString(), any());
+    }
+
+    /**
+     * A worker that throws on its way out must not take the slot with it, or a replica would
+     * quietly lose capacity one failure at a time until it stopped taking work at all.
+     */
+    @Test
+    void aWorkerThatThrowsStillGivesItsSlotBack() {
+        when(jobRepository.findQueuedIds(anyInt())).thenReturn(List.of(JOB_ID));
+        when(jobRepository.claim(any(), anyString(), any(), any())).thenReturn(1);
+        doAnswer(invocation -> {
+            throw new IllegalStateException("something went badly wrong");
+        }).when(worker).run(any(), anyString());
+
+        dispatcher.poll(SAME_THREAD);
+        dispatcher.poll(SAME_THREAD);
+
+        verify(jobRepository, times(2)).findQueuedIds(2);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobServiceTest.java
@@ -1,0 +1,197 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Accepting work: what it checks before it says yes, and what a second click does.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceGenerationJobServiceTest {
+
+    private static final Long ORG_ID = 7L;
+    private static final Long PROJECT_ID = 42L;
+
+    @Mock
+    private ComplianceGenerationJobRepository jobRepository;
+    @Mock
+    private ComplianceGenerationService complianceGenerationService;
+    @Mock
+    private TenantEntityHelper tenantEntityHelper;
+    @Mock
+    private TransactionRetryTemplate retryTemplate;
+
+    private ComplianceGenerationJobService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ComplianceGenerationJobService(jobRepository, complianceGenerationService,
+                new ComplianceJobProperties(), tenantEntityHelper, retryTemplate);
+
+        lenient().doAnswer(invocation -> invocation.getArgument(1, Supplier.class).get())
+                .when(retryTemplate).execute(anyString(), any(Supplier.class));
+    }
+
+    @Test
+    void acceptsAJobRecordingHowMuchWorkItIs() {
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.batchCount(25)).thenReturn(3);
+        when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        when(jobRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ComplianceGenerationJobService.Accepted accepted = service.submit(PROJECT_ID, ORG_ID);
+
+        assertThat(accepted.created()).isTrue();
+        ArgumentCaptor<ComplianceGenerationJob> saved =
+                ArgumentCaptor.forClass(ComplianceGenerationJob.class);
+        verify(jobRepository).save(saved.capture());
+        assertThat(saved.getValue().getStatus()).isEqualTo(ComplianceJobStatus.QUEUED);
+        assertThat(saved.getValue().getRulesTotal()).isEqualTo(25);
+        assertThat(saved.getValue().getBatchesTotal())
+                .as("the caller can show a progress bar before the first batch has run")
+                .isEqualTo(3);
+    }
+
+    /**
+     * A precondition the user can fix is answered immediately as the 400 it has always been.
+     * Accepting the job and letting a worker discover it a minute later would turn a clear
+     * error message into something the user has to go and poll for.
+     */
+    @Test
+    void aPreconditionFailureIsRaisedAtAcceptTimeAndQueuesNothing() {
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenThrow(new InvalidRequestException("This project has no type set."));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.submit(PROJECT_ID, ORG_ID))
+                .withMessageContaining("no type set");
+
+        verify(jobRepository, never()).save(any());
+    }
+
+    /**
+     * Two clicks are one run. Two runs would both spend a minute of inference and then race to
+     * create the same inspections, which is the duplicate the inspection-level unique index had
+     * to be added to catch.
+     */
+    @Test
+    void aSecondRequestJoinsTheRunAlreadyInFlight() {
+        ComplianceGenerationJob running = queuedJob();
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.of(running));
+
+        ComplianceGenerationJobService.Accepted accepted = service.submit(PROJECT_ID, ORG_ID);
+
+        assertThat(accepted.created())
+                .as("nothing new was started, so the caller is answered 200 rather than 202")
+                .isFalse();
+        assertThat(accepted.job().status()).isEqualTo(ComplianceJobStatus.QUEUED);
+        verify(jobRepository, never()).save(any());
+    }
+
+    /**
+     * The read above is a read, so it cannot be the guarantee: two requests arriving together
+     * both see no active job and both insert. The partial unique index rejects the loser, and
+     * the loser then reads back the winner and hands that to its caller, so both end up
+     * watching one run rather than one of them being told about a conflict it cannot act on.
+     */
+    @Test
+    void aRequestThatLosesTheInsertRaceReturnsTheWinnersJob() {
+        ComplianceGenerationJob winner = queuedJob();
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(winner));
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        when(jobRepository.save(any())).thenThrow(uniqueViolation());
+
+        ComplianceGenerationJobService.Accepted accepted = service.submit(PROJECT_ID, ORG_ID);
+
+        assertThat(accepted.created()).isFalse();
+        assertThat(accepted.job().id()).isEqualTo(winner.getId());
+    }
+
+    /**
+     * The winner can legitimately have finished between the constraint rejecting our insert and
+     * our reading it back. That is not an error, and the newest job for the project is still
+     * the one the caller wanted to be told about.
+     */
+    @Test
+    void aRequestThatLosesToAJobThatHasSinceFinishedReturnsThatFinishedJob() {
+        ComplianceGenerationJob finished = queuedJob();
+        finished.setStatus(ComplianceJobStatus.NOTHING_TO_REPORT);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
+        when(jobRepository.findLatestForProject(anyLong(), anyLong(), any(Pageable.class)))
+                .thenReturn(List.of(finished));
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        when(jobRepository.save(any())).thenThrow(uniqueViolation());
+
+        ComplianceGenerationJobService.Accepted accepted = service.submit(PROJECT_ID, ORG_ID);
+
+        assertThat(accepted.created()).isFalse();
+        assertThat(accepted.job().status()).isEqualTo(ComplianceJobStatus.NOTHING_TO_REPORT);
+    }
+
+    /** A failure that is not the duplicate is not swallowed as one. */
+    @Test
+    void anUnrelatedWriteFailureIsNotMistakenForALostRace() {
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
+        when(jobRepository.save(any())).thenThrow(new IllegalStateException("the disk is full"));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> service.submit(PROJECT_ID, ORG_ID))
+                .withMessageContaining("disk is full");
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    private static ComplianceGenerationJob queuedJob() {
+        ComplianceGenerationJob job = new ComplianceGenerationJob();
+        job.setId(java.util.UUID.randomUUID());
+        job.setProjectId(PROJECT_ID);
+        job.setStatus(ComplianceJobStatus.QUEUED);
+        job.setRulesTotal(25);
+        job.setBatchesTotal(3);
+        job.setMaxAttempts(3);
+        return job;
+    }
+
+    /** What the partial unique index throws up through Spring when it rejects a second job. */
+    private static DataIntegrityViolationException uniqueViolation() {
+        return new DataIntegrityViolationException(
+                "could not execute statement [duplicate key value violates unique constraint "
+                        + "\"uk_compliance_job_active\"]",
+                new SQLException("duplicate key value violates unique constraint", "23505"));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobWorkerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobWorkerTest.java
@@ -1,0 +1,376 @@
+package org.tornotron.echno_backend.compliance.job;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationProgress;
+import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.inspection.dtos.InspectionDto;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What a run means, decided without a thread pool anywhere near it.
+ *
+ * <p>The five terminal outcomes are the point. A job that finished having created nothing is
+ * not the same thing as a job that fell over, and before the truncation checks landed those
+ * two arrived at the user as the same empty list. Moving generation into the background is
+ * exactly the sort of change that would quietly put that ambiguity back, one layer further
+ * from anyone who could notice it, so it is pinned here.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceGenerationJobWorkerTest {
+
+    private static final UUID JOB_ID = UUID.fromString("11111111-2222-3333-4444-555555555555");
+    private static final Long ORG_ID = 7L;
+    private static final Long PROJECT_ID = 42L;
+    private static final String NODE = "replica-a";
+
+    @Mock
+    private ComplianceGenerationJobRepository jobRepository;
+    @Mock
+    private ComplianceGenerationService complianceGenerationService;
+    @Mock
+    private TenantScopedJobRunner tenantScopedJobRunner;
+    @Mock
+    private TransactionRetryTemplate retryTemplate;
+
+    private ComplianceGenerationJobWorker worker;
+    private ComplianceGenerationJob row;
+
+    @BeforeEach
+    void setUp() {
+        ComplianceJobProperties properties = new ComplianceJobProperties();
+        worker = new ComplianceGenerationJobWorker(
+                jobRepository, complianceGenerationService, tenantScopedJobRunner,
+                retryTemplate, properties);
+
+        // The transaction boundary is not what these tests are about, so the template runs the
+        // work where it stands.
+        lenient().doAnswer(invocation -> invocation.getArgument(1, Supplier.class).get())
+                .when(retryTemplate).execute(anyString(), any(Supplier.class));
+        lenient().doAnswer(invocation -> {
+            invocation.getArgument(1, Runnable.class).run();
+            return null;
+        }).when(retryTemplate).executeWithoutResult(anyString(), any(Runnable.class));
+
+        lenient().doAnswer(invocation -> {
+            TenantContext.setCurrentOrgId(invocation.getArgument(0));
+            try {
+                invocation.getArgument(1, Runnable.class).run();
+            } finally {
+                TenantContext.clear();
+            }
+            return null;
+        }).when(tenantScopedJobRunner).runForTenant(anyLong(), any(Runnable.class));
+
+        row = new ComplianceGenerationJob();
+        row.setStatus(ComplianceJobStatus.RUNNING);
+        row.setClaimedBy(NODE);
+        row.setProjectId(PROJECT_ID);
+        row.setAttempt(1);
+        lenient().when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.of(dispatchRow(1, 3)));
+        lenient().when(jobRepository.findByIdScoped(JOB_ID, ORG_ID)).thenReturn(Optional.of(row));
+    }
+
+    @Test
+    void aRunThatCreatedComplianceIsSucceeded() {
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenReturn(createdRows(2));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.SUCCEEDED);
+        assertThat(row.getCreatedCount()).isEqualTo(2);
+        assertThat(row.getErrorMessage()).isNull();
+        assertThat(row.getFinishedAt()).isNotNull();
+    }
+
+    /**
+     * The distinction the whole status set exists for. Nothing was created and nothing went
+     * wrong, and calling that "succeeded with zero" would leave the user unable to tell it from
+     * a run whose answer was thrown away.
+     */
+    @Test
+    void aRunThatCoveredEveryRuleAndCreatedNothingIsNothingToReport() {
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenReturn(List.of());
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.NOTHING_TO_REPORT);
+        assertThat(row.getCreatedCount()).isZero();
+        assertThat(row.getErrorMessage()).isNull();
+    }
+
+    /**
+     * And the other half of it. A model answer cut short is a failure, not an empty result, and
+     * it must not be recorded as one.
+     */
+    @Test
+    void aTruncatedModelAnswerIsFailedAndNotAnEmptySuccess() {
+        row.setStatus(ComplianceJobStatus.RUNNING);
+        row.setAttempt(3);
+        when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.of(dispatchRow(3, 3)));
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenThrow(new ComplianceAiException(
+                        "The compliance AI response was cut short by its token limit"));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.FAILED);
+        assertThat(row.getCreatedCount()).isZero();
+        assertThat(row.getErrorMessage()).contains("cut short");
+    }
+
+    @Test
+    void aFailureWithAttemptsLeftGoesBackToTheQueueWithTheReasonOnIt() {
+        when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.of(dispatchRow(1, 3)));
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenThrow(new ComplianceAiException("the endpoint returned 503"));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.QUEUED);
+        assertThat(row.getClaimedBy()).isNull();
+        assertThat(row.getLeaseExpiresAt()).isNull();
+        assertThat(row.getErrorMessage())
+                .as("a caller polling through a retry should be told what is going wrong")
+                .contains("Attempt 1 of 3")
+                .contains("503");
+        assertThat(row.getFinishedAt()).isNull();
+    }
+
+    /**
+     * Progress is reset on the way back to the queue. Leaving it would show a job that is
+     * waiting to start over as though it were two batches into a run.
+     */
+    @Test
+    void requeueingResetsTheProgressCounters() {
+        row.setBatchesDone(2);
+        row.setRulesAssessed(20);
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenThrow(new ComplianceAiException("the endpoint returned 503"));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getBatchesDone()).isZero();
+        assertThat(row.getRulesAssessed()).isZero();
+    }
+
+    /**
+     * A precondition failure is decided from the project row and the configuration, so every
+     * further attempt would read the same rows and fail identically. Retrying it would only
+     * delay telling the user what to fix.
+     */
+    @Test
+    void aPreconditionFailureIsTerminalWithoutSpendingTheRemainingAttempts() {
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenThrow(new InvalidRequestException("This project has no type set."));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.FAILED);
+        assertThat(row.getErrorMessage()).contains("no type set");
+    }
+
+    @Test
+    void theLastAttemptFailsRatherThanQueueingForever() {
+        row.setAttempt(3);
+        when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.of(dispatchRow(3, 3)));
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenThrow(new ComplianceAiException("the endpoint returned 503"));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.FAILED);
+        assertThat(row.getFinishedAt()).isNotNull();
+    }
+
+    /**
+     * The work is tenant-scoped from an id read off the row, never from whatever happened to
+     * be on the pooled thread. Both isolation mechanisms fail open on a missing context, so a
+     * worker that skipped this would read every organization's rows and look healthy doing it.
+     */
+    @Test
+    void runsTheWorkUnderTheTenantNamedOnTheJobRow() {
+        AtomicReference<Long> tenantDuringWork = new AtomicReference<>();
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenAnswer(invocation -> {
+                    tenantDuringWork.set(TenantContext.getCurrentOrgId());
+                    return List.of();
+                });
+
+        worker.run(JOB_ID, NODE);
+
+        verify(tenantScopedJobRunner).runForTenant(eq(ORG_ID), any(Runnable.class));
+        assertThat(tenantDuringWork.get()).isEqualTo(ORG_ID);
+    }
+
+    /**
+     * A worker whose lease expired has had its job taken by another replica. Writing an outcome
+     * now would overwrite what the new owner is doing with a result from a run nobody is
+     * watching any more.
+     */
+    @Test
+    void doesNotWriteAnOutcomeOntoAJobItNoLongerHolds() {
+        row.setStatus(ComplianceJobStatus.RUNNING);
+        row.setClaimedBy("replica-b");
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenReturn(createdRows(1));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.RUNNING);
+        assertThat(row.getCreatedCount()).isZero();
+        verify(jobRepository, never()).save(any());
+    }
+
+    /**
+     * Progress and the lease move together, and both are conditional on still holding the
+     * claim, so a worker that has been superseded cannot rewind the new owner's progress.
+     */
+    @Test
+    void progressWritesCarryTheLeaseAndTheClaimHolder() {
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenAnswer(invocation -> {
+                    invocation.getArgument(2, ComplianceGenerationProgress.class)
+                            .batchCompleted(2, 3, 20, 25);
+                    return List.of();
+                });
+        when(jobRepository.recordProgress(any(), anyString(), anyInt(), anyInt(), anyInt(), any(), any()))
+                .thenReturn(1);
+
+        worker.run(JOB_ID, NODE);
+
+        ArgumentCaptor<LocalDateTime> lease = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(jobRepository).recordProgress(eq(JOB_ID), eq(NODE), eq(1), eq(2), eq(20),
+                lease.capture(), any(LocalDateTime.class));
+        assertThat(lease.getValue())
+                .as("finishing a batch is the evidence this worker is alive, so it extends the claim")
+                .isAfter(LocalDateTime.now());
+    }
+
+    /**
+     * The preconditions are checked again on the worker, because the row outlives the
+     * configuration it was accepted under. The sharpest case is the AI key disappearing in a
+     * restart: the generation call answers an unconfigured service with an empty list, and a
+     * worker that reached it would record NOTHING_TO_REPORT for a run that asked nothing.
+     */
+    @Test
+    void aPreconditionThatLapsedBetweenAcceptAndRunFailsTheJobRatherThanReportingNothing() {
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenThrow(new InvalidRequestException(
+                        "The compliance AI service is not configured, so suggestions cannot be "
+                                + "generated. Set the compliance AI key and try again."));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.FAILED);
+        assertThat(row.getErrorMessage()).contains("not configured");
+        verify(complianceGenerationService, never()).generateForProject(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * The replica name alone does not identify a claim. A job whose lease lapsed can be
+     * requeued and re-claimed by the same replica, and then the row carries this worker's own
+     * name with a later attempt. The superseded run must recognise that the row is no longer
+     * its own, exactly as it would had another replica taken it.
+     */
+    @Test
+    void doesNotWriteAnOutcomeOntoAJobItsOwnReplicaReclaimed() {
+        row.setStatus(ComplianceJobStatus.RUNNING);
+        row.setClaimedBy(NODE);
+        row.setAttempt(2);
+        when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.of(dispatchRow(1, 3)));
+        when(complianceGenerationService.generateForProject(eq(PROJECT_ID), eq(ORG_ID), any()))
+                .thenReturn(createdRows(1));
+
+        worker.run(JOB_ID, NODE);
+
+        assertThat(row.getStatus()).isEqualTo(ComplianceJobStatus.RUNNING);
+        assertThat(row.getCreatedCount()).isZero();
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
+    void aJobThatVanishedBetweenTheClaimAndTheRunIsLeftAlone() {
+        when(jobRepository.findDispatchRow(JOB_ID)).thenReturn(Optional.empty());
+
+        worker.run(JOB_ID, NODE);
+
+        verify(complianceGenerationService, never()).generateForProject(anyLong(), anyLong(), any());
+        verify(jobRepository, never()).save(any());
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    private static ComplianceGenerationJobRepository.DispatchRow dispatchRow(int attempt, int maxAttempts) {
+        return new ComplianceGenerationJobRepository.DispatchRow() {
+            @Override
+            public Long getOrganizationId() {
+                return ORG_ID;
+            }
+
+            @Override
+            public Long getProjectId() {
+                return PROJECT_ID;
+            }
+
+            @Override
+            public int getAttempt() {
+                return attempt;
+            }
+
+            @Override
+            public int getMaxAttempts() {
+                return maxAttempts;
+            }
+
+            @Override
+            public int getRulesTotal() {
+                return 25;
+            }
+
+            @Override
+            public int getBatchesTotal() {
+                return 3;
+            }
+        };
+    }
+
+    /**
+     * A result list of the given length. The worker reads nothing but the size, and an
+     * InspectionDto carries thirty-seven components, so filling them in would be thirty-seven
+     * pieces of noise standing in for the number two.
+     */
+    private static List<InspectionDto> createdRows(int count) {
+        return Arrays.asList(new InspectionDto[count]);
+    }
+}


### PR DESCRIPTION
Closes #482.

#514 took the model call out of the transaction and #528 made a cut-short answer fail loudly instead of writing nothing. Both left the run itself on the request thread, where it dies at the sixty-second edge timeout no matter how well it behaves. This moves it off, and splits the rule catalogue so no single call has to carry all of it.

## The token ceiling, measured

This was recorded as blocked on a key. It was not: the key is configured on staging, and the numbers below come from real calls to the configured endpoint (`llama-4-maverick` on DigitalOcean Gradient) through the lab proxy, using a prompt built exactly the way `buildUserPrompt` builds it, over the seeded rule catalogue extended to the sizes shown.

| Rules | prompt tokens | completion tokens | tokens/rule | elapsed | finish_reason | elements parsed |
|---|---|---|---|---|---|---|
| 6 | 695 | 339 | 56.5 | 13.2 s | stop | 6 |
| 8 | 825 | 451 | 56.4 | 20.3 s | stop | 8 |
| 10 | 958 | 573 | 57.3 | 17.2 s | stop | 10 |
| 12 | 1096 | 701 | 58.4 | 23.4 s | stop | 12 |
| 21 | 1710 | 1209 | 57.6 | 38.4 s | stop | 21 |
| 40 | 3048 | 2376 | 59.4 | 58.3 s | stop | 40 |
| 60 | 4444 | 3187 | 53.1 | 108.5 s | stop | 60 |
| **72** | 5286 | **4096 (capped)** | - | 257.7 s | **length** | **none: the array never closes** |

**About 57 completion tokens per rule.** The 72-rule run is the ceiling landing exactly where that predicts: `finish_reason: length`, the budget spent to the token, and a response whose array never closes, which is precisely the second of #528's three truncation checks firing on live data. Two things worth noting beyond the headline:

- **Wall clock is the tighter limit, and it bites first.** At about 1.7 s per rule, 40 rules already takes 58 s. So the sixty-second ceiling arrives at roughly 40 rules and the token ceiling at roughly 72. The issue estimated both at 30 to 35; the shape of the argument was right and the numbers were pessimistic.
- **The model gets terser as it approaches the cap** (53.1 tokens/rule at 60 against 57 to 59 below it), so answer quality degrades before truncation does. That is a further argument for a batch size nowhere near the cap.

**Batch size: 10.** Ten rules costs about 600 completion tokens, under a sixth of the 4096 budget, and takes about 20 seconds against a 60-second read timeout. Twenty would still fit the token budget but would sit at roughly two thirds of the read timeout, which is not enough margin for one slow call. Both numbers are configuration (`compliance.ai.batch-size`), because the figure that has to hold is not the average rule but the worst rule in someone's catalogue.

**The batches run concurrently, also on evidence.** The issue asked whether chunked calls serialise per API key. They do not: four simultaneous ten-rule calls finished in 22 s where the same four run one after another took 91. So a 70-rule catalogue costs roughly one batch of wall clock rather than seven. `compliance.ai.batch-concurrency` defaults to 4, and setting it to 1 is the right move for an endpoint that rate-limits per key.

## The queue

New table `compliance_generation_jobs` (changelog 062). `POST /compliance/jobs?projectId=` inserts a row and answers with it; `GET /compliance/jobs/{id}` is the poll; `GET /compliance/jobs?projectId=` returns the latest run for a project, which is how a page that was reloaded mid-run finds what it was watching.

**Status model.** Five states, because a caller has five things to show and no fewer:

| status | means |
|---|---|
| `queued` | accepted, waiting for a worker |
| `running` | a worker has it; the progress counters move here |
| `succeeded` | every rule assessed, compliances created |
| `nothing-to-report` | every rule assessed, nothing to create (none applied, or all already existed) |
| `failed` | did not cover every rule; nothing created |

Splitting `succeeded` from `nothing-to-report` is the whole point of the set. Before #528, "the answer was cut short and we lost it" and "there is nothing outstanding for this project" both reached the user as an empty list. A job that recorded both as one success state would have put that ambiguity straight back, one layer further from anyone who could notice. `failed` is the third of the three, and it never carries a count.

**Progress.** `batchesDone/batchesTotal` and `rulesAssessed/rulesTotal`, written after each batch in their own short transaction. They are progress and never a partial result: a run that stops at batch three has assessed some rules and produced nothing.

**Preconditions stay at accept time.** No project, no project type, no recognisable state, no rules for the jurisdiction, AI not configured: all decidable from the database and configuration, so they are raised on the request as the 400 or 404 they have always been. Only failures that genuinely need the model come back later as a failed job.

**One job per project.** A partial unique index on `(organization_id, project_id) WHERE status IN ('QUEUED','RUNNING')`. A second click joins the run in flight rather than starting a second one, and the loser of an insert race reads back the winner and hands that to its caller. This is #510's race closed one step earlier, where it matters more, because a duplicate run spends a minute of inference before it gets far enough to collide.

**Which replica.** Every replica polls every two seconds; a claim is `UPDATE ... SET status='RUNNING' WHERE id=? AND status='QUEUED'` and only one can win. No leader (a replica that wrongly believes it is one is a failure mode this design cannot have), no advisory locks (CockroachDB has none), no broker (Redis is optional and off by default here, so a Redis-only queue would be a second configuration axis for every environment). The claim writes a lease that the worker pushes forward as it finishes each batch, so progress and liveness are the same signal and cannot get out of step. A dead replica's lease goes stale and the next poll on any replica returns the row to the queue, or fails it if its attempts are gone. The attempt is counted by the claim, so a job that kills its worker before the worker writes anything still stops eventually.

**Tenancy.** The poller cannot have a tenant, since its job is to find out which tenant to become, so its queries are native and return bare scalars, never entities: a Hibernate `@Filter` does not apply to native SQL, so the intent is in the query rather than in ambient thread state a later edit could widen. Everything after the claim runs inside `TenantScopedJobRunner`, which refuses a null org id rather than running unscoped.

**Approval queues too.** `ComplianceGenerationListener` inserts a job instead of running generation on an `@Async` thread. That thread was watched by nothing and outlived by nothing: a replica restarted mid-run left an approved project with no compliances and no record that generation had ever been attempted.

## Partial batch failure

**A failed batch fails the whole run and creates nothing.** Batch 3 of 5 failing means the run has no opinion at all about the rules in batches 3 to 5. Handing back batches 1 and 2 would create their compliances and show the user a finished result silently missing three fifths of the jurisdiction, which is the exact failure this module exists to prevent, and is #528's rule applied one level up. The job goes to `failed`, or back to `queued` if it has attempts left, with the reason on the row either way so a caller polling through a retry is told what is going wrong. Re-running is cheap and idempotent per rule, which is what makes throwing the work away affordable.

## `POST /compliance/regenerate` is still there

Unchanged, still synchronous, still 200/409/502, so `echno-web` #315 keeps working. It is marked in the OpenAPI description as the shape to move off, and should be deleted once the web client is on the job endpoints. Batching pushes its ceiling out (a 70-rule catalogue now runs in about the time one batch takes) but does not remove it, and it will not survive a big enough catalogue.

## Tests

Every new test was run against the code without its fix to confirm it fails for the reason it claims. See the failing-test table in the review notes.

`ComplianceGenerationServiceIT` gained the job-table cases rather than getting a sibling IT, so the suite keeps one cached Spring context instead of two. Those are the cases only a real CockroachDB can settle: that the partial index predicate holds, that finished jobs do not block a new run, that two claims cannot both win, and that lease recovery moves a row the way it is supposed to. Everything else is plain JUnit and Mockito with no context at all.

## Not done here

- **The web client.** Nothing in `echno-web` uses the job endpoints yet; that is its own change, and until it lands the button still goes through `regenerate`.
- **The nightly sweep.** When Anand's catalogue lands, every already-approved project in an affected jurisdiction is silently missing compliances and nothing regenerates them. That needs a change timestamp on `ComplianceRule` and is a separate piece of work.
- **The hardcoded 60 s read timeout** in `requestFactory()`. It is no longer the binding constraint at a batch size of ten, but it is still a constant where the rest of this is configuration.

