### PR TITLE
Refuse a project created already approved, and an issue created already resolved

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -37,6 +37,12 @@ public class IssueService {
 
     private static final String ISSUES_FOLDER = "issues";
 
+    /**
+     * The state an issue starts in, and the only one create accepts. It is what the web client's
+     * issue form already defaults to.
+     */
+    private static final IssueStatus CREATION_STATUS = IssueStatus.open;
+
     private final IssueRepository issueRepository;
     private final TaskRepository taskRepository;
     private final AttachmentService attachmentService;
@@ -66,16 +72,21 @@ public class IssueService {
     /**
      * Creates a new issue against a task, with any attachments that came with it.
      *
+     * <p>The issue starts {@link IssueStatus#open}, whether the payload says so or says nothing,
+     * and any other starting value is refused: see {@link #requireCreatableStatus}.
+     *
      * @param issueCreationDto DTO containing the details for the new issue.
      * @param attachments      Files uploaded with the issue, or null when there are none.
      * @return The created issue.
      * @throws ConstraintViolationException if the payload fails its own constraints.
+     * @throws InvalidRequestException if the payload asks for a status other than open.
      * @throws ResourceNotFoundException if the task, the creator or the assignee is not found in
      *                                   this organization.
      */
     @Transactional
     public IssueSimpleDto addIssue(IssueCreationDto issueCreationDto, List<MultipartFile> attachments) {
         payloadValidator.requireValid(issueCreationDto);
+        requireCreatableStatus(issueCreationDto.getStatus());
         Task task = taskRepository.findByIdAndOrganization_Id(issueCreationDto.getTaskId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task with ID " + issueCreationDto.getTaskId() + " was not found in this organization"));
         Employee creator = employeeRepository.findByIdAndOrganizationId(issueCreationDto.getCreatedById(), TenantContext.getCurrentOrgId())
@@ -84,7 +95,7 @@ public class IssueService {
         issue.setTitle(issueCreationDto.getTitle());
         issue.setDescription(issueCreationDto.getDescription());
         issue.setType(parseIssueType(issueCreationDto.getType()));
-        issue.setStatus(parseIssueStatus(issueCreationDto.getStatus()));
+        issue.setStatus(CREATION_STATUS);
         issue.setCreatedBy(creator);
         issue.setTask(task);
         issue.setOrganization(task.getOrganization());
@@ -161,6 +172,33 @@ public class IssueService {
             return IssueType.valueOf(type);
         } catch (IllegalArgumentException e) {
             throw new InvalidRequestException("'" + type + "' is not a valid issue type");
+        }
+    }
+
+    /**
+     * Refuses an issue asked to be created in any state but {@link #CREATION_STATUS}.
+     *
+     * <p>Raising an issue is open to every member of the tenant
+     * ({@code IssueControllerWeb.createIssue}), while changing one is not: the patch endpoint
+     * wants {@code system-admin} or {@code project-manager}. A create that copied the payload's
+     * status therefore handed every member the moves that gate was written to withhold, and
+     * {@code resolved} and {@code closed} most of all, since an issue nobody with the authority to
+     * close it ever closed reads exactly like one that was properly dealt with.
+     *
+     * <p>This is the rule {@code PurchaseOrderService.createPurchaseOrder} applies: a create may
+     * not reach a state whose transition carries a check or an event. Here the patch endpoint
+     * gates every transition, so {@code open} is all that is left.
+     *
+     * @param status The status the create payload asked for, or null when it asked for none.
+     * @throws InvalidRequestException if that status is anything but {@link #CREATION_STATUS}.
+     */
+    private void requireCreatableStatus(IssueStatus status) {
+        if (status != null && status != CREATION_STATUS) {
+            throw new InvalidRequestException(
+                    "An issue is raised as " + CREATION_STATUS + " and cannot be created as "
+                            + status + ". Raise it first, then move it with the issue update "
+                            + "endpoint, which is where the authority to change an issue's status "
+                            + "is checked.");
         }
     }
 

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -1,12 +1,14 @@
 package org.tornotron.echno_backend.issue.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
 
 @Data
 public class IssueCreationDto {
@@ -34,9 +36,19 @@ public class IssueCreationDto {
     @JsonAlias("issueType")
     private String type;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private String status;
+    /**
+     * The state the issue starts in. Optional, and {@code open} is the only value accepted:
+     * raising an issue is open to every member of the tenant, while moving one is not, so any
+     * other starting value would be a state the same caller could not have reached by asking
+     * for it. See {@code IssueService.addIssue}.
+     */
+    @Schema(description = "State the issue starts in. Optional, and open is the only value "
+            + "accepted, so leaving it out is the same as sending open. Every later state change "
+            + "goes through PATCH /issues/{id}, which only a system-admin or project-manager may "
+            + "call; being able to raise an issue that is already resolved or closed would hand "
+            + "every member the one move that endpoint exists to withhold.",
+            example = "open", allowableValues = {"open"})
+    private IssueStatus status;
 
     private Long createdById;
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -46,6 +46,13 @@ public class ProjectService {
 
     private static final String PROJECTS_FOLDER = "projects";
 
+    /**
+     * The state a project starts in when the create payload names none. It is what the web
+     * client's create form already defaults to, and what {@code echno-core} documents the server
+     * as defaulting to, so making it explicit here settles a contract both sides had assumed.
+     */
+    private static final ProjectCreationStatus DEFAULT_CREATION_STATUS = ProjectCreationStatus.upcoming;
+
     private final ProjectRepository repository;
     private final OrganizationRepository organizationRepository;
     private final EmployeeRepository employeeRepository;
@@ -88,13 +95,19 @@ public class ProjectService {
     /**
      * Creates a new project.
      *
+     * <p>The project starts in the status the payload names, or {@link #DEFAULT_CREATION_STATUS}
+     * when it names none. {@code approved} is the one value refused, because approval is a
+     * transition and not a starting value: see {@link #requireNotApprovedOnCreate}.
+     *
      * @param projectDto DTO containing the details for the new project.
      * @return A simple DTO of the newly created project.
+     * @throws InvalidRequestException if the payload asks for a project that is already approved.
      * @throws ResourceNotFoundException if the organization specified in the DTO does not exist.
      */
     @Transactional
     public ProjectSimpleDto addProject(ProjectCreationDto projectDto,List<MultipartFile> attachments) {
             payloadValidator.requireValid(projectDto);
+            requireNotApprovedOnCreate(projectDto.getStatus());
             Long orgId = TenantContext.getCurrentOrgId();
             Organization organization = organizationRepository.findById(orgId)
                     .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -110,7 +123,9 @@ public class ProjectService {
             project.setCreatedAt(LocalDateTime.now());
             project.setProjectLatitude(projectDto.getProjectLatitude());
             project.setProjectLongitude(projectDto.getProjectLongitude());
-            project.setStatus(ProjectCreationStatus.valueOf(projectDto.getStatus()));
+            project.setStatus(projectDto.getStatus() != null
+                    ? projectDto.getStatus()
+                    : DEFAULT_CREATION_STATUS);
             if (projectDto.getProjectType() != null && !projectDto.getProjectType().isBlank()) {
                 project.setProjectType(ProjectType.valueOf(projectDto.getProjectType()));
             }
@@ -313,6 +328,37 @@ public class ProjectService {
         Long orgId = project.getOrganization() != null ? project.getOrganization().getId() : null;
         // The listener runs AFTER_COMMIT, so the row is durable before the AI flow reads it.
         eventPublisher.publishEvent(new ProjectApprovedEvent(this, project.getId(), orgId));
+    }
+
+    /**
+     * Refuses a project asked to be created already approved.
+     *
+     * <p>Approval is the only project transition with anything behind it. {@link #onApproval}
+     * checks that the project's state is known and publishes {@link ProjectApprovedEvent}, which
+     * is what draws up the project's compliance inspections. Both run on the patch path, so a
+     * create that wrote {@code approved} straight onto the row skipped them, and no later patch
+     * could make up for it: {@link #onApproval} fires only on the transition INTO approved, and a
+     * project that was born approved never makes that transition. The project stays approved for
+     * good with no compliance work ever drawn up, and its only outward sign is an absence.
+     *
+     * <p>Every other status is a label with no transition behind it, so create still accepts them
+     * all. This is the same rule {@code PurchaseOrderService.createPurchaseOrder} applies: a
+     * create may not reach a state whose transition carries a check or an event; the set of
+     * states that leaves is whatever each entity's state machine happens to gate.
+     *
+     * @param status The status the create payload asked for, or null when it asked for none.
+     * @throws InvalidRequestException if that status is {@code approved}.
+     */
+    private void requireNotApprovedOnCreate(ProjectCreationStatus status) {
+        if (status == ProjectCreationStatus.approved) {
+            throw new InvalidRequestException(
+                    "A project cannot be created already approved. Approval draws up the project's "
+                            + "compliance inspections from the regulations of the state it is built "
+                            + "in, and a project created as approved never makes that transition, so "
+                            + "those inspections would never be drawn up and nothing later could put "
+                            + "it right. Create the project, then approve it with "
+                            + "PATCH /projects/{id}.");
+        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -3,13 +3,12 @@ package org.tornotron.echno_backend.project.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -53,11 +52,19 @@ public class ProjectCreationDto {
     @Schema(description = "Creation timestamp, set server side when omitted.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "Initial project status.", example = "IN_PROGRESS")
-    @NotBlank(message = "status is required")
-    @Size(min = 3,max = 50,message = "status must be between 3 and 50 characters")
-    @Enumerated(EnumType.STRING)
-    private String status;
+    /**
+     * The state the project starts in. Optional, and {@code approved} is refused: approval draws
+     * up the project's compliance inspections, so it is a transition rather than a starting
+     * value. See {@code ProjectService.addProject}.
+     */
+    @Schema(description = "State the project starts in. Optional, and upcoming when left out. "
+            + "Every value except approved is accepted. A project is approved through "
+            + "PATCH /projects/{id}, which is what checks that its state is known and draws up its "
+            + "compliance inspections; approving it on the create form would skip both, and nothing "
+            + "later can put that right because the project is already approved by then.",
+            example = "upcoming",
+            allowableValues = {"open", "closed", "upcoming", "completed", "dropped", "onHold", "cancelled"})
+    private ProjectCreationStatus status;
 
     /** Optional construction category (e.g. RESIDENTIAL, COMMERCIAL). Drives compliance matching. */
     @Schema(description = "Optional construction category. Drives compliance matching.", example = "RESIDENTIAL")

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreateStatusTest.java
@@ -1,0 +1,174 @@
+package org.tornotron.echno_backend.issue;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Raising an issue is open to every member of the tenant; changing one is not, and wants
+ * {@code system-admin} or {@code project-manager}. A create that copied the payload's status
+ * therefore let a member land an issue straight in {@code resolved} or {@code closed}, which is
+ * the move that gate exists to withhold. These pin that create takes only {@code open}.
+ *
+ * <p>Plain Mockito with a real validator and no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class IssueCreateStatusTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private IssueRepository issueRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private IssueMapper issueMapper;
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    private IssueService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new IssueService(issueRepository, taskRepository, attachmentService,
+                issueMapper, employeeRepository, new PayloadValidator(validator));
+
+        TenantContext.setCurrentOrgId(1L);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        Task task = new Task();
+        task.setOrganization(organization);
+        when(taskRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(task));
+        when(employeeRepository.findByIdAndOrganizationId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(new Employee()));
+        when(issueRepository.save(any(Issue.class))).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private IssueCreationDto validDto() {
+        IssueCreationDto dto = new IssueCreationDto();
+        dto.setTitle("Honeycombing on the block A raft");
+        dto.setDescription("Voids visible along the north edge of the pour after stripping.");
+        dto.setType("quality");
+        dto.setTaskId(11L);
+        dto.setCreatedById(5L);
+        return dto;
+    }
+
+    @Test
+    void addIssue_refusesAnIssueRaisedAlreadyResolved() {
+        IssueCreationDto dto = validDto();
+        dto.setStatus(IssueStatus.resolved);
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be created as resolved");
+
+        verify(issueRepository, never()).save(any());
+    }
+
+    @Test
+    void addIssue_refusesAnIssueRaisedAlreadyClosed() {
+        IssueCreationDto dto = validDto();
+        dto.setStatus(IssueStatus.closed);
+
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be created as closed");
+
+        verify(issueRepository, never()).save(any());
+    }
+
+    @Test
+    void addIssue_refusesEveryStartingStateButOpen() {
+        // The patch endpoint gates every transition, not only the terminal ones, so any other
+        // starting value is a state the same caller could not have asked to move the issue into.
+        for (IssueStatus status : IssueStatus.values()) {
+            if (status == IssueStatus.open) {
+                continue;
+            }
+            IssueCreationDto dto = validDto();
+            dto.setStatus(status);
+
+            assertThatThrownBy(() -> service.addIssue(dto, null))
+                    .isInstanceOf(InvalidRequestException.class);
+        }
+
+        verify(issueRepository, never()).save(any());
+    }
+
+    @Test
+    void addIssue_raisesTheIssueOpenWhenThePayloadNamesNoStatus() {
+        IssueCreationDto dto = validDto();
+        dto.setStatus(null);
+
+        service.addIssue(dto, null);
+
+        assertThat(savedIssue().getStatus()).isEqualTo(IssueStatus.open);
+    }
+
+    @Test
+    void addIssue_raisesTheIssueOpenWhenThePayloadAsksForOpen() {
+        IssueCreationDto dto = validDto();
+        dto.setStatus(IssueStatus.open);
+
+        service.addIssue(dto, null);
+
+        assertThat(savedIssue().getStatus()).isEqualTo(IssueStatus.open);
+    }
+
+    private Issue savedIssue() {
+        ArgumentCaptor<Issue> captor = ArgumentCaptor.forClass(Issue.class);
+        verify(issueRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
@@ -2,9 +2,12 @@ package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * The create endpoint parses {@link IssueCreationDto} from a multipart string
@@ -24,7 +27,7 @@ class IssueCreationDtoTest {
                 IssueCreationDto.class);
 
         assertThat(dto.getType()).isEqualTo("safety");
-        assertThat(dto.getStatus()).isEqualTo("open");
+        assertThat(dto.getStatus()).isEqualTo(IssueStatus.open);
     }
 
     @Test
@@ -34,5 +37,25 @@ class IssueCreationDtoTest {
                 IssueCreationDto.class);
 
         assertThat(dto.getType()).isEqualTo("quality");
+    }
+
+    /**
+     * The reason a field can be taken off a create payload without sequencing the deploy behind
+     * the web client's. {@link Jackson2ObjectMapperBuilder} is what Spring Boot's Jackson
+     * auto-configuration builds the injected mapper from, and it leaves
+     * {@code FAIL_ON_UNKNOWN_PROPERTIES} off; nothing in {@code application.yml} turns it back
+     * on. So a client still sending a field the payload no longer declares is not broken by the
+     * backend going first, and a client that has stopped sending one is not broken by it going
+     * second.
+     */
+    @Test
+    void ignoresAFieldThePayloadNoLongerDeclares() {
+        ObjectMapper springMapper = Jackson2ObjectMapperBuilder.json().build();
+
+        assertThatCode(() -> springMapper.readValue(
+                "{\"title\":\"A title\",\"description\":\"A description\",\"type\":\"quality\","
+                        + "\"aFieldThisPayloadDoesNotHave\":\"anything\"}",
+                IssueCreationDto.class))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.mapper.IssueMapper;
 import org.tornotron.echno_backend.task.TaskRepository;
 
@@ -70,7 +71,7 @@ class IssueCreationValidationTest {
         dto.setTitle("Honeycombing on the block A raft");
         dto.setDescription("Voids visible along the north edge of the pour after stripping.");
         dto.setType("quality");
-        dto.setStatus("open");
+        dto.setStatus(IssueStatus.open);
         dto.setTaskId(11L);
         dto.setCreatedById(5L);
         return dto;
@@ -113,15 +114,6 @@ class IssueCreationValidationTest {
     void addIssue_rejectsAMissingType() {
         IssueCreationDto dto = validDto();
         dto.setType(null);
-
-        assertThatThrownBy(() -> service.addIssue(dto, null))
-                .isInstanceOf(ConstraintViolationException.class);
-    }
-
-    @Test
-    void addIssue_rejectsAMissingStatus() {
-        IssueCreationDto dto = validDto();
-        dto.setStatus(null);
 
         assertThatThrownBy(() -> service.addIssue(dto, null))
                 .isInstanceOf(ConstraintViolationException.class);

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreateStatusTest.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.project;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Approval is the one project transition with anything behind it: a check that the project's
+ * state is known, and the event that draws up its compliance inspections. Both live on the patch
+ * path, so a create that wrote {@code approved} onto the row went round them, and no later patch
+ * could make up for it, because the approval hook fires only on the transition INTO approved and
+ * a project born approved never makes it. These pin that create refuses that value and lets the
+ * rest through.
+ *
+ * <p>Plain Mockito with a real validator and no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectCreateStatusTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private ProjectRepository repository;
+    @Mock
+    private OrganizationRepository organizationRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private ProjectMapper projectMapper;
+    @Mock
+    private EmployeeMapper employeeMapper;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private CustomerRepository customerRepository;
+
+    private ProjectService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new ProjectService(repository, organizationRepository, employeeRepository,
+                attachmentService, projectMapper, employeeMapper, eventPublisher,
+                customerRepository, new PayloadValidator(validator));
+
+        TenantContext.setCurrentOrgId(1L);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(organization));
+        when(repository.existsProjectByProjectName(anyString())).thenReturn(false);
+        when(repository.save(any(Project.class))).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private ProjectCreationDto validDto() {
+        ProjectCreationDto dto = new ProjectCreationDto();
+        dto.setProjectName("Riverside Tower");
+        dto.setProjectAddress("12 Mount Road, Mylapore, Tamil Nadu");
+        dto.setProjectState("Tamil Nadu");
+        return dto;
+    }
+
+    @Test
+    void addProject_refusesAProjectAskedToBeCreatedAlreadyApproved() {
+        // Nothing is written and nothing is published: an approved row with no event behind it is
+        // the state that can never be put right, since the approval hook fires only on the
+        // transition into approved and a project born approved never makes it.
+        ProjectCreationDto dto = validDto();
+        dto.setStatus(ProjectCreationStatus.approved);
+
+        assertThatThrownBy(() -> service.addProject(dto, null))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be created already approved");
+
+        verify(repository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(Object.class));
+    }
+
+    @Test
+    void addProject_startsAProjectUpcomingWhenThePayloadNamesNoStatus() {
+        ProjectCreationDto dto = validDto();
+        dto.setStatus(null);
+
+        service.addProject(dto, null);
+
+        assertThat(savedProject().getStatus()).isEqualTo(ProjectCreationStatus.upcoming);
+    }
+
+    @Test
+    void addProject_keepsEveryStatusThatCarriesNoTransitionBehindIt() {
+        // Only approved has a check and an event behind it, so narrowing further would refuse
+        // what the create form offers today for no gain.
+        for (ProjectCreationStatus status : ProjectCreationStatus.values()) {
+            if (status == ProjectCreationStatus.approved) {
+                continue;
+            }
+            ProjectCreationDto dto = validDto();
+            dto.setStatus(status);
+
+            assertThatCode(() -> service.addProject(dto, null)).doesNotThrowAnyException();
+        }
+    }
+
+    private Project savedProject() {
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        verify(repository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -70,7 +71,7 @@ class ProjectCreationValidationTest {
         ProjectCreationDto dto = new ProjectCreationDto();
         dto.setProjectName("Riverside Tower");
         dto.setProjectAddress("12 Mount Road, Mylapore");
-        dto.setStatus("upcoming");
+        dto.setStatus(ProjectCreationStatus.upcoming);
         return dto;
     }
 


### PR DESCRIPTION
Part of #541. Fixes the two entries in that survey that are not hygiene, and leaves the other fourteen where they are, so **#541 stays open**.

#541 ranked sixteen create endpoints that copy a caller-supplied status onto the entity. Most of them reach a terminal value the update path would have let the same caller reach anyway, so they are state-machine hygiene. Two are not:

- **Project.** `status: "approved"` on create writes an approved project past both halves of the approval contract: `requireStateForApproval`, and the `ProjectApprovedEvent` publish that draws up the project's compliance inspections. The project is then approved for good with no compliance work ever done, and no later patch can put it right, because `onApproval` fires only on the transition INTO approved and a project born approved never makes that transition. Its only outward sign is an absence.
- **Issue.** Raising an issue is open to every member of the tenant (`IssueControllerWeb:136`); moving one wants `system-admin` or `project-manager` (`:156`). Create let a member land an issue straight in `resolved` or `closed`, which is precisely the move the gate exists to withhold.

## The shape, and why it is the same shape as #540

#540 put one rule on `PurchaseOrderService.createPurchaseOrder`: **a create may not reach a state whose transition carries a check or an event; every later change goes through the path that carries them.** The field stays on the payload, typed as its enum and optional, so a caller asking for a state it may not have is told so rather than quietly given another one, and the `allowableValues` on the schema says which values are real.

Both fixes here are that rule applied unchanged. What differs is only the size of the allow-set it leaves, because it is each entity's own state machine that decides which transitions are gated:

| | gated transition | left for create | absent status means |
|---|---|---|---|
| Purchase order (#540) | approve, send, and every later move, behind `PATCH /{id}/status` | `DRAFT` | `DRAFT` |
| Project | `approved` alone: `requireStateForApproval` plus the compliance event, on `PATCH /projects/{id}` | every status except `approved` | `upcoming` |
| Issue | every status change, behind `PATCH /issues/{id}` and its role gate | `open` | `open` |

**Why the project allow-set is not narrowed to one value.** `approved` is the only project status with anything behind it; the other seven are labels, and the patch path applies no check to them that create would be going round. Narrowing to `upcoming` alone would start refusing the `open` that five live projects sit in and that the create form offers, for no safety gained. If you want the tighter single-state rule anyway, it is a one-line change to `requireNotApprovedOnCreate`. The issue allow-set genuinely is one value, because the patch endpoint there gates every transition rather than one.

**`upcoming` as the project default is not a new decision.** `echno-core`'s `ProjectCreate.status` already documents "Defaults server-side to `ProjectStatus.upcoming` when omitted", and the web create form already starts there. The field was `@NotBlank` on the backend, so that documented default had never once been the server's actual behaviour. It is now.

## Existing data: one approved project, and it has no compliance

Read-only against the live `echno.in` database on `.116`.

| | |
|---|---|
| Projects in the tenant | 27 |
| By status | `upcoming` 19, `open` 5, `approved` **1**, `completed` 1, `onHold` 1 |
| Approved projects | id 27, "Demo Project", org 1, created 2026-08-25 |
| Its inspections | **0**, of any type, compliance or otherwise |

So exactly one project is approved, and it has no compliance inspections. Two things about it that matter, and one I could not settle:

- **Whether it was created approved or patched to approved cannot be determined.** There is no audit trail on `project`, the table has no `updated_at`, and this deployment has no compliance-job rows to read either. The tempting argument, that `project_state` is null and its address is "Chennai" which names no state, so the approval gate would have refused it, does not hold: `requireStateForApproval` landed on 2026-08-28 and the project was created on 2026-08-25. Before that, the patch path would have approved it just as happily. I can say the row is consistent with a create-as-approved and cannot say it was one.
- **It could not have generated compliance by either route.** It has no `projectState`, and the address scan finds no state in "Chennai", so `IndianStateResolver.forProject` returns null for it. Even a correctly published event would have found no jurisdiction to draw rules from.

**Recommendation, and no migration in this PR.** Do not backfill. Firing `ProjectApprovedEvent` retroactively for already-approved projects is a decision about generating real compliance work against real jurisdictions, not a cleanup, and it is not one a migration should make quietly on somebody's behalf. For this single row the concrete step is smaller than a migration anyway: it is a demo project with no state set, so someone should set its state and, if it is meant to be a live project at all, regenerate its compliance through `POST /compliance/regenerate`. What is worth building separately, and is already noted as not-done on #540, is the sweep that finds approved projects with no compliances and offers to generate them, since Anand's rule catalogue landing will create the same gap for projects approved perfectly legitimately.

## Deploy ordering: there is none to arrange

Both fields stay on their payloads, so nothing the web client sends today stops being understood by a backend that deploys first. The one interaction is intended and is the point of the change: a create that names `approved` for a project, or anything but `open` for an issue, now comes back 400 with a message naming the endpoint to use instead.

The broader claim from #540, that a field can be taken off a create payload without sequencing the deploy behind the client's, holds here too and is now pinned by a test rather than asserted. `Jackson2ObjectMapperBuilder` is what Spring Boot's Jackson auto-configuration builds the injected `ObjectMapper` from, it leaves `FAIL_ON_UNKNOWN_PROPERTIES` off, and nothing in `application.yml` turns it back on (`spring.jackson` there sets only `date-format` and `write-dates-as-timestamps`). `JsonPartBinder` takes that same injected mapper, so both multipart create paths inherit it. `IssueCreationDtoTest.ignoresAFieldThePayloadNoLongerDeclares` holds that property. Nobody needs to sequence anything.

## The web client will need a follow-up

Not a deploy dependency, but a real one: `project-form.tsx` offers `ProjectStatus.approved` in the create dropdown, and `issue-form.tsx` offers all eight issue statuses in create mode. Both choices now come back 400. Filed as tornotron/echno-web#319 to hide the ineligible options on create; until it lands the failure is a clear message rather than a wrong write, which is the right way round.

## Tests

Nine tests, all plain JUnit and Mockito with a real Hibernate Validator and no Spring context, so the run gains no cached context.

Each was run against the code with the guard reverted (the `requireNotApprovedOnCreate` / `requireCreatableStatus` calls removed and the payload's status copied straight onto the entity, as before). Not padded: three of the nine pass under the revert, and they are listed as passing with the reason.

| Test | Without the fix | Why |
|---|---|---|
| `ProjectCreateStatusTest.addProject_refusesAProjectAskedToBeCreatedAlreadyApproved` | **FAILED** | No exception raised; the approved project is saved. The companion assertion that no event is published passes under the revert, because publishing nothing is exactly the defect. |
| `ProjectCreateStatusTest.addProject_startsAProjectUpcomingWhenThePayloadNamesNoStatus` | **FAILED** | Saved with a null status; there was no default. |
| `ProjectCreateStatusTest.addProject_keepsEveryStatusThatCarriesNoTransitionBehindIt` | passed | It pins that the fix did not over-narrow. Nothing was refused before, so it could not have failed. Regression guard on the allow-set, not proof of the defect. |
| `IssueCreateStatusTest.addIssue_refusesAnIssueRaisedAlreadyResolved` | **FAILED** | The issue is saved `resolved` by a caller with only member rights. |
| `IssueCreateStatusTest.addIssue_refusesAnIssueRaisedAlreadyClosed` | **FAILED** | Same, `closed`. |
| `IssueCreateStatusTest.addIssue_refusesEveryStartingStateButOpen` | **FAILED** | Every one of the other seven statuses is accepted. |
| `IssueCreateStatusTest.addIssue_raisesTheIssueOpenWhenThePayloadNamesNoStatus` | **FAILED** | Saved with a null status; status was `@NotNull` and there was no default. |
| `IssueCreateStatusTest.addIssue_raisesTheIssueOpenWhenThePayloadAsksForOpen` | passed | `open` in, `open` out, before and after. It pins that the legitimate case still works. |
| `IssueCreationDtoTest.ignoresAFieldThePayloadNoLongerDeclares` | passed | It pins the deploy-ordering property above, which is a property of the mapper and not of this fix. |

Existing tests adjusted for the enum-typed fields: `ProjectCreationValidationTest` and `IssueCreationValidationTest` set the enum instead of a string, and `IssueCreationValidationTest.addIssue_rejectsAMissingStatus` is gone, because a missing status is now the documented way to ask for the default rather than a constraint failure.

`./gradlew test --tests "*.project.*" --tests "*.issue.*" --tests "*ReadWriteGuardSymmetryTest" --tests "*CappedWebListingTest" --tests "*GlobalExceptionHandlerTest"` is green on the lab box, `ProjectRepositoryIT` and `ProjectApprovalStateTest` included. The full suite runs on CI here.

## Still open on #541, deliberately

Closing #541 on this PR would lose the other fourteen. Left exactly as they are:

- **StockAdjustment** (#541 rank 3). Free string, so `"APPROVED"` is accepted while `approvedBy` and `approvedAt` stay null, and there is no status endpoint to correct or audit it. Needs an enum and a status endpoint built, not a guard added.
- **SiteTransfer** (rank 4). `COMPLETED` on create goes round the role-gated `PATCH /{id}/status` while stock movement publishes either way, so a transfer is recorded as received with nobody confirming receipt. Same role guards both paths, so it is a state-machine hole rather than an escalation.
- **Expense, Receipt, SubContract, Asset** (rank 5). Free strings with no enum, no state machine and no status endpoint. `"approved"` is data today, which is the only reason the risk is low.
- **Task, WBS, Indent, Vendor, Labour, Employee join, InviteCode** (rank 6). Enum-validated, terminal values reachable, but the update path carries the identical role gate. Hygiene.
- **`EmployeeCreationDto.status`** (rank 7). `@NotBlank`, documented in Swagger, then silently discarded. Delete it rather than gate it.
- **`ConstructionPaymentService` update** (the adjacent item). Copies `req.status()` wholesale on update, so `COMPLETED` and `REFUNDED` are reachable through a plain `PUT`. Same class of defect on the update path, and not touched here.

## Review

No CodeRabbit review ran. The bot's check reports `pass` with "Review rate limited", which is the free-quota refusal that has been standing for hours today and means no review was performed. Merged on green CI plus my own reading, and logged on ClickUp `86d45heqm` for the retro pass once the quota resets.
