### PR TITLE
Give an asset a ledger to say where it has been, and somewhere to keep its papers

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/asset/Asset.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/Asset.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.vendor.Vendor;
 
@@ -19,6 +20,12 @@ import java.time.LocalDateTime;
  * A fixed asset in the organization's asset register. Type/status/condition are stored as
  * plain strings because the web client sends kebab-case values (e.g. {@code heavy-equipment})
  * that are not valid Java enum identifiers; the frontend validates them.
+ *
+ * <p>Where the asset is and who holds it ({@link #assignedProject}, {@link #location},
+ * {@link #assignedTo}, {@link #assignedToId}) is not a second source of truth beside the
+ * movement ledger. Those four columns are a cache of the latest {@link AssetMovement}, and
+ * every write path goes through the one method that appends the entry and sets them together,
+ * so they cannot come to disagree with the history.
  */
 @Entity
 @Data
@@ -63,14 +70,34 @@ public class Asset implements TenantScopedEntity {
     @Column(name = "depreciation_rate")
     private Double depreciationRate;
 
+    /**
+     * Name of the current custodian. Ledger-derived: written only by
+     * {@code AssetService.applyPlacement}, alongside an {@link AssetMovement}.
+     */
     @Column(name = "assigned_to")
     private String assignedTo;
 
+    /** Id of the current custodian. Ledger-derived, as {@link #assignedTo}. */
     @Column(name = "assigned_to_id")
     private Long assignedToId;
 
-    @Column(name = "assigned_project")
-    private String assignedProject;
+    /**
+     * The project the asset is currently deployed on. Ledger-derived: written only by
+     * {@code AssetService.applyPlacement}, alongside an {@link AssetMovement}.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_project_id")
+    private Project assignedProject;
+
+    /**
+     * The free-text project name this asset carried before {@link #assignedProject} became a
+     * reference. Read-only: mapped {@code insertable = false, updatable = false} so nothing can
+     * write it again, which is what makes the reference migration reversible and keeps a value
+     * that matched no project from being lost. The same text is also copied into the asset's
+     * opening ledger entry.
+     */
+    @Column(name = "assigned_project", insertable = false, updatable = false)
+    private String legacyAssignedProject;
 
     @Column(name = "manufacturer")
     private String manufacturer;
@@ -121,6 +148,10 @@ public class Asset implements TenantScopedEntity {
     @JoinColumn(name = "vendor_id")
     private Vendor vendor;
 
+    /**
+     * The storage location the asset currently sits at. Ledger-derived, as
+     * {@link #assignedProject}.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private StorageLocation location;

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -153,8 +154,8 @@ public class AssetControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })
     public ResponseEntity<Page<AssetMovementDto>> readMovements(@PathVariable Long id,
-                                                                @RequestParam(defaultValue = "0") int pageNo,
-                                                                @RequestParam(defaultValue = "20") int pageSize) {
+                                                                @RequestParam(defaultValue = "0") @Min(0) int pageNo,
+                                                                @RequestParam(defaultValue = "20") @Min(1) int pageSize) {
         return new ResponseEntity<>(assetService.getMovements(id, pageNo, pageSize), HttpStatus.OK);
     }
 
@@ -165,8 +166,10 @@ public class AssetControllerWeb {
             description = "Turns consecutive ledger entries into the stretches of time the asset "
                     + "spent in one place, oldest first, with the number of whole days each lasted "
                     + "and the last one left open. Derived from the ledger on every read, so it "
-                    + "cannot drift from it. Reads at most the 500 oldest entries; use the movements "
-                    + "endpoint for an asset with a longer history than that."
+                    + "cannot drift from it. Reads at most the 500 most recent entries: "
+                    + "X-Total-Count carries the true number of movements and X-Result-Capped is "
+                    + "set when older ones were left out, in which case the movements endpoint has "
+                    + "the rest."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Placement history returned"),
@@ -174,7 +177,7 @@ public class AssetControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })
     public ResponseEntity<List<AssetPlacementSpanDto>> readPlacementHistory(@PathVariable Long id) {
-        return new ResponseEntity<>(assetService.getPlacementHistory(id), HttpStatus.OK);
+        return UnpagedResultCap.respond(assetService.getPlacementHistory(id));
     }
 
     @GetMapping("/{id}/documents")

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -12,6 +12,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
 import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementCreationDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
+import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
@@ -25,7 +29,9 @@ import java.util.List;
         description = "Fixed assets in the organization's asset register: excavators, cranes, vehicles "
                 + "and similar equipment tracked with purchase, condition, maintenance and insurance "
                 + "detail. Endpoints cover listing, paginated listing, lookup by id, creation, update and "
-                + "deletion, scoped to the caller's current tenant organization."
+                + "deletion, plus the append-only movement ledger that records where each asset has been "
+                + "and the documents filed against it. All scoped to the caller's current tenant "
+                + "organization."
 )
 public class AssetControllerWeb {
 
@@ -113,14 +119,114 @@ public class AssetControllerWeb {
         return new ResponseEntity<>(assetService.updateAsset(id, creationDto), HttpStatus.OK);
     }
 
+    @PostMapping("/{id}/movements")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Move an asset",
+            description = "Appends an entry to the asset's movement ledger and brings the asset's "
+                    + "current project, storage location and custodian with it. A reason is required: "
+                    + "an entry with no stated reason is what makes a ledger unexplainable. Entries are "
+                    + "never edited or deleted, so an entry made in error is put right by sending "
+                    + "correctsMovementId, which records this entry as a CORRECTION of that one."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Movement recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, the movement is dated in the future, or it would move the asset nowhere"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset, project, location or corrected entry with the given id")
+    })
+    public ResponseEntity<AssetMovementDto> recordMovement(@PathVariable Long id,
+                                                           @Valid @RequestBody AssetMovementCreationDto creationDto) {
+        return new ResponseEntity<>(assetService.recordMovement(id, creationDto), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}/movements")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Read an asset's movement ledger",
+            description = "Returns a page of the asset's movement entries, newest first: what moved, "
+                    + "from where to where, when, by whom and why."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of movements returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
+    public ResponseEntity<Page<AssetMovementDto>> readMovements(@PathVariable Long id,
+                                                                @RequestParam(defaultValue = "0") int pageNo,
+                                                                @RequestParam(defaultValue = "20") int pageSize) {
+        return new ResponseEntity<>(assetService.getMovements(id, pageNo, pageSize), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}/placement-history")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Read how long an asset spent in each place",
+            description = "Turns consecutive ledger entries into the stretches of time the asset "
+                    + "spent in one place, oldest first, with the number of whole days each lasted "
+                    + "and the last one left open. Derived from the ledger on every read, so it "
+                    + "cannot drift from it. Reads at most the 500 oldest entries; use the movements "
+                    + "endpoint for an asset with a longer history than that."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Placement history returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
+    public ResponseEntity<List<AssetPlacementSpanDto>> readPlacementHistory(@PathVariable Long id) {
+        return new ResponseEntity<>(assetService.getPlacementHistory(id), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}/documents")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List an asset's documents",
+            description = "Returns the files filed against the asset: purchase invoice, warranty, "
+                    + "insurance, registration, certifications and service records, each with its "
+                    + "document type and expiry where one was recorded. Upload them through the "
+                    + "attachment endpoints with entityType ASSET_DOCUMENTS and the asset id, then "
+                    + "record the type and expiry with PATCH /api/v1/attachment/web/attachmentId/"
+                    + "{attachmentId}/document."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Documents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
+    })
+    public ResponseEntity<List<AttachmentDto>> readDocuments(@PathVariable Long id) {
+        return new ResponseEntity<>(assetService.getDocuments(id), HttpStatus.OK);
+    }
+
+    @GetMapping("/documents/expiring")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List asset documents that are about to expire",
+            description = "Returns every asset document in the organization whose expiry falls on or "
+                    + "before the given number of days from today, soonest first. Documents that have "
+                    + "already lapsed are included, since those are the ones that most need chasing. "
+                    + "Capped at 500 rows."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Expiring documents returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "withinDays was negative"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
+    })
+    public ResponseEntity<List<AttachmentDto>> readExpiringDocuments(
+            @RequestParam(defaultValue = "30") int withinDays) {
+        return new ResponseEntity<>(assetService.getExpiringDocuments(withinDays), HttpStatus.OK);
+    }
+
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Delete an asset",
-            description = "Removes the asset with the given id from the register."
+            description = "Removes the asset with the given id from the register. Refused once the "
+                    + "asset carries movement entries, because deleting it would take the record of "
+                    + "where the machine has been with it; retire it by setting its status instead."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Asset deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The asset has recorded movements and cannot be deleted"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetDocuments.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetDocuments.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.asset;
+
+/**
+ * The attachment entity type an asset's documents are filed under: purchase invoices,
+ * warranties, insurance policies, registration papers, certifications and service records.
+ *
+ * <p>Nothing had to be built for the storage side of this. {@code attachment} is already keyed
+ * on a free-form {@code entity_type} plus an {@code entity_id}, and the upload, presign,
+ * register, list and delete endpoints all take both as path variables, so an asset's documents
+ * upload through the endpoints that were already there. The storage folder those endpoints
+ * derive is the part of the type before the first underscore, which is why the value follows
+ * the {@code PROJECT_ATTACHMENTS} / {@code TASK_ATTACHMENTS} shape already in use: it lands
+ * asset files under {@code asset/}.
+ */
+public final class AssetDocuments {
+
+    /** Value of {@code attachment.entity_type} for a document filed against an asset. */
+    public static final String ENTITY_TYPE = "ASSET_DOCUMENTS";
+
+    private AssetDocuments() {
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetMovement.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetMovement.java
@@ -1,0 +1,130 @@
+package org.tornotron.echno_backend.asset;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.Immutable;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.time.LocalDateTime;
+
+/**
+ * One entry in an asset's movement ledger: what moved, from where to where, when, by whom
+ * and why.
+ *
+ * <p><strong>Append-only.</strong> The entity is {@link Immutable}, so a row that has been
+ * written is never updated, and {@link AssetMovementRepository} exposes no delete. An entry
+ * made in error is superseded by a {@link AssetMovementType#CORRECTION} that names it in
+ * {@code correctsMovementId}, exactly as a stock correction is a further adjustment rather
+ * than an edit of the one that was wrong.
+ *
+ * <p><strong>Names are snapshotted alongside the foreign keys.</strong> {@code toProject}
+ * and {@code toLocation} can be set to null by a later delete of the row they point at, and
+ * a project can be renamed. History that evaporates when a project is tidied away is not
+ * history, so the name as it read at the time is stored with the entry. The snapshot is also
+ * what carries the free text of an asset whose old {@code assigned_project} string matched no
+ * project when the reference migration ran: the string survives in the ledger rather than
+ * being dropped.
+ */
+@Entity
+@Table(name = "asset_movement", indexes = {
+        @Index(name = "idx_asset_movement_asset", columnList = "asset_id, moved_at"),
+        @Index(name = "idx_asset_movement_organization", columnList = "organization_id")
+})
+@Immutable
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AssetMovement implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "asset_id", nullable = false)
+    private Asset asset;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "movement_type", nullable = false, length = 30)
+    private AssetMovementType movementType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_project_id")
+    private Project fromProject;
+
+    @Column(name = "from_project_name", length = 255)
+    private String fromProjectName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_project_id")
+    private Project toProject;
+
+    @Column(name = "to_project_name", length = 255)
+    private String toProjectName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_location_id")
+    private StorageLocation fromLocation;
+
+    @Column(name = "from_location_name", length = 255)
+    private String fromLocationName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_location_id")
+    private StorageLocation toLocation;
+
+    @Column(name = "to_location_name", length = 255)
+    private String toLocationName;
+
+    @Column(name = "from_assigned_to_id")
+    private Long fromAssignedToId;
+
+    @Column(name = "from_assigned_to", length = 200)
+    private String fromAssignedTo;
+
+    @Column(name = "to_assigned_to_id")
+    private Long toAssignedToId;
+
+    @Column(name = "to_assigned_to", length = 200)
+    private String toAssignedTo;
+
+    /** When the asset actually moved. Supplied by the caller, so it can be backdated. */
+    @Column(name = "moved_at", nullable = false)
+    private LocalDateTime movedAt;
+
+    /** When the entry was written. Set by the database clock and never supplied by a caller. */
+    @CreationTimestamp
+    @Column(name = "recorded_at", nullable = false, updatable = false)
+    private LocalDateTime recordedAt;
+
+    /** The user who recorded the movement, null only where no user context was available. */
+    @Column(name = "moved_by")
+    private Long movedBy;
+
+    /** Why the asset moved. Required: a movement with no stated reason is what makes a ledger unexplainable. */
+    @Column(name = "reason", nullable = false, length = 255)
+    private String reason;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    /** An external document this movement came from, for example a site transfer number. */
+    @Column(name = "reference_number", length = 100)
+    private String referenceNumber;
+
+    /** The entry this one restates, set only on a {@link AssetMovementType#CORRECTION}. */
+    @Column(name = "corrects_movement_id")
+    private Long correctsMovementId;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetMovementRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetMovementRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,13 +24,25 @@ public interface AssetMovementRepository extends Repository<AssetMovement, Long>
     /** One entry by id, refusing to cross tenants. */
     Optional<AssetMovement> findByIdAndOrganization_Id(Long id, Long organizationId);
 
-    /** The ledger for one asset, newest first, for the history screen. */
+    /**
+     * The ledger for one asset, newest first. Serves both the history screen and the placement
+     * spans read off it.
+     *
+     * <p>Newest first rather than oldest on purpose: a capped read of the oldest entries would
+     * mark whichever entry the cap stopped at as the placement the asset is still in, which is a
+     * plain untruth about where the machine is. The page also carries the whole ledger's size, so
+     * a shortened read can say that it was shortened.
+     */
     Page<AssetMovement> findByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
             Long assetId, Long organizationId, Pageable pageable);
 
-    /** The ledger for one asset, oldest first, for working out how long each placement lasted. */
-    List<AssetMovement> findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
-            Long assetId, Long organizationId, Pageable pageable);
+    /**
+     * The latest entry on one asset's ledger, which is the one the asset's placement columns
+     * cache. Used to refuse an entry dated before it, so appended order and chronological order
+     * stay the same thing.
+     */
+    Optional<AssetMovement> findFirstByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
+            Long assetId, Long organizationId);
 
     /** Whether an asset has any recorded history, which is what makes it undeletable. */
     boolean existsByAsset_IdAndOrganization_Id(Long assetId, Long organizationId);

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetMovementRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetMovementRepository.java
@@ -1,0 +1,41 @@
+package org.tornotron.echno_backend.asset;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Reads and appends to the asset movement ledger.
+ *
+ * <p>This deliberately extends {@link Repository} rather than {@code JpaRepository}. Spring
+ * Data only implements the methods a repository actually declares, so the ledger has no
+ * {@code delete}, {@code deleteAll} or {@code saveAll}-over-existing surface for anything to
+ * call by accident. Append-only is a property of the type here, not a convention someone has
+ * to remember; {@link AssetMovement} is {@code @Immutable} on top of that, so an entry cannot
+ * be edited through a loaded instance either.
+ */
+public interface AssetMovementRepository extends Repository<AssetMovement, Long> {
+
+    /** Appends an entry. The only write this repository offers. */
+    AssetMovement save(AssetMovement movement);
+
+    /** One entry by id, refusing to cross tenants. */
+    Optional<AssetMovement> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /** The ledger for one asset, newest first, for the history screen. */
+    Page<AssetMovement> findByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
+            Long assetId, Long organizationId, Pageable pageable);
+
+    /** The ledger for one asset, oldest first, for working out how long each placement lasted. */
+    List<AssetMovement> findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+            Long assetId, Long organizationId, Pageable pageable);
+
+    /** Whether an asset has any recorded history, which is what makes it undeletable. */
+    boolean existsByAsset_IdAndOrganization_Id(Long assetId, Long organizationId);
+
+    /** How many entries an asset carries, so a refusal to delete it can say. */
+    long countByAsset_IdAndOrganization_Id(Long assetId, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetMovementType.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetMovementType.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.asset;
+
+/**
+ * What a row in the asset movement ledger records.
+ *
+ * <p>Unlike the asset's own type, category and status, this value is never supplied
+ * free-form by the web client: it names a kind of ledger entry rather than a label on
+ * a screen, so it is an enum and the set is closed.
+ */
+public enum AssetMovementType {
+
+    /**
+     * The opening entry for an asset: where it was when it first entered the register,
+     * or when the ledger itself was introduced. Every asset has at most one.
+     */
+    REGISTRATION,
+
+    /** The asset physically moved: its project, its storage location, or both changed. */
+    TRANSFER,
+
+    /** The asset stayed put and changed hands: a new custodian took responsibility for it. */
+    ASSIGNMENT,
+
+    /**
+     * An earlier entry was wrong and is being restated. The ledger is append-only, so a
+     * correction is a new row that names the row it corrects rather than an edit of it.
+     */
+    CORRECTION
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetRepository.java
@@ -1,5 +1,8 @@
 package org.tornotron.echno_backend.asset;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +12,13 @@ public interface AssetRepository extends JpaRepository<Asset, Long> {
     Optional<Asset> findByIdAndOrganization_Id(Long id, Long organizationId);
 
     boolean existsByAssetIdAndOrganization_Id(String assetId, Long organizationId);
+
+    /**
+     * The listing read, with the four to-one associations the DTO flattens fetched in the same
+     * query. Without the graph a page of 500 assets costs 500 further selects now that the
+     * project the asset is deployed on is a reference rather than a string.
+     */
+    @Override
+    @EntityGraph(attributePaths = {"vendor", "location", "assignedProject", "organization"})
+    Page<Asset> findAll(Pageable pageable);
 }

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.asset;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -31,6 +32,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -254,12 +256,17 @@ public class AssetService {
      * the point of an append-only ledger: what was believed at the time is still legible.
      */
     @Transactional(readOnly = true)
-    public List<AssetPlacementSpanDto> getPlacementHistory(Long assetId) {
+    public Page<AssetPlacementSpanDto> getPlacementHistory(Long assetId) {
         requireAsset(assetId);
-        List<AssetMovement> movements = assetMovementRepository
-                .findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+        Page<AssetMovement> page = assetMovementRepository
+                .findByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
                         assetId, TenantContext.getCurrentOrgId(),
                         PageRequest.of(0, MAX_HISTORY_ENTRIES));
+        // Read newest-first so the cap drops the oldest entries, then turn it back into
+        // chronological order to build the spans. Capping the oldest end instead would leave
+        // whichever entry the cap stopped at looking like the placement the asset is still in.
+        List<AssetMovement> movements = new ArrayList<>(page.getContent());
+        Collections.reverse(movements);
 
         LocalDateTime now = LocalDateTime.now();
         List<AssetPlacementSpanDto> spans = new ArrayList<>(movements.size());
@@ -283,7 +290,9 @@ public class AssetService {
             span.setDays(Duration.between(movement.getMovedAt(), end != null ? end : now).toDays());
             spans.add(span);
         }
-        return spans;
+        // The total is the whole ledger, not the window, so a capped read says so in its headers
+        // rather than reading as a complete history that happens to be short.
+        return new PageImpl<>(spans, PageRequest.of(0, MAX_HISTORY_ENTRIES), page.getTotalElements());
     }
 
     /**
@@ -365,6 +374,7 @@ public class AssetService {
                     + " cannot be dated " + when + ", which is in the future. A ledger records what"
                     + " has happened, not what is planned.");
         }
+        requireNotBeforeTheLatestEntry(asset, when);
 
         AssetMovement movement = new AssetMovement();
         movement.setAsset(asset);
@@ -397,6 +407,36 @@ public class AssetService {
         asset.setAssignedTo(toAssignedTo);
 
         return appended;
+    }
+
+    /**
+     * Refuses an entry dated before the one already at the end of the ledger.
+     *
+     * <p>A movement may be backdated, for one entered a few days after the machine actually
+     * moved, but not past the last thing recorded. This is what keeps the asset's placement
+     * columns honest: they are set from the entry being appended, so if an entry could land
+     * before an existing later one, the asset would end up showing the older placement while
+     * the ledger's last entry said something else, and the cache and the history would disagree.
+     * That is precisely the failure this whole change exists to remove.
+     *
+     * <p>A movement that really did happen before the last recorded one is entered as a
+     * correction of that entry, which states where the asset is and says what it supersedes.
+     *
+     * @throws InvalidRequestException if the entry is dated before the latest one on the ledger.
+     */
+    private void requireNotBeforeTheLatestEntry(Asset asset, LocalDateTime when) {
+        assetMovementRepository
+                .findFirstByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
+                        asset.getId(), TenantContext.getCurrentOrgId())
+                .filter(latest -> when.isBefore(latest.getMovedAt()))
+                .ifPresent(latest -> {
+                    throw new InvalidRequestException("A movement of asset with ID " + asset.getId()
+                            + " cannot be dated " + when + ", which is before the last entry on its"
+                            + " ledger at " + latest.getMovedAt() + ". Entries are appended in the"
+                            + " order things happened, and the asset's current placement is read off"
+                            + " the last of them. Record a correction of entry " + latest.getId()
+                            + " instead.");
+                });
     }
 
     /** The kind of entry the change amounts to. A correction is always a correction. */

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
@@ -8,50 +8,118 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
 import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementCreationDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
+import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
 import org.tornotron.echno_backend.asset.mapper.AssetMapper;
+import org.tornotron.echno_backend.asset.mapper.AssetMovementMapper;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.vendor.Vendor;
 import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 
 @Service
 public class AssetService {
+
+    /**
+     * Reason recorded when an asset's placement changes through the create or the update
+     * endpoint rather than through the movements endpoint. It says where the entry came from
+     * instead of inventing a reason for a movement nobody explained, and the caller can supply
+     * a real one in {@code movementReason}.
+     */
+    static final String EDIT_REASON = "Recorded from an asset edit";
+
+    /** Reason recorded on the opening entry an asset gets when it is first registered. */
+    static final String REGISTRATION_REASON = "Asset registered";
+
+    /**
+     * Most ledger entries the placement history reads. An asset that has moved more than this
+     * is far past the point where a screen would show every stretch; the movements endpoint is
+     * paginated and answers that case.
+     */
+    static final int MAX_HISTORY_ENTRIES = 500;
 
     private final AssetRepository assetRepository;
     private final AssetMapper assetMapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final VendorRepository vendorRepository;
     private final StorageLocationRepository storageLocationRepository;
+    private final ProjectRepository projectRepository;
+    private final AssetMovementRepository assetMovementRepository;
+    private final AssetMovementMapper assetMovementMapper;
+    private final UserContextService userContextService;
+    private final AttachmentService attachmentService;
 
     public AssetService(AssetRepository assetRepository,
                         AssetMapper assetMapper,
                         TenantEntityHelper tenantEntityHelper,
                         VendorRepository vendorRepository,
-                        StorageLocationRepository storageLocationRepository) {
+                        StorageLocationRepository storageLocationRepository,
+                        ProjectRepository projectRepository,
+                        AssetMovementRepository assetMovementRepository,
+                        AssetMovementMapper assetMovementMapper,
+                        UserContextService userContextService,
+                        AttachmentService attachmentService) {
         this.assetRepository = assetRepository;
         this.assetMapper = assetMapper;
         this.tenantEntityHelper = tenantEntityHelper;
         this.vendorRepository = vendorRepository;
         this.storageLocationRepository = storageLocationRepository;
+        this.projectRepository = projectRepository;
+        this.assetMovementRepository = assetMovementRepository;
+        this.assetMovementMapper = assetMovementMapper;
+        this.userContextService = userContextService;
+        this.attachmentService = attachmentService;
     }
 
+    /**
+     * Registers an asset and opens its movement ledger.
+     *
+     * <p>The placement the payload names is not written straight onto the asset. It goes
+     * through {@link #applyPlacement}, which appends the opening {@code REGISTRATION} entry and
+     * sets the asset's placement columns from it, so an asset has a history from the moment it
+     * exists rather than from the first time somebody happens to move it.
+     */
     @Transactional
     public AssetDto createAsset(AssetCreationDto creationDto) {
         Asset asset = new Asset();
         applyFields(asset, creationDto);
         asset.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
-        return assetMapper.toDto(assetRepository.save(asset));
+        Asset saved = assetRepository.save(asset);
+
+        applyPlacement(saved,
+                resolveProject(creationDto.getAssignedProjectId()),
+                resolveLocation(creationDto.getLocationId()),
+                creationDto.getAssignedToId(),
+                creationDto.getAssignedTo(),
+                reasonOrDefault(creationDto.getMovementReason(), REGISTRATION_REASON),
+                creationDto.getMovedAt(),
+                null, null, null,
+                true);
+
+        return assetMapper.toDto(assetRepository.save(saved));
     }
 
     @Transactional(readOnly = true)
     public AssetDto getAssetById(Long id) {
-        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
-        return assetMapper.toDto(asset);
+        return assetMapper.toDto(requireAsset(id));
     }
 
 
@@ -62,22 +130,332 @@ public class AssetService {
                 .map(asset -> assetMapper.toDto(asset));
     }
 
+    /**
+     * Updates an asset, recording any change of placement as a movement.
+     *
+     * <p>The asset form sends the whole object, so an edit can move the asset as a side effect.
+     * Rather than refuse that and break the screen, the change goes through the same
+     * {@link #applyPlacement} the movements endpoint uses, so the ledger cannot fall behind the
+     * asset. The entry says it came from an edit unless the payload gives a real reason.
+     */
     @Transactional
     public AssetDto updateAsset(Long id, AssetCreationDto creationDto) {
-        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+        Asset asset = requireAsset(id);
         applyFields(asset, creationDto);
+
+        applyPlacement(asset,
+                resolveProject(creationDto.getAssignedProjectId()),
+                resolveLocation(creationDto.getLocationId()),
+                creationDto.getAssignedToId(),
+                creationDto.getAssignedTo(),
+                reasonOrDefault(creationDto.getMovementReason(), EDIT_REASON),
+                creationDto.getMovedAt(),
+                null, null, null,
+                false);
+
         return assetMapper.toDto(assetRepository.save(asset));
     }
 
+    /**
+     * Deletes an asset that has no recorded history.
+     *
+     * <p>An asset that has moved cannot be deleted. Its ledger is the record of where a machine
+     * was, and deleting the asset would take that with it; the same reasoning that stops a
+     * posted stock adjustment being deleted rather than corrected. Retire the asset by setting
+     * its status instead.
+     *
+     * @throws InvalidRequestException if the asset carries ledger entries.
+     */
     @Transactional
     public void deleteAsset(Long id) {
-        Asset asset = assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+        Asset asset = requireAsset(id);
+        long movements = assetMovementRepository
+                .countByAsset_IdAndOrganization_Id(id, TenantContext.getCurrentOrgId());
+        if (movements > 0) {
+            throw new InvalidRequestException("Asset with ID " + id + " has " + movements
+                    + " recorded movements and cannot be deleted, because deleting it would take the"
+                    + " record of where the machine has been with it. Set its status to retired instead.");
+        }
         assetRepository.delete(asset);
     }
 
-    /** Copies the mutable fields from the creation DTO onto the asset, resolving the vendor and location. */
+    /**
+     * Moves an asset and appends the entry that explains the move.
+     *
+     * <p>This is the only path that exists purely to change where an asset is, and the reason is
+     * mandatory on it. Setting {@code correctsMovementId} records the entry as a
+     * {@code CORRECTION} of an earlier one: the wrong entry stays where it is and this one
+     * supersedes it, in the same shape as a posted stock adjustment, which is corrected by
+     * raising a further adjustment rather than by editing the one that was wrong.
+     *
+     * @throws ResourceNotFoundException if the asset, project, location or corrected entry names nothing in this organization.
+     * @throws InvalidRequestException if the movement is dated in the future, or leaves the asset exactly where it already was without being a correction.
+     */
+    @Transactional
+    public AssetMovementDto recordMovement(Long assetId, AssetMovementCreationDto dto) {
+        Asset asset = requireAsset(assetId);
+
+        Long corrects = dto.getCorrectsMovementId();
+        if (corrects != null) {
+            AssetMovement corrected = assetMovementRepository
+                    .findByIdAndOrganization_Id(corrects, TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Asset movement with ID " + corrects
+                            + " was not found in this organization"));
+            if (!Objects.equals(corrected.getAsset().getId(), assetId)) {
+                throw new InvalidRequestException("Asset movement with ID " + corrects
+                        + " belongs to a different asset, so it cannot be corrected on asset with ID " + assetId);
+            }
+        }
+
+        AssetMovement movement = applyPlacement(asset,
+                resolveProject(dto.getToProjectId()),
+                resolveLocation(dto.getToLocationId()),
+                dto.getToAssignedToId(),
+                dto.getToAssignedTo(),
+                dto.getReason(),
+                dto.getMovedAt(),
+                dto.getNotes(),
+                dto.getReferenceNumber(),
+                corrects,
+                false);
+
+        if (movement == null) {
+            throw new InvalidRequestException("Asset with ID " + assetId
+                    + " is already on that project, at that location and with that custodian, so"
+                    + " there is no movement to record. Send correctsMovementId to restate an"
+                    + " earlier entry instead.");
+        }
+
+        assetRepository.save(asset);
+        return assetMovementMapper.toDto(movement);
+    }
+
+    /** One page of an asset's ledger, newest entry first. */
+    @Transactional(readOnly = true)
+    public Page<AssetMovementDto> getMovements(Long assetId, int pageNo, int pageSize) {
+        requireAsset(assetId);
+        return assetMovementRepository
+                .findByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
+                        assetId, TenantContext.getCurrentOrgId(), PageRequest.of(pageNo, pageSize))
+                .map(assetMovementMapper::toDto);
+    }
+
+    /**
+     * How long the asset spent in each place, worked out from consecutive ledger entries.
+     *
+     * <p>Each entry opens a placement that runs until the next entry, or until now for the one
+     * the asset is in. That is what answers "14 days at Central Yard, 45 days at Silver Oak"
+     * without storing a second copy of anything: the durations are read off the ledger, so they
+     * cannot drift from it.
+     *
+     * <p>A {@code CORRECTION} closes the placement before it exactly as any other entry does.
+     * The superseded stretch stays visible with the length it was recorded as having, which is
+     * the point of an append-only ledger: what was believed at the time is still legible.
+     */
+    @Transactional(readOnly = true)
+    public List<AssetPlacementSpanDto> getPlacementHistory(Long assetId) {
+        requireAsset(assetId);
+        List<AssetMovement> movements = assetMovementRepository
+                .findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+                        assetId, TenantContext.getCurrentOrgId(),
+                        PageRequest.of(0, MAX_HISTORY_ENTRIES));
+
+        LocalDateTime now = LocalDateTime.now();
+        List<AssetPlacementSpanDto> spans = new ArrayList<>(movements.size());
+        for (int i = 0; i < movements.size(); i++) {
+            AssetMovement movement = movements.get(i);
+            boolean last = i == movements.size() - 1;
+            LocalDateTime end = last ? null : movements.get(i + 1).getMovedAt();
+
+            AssetPlacementSpanDto span = new AssetPlacementSpanDto();
+            span.setMovementId(movement.getId());
+            span.setProjectId(movement.getToProject() != null ? movement.getToProject().getId() : null);
+            span.setProjectName(movement.getToProjectName());
+            span.setLocationId(movement.getToLocation() != null ? movement.getToLocation().getId() : null);
+            span.setLocationName(movement.getToLocationName());
+            span.setAssignedToId(movement.getToAssignedToId());
+            span.setAssignedTo(movement.getToAssignedTo());
+            span.setFrom(movement.getMovedAt());
+            span.setTo(end);
+            span.setCurrent(last);
+            span.setReason(movement.getReason());
+            span.setDays(Duration.between(movement.getMovedAt(), end != null ? end : now).toDays());
+            spans.add(span);
+        }
+        return spans;
+    }
+
+    /**
+     * The documents filed against an asset: purchase invoice, warranty, insurance, registration,
+     * certifications and service records, each with its expiry where one was recorded.
+     */
+    @Transactional(readOnly = true)
+    public List<AttachmentDto> getDocuments(Long assetId) {
+        requireAsset(assetId);
+        return attachmentService.getAttachments(AssetDocuments.ENTITY_TYPE, assetId);
+    }
+
+    /**
+     * Asset documents whose expiry falls on or before the given number of days from today,
+     * soonest first. Documents already expired are included, because an insurance policy that
+     * lapsed last week is the case this list exists to surface.
+     */
+    @Transactional(readOnly = true)
+    public List<AttachmentDto> getExpiringDocuments(int withinDays) {
+        if (withinDays < 0) {
+            throw new InvalidRequestException("withinDays must not be negative");
+        }
+        return attachmentService.getExpiringDocuments(AssetDocuments.ENTITY_TYPE,
+                LocalDate.now().plusDays(withinDays));
+    }
+
+    /**
+     * The one place an asset's placement changes.
+     *
+     * <p>Compares the placement asked for against the one the asset holds. If nothing moved, it
+     * writes nothing and returns null, so an ordinary edit of an asset's serial number does not
+     * litter the ledger with entries that record no movement. If something moved, it appends the
+     * entry <em>and</em> sets the asset's four placement columns from that entry's "to" side, in
+     * that order and in one transaction. Those columns are therefore a cache of the ledger and
+     * cannot disagree with it.
+     *
+     * <p>The names of the project and the location are snapshotted onto the entry, because a
+     * project that is renamed or deleted must not rewrite what the history says.
+     *
+     * @param openingEntry Whether this is the asset's first entry, which is recorded as a REGISTRATION even when it moves nothing.
+     * @return The appended entry, or null when nothing moved.
+     */
+    private AssetMovement applyPlacement(Asset asset,
+                                         Project toProject,
+                                         StorageLocation toLocation,
+                                         Long toAssignedToId,
+                                         String toAssignedTo,
+                                         String reason,
+                                         LocalDateTime movedAt,
+                                         String notes,
+                                         String referenceNumber,
+                                         Long correctsMovementId,
+                                         boolean openingEntry) {
+        Project fromProject = asset.getAssignedProject();
+        StorageLocation fromLocation = asset.getLocation();
+        Long fromAssignedToId = asset.getAssignedToId();
+        String fromAssignedTo = asset.getAssignedTo();
+
+        boolean projectChanged = !Objects.equals(idOf(fromProject), idOf(toProject));
+        boolean locationChanged = !Objects.equals(idOf(fromLocation), idOf(toLocation));
+        boolean custodianChanged = !Objects.equals(fromAssignedToId, toAssignedToId)
+                || !Objects.equals(fromAssignedTo, toAssignedTo);
+
+        boolean correction = correctsMovementId != null;
+        if (!projectChanged && !locationChanged && !custodianChanged && !openingEntry && !correction) {
+            return null;
+        }
+
+        if (reason == null || reason.isBlank()) {
+            throw new InvalidRequestException("The movement of asset with ID " + asset.getId()
+                    + " has no reason. Every movement must say why it happened, the same way every"
+                    + " stock movement does; an entry with none is what makes a ledger unexplainable.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime when = movedAt != null ? movedAt : now;
+        if (when.isAfter(now)) {
+            throw new InvalidRequestException("A movement of asset with ID " + asset.getId()
+                    + " cannot be dated " + when + ", which is in the future. A ledger records what"
+                    + " has happened, not what is planned.");
+        }
+
+        AssetMovement movement = new AssetMovement();
+        movement.setAsset(asset);
+        movement.setOrganization(asset.getOrganization());
+        movement.setMovementType(movementType(openingEntry, correction, projectChanged, locationChanged));
+        movement.setFromProject(fromProject);
+        movement.setFromProjectName(projectName(fromProject, asset.getLegacyAssignedProject()));
+        movement.setToProject(toProject);
+        movement.setToProjectName(projectName(toProject, null));
+        movement.setFromLocation(fromLocation);
+        movement.setFromLocationName(fromLocation != null ? fromLocation.getLocationName() : null);
+        movement.setToLocation(toLocation);
+        movement.setToLocationName(toLocation != null ? toLocation.getLocationName() : null);
+        movement.setFromAssignedToId(fromAssignedToId);
+        movement.setFromAssignedTo(fromAssignedTo);
+        movement.setToAssignedToId(toAssignedToId);
+        movement.setToAssignedTo(toAssignedTo);
+        movement.setMovedAt(when);
+        movement.setMovedBy(userContextService.getCurrentUserId());
+        movement.setReason(reason);
+        movement.setNotes(notes);
+        movement.setReferenceNumber(referenceNumber);
+        movement.setCorrectsMovementId(correctsMovementId);
+
+        AssetMovement appended = assetMovementRepository.save(movement);
+
+        asset.setAssignedProject(toProject);
+        asset.setLocation(toLocation);
+        asset.setAssignedToId(toAssignedToId);
+        asset.setAssignedTo(toAssignedTo);
+
+        return appended;
+    }
+
+    /** The kind of entry the change amounts to. A correction is always a correction. */
+    private AssetMovementType movementType(boolean openingEntry, boolean correction,
+                                           boolean projectChanged, boolean locationChanged) {
+        if (correction) {
+            return AssetMovementType.CORRECTION;
+        }
+        if (openingEntry) {
+            return AssetMovementType.REGISTRATION;
+        }
+        return projectChanged || locationChanged
+                ? AssetMovementType.TRANSFER
+                : AssetMovementType.ASSIGNMENT;
+    }
+
+    private Long idOf(Project project) {
+        return project != null ? project.getId() : null;
+    }
+
+    private Long idOf(StorageLocation location) {
+        return location != null ? location.getId() : null;
+    }
+
+    /** The project's name for the snapshot, falling back to text the asset carried before the reference. */
+    private String projectName(Project project, String fallback) {
+        return project != null ? project.getProjectName() : fallback;
+    }
+
+    private String reasonOrDefault(String supplied, String fallback) {
+        return supplied != null && !supplied.isBlank() ? supplied : fallback;
+    }
+
+    private Asset requireAsset(Long id) {
+        return assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+    }
+
+    private Project resolveProject(Long projectId) {
+        if (projectId == null) {
+            return null;
+        }
+        return projectRepository.findByIdAndOrganization_Id(projectId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Project with ID " + projectId + " was not found in this organization"));
+    }
+
+    private StorageLocation resolveLocation(Long locationId) {
+        if (locationId == null) {
+            return null;
+        }
+        return storageLocationRepository.findByIdAndOrganization_Id(locationId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID " + locationId + " was not found in this organization"));
+    }
+
+    /**
+     * Copies the mutable fields from the creation DTO onto the asset, resolving the vendor.
+     *
+     * <p>Where the asset is and who holds it is deliberately not here: those four columns are
+     * set only by {@link #applyPlacement}, alongside the ledger entry that explains them.
+     */
     private void applyFields(Asset asset, AssetCreationDto dto) {
         asset.setAssetId(dto.getAssetId());
         asset.setName(dto.getName());
@@ -90,9 +468,6 @@ public class AssetService {
         asset.setPurchasePrice(dto.getPurchasePrice());
         asset.setCurrentValue(dto.getCurrentValue());
         asset.setDepreciationRate(dto.getDepreciationRate());
-        asset.setAssignedTo(dto.getAssignedTo());
-        asset.setAssignedToId(dto.getAssignedToId());
-        asset.setAssignedProject(dto.getAssignedProject());
         asset.setManufacturer(dto.getManufacturer());
         asset.setModel(dto.getModel());
         asset.setSerialNumber(dto.getSerialNumber());
@@ -115,12 +490,5 @@ public class AssetService {
                     .orElseThrow(() -> new ResourceNotFoundException("Vendor with ID " + dto.getVendorId() + " was not found in this organization"));
         }
         asset.setVendor(vendor);
-
-        StorageLocation location = null;
-        if (dto.getLocationId() != null) {
-            location = storageLocationRepository.findByIdAndOrganization_Id(dto.getLocationId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID " + dto.getLocationId() + " was not found in this organization"));
-        }
-        asset.setLocation(location);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetService.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 
@@ -105,7 +106,7 @@ public class AssetService {
         Asset saved = assetRepository.save(asset);
 
         applyPlacement(saved,
-                resolveProject(creationDto.getAssignedProjectId()),
+                resolveAssignedProject(saved, creationDto),
                 resolveLocation(creationDto.getLocationId()),
                 creationDto.getAssignedToId(),
                 creationDto.getAssignedTo(),
@@ -144,7 +145,7 @@ public class AssetService {
         applyFields(asset, creationDto);
 
         applyPlacement(asset,
-                resolveProject(creationDto.getAssignedProjectId()),
+                resolveAssignedProject(asset, creationDto),
                 resolveLocation(creationDto.getLocationId()),
                 creationDto.getAssignedToId(),
                 creationDto.getAssignedTo(),
@@ -432,6 +433,57 @@ public class AssetService {
     private Asset requireAsset(Long id) {
         return assetRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Asset with ID " + id + " was not found in this organization"));
+    }
+
+    /**
+     * The project a create or update payload puts the asset on.
+     *
+     * <p>{@code assignedProjectId} is the field to send. The legacy {@code assignedProject} name
+     * is honoured only when no id is given, and only because the deployed web client still sends
+     * it: without this, the first save of an asset from an un-updated client would take the asset
+     * off its project and record a movement to nowhere for it. The name is resolved by the rule
+     * the reference migration used, so it resolves at runtime exactly as it did in the backfill.
+     *
+     * <p>A name the payload did not change leaves the asset where it is, whether or not it ever
+     * resolved. A changed name that resolves to nothing, or to more than one project, is refused:
+     * the caller is told to send an id rather than having the asset's project quietly cleared.
+     *
+     * @throws InvalidRequestException if a changed name resolves to no project or to several.
+     */
+    private Project resolveAssignedProject(Asset asset, AssetCreationDto dto) {
+        if (dto.getAssignedProjectId() != null) {
+            return resolveProject(dto.getAssignedProjectId());
+        }
+        String name = dto.getAssignedProject();
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        if (namesTheAssetsCurrentProject(asset, name)) {
+            return asset.getAssignedProject();
+        }
+        List<Project> matches = projectRepository.findByNormalisedName(
+                TenantContext.getCurrentOrgId(), name.trim().toLowerCase(Locale.ROOT));
+        if (matches.size() != 1) {
+            throw new InvalidRequestException("The project name \"" + name + "\" "
+                    + (matches.isEmpty() ? "names no project in this organization"
+                            : "names " + matches.size() + " projects in this organization")
+                    + ". Send assignedProjectId instead, so the asset is put on a project that"
+                    + " actually exists rather than on a guess.");
+        }
+        return matches.get(0);
+    }
+
+    /** Whether the name the payload sent is the one the asset already reads as, unchanged. */
+    private boolean namesTheAssetsCurrentProject(Asset asset, String name) {
+        String trimmed = name.trim();
+        if (asset.getAssignedProject() != null) {
+            return trimmed.equalsIgnoreCase(safeTrim(asset.getAssignedProject().getProjectName()));
+        }
+        return trimmed.equalsIgnoreCase(safeTrim(asset.getLegacyAssignedProject()));
+    }
+
+    private String safeTrim(String value) {
+        return value != null ? value.trim() : null;
     }
 
     private Project resolveProject(Long projectId) {

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
@@ -47,8 +47,10 @@ public class AssetCreationDto {
     @Schema(description = "Id of the employee the asset is currently assigned to, stored alongside the "
             + "name so the asset list can be filtered by assignee.", example = "18")
     private Long assignedToId;
-    @Schema(description = "Name of the project the asset is currently deployed on.", example = "Marina Heights Towers")
-    private String assignedProject;
+    @Schema(description = "Id of the project the asset is deployed on. Changing it records a "
+            + "movement in the asset's ledger; the movement's reason comes from movementReason.",
+            example = "5")
+    private Long assignedProjectId;
     @Schema(description = "Manufacturer of the asset.", example = "JCB India")
     private String manufacturer;
     @Schema(description = "Model name or number.", example = "3DX")
@@ -81,6 +83,20 @@ public class AssetCreationDto {
     private String notes;
     @Schema(description = "Id of the vendor the asset was purchased from.", example = "3")
     private Long vendorId;
-    @Schema(description = "Id of the storage location the asset is stored at.", example = "7")
+    @Schema(description = "Id of the storage location the asset is stored at. Changing it records a "
+            + "movement in the asset's ledger.", example = "7")
     private Long locationId;
+
+    @Schema(description = "Why the asset is where this payload says it is. Recorded against the "
+            + "movement this create or update appends to the asset's ledger. Optional here so the "
+            + "existing asset form keeps working; when it is left out the entry says the movement "
+            + "was recorded from an asset edit rather than inventing a reason. Prefer the dedicated "
+            + "movements endpoint, which requires one.",
+            example = "Mobilised to the Marina Heights site for the piling phase")
+    private String movementReason;
+
+    @Schema(description = "When the asset actually moved, if that is not now. Recorded as the "
+            + "movement date so a movement entered late still sits in the right place in the ledger.",
+            example = "2026-08-20T09:00:00")
+    private java.time.LocalDateTime movedAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetCreationDto.java
@@ -51,6 +51,16 @@ public class AssetCreationDto {
             + "movement in the asset's ledger; the movement's reason comes from movementReason.",
             example = "5")
     private Long assignedProjectId;
+
+    @Schema(description = "Name of the project the asset is deployed on. Superseded by "
+            + "assignedProjectId and kept only so a client that has not been updated yet does not "
+            + "unassign an asset every time it saves one. Used only when assignedProjectId is "
+            + "absent, and resolved by the same rule the reference migration used: per "
+            + "organization, trimmed, case-insensitive, and only where exactly one project carries "
+            + "the name. A name that resolves to nothing is refused rather than quietly clearing "
+            + "the asset's project.",
+            example = "Marina Heights Towers")
+    private String assignedProject;
     @Schema(description = "Manufacturer of the asset.", example = "JCB India")
     private String manufacturer;
     @Schema(description = "Model name or number.", example = "3DX")

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetDto.java
@@ -38,7 +38,13 @@ public class AssetDto {
     private String assignedTo;
     @Schema(description = "Id of the employee the asset is currently assigned to, if known.", example = "18")
     private Long assignedToId;
-    @Schema(description = "Name of the project the asset is currently deployed on.", example = "Marina Heights Towers")
+    @Schema(description = "Id of the project the asset is currently deployed on, resolved from the "
+            + "latest movement in the asset's ledger.", example = "5")
+    private Long assignedProjectId;
+    @Schema(description = "Name of the project the asset is currently deployed on. Read-only and "
+            + "derived: the referenced project's name where the asset names one, otherwise the "
+            + "free text the asset carried before the project became a reference.",
+            example = "Marina Heights Towers")
     private String assignedProject;
     @Schema(description = "Manufacturer of the asset.", example = "JCB India")
     private String manufacturer;

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementCreationDto.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.asset.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "Payload to move an asset: where it is going, when it went, and why. "
+        + "Appends an entry to the asset's movement ledger and brings the asset's current "
+        + "placement with it. Nothing else can change where an asset is.")
+@Data
+public class AssetMovementCreationDto {
+
+    @Schema(description = "Id of the project the asset is moving to. Omit, or send null, to take "
+            + "the asset off any project.", example = "5")
+    private Long toProjectId;
+
+    @Schema(description = "Id of the storage location the asset is moving to. Omit, or send null, "
+            + "to record that it sits at no tracked location.", example = "9")
+    private Long toLocationId;
+
+    @Schema(description = "Id of the custodian taking the asset on.", example = "21")
+    private Long toAssignedToId;
+
+    @Schema(description = "Name of the custodian taking the asset on.", example = "Suresh Nair")
+    @Size(max = 200)
+    private String toAssignedTo;
+
+    @Schema(description = "Why the asset moved. Required: an entry with no stated reason is what "
+            + "makes a ledger unexplainable.",
+            example = "Mobilised to the Marina Heights site for the piling phase")
+    @NotBlank
+    @Size(max = 255)
+    private String reason;
+
+    @Schema(description = "When the asset actually moved. Defaults to now, and may be backdated "
+            + "for a movement entered after the fact. A date in the future is refused.",
+            example = "2026-08-20T09:00:00")
+    private LocalDateTime movedAt;
+
+    @Schema(description = "Free-text notes about the movement.",
+            example = "Delivered on a low bed trailer, hydraulics checked on arrival.")
+    private String notes;
+
+    @Schema(description = "An external document this movement came from, for example a site "
+            + "transfer number.", example = "TRF-2026-000014")
+    @Size(max = 100)
+    private String referenceNumber;
+
+    @Schema(description = "Id of an earlier entry on this asset that this one restates. Setting it "
+            + "records the entry as a CORRECTION, which is how a ledger mistake is put right: the "
+            + "wrong entry stays, and this one supersedes it.", example = "409")
+    private Long correctsMovementId;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementDto.java
@@ -1,0 +1,80 @@
+package org.tornotron.echno_backend.asset.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "One entry in an asset's movement ledger: what moved, from where to where, "
+        + "when, by whom and why. Entries are never edited or deleted; an entry made in error is "
+        + "superseded by a CORRECTION that names it.")
+@Data
+public class AssetMovementDto {
+
+    @Schema(description = "Database id of the ledger entry.", example = "412")
+    private Long id;
+
+    @Schema(description = "Id of the asset that moved.", example = "12")
+    private Long assetId;
+
+    @Schema(description = "Kind of entry: REGISTRATION, TRANSFER, ASSIGNMENT or CORRECTION.",
+            example = "TRANSFER")
+    private String movementType;
+
+    @Schema(description = "Id of the project the asset left, null if it was on none.", example = "3")
+    private Long fromProjectId;
+    @Schema(description = "Name of the project the asset left, as it read at the time.",
+            example = "Central Yard")
+    private String fromProjectName;
+    @Schema(description = "Id of the project the asset moved to, null if it is on none.", example = "5")
+    private Long toProjectId;
+    @Schema(description = "Name of the project the asset moved to, as it read at the time.",
+            example = "Silver Oak Residences")
+    private String toProjectName;
+
+    @Schema(description = "Id of the storage location the asset left.", example = "7")
+    private Long fromLocationId;
+    @Schema(description = "Name of the storage location the asset left, as it read at the time.",
+            example = "Kochi Yard")
+    private String fromLocationName;
+    @Schema(description = "Id of the storage location the asset moved to.", example = "9")
+    private Long toLocationId;
+    @Schema(description = "Name of the storage location the asset moved to, as it read at the time.",
+            example = "Silver Oak Site Store")
+    private String toLocationName;
+
+    @Schema(description = "Id of the custodian who handed the asset over.", example = "18")
+    private Long fromAssignedToId;
+    @Schema(description = "Name of the custodian who handed the asset over.", example = "Ravi Kumar")
+    private String fromAssignedTo;
+    @Schema(description = "Id of the custodian who took the asset on.", example = "21")
+    private Long toAssignedToId;
+    @Schema(description = "Name of the custodian who took the asset on.", example = "Suresh Nair")
+    private String toAssignedTo;
+
+    @Schema(description = "When the asset actually moved.", example = "2026-08-20T09:00:00")
+    private LocalDateTime movedAt;
+
+    @Schema(description = "When the entry was written, which can be later than movedAt for a "
+            + "movement entered after the fact.", example = "2026-08-21T11:42:03")
+    private LocalDateTime recordedAt;
+
+    @Schema(description = "Id of the user who recorded the movement.", example = "4")
+    private Long movedBy;
+
+    @Schema(description = "Why the asset moved.",
+            example = "Mobilised to the Marina Heights site for the piling phase")
+    private String reason;
+
+    @Schema(description = "Free-text notes about the movement.",
+            example = "Delivered on a low bed trailer, hydraulics checked on arrival.")
+    private String notes;
+
+    @Schema(description = "An external document this movement came from, for example a site "
+            + "transfer number.", example = "TRF-2026-000014")
+    private String referenceNumber;
+
+    @Schema(description = "Id of the entry this one restates, set only on a CORRECTION.",
+            example = "409")
+    private Long correctsMovementId;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetPlacementSpanDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetPlacementSpanDto.java
@@ -1,0 +1,52 @@
+package org.tornotron.echno_backend.asset.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "One stretch of time an asset spent in one place, worked out from "
+        + "consecutive entries in its movement ledger. This is what answers \"14 days at Central "
+        + "Yard, 45 days at Silver Oak\".")
+@Data
+public class AssetPlacementSpanDto {
+
+    @Schema(description = "Id of the ledger entry that started this placement.", example = "412")
+    private Long movementId;
+
+    @Schema(description = "Id of the project the asset was on, null if it was on none.", example = "5")
+    private Long projectId;
+    @Schema(description = "Name of the project the asset was on, as it read at the time.",
+            example = "Silver Oak Residences")
+    private String projectName;
+
+    @Schema(description = "Id of the storage location the asset sat at.", example = "9")
+    private Long locationId;
+    @Schema(description = "Name of the storage location the asset sat at, as it read at the time.",
+            example = "Silver Oak Site Store")
+    private String locationName;
+
+    @Schema(description = "Id of the custodian who held the asset over this stretch.", example = "21")
+    private Long assignedToId;
+    @Schema(description = "Name of the custodian who held the asset over this stretch.",
+            example = "Suresh Nair")
+    private String assignedTo;
+
+    @Schema(description = "When the asset arrived.", example = "2026-06-20T09:00:00")
+    private LocalDateTime from;
+
+    @Schema(description = "When it left. Null on the placement it is still in.",
+            example = "2026-08-04T16:30:00")
+    private LocalDateTime to;
+
+    @Schema(description = "How many whole days the placement lasted, counted to now on the "
+            + "placement the asset is still in.", example = "45")
+    private long days;
+
+    @Schema(description = "Whether this is the placement the asset is in now.", example = "false")
+    private boolean current;
+
+    @Schema(description = "Why the asset arrived here.",
+            example = "Mobilised to the Marina Heights site for the piling phase")
+    private String reason;
+}

--- a/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMapper.java
@@ -5,10 +5,20 @@ import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.asset.Asset;
 import org.tornotron.echno_backend.asset.dto.AssetDto;
 
-/** Maps {@link Asset} to its DTO. Vendor/location/organization flatten to id (+ name). */
+/**
+ * Maps {@link Asset} to its DTO. Vendor/location/project/organization flatten to id (+ name).
+ *
+ * <p>{@code assignedProject} on the DTO stays a name for the client that already reads it, but
+ * it is now derived rather than stored: the referenced project's name where the asset names one,
+ * and otherwise the free text the asset carried before the reference migration, which is kept
+ * rather than dropped.
+ */
 @Mapper(componentModel = "spring")
 public interface AssetMapper {
 
+    @Mapping(source = "assignedProject.id", target = "assignedProjectId")
+    @Mapping(target = "assignedProject", expression = "java(asset.getAssignedProject() != null "
+            + "? asset.getAssignedProject().getProjectName() : asset.getLegacyAssignedProject())")
     @Mapping(source = "vendor.id", target = "vendorId")
     @Mapping(source = "vendor.vendorName", target = "vendorName")
     @Mapping(source = "location.id", target = "locationId")

--- a/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMovementMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/mapper/AssetMovementMapper.java
@@ -1,0 +1,22 @@
+package org.tornotron.echno_backend.asset.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.tornotron.echno_backend.asset.AssetMovement;
+import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
+
+/**
+ * Maps {@link AssetMovement} to its DTO. The associations flatten to their id; the name beside
+ * each id is the snapshot the entry carries rather than the association's current name, so a
+ * renamed or deleted project does not rewrite history.
+ */
+@Mapper(componentModel = "spring")
+public interface AssetMovementMapper {
+
+    @Mapping(source = "asset.id", target = "assetId")
+    @Mapping(source = "fromProject.id", target = "fromProjectId")
+    @Mapping(source = "toProject.id", target = "toProjectId")
+    @Mapping(source = "fromLocation.id", target = "fromLocationId")
+    @Mapping(source = "toLocation.id", target = "toLocationId")
+    AssetMovementDto toDto(AssetMovement movement);
+}

--- a/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/common/controller/AttachmentControllerWeb.java
@@ -10,6 +10,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import jakarta.validation.Valid;
+import org.tornotron.echno_backend.common.dto.AttachmentDocumentMetadataDto;
 import org.tornotron.echno_backend.common.dto.PresignedUpload;
 import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
 import org.tornotron.echno_backend.common.dto.UploadRequest;
@@ -154,6 +156,27 @@ public class AttachmentControllerWeb {
     public ResponseEntity<List<AttachmentDto>> readAttachments(@PathVariable String entityType,
                                                                @PathVariable Long entityId) {
         return ResponseEntity.status(HttpStatus.OK).body(attachmentService.getAttachments(entityType,entityId));
+    }
+
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PatchMapping("/attachmentId/{attachmentId}/document")
+    @Operation(
+            summary = "Record what an attachment is and when it expires",
+            description = "Sets the document type, issue date and expiry date on an already-uploaded "
+                    + "file. Applied after the upload so it works for both upload paths and for any "
+                    + "entity that files documents, for example an asset's insurance policy or "
+                    + "warranty. Any field sent as null is cleared."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Document metadata recorded"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attachment with the given id in the caller's organization")
+    })
+    public ResponseEntity<AttachmentDto> updateDocumentMetadata(
+            @PathVariable Long attachmentId,
+            @Valid @RequestBody AttachmentDocumentMetadataDto metadata) {
+        return ResponseEntity.ok(attachmentService.updateDocumentMetadata(attachmentId, metadata));
     }
 
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")

--- a/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDto.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.common.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -25,4 +26,17 @@ public class AttachmentDocumentMetadataDto {
     @Schema(description = "Date the document stops being valid. Send null for a document that does "
             + "not expire.", example = "2027-06-10")
     private LocalDate expiresOn;
+
+    /**
+     * A document cannot stop being valid before it was issued. Checked here rather than in the
+     * service because it is a property of the payload, and a document period the wrong way round
+     * is a typo in the form rather than a state the system should ever hold.
+     *
+     * @return Whether the two dates are in a possible order, or either is absent.
+     */
+    @AssertTrue(message = "expiresOn must not be before issuedOn")
+    @Schema(hidden = true)
+    public boolean isDocumentPeriodInOrder() {
+        return issuedOn == null || expiresOn == null || !expiresOn.isBefore(issuedOn);
+    }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDto.java
@@ -1,0 +1,28 @@
+package org.tornotron.echno_backend.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Schema(description = "What kind of document an already-uploaded file is, and when it stops being "
+        + "valid. Applied after the upload, so it works the same for the direct multipart path and "
+        + "for the presign/register path, and for any entity that files documents rather than only "
+        + "for assets.")
+@Data
+public class AttachmentDocumentMetadataDto {
+
+    @Schema(description = "What kind of document this is: insurance, warranty, registration, "
+            + "certification, service-record, purchase-invoice. Send null to clear it.",
+            example = "insurance")
+    @Size(max = 50)
+    private String documentType;
+
+    @Schema(description = "Date the document was issued. Send null to clear it.", example = "2026-06-10")
+    private LocalDate issuedOn;
+
+    @Schema(description = "Date the document stops being valid. Send null for a document that does "
+            + "not expire.", example = "2027-06-10")
+    private LocalDate expiresOn;
+}

--- a/src/main/java/org/tornotron/echno_backend/common/entity/Attachment.java
+++ b/src/main/java/org/tornotron/echno_backend/common/entity/Attachment.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.task.Task;
 import org.tornotron.echno_backend.user.User;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -28,7 +29,8 @@ import java.time.LocalDateTime;
 @Data
 @NoArgsConstructor
 @Table(name = "attachment", indexes = {
-        @Index(name = "idx_attachment_entity", columnList = "entity_type, entity_id")
+        @Index(name = "idx_attachment_entity", columnList = "entity_type, entity_id"),
+        @Index(name = "idx_attachment_expiry", columnList = "organization_id, entity_type, expires_on")
 })
 @Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 public class Attachment implements TenantScopedEntity {
@@ -78,6 +80,28 @@ public class Attachment implements TenantScopedEntity {
      */
     @Column(name = "original_filename", length = 255)
     private String originalFilename;
+
+    /**
+     * What kind of document this file is, where the file is a document rather than a photo:
+     * {@code insurance}, {@code warranty}, {@code registration}, {@code certification},
+     * {@code service-record}, {@code purchase-invoice}. Free-form for the same reason
+     * {@link #entityType} is, and for the same reason the asset module stores its type and
+     * category as strings: the web client sends kebab-case values and validates them.
+     */
+    @Column(name = "document_type", length = 50)
+    private String documentType;
+
+    /** The date the document was issued, where that is worth recording. */
+    @Column(name = "issued_on")
+    private LocalDate issuedOn;
+
+    /**
+     * The date the document stops being valid. Null for a file that does not expire, which is
+     * most of them. This is the column that makes an insurance policy or a certification
+     * trackable rather than merely stored.
+     */
+    @Column(name = "expires_on")
+    private LocalDate expiresOn;
 
     /**
      * Timestamp when the attachment was created.

--- a/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
@@ -1,15 +1,55 @@
 package org.tornotron.echno_backend.common.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.time.LocalDate;
+
+@Schema(description = "A file attached to an entity, with a short-lived download URL and, where "
+        + "the file is a document rather than a photo, what kind of document it is and when it "
+        + "stops being valid.")
 @Data
 public class AttachmentDto {
+
+    @Schema(description = "Database id of the attachment.", example = "88")
     private Long id;
+
+    @Schema(description = "Time-limited download URL for the stored file.")
     private String url;
+
+    @Schema(description = "The entity type the file is filed under.", example = "ASSET_DOCUMENTS")
     private String entityType;
+
+    @Schema(description = "MIME type of the file.", example = "application/pdf")
     private String contentType;
+
+    @Schema(description = "Size of the file in bytes.", example = "284410")
     private Long fileSize;
+
+    @Schema(description = "Original filename as uploaded.", example = "insurance-policy-2026.pdf")
     private String fileName;
+
+    @Schema(description = "When the attachment record was created.", example = "2026-08-20T09:00:00")
     private String createdAt;
+
+    @Schema(description = "When the attachment record was last updated.", example = "2026-08-21T11:42:03")
     private String updatedAt;
+
+    @Schema(description = "What kind of document this is, where it is a document.", example = "insurance")
+    private String documentType;
+
+    @Schema(description = "Date the document was issued.", example = "2026-06-10")
+    private LocalDate issuedOn;
+
+    @Schema(description = "Date the document stops being valid. Null for a file that does not expire.",
+            example = "2027-06-10")
+    private LocalDate expiresOn;
+
+    @Schema(description = "Whether the document has already expired. Null where it carries no expiry.",
+            example = "false")
+    private Boolean expired;
+
+    @Schema(description = "Whole days until the document expires, negative once it has. Null where "
+            + "it carries no expiry.", example = "285")
+    private Long daysUntilExpiry;
 }

--- a/src/main/java/org/tornotron/echno_backend/common/mapper/AttachmentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/common/mapper/AttachmentMapper.java
@@ -10,6 +10,8 @@ import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Maps {@link Attachment} to its DTO, resolving a short-lived presigned download URL
@@ -29,10 +31,29 @@ public abstract class AttachmentMapper {
     @Mapping(source = "originalFilename", target = "fileName")
     @Mapping(target = "createdAt", expression = "java(attachment.getCreatedAt().toString())")
     @Mapping(target = "updatedAt", expression = "java(attachment.getUpdatedAt().toString())")
+    @Mapping(target = "expired", ignore = true) // derived from expiresOn in fillExpiry
+    @Mapping(target = "daysUntilExpiry", ignore = true) // derived from expiresOn in fillExpiry
     public abstract AttachmentDto toDto(Attachment attachment);
 
     @AfterMapping
     protected void fillUrl(Attachment attachment, @MappingTarget AttachmentDto dto) {
         dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
+        fillExpiry(attachment.getExpiresOn(), dto);
+    }
+
+    /**
+     * Fills the two derived expiry fields. They are computed on read rather than stored, so a
+     * document cannot sit in the database marked valid the morning after it lapsed.
+     *
+     * @param expiresOn The document's expiry date, or null where it has none.
+     * @param dto The DTO being filled.
+     */
+    public static void fillExpiry(LocalDate expiresOn, AttachmentDto dto) {
+        if (expiresOn == null) {
+            return;
+        }
+        LocalDate today = LocalDate.now();
+        dto.setExpired(expiresOn.isBefore(today));
+        dto.setDaysUntilExpiry(ChronoUnit.DAYS.between(today, expiresOn));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/repository/AttachmentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/common/repository/AttachmentRepository.java
@@ -1,11 +1,14 @@
 package org.tornotron.echno_backend.common.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for managing Attachment entities.
@@ -42,4 +45,29 @@ public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
 
     boolean existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
             String entityType, Long entityId, String originalFilename, Long fileSize);
+
+    /**
+     * One attachment by id, refusing to cross tenants. The unscoped {@code findById} lets a
+     * member of one organization reach another's attachment by numeric id, so every path this
+     * change adds uses this one.
+     *
+     * @param id           The attachment id
+     * @param organizationId The organization the caller is acting in
+     * @return The attachment, if it belongs to that organization
+     */
+    Optional<Attachment> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Documents of one entity type whose expiry falls on or before a cutoff, soonest first.
+     * Already-expired documents come back too, since a policy that lapsed last week is exactly
+     * what the caller is looking for.
+     *
+     * @param entityType     The attachment entity type, for example ASSET_DOCUMENTS
+     * @param organizationId The organization the caller is acting in
+     * @param cutoff         The latest expiry date to include
+     * @param pageable       Bound on the rows returned
+     * @return The matching attachments, ordered by expiry
+     */
+    List<Attachment> findByEntityTypeAndOrganization_IdAndExpiresOnLessThanEqualOrderByExpiresOnAscIdAsc(
+            String entityType, Long organizationId, LocalDate cutoff, Pageable pageable);
 }

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -7,10 +7,13 @@ import org.tornotron.echno_backend.common.dto.StoredFile;
 import org.tornotron.echno_backend.common.dto.PresignedUpload;
 import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
 import org.tornotron.echno_backend.common.dto.UploadRequest;
+import org.tornotron.echno_backend.common.dto.AttachmentDocumentMetadataDto;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
 import org.tornotron.echno_backend.common.repository.AttachmentRepository;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.attendance.AttendanceRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
@@ -20,6 +23,7 @@ import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +40,9 @@ public class AttachmentService {
     // a large file on a slow site connection, not long enough to be worth reusing.
     private static final java.time.Duration UPLOAD_URL_EXPIRY = java.time.Duration.ofMinutes(15);
 
+    /** Ceiling on the expiring-documents read, so the response stays bounded as history grows. */
+    private static final int MAX_EXPIRING_DOCUMENTS = 500;
+
     private final AttachmentRepository attachmentRepository;
     private final FileStorageService fileStorageService;
     private final OrganizationRepository organizationRepository;
@@ -45,8 +52,10 @@ public class AttachmentService {
     private final UserRepository userRepository;
     private final AttendanceRepository attendanceRepository;
     private final TenantEntityHelper tenantEntityHelper;
+    private final AttachmentMapper attachmentMapper;
 
-    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, OrganizationRepository organizationRepository, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository, TenantEntityHelper tenantEntityHelper) {
+    public AttachmentService(AttachmentRepository attachmentRepository, FileStorageService fileStorageService, OrganizationRepository organizationRepository, ProjectRepository projectRepository, TaskRepository taskRepository, IssueRepository issueRepository, UserRepository userRepository, AttendanceRepository attendanceRepository, TenantEntityHelper tenantEntityHelper, AttachmentMapper attachmentMapper) {
+        this.attachmentMapper = attachmentMapper;
         this.attachmentRepository = attachmentRepository;
         this.fileStorageService = fileStorageService;
         this.organizationRepository = organizationRepository;
@@ -146,8 +155,56 @@ public class AttachmentService {
                     dto.setFileName(attachment.getOriginalFilename());
                     dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
                     dto.setCreatedAt(attachment.getCreatedAt().toString());
+                    dto.setDocumentType(attachment.getDocumentType());
+                    dto.setIssuedOn(attachment.getIssuedOn());
+                    dto.setExpiresOn(attachment.getExpiresOn());
+                    AttachmentMapper.fillExpiry(attachment.getExpiresOn(), dto);
                     return dto;
                 }).toList();
+    }
+
+    /**
+     * Records what kind of document an uploaded file is and when it stops being valid.
+     *
+     * <p>Separate from the upload so it serves both upload paths and every entity that files
+     * documents, rather than being bolted onto the asset half of one of them. The two columns
+     * it writes are the only part of "documents with expiry tracking" the generic attachment
+     * table did not already have.
+     *
+     * @param attachmentId The attachment to annotate
+     * @param metadata     The document type and dates, any of which may be null to clear
+     * @return The updated attachment as a DTO
+     * @throws ResourceNotFoundException if no such attachment exists in the caller's organization
+     */
+    @Transactional
+    public AttachmentDto updateDocumentMetadata(Long attachmentId, AttachmentDocumentMetadataDto metadata) {
+        Attachment attachment = attachmentRepository
+                .findByIdAndOrganization_Id(attachmentId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Attachment with ID " + attachmentId + " was not found in this organization"));
+        attachment.setDocumentType(metadata.getDocumentType());
+        attachment.setIssuedOn(metadata.getIssuedOn());
+        attachment.setExpiresOn(metadata.getExpiresOn());
+        return attachmentMapper.toDto(attachmentRepository.save(attachment));
+    }
+
+    /**
+     * Documents of one entity type expiring on or before a cutoff, soonest first, for the
+     * caller's organization. Already-expired documents are included.
+     *
+     * @param entityType The attachment entity type, for example ASSET_DOCUMENTS
+     * @param cutoff     The latest expiry date to include
+     * @return The matching documents, capped at {@link #MAX_EXPIRING_DOCUMENTS}
+     */
+    @Transactional(readOnly = true)
+    public List<AttachmentDto> getExpiringDocuments(String entityType, LocalDate cutoff) {
+        return attachmentRepository
+                .findByEntityTypeAndOrganization_IdAndExpiresOnLessThanEqualOrderByExpiresOnAscIdAsc(
+                        entityType, TenantContext.getCurrentOrgId(), cutoff,
+                        org.springframework.data.domain.PageRequest.of(0, MAX_EXPIRING_DOCUMENTS))
+                .stream()
+                .map(attachmentMapper::toDto)
+                .toList();
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
@@ -53,4 +53,24 @@ public interface ProjectRepository extends JpaRepository<Project,Long> {
             WHERE :search IS NULL OR LOWER(p.projectName) LIKE :search ESCAPE '\\'
             """)
     Page<Project> search(@Param("search") String search, Pageable pageable);
+
+    /**
+     * Projects in one organization whose trimmed, lower-cased name equals the given key.
+     *
+     * <p>Returns a list rather than one project on purpose: two projects in an organization may
+     * share a name, and a caller resolving a name to a reference has to be able to tell an
+     * unambiguous match from a guess. It matches the rule the asset reference migration uses, so
+     * a name resolves the same way at runtime as it did during the backfill.
+     *
+     * @param organizationId The organization to search within.
+     * @param name           The project name, already trimmed and lower-cased by the caller.
+     * @return Every project in that organization carrying the name.
+     */
+    @Query("""
+            SELECT p FROM Project p
+            WHERE p.organization.id = :organizationId
+              AND LOWER(TRIM(p.projectName)) = :name
+            """)
+    List<Project> findByNormalisedName(@Param("organizationId") Long organizationId,
+                                       @Param("name") String name);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -319,4 +319,13 @@
     <!-- v4.0 - Server-allocated document numbers, and per-tenant uniqueness for them -->
     <include file="db/changelog/v4.0/061-document-number-sequences.xml"/>
 
+    <!-- v4.0 - Assets: the project an asset is deployed on becomes a reference, keeping the old text -->
+    <include file="db/changelog/v4.0/063-add-asset-assigned-project-ref.xml"/>
+
+    <!-- v4.0 - Assets: the append-only movement ledger, plus an opening entry for every asset -->
+    <include file="db/changelog/v4.0/064-create-asset-movement.xml"/>
+
+    <!-- v4.0 - Attachments: what a file is and when it stops being valid, shared by every module -->
+    <include file="db/changelog/v4.0/065-add-attachment-document-metadata.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/063-add-asset-assigned-project-ref.xml
+++ b/src/main/resources/db/changelog/v4.0/063-add-asset-assigned-project-ref.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Turns asset.assigned_project from free text into a reference to a real project.
+
+        The free text is NOT touched. assigned_project keeps every value it holds, is mapped
+        read-only on the entity so nothing can write it again, and is what a rollback restores
+        from. A row whose text matched no project keeps that text and simply has no reference,
+        which is the honest outcome: the string is preserved rather than guessed at or dropped.
+
+        Rows the backfill could not resolve are listed by:
+
+            SELECT id, organization_id, assigned_project
+            FROM asset
+            WHERE assigned_project IS NOT NULL
+              AND btrim(assigned_project) <> ''
+              AND assigned_project_id IS NULL;
+    -->
+
+    <changeSet id="063-add-asset-assigned-project-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="asset" columnName="assigned_project_id"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="asset">
+            <column name="assigned_project_id" type="BIGINT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="asset"
+                                 baseColumnNames="assigned_project_id"
+                                 constraintName="fk_asset_assigned_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <createIndex tableName="asset" indexName="idx_asset_assigned_project">
+            <column name="assigned_project_id"/>
+        </createIndex>
+    </changeSet>
+
+    <!--
+        Resolves the text to a project, conservatively.
+
+        Matching is per organization, trimmed and case-insensitive, and only where exactly one
+        project in that organization carries the name. Two projects sharing a name leave the row
+        unresolved rather than have the migration pick one, because a wrong reference is worse
+        than an absent one: an absent one still has the text beside it.
+    -->
+    <changeSet id="063-backfill-asset-assigned-project-id" author="echno">
+        <sql>
+            UPDATE asset
+            SET assigned_project_id = m.project_id
+            FROM (
+                SELECT p.organization_id AS organization_id,
+                       lower(btrim(p.project_name)) AS match_key,
+                       min(p.id) AS project_id,
+                       count(*) AS candidates
+                FROM project p
+                WHERE p.project_name IS NOT NULL
+                  AND btrim(p.project_name) &lt;&gt; ''
+                GROUP BY p.organization_id, lower(btrim(p.project_name))
+            ) AS m
+            WHERE asset.assigned_project IS NOT NULL
+              AND btrim(asset.assigned_project) &lt;&gt; ''
+              AND asset.assigned_project_id IS NULL
+              AND asset.organization_id = m.organization_id
+              AND lower(btrim(asset.assigned_project)) = m.match_key
+              AND m.candidates = 1;
+        </sql>
+        <rollback>
+            <sql>UPDATE asset SET assigned_project_id = NULL;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/064-create-asset-movement.xml
+++ b/src/main/resources/db/changelog/v4.0/064-create-asset-movement.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        The asset movement ledger: where every asset has been, who held it, and why it moved.
+
+        Append-only by design. Nothing updates or deletes a row; an entry made in error is
+        superseded by a CORRECTION that names it in corrects_movement_id, the same way a stock
+        correction is a further adjustment rather than an edit of the one that was wrong.
+
+        The from_/to_ names sit beside the from_/to_ ids on purpose. The foreign keys are
+        ON DELETE SET NULL so a project can still be removed, and a project can be renamed at
+        any time; history that evaporates when a project is tidied away is not history, so the
+        name as it read at the time is stored with the entry.
+    -->
+    <changeSet id="064-create-asset-movement" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="asset_movement"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="asset_movement">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="asset_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="movement_type" type="VARCHAR(30)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="from_project_id" type="BIGINT"/>
+            <column name="from_project_name" type="VARCHAR(255)"/>
+            <column name="to_project_id" type="BIGINT"/>
+            <column name="to_project_name" type="VARCHAR(255)"/>
+
+            <column name="from_location_id" type="BIGINT"/>
+            <column name="from_location_name" type="VARCHAR(255)"/>
+            <column name="to_location_id" type="BIGINT"/>
+            <column name="to_location_name" type="VARCHAR(255)"/>
+
+            <column name="from_assigned_to_id" type="BIGINT"/>
+            <column name="from_assigned_to" type="VARCHAR(200)"/>
+            <column name="to_assigned_to_id" type="BIGINT"/>
+            <column name="to_assigned_to" type="VARCHAR(200)"/>
+
+            <column name="moved_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="recorded_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="moved_by" type="BIGINT"/>
+
+            <column name="reason" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notes" type="TEXT"/>
+            <column name="reference_number" type="VARCHAR(100)"/>
+            <column name="corrects_movement_id" type="BIGINT"/>
+        </createTable>
+
+        <!--
+            RESTRICT, not CASCADE. Deleting an asset would otherwise take the record of where the
+            machine has been with it; the service refuses the delete and points at retiring the
+            asset instead, and this constraint is what makes that true at the database as well.
+        -->
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="asset_id"
+                                 constraintName="fk_asset_movement_asset"
+                                 referencedTableName="asset"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_asset_movement_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="from_project_id"
+                                 constraintName="fk_asset_movement_from_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="to_project_id"
+                                 constraintName="fk_asset_movement_to_project"
+                                 referencedTableName="project"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="from_location_id"
+                                 constraintName="fk_asset_movement_from_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="to_location_id"
+                                 constraintName="fk_asset_movement_to_location"
+                                 referencedTableName="storage_location"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+
+        <addForeignKeyConstraint baseTableName="asset_movement"
+                                 baseColumnNames="corrects_movement_id"
+                                 constraintName="fk_asset_movement_corrects"
+                                 referencedTableName="asset_movement"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="asset_movement" indexName="idx_asset_movement_asset">
+            <column name="asset_id"/>
+            <column name="moved_at"/>
+        </createIndex>
+        <createIndex tableName="asset_movement" indexName="idx_asset_movement_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <!--
+        The opening balance.
+
+        Every asset that is somewhere gets one REGISTRATION entry saying where it was when the
+        ledger was introduced, so the history is not blank for assets that already exist. It
+        cannot say when the asset arrived there, because nothing recorded that, so it is dated
+        from the asset's own created_at and says as much in its reason.
+
+        to_project_name is where the free text of an unresolved assigned_project survives: an
+        asset whose old string matched no project still has that string in its ledger, which is
+        the difference between migrating the data and losing it.
+    -->
+    <changeSet id="064-seed-asset-movement-opening-entries" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT count(*) FROM asset_movement</sqlCheck>
+        </preConditions>
+
+        <sql>
+            INSERT INTO asset_movement (
+                asset_id, organization_id, movement_type,
+                to_project_id, to_project_name,
+                to_location_id, to_location_name,
+                to_assigned_to_id, to_assigned_to,
+                moved_at, recorded_at, reason
+            )
+            SELECT a.id,
+                   a.organization_id,
+                   'REGISTRATION',
+                   a.assigned_project_id,
+                   COALESCE(p.project_name, NULLIF(btrim(a.assigned_project), '')),
+                   a.location_id,
+                   l.location_name,
+                   a.assigned_to_id,
+                   a.assigned_to,
+                   COALESCE(a.created_at, CURRENT_TIMESTAMP),
+                   CURRENT_TIMESTAMP,
+                   'Opening entry recorded when the asset movement ledger was introduced. Where the asset was before this date was not tracked.'
+            FROM asset a
+            LEFT JOIN project p ON p.id = a.assigned_project_id
+            LEFT JOIN storage_location l ON l.id = a.location_id
+            WHERE a.assigned_project_id IS NOT NULL
+               OR NULLIF(btrim(COALESCE(a.assigned_project, '')), '') IS NOT NULL
+               OR a.location_id IS NOT NULL
+               OR a.assigned_to_id IS NOT NULL
+               OR NULLIF(btrim(COALESCE(a.assigned_to, '')), '') IS NOT NULL;
+        </sql>
+        <rollback>
+            <sql>DELETE FROM asset_movement WHERE movement_type = 'REGISTRATION';</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/065-add-attachment-document-metadata.xml
+++ b/src/main/resources/db/changelog/v4.0/065-add-attachment-document-metadata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        What a file is, and when it stops being valid.
+
+        The shared attachment table is widened rather than assets being given a documents table
+        of their own. Attachments are already generic: entity_type is free-form and the upload,
+        presign, register, list and delete endpoints all take the type and the id as path
+        variables, so an asset's insurance policy stores through the endpoints that already
+        exist. The only thing missing was somewhere to say what the file is and when it lapses,
+        and inspections want the same two columns, so putting them on the shared table answers
+        both asks once.
+
+        Both columns are nullable and every existing row keeps working: a photo attached to a
+        task has no document type and no expiry, which is exactly what null means here.
+    -->
+    <changeSet id="065-add-attachment-document-metadata" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="attachment" columnName="expires_on"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="attachment">
+            <column name="document_type" type="VARCHAR(50)"/>
+            <column name="issued_on" type="DATE"/>
+            <column name="expires_on" type="DATE"/>
+        </addColumn>
+
+        <createIndex tableName="attachment" indexName="idx_attachment_expiry">
+            <column name="organization_id"/>
+            <column name="entity_type"/>
+            <column name="expires_on"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetMovementIsAppendOnlyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetMovementIsAppendOnlyTest.java
@@ -1,0 +1,57 @@
+package org.tornotron.echno_backend.asset;
+
+import org.hibernate.annotations.Immutable;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Append-only is a property of the ledger's types, not a convention someone has to remember.
+ *
+ * <p>{@link AssetMovementRepository} extends {@code Repository} rather than {@code JpaRepository},
+ * so Spring Data implements only the methods it declares and there is no {@code delete} or
+ * {@code deleteAll} for anything to reach for. {@link AssetMovement} is {@code @Immutable} on top
+ * of that, so an entry loaded and modified is not flushed either. This test fails the moment
+ * either of those is relaxed, which is the point: the guarantee should not be quietly removable
+ * by widening an interface.
+ */
+class AssetMovementIsAppendOnlyTest {
+
+    @Test
+    void theLedgerRepositoryOffersNoWayToDeleteAnEntry() {
+        String[] destructive = Arrays.stream(AssetMovementRepository.class.getMethods())
+                .map(Method::getName)
+                .filter(name -> name.startsWith("delete") || name.startsWith("remove"))
+                .toArray(String[]::new);
+
+        assertThat(destructive)
+                .as("the asset movement ledger must expose no delete of any kind")
+                .isEmpty();
+    }
+
+    @Test
+    void theLedgerRepositoryDoesNotInheritTheFullJpaSurface() {
+        assertThat(org.springframework.data.jpa.repository.JpaRepository.class
+                .isAssignableFrom(AssetMovementRepository.class))
+                .as("extending JpaRepository would hand the ledger deleteAll and saveAll")
+                .isFalse();
+    }
+
+    @Test
+    void anEntryCannotBeEditedOnceWritten() {
+        assertThat(AssetMovement.class.getAnnotation(Immutable.class))
+                .as("a ledger entry that can be updated is not a ledger entry")
+                .isNotNull();
+    }
+
+    @Test
+    void aCorrectionIsHowAnEntryIsPutRight() {
+        assertThat(AssetMovementType.values()).contains(AssetMovementType.CORRECTION);
+        assertThat(AssetMovement.class.getDeclaredFields())
+                .extracting(java.lang.reflect.Field::getName)
+                .contains("correctsMovementId");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
@@ -1,0 +1,369 @@
+package org.tornotron.echno_backend.asset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.asset.dto.AssetCreationDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementCreationDto;
+import org.tornotron.echno_backend.asset.mapper.AssetMapper;
+import org.tornotron.echno_backend.asset.mapper.AssetMovementMapper;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the asset movement ledger.
+ *
+ * <p>What is worth pinning here is not that rows get written but that they cannot be avoided:
+ * the asset's project, location and custodian are a cache of the latest ledger entry rather than
+ * a second source of truth, so every path that changes them has to append an entry, an entry has
+ * to say why, and an entry once written is superseded rather than edited. Plain Mockito with no
+ * Spring context, so nothing here adds a cached application context to the test JVM.
+ */
+@ExtendWith(MockitoExtension.class)
+class AssetMovementLedgerTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ASSET = 12L;
+    private static final Long PROJECT_A = 3L;
+    private static final Long PROJECT_B = 5L;
+    private static final Long LOCATION = 7L;
+    private static final Long USER = 4L;
+
+    @Mock private AssetRepository assetRepository;
+    @Mock private AssetMapper assetMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AssetMovementRepository assetMovementRepository;
+    @Mock private AssetMovementMapper assetMovementMapper;
+    @Mock private UserContextService userContextService;
+    @Mock private AttachmentService attachmentService;
+
+    private AssetService service;
+    private Organization organization;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        organization = new Organization();
+        organization.setId(ORG);
+
+        service = new AssetService(assetRepository, assetMapper, tenantEntityHelper, vendorRepository,
+                storageLocationRepository, projectRepository, assetMovementRepository,
+                assetMovementMapper, userContextService, attachmentService);
+
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(organization);
+        lenient().when(assetRepository.save(any(Asset.class))).thenAnswer(inv -> {
+            Asset asset = inv.getArgument(0);
+            if (asset.getId() == null) {
+                asset.setId(ASSET);
+            }
+            return asset;
+        });
+        lenient().when(assetMovementRepository.save(any(AssetMovement.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(USER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private Project project(Long id, String name) {
+        Project project = new Project();
+        project.setId(id);
+        project.setProjectName(name);
+        return project;
+    }
+
+    private StorageLocation location(Long id, String name) {
+        StorageLocation storageLocation = new StorageLocation();
+        storageLocation.setId(id);
+        storageLocation.setLocationName(name);
+        return storageLocation;
+    }
+
+    private Asset existingAsset() {
+        Asset asset = new Asset();
+        asset.setId(ASSET);
+        asset.setName("JCB 3DX Backhoe Loader");
+        asset.setOrganization(organization);
+        return asset;
+    }
+
+    private AssetCreationDto creationDto() {
+        AssetCreationDto dto = new AssetCreationDto();
+        dto.setName("JCB 3DX Backhoe Loader");
+        return dto;
+    }
+
+    private AssetMovementCreationDto movementDto(Long toProjectId, String reason) {
+        AssetMovementCreationDto dto = new AssetMovementCreationDto();
+        dto.setToProjectId(toProjectId);
+        dto.setReason(reason);
+        return dto;
+    }
+
+    private AssetMovement captureMovement() {
+        ArgumentCaptor<AssetMovement> captor = ArgumentCaptor.forClass(AssetMovement.class);
+        verify(assetMovementRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void create_opensTheLedgerWithARegistrationEntry() {
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_A, ORG))
+                .thenReturn(Optional.of(project(PROJECT_A, "Central Yard")));
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProjectId(PROJECT_A);
+
+        service.createAsset(dto);
+
+        AssetMovement movement = captureMovement();
+        assertThat(movement.getMovementType()).isEqualTo(AssetMovementType.REGISTRATION);
+        assertThat(movement.getToProject().getId()).isEqualTo(PROJECT_A);
+        assertThat(movement.getFromProject()).isNull();
+        assertThat(movement.getReason()).isEqualTo(AssetService.REGISTRATION_REASON);
+        assertThat(movement.getMovedBy()).isEqualTo(USER);
+    }
+
+    @Test
+    void update_thatMovesTheAsset_appendsATransferAndBringsTheAssetWithIt() {
+        Asset asset = existingAsset();
+        asset.setAssignedProject(project(PROJECT_A, "Central Yard"));
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProjectId(PROJECT_B);
+
+        service.updateAsset(ASSET, dto);
+
+        AssetMovement movement = captureMovement();
+        assertThat(movement.getMovementType()).isEqualTo(AssetMovementType.TRANSFER);
+        assertThat(movement.getFromProject().getId()).isEqualTo(PROJECT_A);
+        assertThat(movement.getToProject().getId()).isEqualTo(PROJECT_B);
+        assertThat(movement.getReason()).isEqualTo(AssetService.EDIT_REASON);
+        // The asset follows the entry rather than being set independently of it.
+        assertThat(asset.getAssignedProject().getId()).isEqualTo(PROJECT_B);
+    }
+
+    @Test
+    void update_thatMovesNothing_appendsNoEntry() {
+        Asset asset = existingAsset();
+        asset.setAssignedProject(project(PROJECT_A, "Central Yard"));
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_A, ORG))
+                .thenReturn(Optional.of(project(PROJECT_A, "Central Yard")));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProjectId(PROJECT_A);
+        dto.setSerialNumber("JCB3DX2023-0456");
+
+        service.updateAsset(ASSET, dto);
+
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void recordMovement_carriesTheReasonTheCallerGave() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        service.recordMovement(ASSET, movementDto(PROJECT_B, "Mobilised for the piling phase"));
+
+        assertThat(captureMovement().getReason()).isEqualTo("Mobilised for the piling phase");
+    }
+
+    @Test
+    void recordMovement_snapshotsTheProjectNameSoARenameCannotRewriteHistory() {
+        Asset asset = existingAsset();
+        Project from = project(PROJECT_A, "Central Yard");
+        asset.setAssignedProject(from);
+        asset.setLocation(location(LOCATION, "Kochi Yard"));
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        service.recordMovement(ASSET, movementDto(PROJECT_B, "Mobilised for the piling phase"));
+
+        AssetMovement movement = captureMovement();
+        assertThat(movement.getFromProjectName()).isEqualTo("Central Yard");
+        assertThat(movement.getToProjectName()).isEqualTo("Silver Oak Residences");
+        assertThat(movement.getFromLocationName()).isEqualTo("Kochi Yard");
+
+        // The project is renamed afterwards; the entry still reads as it did at the time.
+        from.setProjectName("Central Yard (closed)");
+        assertThat(movement.getFromProjectName()).isEqualTo("Central Yard");
+    }
+
+    @Test
+    void recordMovement_keepsTheFreeTextOfAnAssetThatNeverMatchedAProject() {
+        Asset asset = existingAsset();
+        asset.setLegacyAssignedProject("Marina Heights - phase 2 (old sheet)");
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        service.recordMovement(ASSET, movementDto(PROJECT_B, "Mobilised for the piling phase"));
+
+        assertThat(captureMovement().getFromProjectName())
+                .isEqualTo("Marina Heights - phase 2 (old sheet)");
+    }
+
+    @Test
+    void recordMovement_withNoStatedReason_isRefused() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, movementDto(PROJECT_B, "   ")))
+                .withMessageContaining("must say why it happened");
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void recordMovement_thatMovesNothing_isRefused() {
+        Asset asset = existingAsset();
+        asset.setAssignedProject(project(PROJECT_A, "Central Yard"));
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_A, ORG))
+                .thenReturn(Optional.of(project(PROJECT_A, "Central Yard")));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, movementDto(PROJECT_A, "Nothing changed")))
+                .withMessageContaining("no movement to record");
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void recordMovement_datedInTheFuture_isRefused() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        AssetMovementCreationDto dto = movementDto(PROJECT_B, "Planned mobilisation");
+        dto.setMovedAt(LocalDateTime.now().plusDays(3));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, dto))
+                .withMessageContaining("in the future");
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void recordMovement_correctingAnEarlierEntry_appendsACorrectionRatherThanEditingIt() {
+        Asset asset = existingAsset();
+        Project onSite = project(PROJECT_A, "Central Yard");
+        asset.setAssignedProject(onSite);
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_A, ORG)).thenReturn(Optional.of(onSite));
+
+        AssetMovement wrong = new AssetMovement();
+        wrong.setId(409L);
+        wrong.setAsset(asset);
+        when(assetMovementRepository.findByIdAndOrganization_Id(409L, ORG)).thenReturn(Optional.of(wrong));
+
+        AssetMovementCreationDto dto = movementDto(PROJECT_A, "The 12 Aug transfer named the wrong yard");
+        dto.setCorrectsMovementId(409L);
+
+        service.recordMovement(ASSET, dto);
+
+        AssetMovement movement = captureMovement();
+        // A correction is a new entry even though it moves the asset nowhere.
+        assertThat(movement.getMovementType()).isEqualTo(AssetMovementType.CORRECTION);
+        assertThat(movement.getCorrectsMovementId()).isEqualTo(409L);
+        // The wrong entry is untouched: it is superseded, not edited.
+        assertThat(movement).isNotSameAs(wrong);
+        assertThat(wrong.getCorrectsMovementId()).isNull();
+        assertThat(wrong.getMovementType()).isNull();
+    }
+
+    @Test
+    void recordMovement_correctingAnEntryOfAnotherAsset_isRefused() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+
+        Asset other = new Asset();
+        other.setId(99L);
+        AssetMovement elsewhere = new AssetMovement();
+        elsewhere.setId(409L);
+        elsewhere.setAsset(other);
+        when(assetMovementRepository.findByIdAndOrganization_Id(409L, ORG)).thenReturn(Optional.of(elsewhere));
+
+        AssetMovementCreationDto dto = movementDto(PROJECT_B, "Restating an entry");
+        dto.setCorrectsMovementId(409L);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, dto))
+                .withMessageContaining("belongs to a different asset");
+    }
+
+    @Test
+    void delete_isRefusedOnceTheAssetHasMoved() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(assetMovementRepository.countByAsset_IdAndOrganization_Id(ASSET, ORG)).thenReturn(3L);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.deleteAsset(ASSET))
+                .withMessageContaining("3 recorded movements");
+        verify(assetRepository, never()).delete(any(Asset.class));
+    }
+
+    @Test
+    void delete_isAllowedForAnAssetThatHasNoHistory() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(assetMovementRepository.countByAsset_IdAndOrganization_Id(ASSET, ORG)).thenReturn(0L);
+
+        service.deleteAsset(ASSET);
+
+        verify(assetRepository).delete(asset);
+    }
+
+    @Test
+    void recordMovement_toAProjectOfAnotherOrganization_isRefused() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, movementDto(PROJECT_B, "Mobilised")))
+                .withMessageContaining("Project with ID " + PROJECT_B);
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
@@ -368,6 +368,52 @@ class AssetMovementLedgerTest {
     }
 
     @Test
+    void recordMovement_datedBeforeTheLastEntryOnTheLedger_isRefused() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        AssetMovement latest = new AssetMovement();
+        latest.setId(409L);
+        latest.setMovedAt(LocalDateTime.now().minusDays(2));
+        when(assetMovementRepository.findFirstByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(ASSET, ORG))
+                .thenReturn(Optional.of(latest));
+
+        AssetMovementCreationDto dto = movementDto(PROJECT_B, "Entered late");
+        dto.setMovedAt(LocalDateTime.now().minusDays(9));
+
+        // Appending behind an existing entry would leave the asset showing the older placement
+        // while the ledger's last entry said otherwise.
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.recordMovement(ASSET, dto))
+                .withMessageContaining("before the last entry on its ledger");
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void recordMovement_backdatedButStillAfterTheLastEntry_isAccepted() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_B, ORG))
+                .thenReturn(Optional.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        AssetMovement latest = new AssetMovement();
+        latest.setId(409L);
+        latest.setMovedAt(LocalDateTime.now().minusDays(9));
+        when(assetMovementRepository.findFirstByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(ASSET, ORG))
+                .thenReturn(Optional.of(latest));
+
+        LocalDateTime when = LocalDateTime.now().minusDays(2);
+        AssetMovementCreationDto dto = movementDto(PROJECT_B, "Entered two days after the machine moved");
+        dto.setMovedAt(when);
+
+        service.recordMovement(ASSET, dto);
+
+        assertThat(captureMovement().getMovedAt()).isEqualTo(when);
+    }
+
+    @Test
     void recordMovement_correctingAnEarlierEntry_appendsACorrectionRatherThanEditingIt() {
         Asset asset = existingAsset();
         Project onSite = project(PROJECT_A, "Central Yard");

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetMovementLedgerTest.java
@@ -25,6 +25,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.vendor.VendorRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,6 +192,88 @@ class AssetMovementLedgerTest {
         service.updateAsset(ASSET, dto);
 
         verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+    }
+
+    @Test
+    void update_fromAClientStillSendingTheProjectName_resolvesItRatherThanUnassigningTheAsset() {
+        Asset asset = existingAsset();
+        Project central = project(PROJECT_A, "Central Yard");
+        asset.setAssignedProject(central);
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProject("Silver Oak Residences");
+        when(projectRepository.findByNormalisedName(ORG, "silver oak residences"))
+                .thenReturn(List.of(project(PROJECT_B, "Silver Oak Residences")));
+
+        service.updateAsset(ASSET, dto);
+
+        assertThat(captureMovement().getToProject().getId()).isEqualTo(PROJECT_B);
+        assertThat(asset.getAssignedProject().getId()).isEqualTo(PROJECT_B);
+    }
+
+    @Test
+    void update_thatDidNotTouchTheProjectName_leavesTheAssetWhereItIs() {
+        Asset asset = existingAsset();
+        asset.setAssignedProject(project(PROJECT_A, "Central Yard"));
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProject("Central Yard");
+        dto.setSerialNumber("JCB3DX2023-0456");
+
+        service.updateAsset(ASSET, dto);
+
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+        assertThat(asset.getAssignedProject().getId()).isEqualTo(PROJECT_A);
+    }
+
+    @Test
+    void update_resendingTextThatNeverResolved_leavesTheAssetWhereItIs() {
+        Asset asset = existingAsset();
+        asset.setLegacyAssignedProject("Marina Hts - phase 2 (old sheet)");
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProject("Marina Hts - phase 2 (old sheet)");
+
+        service.updateAsset(ASSET, dto);
+
+        verify(assetMovementRepository, never()).save(any(AssetMovement.class));
+        assertThat(asset.getAssignedProject()).isNull();
+    }
+
+    @Test
+    void update_withAChangedProjectNameThatResolvesToNothing_isRefusedRatherThanClearing() {
+        Asset asset = existingAsset();
+        Project central = project(PROJECT_A, "Central Yard");
+        asset.setAssignedProject(central);
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByNormalisedName(ORG, "somewhere that does not exist"))
+                .thenReturn(List.of());
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProject("Somewhere that does not exist");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.updateAsset(ASSET, dto))
+                .withMessageContaining("Send assignedProjectId instead");
+        assertThat(asset.getAssignedProject()).isSameAs(central);
+    }
+
+    @Test
+    void update_withAnAmbiguousProjectName_isRefusedRatherThanGuessing() {
+        Asset asset = existingAsset();
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+        when(projectRepository.findByNormalisedName(ORG, "phase 1"))
+                .thenReturn(List.of(project(PROJECT_A, "Phase 1"), project(PROJECT_B, "Phase 1")));
+
+        AssetCreationDto dto = creationDto();
+        dto.setAssignedProject("Phase 1");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.updateAsset(ASSET, dto))
+                .withMessageContaining("names 2 projects");
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetPlacementHistoryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetPlacementHistoryTest.java
@@ -1,0 +1,130 @@
+package org.tornotron.echno_backend.asset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
+import org.tornotron.echno_backend.asset.mapper.AssetMapper;
+import org.tornotron.echno_backend.asset.mapper.AssetMovementMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the placement history the ledger is read into: "14 days at Central Yard,
+ * 45 days at Silver Oak". The durations are worked out from consecutive entries on every read
+ * rather than stored anywhere, which is what stops them drifting from the ledger, so what needs
+ * pinning is that consecutive entries close each other and only the last stretch stays open.
+ */
+@ExtendWith(MockitoExtension.class)
+class AssetPlacementHistoryTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ASSET = 12L;
+
+    @Mock private AssetRepository assetRepository;
+    @Mock private AssetMapper assetMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AssetMovementRepository assetMovementRepository;
+    @Mock private AssetMovementMapper assetMovementMapper;
+    @Mock private UserContextService userContextService;
+    @Mock private AttachmentService attachmentService;
+
+    private AssetService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AssetService(assetRepository, assetMapper, tenantEntityHelper, vendorRepository,
+                storageLocationRepository, projectRepository, assetMovementRepository,
+                assetMovementMapper, userContextService, attachmentService);
+
+        Organization organization = new Organization();
+        organization.setId(ORG);
+        Asset asset = new Asset();
+        asset.setId(ASSET);
+        asset.setOrganization(organization);
+        when(assetRepository.findByIdAndOrganization_Id(ASSET, ORG)).thenReturn(Optional.of(asset));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private AssetMovement entry(Long id, String projectName, LocalDateTime movedAt, String reason) {
+        AssetMovement movement = new AssetMovement();
+        movement.setId(id);
+        movement.setToProjectName(projectName);
+        movement.setMovedAt(movedAt);
+        movement.setReason(reason);
+        return movement;
+    }
+
+    @Test
+    void eachEntryIsClosedByTheNextOne_andOnlyTheLastStretchIsStillOpen() {
+        LocalDateTime now = LocalDateTime.now();
+        List<AssetMovement> ledger = List.of(
+                entry(1L, "Central Yard", now.minusDays(59), "Registered"),
+                entry(2L, "Silver Oak Residences", now.minusDays(45), "Mobilised for the piling phase"),
+                entry(3L, "Marina Heights Towers", now.minusDays(10), "Moved to the tower crane base"));
+        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+                eq(ASSET), eq(ORG), any(Pageable.class))).thenReturn(ledger);
+
+        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET);
+
+        assertThat(spans).hasSize(3);
+        assertThat(spans).extracting(AssetPlacementSpanDto::getProjectName)
+                .containsExactly("Central Yard", "Silver Oak Residences", "Marina Heights Towers");
+        assertThat(spans).extracting(AssetPlacementSpanDto::getDays)
+                .containsExactly(14L, 35L, 10L);
+        assertThat(spans).extracting(AssetPlacementSpanDto::isCurrent)
+                .containsExactly(false, false, true);
+        assertThat(spans.get(0).getTo()).isEqualTo(ledger.get(1).getMovedAt());
+        assertThat(spans.get(2).getTo()).isNull();
+    }
+
+    @Test
+    void aSingleEntryIsOneOpenStretchCountedToNow() {
+        LocalDateTime now = LocalDateTime.now();
+        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+                eq(ASSET), eq(ORG), any(Pageable.class)))
+                .thenReturn(List.of(entry(1L, "Central Yard", now.minusDays(21), "Registered")));
+
+        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET);
+
+        assertThat(spans).hasSize(1);
+        assertThat(spans.get(0).getDays()).isEqualTo(21L);
+        assertThat(spans.get(0).isCurrent()).isTrue();
+        assertThat(spans.get(0).getReason()).isEqualTo("Registered");
+    }
+
+    @Test
+    void anAssetWithNoLedgerHasNoHistoryRatherThanAnInventedOne() {
+        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
+                eq(ASSET), eq(ORG), any(Pageable.class))).thenReturn(List.of());
+
+        assertThat(service.getPlacementHistory(ASSET)).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetPlacementHistoryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetPlacementHistoryTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
 import org.tornotron.echno_backend.asset.mapper.AssetMapper;
@@ -89,10 +92,10 @@ class AssetPlacementHistoryTest {
                 entry(1L, "Central Yard", now.minusDays(59), "Registered"),
                 entry(2L, "Silver Oak Residences", now.minusDays(45), "Mobilised for the piling phase"),
                 entry(3L, "Marina Heights Towers", now.minusDays(10), "Moved to the tower crane base"));
-        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
-                eq(ASSET), eq(ORG), any(Pageable.class))).thenReturn(ledger);
+        // The repository answers newest first; the service turns it back into reading order.
+        stubLedger(List.of(ledger.get(2), ledger.get(1), ledger.get(0)), 3L);
 
-        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET);
+        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET).getContent();
 
         assertThat(spans).hasSize(3);
         assertThat(spans).extracting(AssetPlacementSpanDto::getProjectName)
@@ -108,11 +111,9 @@ class AssetPlacementHistoryTest {
     @Test
     void aSingleEntryIsOneOpenStretchCountedToNow() {
         LocalDateTime now = LocalDateTime.now();
-        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
-                eq(ASSET), eq(ORG), any(Pageable.class)))
-                .thenReturn(List.of(entry(1L, "Central Yard", now.minusDays(21), "Registered")));
+        stubLedger(List.of(entry(1L, "Central Yard", now.minusDays(21), "Registered")), 1L);
 
-        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET);
+        List<AssetPlacementSpanDto> spans = service.getPlacementHistory(ASSET).getContent();
 
         assertThat(spans).hasSize(1);
         assertThat(spans.get(0).getDays()).isEqualTo(21L);
@@ -122,9 +123,32 @@ class AssetPlacementHistoryTest {
 
     @Test
     void anAssetWithNoLedgerHasNoHistoryRatherThanAnInventedOne() {
-        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtAscIdAsc(
-                eq(ASSET), eq(ORG), any(Pageable.class))).thenReturn(List.of());
+        stubLedger(List.of(), 0L);
 
         assertThat(service.getPlacementHistory(ASSET)).isEmpty();
+    }
+
+    @Test
+    void aCappedReadKeepsTheNewestEntriesAndReportsTheWholeLedgerAsTheTotal() {
+        LocalDateTime now = LocalDateTime.now();
+        // Two entries returned out of eight hundred: the cap dropped the oldest, not the newest,
+        // so the placement marked current is genuinely where the asset is.
+        stubLedger(List.of(
+                entry(800L, "Marina Heights Towers", now.minusDays(4), "Moved to the tower crane base"),
+                entry(799L, "Silver Oak Residences", now.minusDays(30), "Mobilised for the piling phase")),
+                800L);
+
+        Page<AssetPlacementSpanDto> history = service.getPlacementHistory(ASSET);
+
+        assertThat(history.getContent()).extracting(AssetPlacementSpanDto::getProjectName)
+                .containsExactly("Silver Oak Residences", "Marina Heights Towers");
+        assertThat(history.getContent().get(1).isCurrent()).isTrue();
+        assertThat(history.getTotalElements()).isEqualTo(800L);
+    }
+
+    private void stubLedger(List<AssetMovement> newestFirst, long total) {
+        when(assetMovementRepository.findByAsset_IdAndOrganization_IdOrderByMovedAtDescIdDesc(
+                eq(ASSET), eq(ORG), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(newestFirst, PageRequest.of(0, 500), total));
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/asset/AssetRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/asset/AssetRepositoryIT.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import org.tornotron.echno_backend.user.User;
 
@@ -109,6 +110,190 @@ class AssetRepositoryIT extends AbstractIntegrationTest {
 
         Asset reloaded = assetRepository.findById(asset.getId()).orElseThrow();
         assertThat(reloaded.getAssignedToId()).isNull();
+    }
+
+    @Test
+    void assignedProjectBackfill_resolvesAUniqueNameToTheProject() {
+        Organization org = persistOrganization("Org F");
+        Project marina = persistProject(org, "Marina Heights Towers");
+        Asset asset = persistAssetWithLegacyProject(org, "Excavator", "Marina Heights Towers");
+
+        runAssignedProjectBackfill();
+        em.clear();
+
+        Asset reloaded = assetRepository.findById(asset.getId()).orElseThrow();
+        assertThat(reloaded.getAssignedProject().getId()).isEqualTo(marina.getId());
+        // The text is kept even where it resolved, which is what makes the migration reversible.
+        assertThat(reloaded.getLegacyAssignedProject()).isEqualTo("Marina Heights Towers");
+    }
+
+    @Test
+    void assignedProjectBackfill_matchesPastCaseAndSurroundingSpace() {
+        Organization org = persistOrganization("Org G");
+        Project silverOak = persistProject(org, "Silver Oak Residences");
+        Asset asset = persistAssetWithLegacyProject(org, "Loader", "  silver oak residences ");
+
+        runAssignedProjectBackfill();
+        em.clear();
+
+        assertThat(assetRepository.findById(asset.getId()).orElseThrow().getAssignedProject().getId())
+                .isEqualTo(silverOak.getId());
+    }
+
+    @Test
+    void assignedProjectBackfill_leavesTextThatNamesNoProjectUnresolvedAndKeepsIt() {
+        Organization org = persistOrganization("Org H");
+        persistProject(org, "Marina Heights Towers");
+        Asset asset = persistAssetWithLegacyProject(org, "Concrete Pump", "Marina Hts - phase 2 (old sheet)");
+
+        runAssignedProjectBackfill();
+        em.clear();
+
+        Asset reloaded = assetRepository.findById(asset.getId()).orElseThrow();
+        assertThat(reloaded.getAssignedProject()).isNull();
+        // Nothing is dropped: the unresolved text is still there to be read and corrected by hand.
+        assertThat(reloaded.getLegacyAssignedProject()).isEqualTo("Marina Hts - phase 2 (old sheet)");
+    }
+
+    @Test
+    void assignedProjectBackfill_leavesAnAmbiguousNameUnresolved() {
+        Organization org = persistOrganization("Org I");
+        // Two projects share the name in one organization: a guess would be worse than nothing.
+        persistProject(org, "Phase 1");
+        persistProject(org, "Phase 1");
+        Asset asset = persistAssetWithLegacyProject(org, "Tower Crane", "Phase 1");
+
+        runAssignedProjectBackfill();
+        em.clear();
+
+        Asset reloaded = assetRepository.findById(asset.getId()).orElseThrow();
+        assertThat(reloaded.getAssignedProject()).isNull();
+        assertThat(reloaded.getLegacyAssignedProject()).isEqualTo("Phase 1");
+    }
+
+    @Test
+    void assignedProjectBackfill_doesNotMatchAcrossOrganizations() {
+        Organization mine = persistOrganization("Org J");
+        Organization theirs = persistOrganization("Org K");
+        persistProject(theirs, "Shared Name Site");
+        Asset asset = persistAssetWithLegacyProject(mine, "Roller", "Shared Name Site");
+
+        runAssignedProjectBackfill();
+        em.clear();
+
+        assertThat(assetRepository.findById(asset.getId()).orElseThrow().getAssignedProject()).isNull();
+    }
+
+    @Test
+    void openingEntrySeed_carriesUnresolvedFreeTextIntoTheLedgerRatherThanLosingIt() {
+        Organization org = persistOrganization("Org L");
+        Asset asset = persistAssetWithLegacyProject(org, "Grader", "Marina Hts - phase 2 (old sheet)");
+
+        runAssignedProjectBackfill();
+        runOpeningEntrySeed();
+        em.clear();
+
+        Object[] entry = (Object[]) em.getEntityManager().createNativeQuery(
+                        "SELECT movement_type, to_project_id, to_project_name FROM asset_movement "
+                                + "WHERE asset_id = :id")
+                .setParameter("id", asset.getId())
+                .getSingleResult();
+        assertThat(entry[0]).isEqualTo("REGISTRATION");
+        assertThat(entry[1]).isNull();
+        // The text that matched no project is what the ledger records the asset as having been on.
+        assertThat(entry[2]).isEqualTo("Marina Hts - phase 2 (old sheet)");
+    }
+
+    @Test
+    void openingEntrySeed_skipsAnAssetThatIsNowhereRatherThanInventingAnEntry() {
+        Organization org = persistOrganization("Org M");
+        Asset asset = persistAsset(org, "Spare Compressor");
+        em.flush();
+
+        runOpeningEntrySeed();
+        em.clear();
+
+        Object count = em.getEntityManager().createNativeQuery(
+                        "SELECT count(*) FROM asset_movement WHERE asset_id = :id")
+                .setParameter("id", asset.getId())
+                .getSingleResult();
+        assertThat(((Number) count).longValue()).isZero();
+    }
+
+    /** Runs the SQL from changeset 064-seed-asset-movement-opening-entries. */
+    private void runOpeningEntrySeed() {
+        em.getEntityManager().createNativeQuery(
+                "INSERT INTO asset_movement ("
+                        + "  asset_id, organization_id, movement_type,"
+                        + "  to_project_id, to_project_name,"
+                        + "  to_location_id, to_location_name,"
+                        + "  to_assigned_to_id, to_assigned_to,"
+                        + "  moved_at, recorded_at, reason) "
+                        + "SELECT a.id, a.organization_id, 'REGISTRATION', a.assigned_project_id,"
+                        + "       COALESCE(p.project_name, NULLIF(btrim(a.assigned_project), '')),"
+                        + "       a.location_id, l.location_name, a.assigned_to_id, a.assigned_to,"
+                        + "       COALESCE(a.created_at, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP,"
+                        + "       'Opening entry recorded when the asset movement ledger was introduced.' "
+                        + "FROM asset a "
+                        + "LEFT JOIN project p ON p.id = a.assigned_project_id "
+                        + "LEFT JOIN storage_location l ON l.id = a.location_id "
+                        + "WHERE (a.assigned_project_id IS NOT NULL"
+                        + "   OR NULLIF(btrim(COALESCE(a.assigned_project, '')), '') IS NOT NULL"
+                        + "   OR a.location_id IS NOT NULL"
+                        + "   OR a.assigned_to_id IS NOT NULL"
+                        + "   OR NULLIF(btrim(COALESCE(a.assigned_to, '')), '') IS NOT NULL) "
+                        + "  AND NOT EXISTS (SELECT 1 FROM asset_movement m WHERE m.asset_id = a.id)")
+                .executeUpdate();
+    }
+
+    /**
+     * Runs the SQL from changeset 063-backfill-asset-assigned-project-id against the test
+     * database, so the match rules are exercised as real CockroachDB rather than argued about.
+     */
+    private void runAssignedProjectBackfill() {
+        em.getEntityManager().createNativeQuery(
+                "UPDATE asset "
+                        + "SET assigned_project_id = m.project_id "
+                        + "FROM ("
+                        + "  SELECT p.organization_id AS organization_id,"
+                        + "         lower(btrim(p.project_name)) AS match_key,"
+                        + "         min(p.id) AS project_id,"
+                        + "         count(*) AS candidates"
+                        + "  FROM project p"
+                        + "  WHERE p.project_name IS NOT NULL AND btrim(p.project_name) <> ''"
+                        + "  GROUP BY p.organization_id, lower(btrim(p.project_name))"
+                        + ") AS m "
+                        + "WHERE asset.assigned_project IS NOT NULL "
+                        + "  AND btrim(asset.assigned_project) <> '' "
+                        + "  AND asset.assigned_project_id IS NULL "
+                        + "  AND asset.organization_id = m.organization_id "
+                        + "  AND lower(btrim(asset.assigned_project)) = m.match_key "
+                        + "  AND m.candidates = 1")
+                .executeUpdate();
+    }
+
+    private Project persistProject(Organization org, String name) {
+        Project project = new Project();
+        project.setOrganization(org);
+        project.setProjectName(name);
+        em.persist(project);
+        return project;
+    }
+
+    /**
+     * Persists an asset carrying the free text the reference migration has to deal with. The
+     * column is mapped read-only on the entity now, which is the point, so the text goes in the
+     * way it is already there in a live database: with SQL.
+     */
+    private Asset persistAssetWithLegacyProject(Organization org, String name, String legacyProject) {
+        Asset asset = persistAsset(org, name);
+        em.flush();
+        em.getEntityManager()
+                .createNativeQuery("UPDATE asset SET assigned_project = :text WHERE id = :id")
+                .setParameter("text", legacyProject)
+                .setParameter("id", asset.getId())
+                .executeUpdate();
+        return asset;
     }
 
     /** Runs the SQL from changeset 041-backfill-asset-assigned-to-id against the test database. */

--- a/src/test/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDtoTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/dto/AttachmentDocumentMetadataDtoTest.java
@@ -1,0 +1,66 @@
+package org.tornotron.echno_backend.common.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The one constraint on the document metadata payload that no single field can carry: a document
+ * cannot stop being valid before it was issued. Run against a bare Jakarta validator rather than
+ * through the web layer, so it costs no Spring context.
+ */
+class AttachmentDocumentMetadataDtoTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void startValidator() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void stopValidator() {
+        factory.close();
+    }
+
+    private AttachmentDocumentMetadataDto dto(LocalDate issuedOn, LocalDate expiresOn) {
+        AttachmentDocumentMetadataDto dto = new AttachmentDocumentMetadataDto();
+        dto.setDocumentType("insurance");
+        dto.setIssuedOn(issuedOn);
+        dto.setExpiresOn(expiresOn);
+        return dto;
+    }
+
+    @Test
+    void anExpiryBeforeTheIssueDateIsRefused() {
+        assertThat(validator.validate(dto(LocalDate.of(2026, 6, 10), LocalDate.of(2026, 1, 1))))
+                .extracting(v -> v.getMessage())
+                .containsExactly("expiresOn must not be before issuedOn");
+    }
+
+    @Test
+    void anExpiryOnTheIssueDateIsAllowed() {
+        assertThat(validator.validate(dto(LocalDate.of(2026, 6, 10), LocalDate.of(2026, 6, 10)))).isEmpty();
+    }
+
+    @Test
+    void anExpiryAfterTheIssueDateIsAllowed() {
+        assertThat(validator.validate(dto(LocalDate.of(2026, 6, 10), LocalDate.of(2027, 6, 10)))).isEmpty();
+    }
+
+    @Test
+    void aDocumentWithOnlyOneOfTheTwoDatesIsAllowed() {
+        assertThat(validator.validate(dto(null, LocalDate.of(2027, 6, 10)))).isEmpty();
+        assertThat(validator.validate(dto(LocalDate.of(2026, 6, 10), null))).isEmpty();
+        assertThat(validator.validate(dto(null, null))).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
@@ -1,0 +1,147 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.common.dto.AttachmentDocumentMetadataDto;
+import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.repository.AttachmentRepository;
+import org.tornotron.echno_backend.issue.IssueRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.TaskRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the document half of the asset ticket, which lands on the shared attachment
+ * table rather than on a table of its own.
+ *
+ * <p>Two things are worth pinning. The expiry flags are derived on read, so a policy cannot sit
+ * in the database marked valid the morning after it lapsed. And the metadata patch resolves the
+ * attachment through the tenant-scoped finder, so a member of one organization cannot annotate
+ * another's file by guessing a numeric id.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttachmentDocumentMetadataTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ATTACHMENT = 88L;
+
+    @Mock private AttachmentRepository attachmentRepository;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private IssueRepository issueRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private AttachmentMapper attachmentMapper;
+
+    private AttachmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AttachmentService(attachmentRepository, fileStorageService, organizationRepository,
+                projectRepository, taskRepository, issueRepository, userRepository, attendanceRepository,
+                tenantEntityHelper, attachmentMapper);
+        lenient().when(attachmentRepository.save(any(Attachment.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(attachmentMapper.toDto(any(Attachment.class))).thenAnswer(inv -> {
+            Attachment attachment = inv.getArgument(0);
+            AttachmentDto dto = new AttachmentDto();
+            dto.setId(attachment.getId());
+            dto.setDocumentType(attachment.getDocumentType());
+            dto.setIssuedOn(attachment.getIssuedOn());
+            dto.setExpiresOn(attachment.getExpiresOn());
+            AttachmentMapper.fillExpiry(attachment.getExpiresOn(), dto);
+            return dto;
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private AttachmentDocumentMetadataDto metadata(String type, LocalDate expiresOn) {
+        AttachmentDocumentMetadataDto dto = new AttachmentDocumentMetadataDto();
+        dto.setDocumentType(type);
+        dto.setExpiresOn(expiresOn);
+        return dto;
+    }
+
+    @Test
+    void metadataIsRecordedAgainstTheAttachment() {
+        Attachment attachment = new Attachment();
+        attachment.setId(ATTACHMENT);
+        when(attachmentRepository.findByIdAndOrganization_Id(ATTACHMENT, ORG))
+                .thenReturn(Optional.of(attachment));
+
+        AttachmentDto dto = service.updateDocumentMetadata(ATTACHMENT,
+                metadata("insurance", LocalDate.now().plusDays(285)));
+
+        assertThat(attachment.getDocumentType()).isEqualTo("insurance");
+        assertThat(dto.getExpiresOn()).isEqualTo(LocalDate.now().plusDays(285));
+        verify(attachmentRepository).save(attachment);
+        // Resolved through the tenant-scoped finder, not the unscoped findById.
+        verify(attachmentRepository).findByIdAndOrganization_Id(ATTACHMENT, ORG);
+    }
+
+    @Test
+    void anAttachmentOfAnotherOrganizationIsNotFound() {
+        when(attachmentRepository.findByIdAndOrganization_Id(ATTACHMENT, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.updateDocumentMetadata(ATTACHMENT, metadata("insurance", null)))
+                .withMessageContaining("was not found in this organization");
+        verify(attachmentRepository, never()).save(any(Attachment.class));
+    }
+
+    @Test
+    void aDocumentThatHasLapsedReadsAsExpired() {
+        AttachmentDto dto = new AttachmentDto();
+        AttachmentMapper.fillExpiry(LocalDate.now().minusDays(7), dto);
+
+        assertThat(dto.getExpired()).isTrue();
+        assertThat(dto.getDaysUntilExpiry()).isEqualTo(-7L);
+    }
+
+    @Test
+    void aDocumentExpiringTodayHasNotLapsedYet() {
+        AttachmentDto dto = new AttachmentDto();
+        AttachmentMapper.fillExpiry(LocalDate.now(), dto);
+
+        assertThat(dto.getExpired()).isFalse();
+        assertThat(dto.getDaysUntilExpiry()).isZero();
+    }
+
+    @Test
+    void aFileWithNoExpiryCarriesNoExpiryFlagsRatherThanFalseOnes() {
+        AttachmentDto dto = new AttachmentDto();
+        AttachmentMapper.fillExpiry(null, dto);
+
+        assertThat(dto.getExpired()).isNull();
+        assertThat(dto.getDaysUntilExpiry()).isNull();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentDocumentMetadataTest.java
@@ -98,11 +98,12 @@ class AttachmentDocumentMetadataTest {
         when(attachmentRepository.findByIdAndOrganization_Id(ATTACHMENT, ORG))
                 .thenReturn(Optional.of(attachment));
 
-        AttachmentDto dto = service.updateDocumentMetadata(ATTACHMENT,
-                metadata("insurance", LocalDate.now().plusDays(285)));
+        LocalDate expiry = LocalDate.now().plusDays(285);
+
+        AttachmentDto dto = service.updateDocumentMetadata(ATTACHMENT, metadata("insurance", expiry));
 
         assertThat(attachment.getDocumentType()).isEqualTo("insurance");
-        assertThat(dto.getExpiresOn()).isEqualTo(LocalDate.now().plusDays(285));
+        assertThat(dto.getExpiresOn()).isEqualTo(expiry);
         verify(attachmentRepository).save(attachment);
         // Resolved through the tenant-scoped finder, not the unscoped findById.
         verify(attachmentRepository).findByIdAndOrganization_Id(ATTACHMENT, ORG);

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
@@ -40,6 +40,7 @@ class AttachmentServiceTenancyTest {
     @Mock private UserRepository userRepository;
     @Mock private AttendanceRepository attendanceRepository;
     @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private org.tornotron.echno_backend.common.mapper.AttachmentMapper attachmentMapper;
     @Mock private MultipartFile file;
 
     private AttachmentService service;
@@ -48,7 +49,7 @@ class AttachmentServiceTenancyTest {
     void setUp() {
         service = new AttachmentService(attachmentRepository, fileStorageService, organizationRepository,
                 projectRepository, taskRepository, issueRepository, userRepository, attendanceRepository,
-                tenantEntityHelper);
+                tenantEntityHelper, attachmentMapper);
     }
 
     @Test


### PR DESCRIPTION
Closes #534

Anand's 28 Aug QA pass (ClickUp `86d45vjd0`) asks for asset documents and a full location history. Three things in the data model were in the way, and this addresses all three. The site-transfer half of the ticket (point 4) is deliberately not here; it is a design decision rather than an implementation detail, and it is called out at the bottom.

## 1. The project an asset is on becomes a reference

`assignedProject` was a `String`. Nothing guaranteed it named a real project, nothing could join on it, and two spellings of one site were two different places.

It is now `assigned_project_id`, a foreign key to `project` with `ON DELETE SET NULL`, indexed. `assignedProjectId` is what the create and update payloads send. `assignedProject` stays on the read DTO as a name so the current frontend keeps working, but it is **derived**: the referenced project's name where the asset names one, and the old free text where it does not.

### The migration, and what happens to text that resolves to nothing

**The free text is never rewritten and never dropped.** `asset.assigned_project` keeps every value it holds. On the entity it is now mapped `insertable = false, updatable = false` as `legacyAssignedProject`, so nothing can write it again. That is what makes the change reversible: rolling back means dropping one column, and the string underneath is exactly as it was.

The backfill is deliberately conservative. It matches per organization, trimmed and case-insensitive, and **only where exactly one project in that organization carries the name**:

```sql
UPDATE asset SET assigned_project_id = m.project_id
FROM (SELECT p.organization_id, lower(btrim(p.project_name)) AS match_key,
             min(p.id) AS project_id, count(*) AS candidates
      FROM project p WHERE p.project_name IS NOT NULL AND btrim(p.project_name) <> ''
      GROUP BY p.organization_id, lower(btrim(p.project_name))) AS m
WHERE asset.assigned_project IS NOT NULL AND btrim(asset.assigned_project) <> ''
  AND asset.assigned_project_id IS NULL
  AND asset.organization_id = m.organization_id
  AND lower(btrim(asset.assigned_project)) = m.match_key
  AND m.candidates = 1;
```

Two projects sharing a name leave the row unresolved rather than have the migration pick one. **A wrong reference is worse than an absent one, because an absent one still has the text beside it.** Unmatchable rows are listed by one query, which is in a comment at the top of the changeset:

```sql
SELECT id, organization_id, assigned_project FROM asset
WHERE assigned_project IS NOT NULL AND btrim(assigned_project) <> '' AND assigned_project_id IS NULL;
```

Those rows also keep their text inside the ledger, see below. Nothing about them is silent: they read the same in the API as they did before, they simply have no reference yet.

`AssetRepositoryIT` runs the migration's own SQL against a real CockroachDB and pins all five rules: a unique name resolves, case and surrounding space do not stop it, an ambiguous name does not resolve, a name belonging to another organization does not resolve, and text that names no project stays exactly as it was.

## 2. The movement ledger

New `asset_movement` table. One row per movement: **what moved, from where to where, when, by whom and why.**

| | |
|---|---|
| what | `asset_id` |
| from / to | `from_project_id` / `to_project_id`, `from_location_id` / `to_location_id`, `from_assigned_to_id` / `to_assigned_to_id` |
| when | `moved_at` (the caller's, backdatable, refused if in the future) and `recorded_at` (the database clock, never supplied) |
| by whom | `moved_by` |
| why | `reason`, `NOT NULL`, plus `notes` and `reference_number` |
| kind | `movement_type`: `REGISTRATION`, `TRANSFER`, `ASSIGNMENT`, `CORRECTION` |

**Append-only, and not by convention.** `AssetMovementRepository` extends `Repository` rather than `JpaRepository`, so Spring Data implements only what it declares and there is no `delete`, `deleteAll` or bulk write for anything to reach for. `AssetMovement` is `@Immutable` on top of that, so an entry loaded and modified is not flushed either. `AssetMovementIsAppendOnlyTest` fails if either is relaxed, which is the point: the guarantee should not be quietly removable by widening an interface.

**A correction is a new entry.** Same shape as a posted stock adjustment on `development` after #529, which is corrected by raising a further adjustment rather than by editing the one that was wrong. Sending `correctsMovementId` records a `CORRECTION` naming the entry it restates; the wrong entry stays where it is and stays legible.

**A movement must say why it happened**, echoing `StockAdjustmentService`'s "every stock movement must say why it happened". `reason` is `@NotBlank` on the request and non-null in the schema, and the service refuses a blank one rather than trusting the DTO alone.

**Deleting an asset that has moved is refused.** Its ledger is the record of where a machine was; deleting the asset takes that with it. The FK is `ON DELETE RESTRICT` so the database agrees with the service, and the refusal points at setting the status to retired instead.

**Names are snapshotted beside the foreign keys.** `from_project_name`, `to_project_name`, `from_location_name`, `to_location_name`. A project can be renamed at any time and the FKs are `SET NULL` so it can still be deleted; history that evaporates when a project is tidied away is not history. The snapshot is also where an unresolved `assigned_project` string survives, so the free text ends up in the ledger rather than nowhere.

**Existing assets do not start blank.** Changeset `064` seeds one `REGISTRATION` entry per asset that is somewhere, dated from the asset's own `created_at` and saying in its reason that where it was before that was not tracked. It is guarded on the table being empty, so it is idempotent.

### Current location is derived, not a second truth

This is the part worth reviewing hardest. `assignedProject`, `location`, `assignedTo` and `assignedToId` on `Asset` are now a **cache of the latest ledger entry**. Exactly one private method, `applyPlacement`, writes them, and it appends the entry first and sets the columns from that entry's "to" side, in one transaction. Every path goes through it:

- **create** opens the ledger with a `REGISTRATION`, so an asset has history from the moment it exists rather than from the first time somebody happens to move it;
- **update** records whatever the edit moved. The asset form sends the whole object, so an edit can move the asset as a side effect. Refusing that would break the screen, so instead the edit records a real entry, with the reason from the new optional `movementReason` field, falling back to `"Recorded from an asset edit"`. That fallback **says where the entry came from instead of inventing a reason for a movement nobody explained**;
- **`POST /assets/web/{id}/movements`** is the path that exists purely to move an asset, and requires a reason.

An update that moves nothing writes nothing, so editing a serial number does not litter the ledger.

### Reading it

- `GET /assets/web/{id}/movements`: paginated, newest first.
- `GET /assets/web/{id}/placement-history`: the stretches of time the asset spent in one place, with the whole days each lasted and the last one left open. This is what answers Anand's "14 days at Central Yard, 45 days at Silver Oak". It is computed from consecutive entries on every read rather than stored, so it cannot drift from the ledger. It reads the 500 **most recent** entries and reports the true total in `X-Total-Count`, with `X-Result-Capped` when older ones were left out: capping the other end would have left whichever entry the cap stopped at looking like the placement the asset is still in.

**A movement cannot be dated before the last entry on the ledger.** It can be backdated, for one entered a few days after the machine actually moved, but not past what is already recorded, because the asset's placement is set from the entry being appended. Without this an entry could land behind a later one and leave the asset showing the older placement while the ledger's last entry said otherwise, which is the disagreement this whole change exists to remove. A movement that really did happen earlier is entered as a correction of that entry.

## 3. Documents: yes, it was as small as expected

Confirmed before assuming it. `attachment.entity_type` is a free-form `String`, and the upload, presign, register, list and delete endpoints all take the type and the id as path variables. The storage folder is derived as the part of the type before the first underscore, so `ASSET_DOCUMENTS` lands files under `asset/` with no code change at all. **The storage half needed nothing.**

What was genuinely missing was somewhere to say what a file is and when it stops being valid. Three nullable columns go on the **shared** `attachment` table rather than assets getting a documents table of their own: `document_type`, `issued_on`, `expires_on`. Inspections want attachments too (`86d45v86y`), and the issue asks that the two land on the same answer; widening the shared table answers both once. Every existing row keeps working, because a photo on a task has no document type and no expiry, which is what null means here.

- `PATCH /api/v1/attachment/web/attachmentId/{id}/document` records the three. Applied after the upload so it serves both upload paths and every entity, not just assets. It resolves the attachment through a new tenant-scoped finder, which the existing delete path still does not.
- `GET /assets/web/{id}/documents` lists an asset's documents.
- `GET /assets/web/documents/expiring?withinDays=30` lists the organization's asset documents due to lapse, soonest first, already-lapsed included, capped at 500.
- `expired` and `daysUntilExpiry` are **derived on read**, so a policy cannot sit in the database marked valid the morning after it lapsed.

## Compatibility with the frontend that is deployed today

The asset form sends `assignedProject` as a name. Until it is updated, a save would have put null on the new reference and recorded a movement taking the asset off its project, on the first edit after deploy. So the name is still honoured when no id is given, resolved by the same rule the migration used. A name the payload did not change leaves the asset where it is, whether or not it ever resolved. A changed name that resolves to nothing, or to several projects, is refused with a message naming the field to send instead, rather than clearing the asset's project quietly. Nothing needs to be coordinated on deploy order.

## Conventions, and #529

#529 (PR #539) merged while this was in progress, so this follows it rather than inventing a second vocabulary: a ledger entry carries opening/closing state, a reason and a reference; a reason is mandatory and the refusal says so in the same words; a mistake is corrected by a further entry rather than an edit; and a document whose entries are on the ledger is frozen against destruction with a message that names the alternative. Where #529's ledger is `InventoryTransaction` for materials, this is `asset_movement` for assets.

## Migration numbers

`063`, `064`, `065`. `061` was taken by #540, and `062` is left free for #542, which is still open and currently claims `061`. Expect to renumber if anything else lands first.

## Tests, and that each one fails without its fix

Every test is plain JUnit and Mockito with no Spring context, except the migration tests, which were **added to the existing `AssetRepositoryIT`** so they reuse its configuration rather than caching another context in the test JVM. That matters here because this PR adds an `@Entity`, and a new cached context is what makes an unrelated test start failing on heap. The full suite is green on `.116` and in CI.

Twenty-six mutations of the new logic, each applied and reverted around one run; every one is killed.

| # | The fix removed | Test that then fails |
|---|---|---|
| M1 | the placement is written onto the asset with no entry appended | six in `AssetMovementLedgerTest`, including `create_opensTheLedgerWithARegistrationEntry` |
| M2 | the reason requirement | `recordMovement_withNoStatedReason_isRefused` |
| M3 | the future-date refusal | `recordMovement_datedInTheFuture_isRefused` |
| M4 | the project and location name snapshots | `recordMovement_snapshotsTheProjectNameSoARenameCannotRewriteHistory`, `recordMovement_keepsTheFreeTextOfAnAssetThatNeverMatchedAProject` |
| M5 | the refusal to delete an asset that has moved | `delete_isRefusedOnceTheAssetHasMoved` |
| M6 | recording a correction as its own kind of entry | `recordMovement_correctingAnEarlierEntry_appendsACorrectionRatherThanEditingIt` |
| M7 | the check that a corrected entry belongs to this asset | `recordMovement_correctingAnEntryOfAnotherAsset_isRefused` |
| M8 | bringing the asset's columns along with the entry | `update_thatMovesTheAsset_appendsATransferAndBringsTheAssetWithIt` |
| M9 | leaving the current placement open | `eachEntryIsClosedByTheNextOne_andOnlyTheLastStretchIsStillOpen` |
| M10 | the ledger repository's narrow interface (`extends JpaRepository`) | `theLedgerRepositoryOffersNoWayToDeleteAnEntry`, `theLedgerRepositoryDoesNotInheritTheFullJpaSurface` |
| M11 | `@Immutable` on the entry | `anEntryCannotBeEditedOnceWritten` |
| M12 | the tenant scope on the metadata patch | `metadataIsRecordedAgainstTheAttachment`, `anAttachmentOfAnotherOrganizationIsNotFound` |
| M13 | expiry counted from the day after, not the day of | `aDocumentExpiringTodayHasNotLapsedYet` |
| M14 | the "nothing moved, write nothing" short circuit | `update_thatMovesNothing_appendsNoEntry`, `recordMovement_thatMovesNothing_isRefused` |
| M15 | the guard for a file with no expiry | `aFileWithNoExpiryCarriesNoExpiryFlagsRatherThanFalseOnes` |
| M16 | the tenant scope on resolving a movement's project | eleven in `AssetMovementLedgerTest` |
| M17 | the backfill's guard against an ambiguous name | `assignedProjectBackfill_leavesAnAmbiguousNameUnresolved` |
| M18 | the backfill's per-organization match | `assignedProjectBackfill_doesNotMatchAcrossOrganizations` |
| M19 | the backfill's trimming and case folding | `assignedProjectBackfill_resolvesAUniqueNameToTheProject`, `assignedProjectBackfill_matchesPastCaseAndSurroundingSpace` |
| M20 | the opening entry's fallback to the unresolved free text | `openingEntrySeed_carriesUnresolvedFreeTextIntoTheLedgerRatherThanLosingIt` |
| M21 | the refusal of an entry dated before the last one | `recordMovement_datedBeforeTheLastEntryOnTheLedger_isRefused`, `recordMovement_backdatedButStillAfterTheLastEntry_isAccepted` |
| M22 | turning the capped history back into reading order | `eachEntryIsClosedByTheNextOne_andOnlyTheLastStretchIsStillOpen`, `aCappedReadKeepsTheNewestEntriesAndReportsTheWholeLedgerAsTheTotal` |
| M23 | reporting the whole ledger as the total on a shortened read | `aCappedReadKeepsTheNewestEntriesAndReportsTheWholeLedgerAsTheTotal` |
| M24 | leaving the asset alone when the name did not change | `update_thatDidNotTouchTheProjectName_leavesTheAssetWhereItIs`, `update_resendingTextThatNeverResolved_leavesTheAssetWhereItIs` |
| M25 | refusing a name that resolves to nothing or to several | `update_withAChangedProjectNameThatResolvesToNothing_isRefusedRatherThanClearing`, `update_withAnAmbiguousProjectName_isRefusedRatherThanGuessing` |
| M26 | the expiry-before-issue constraint | `anExpiryBeforeTheIssueDateIsRefused` |

## Not in this PR

**Point 4 of the ticket, moving an asset through a site transfer.** `site_transfer_item` is material-keyed, and carrying an asset on it needs either a second item type on the transfer or a separate asset-transfer flow. That is a design decision, so it is left out rather than guessed at. The ground is prepared: `asset_movement.reference_number` is where a transfer number goes, and the movements endpoint accepts it today.

**Web work.** `assignedProjectId` on create and update, the movements and placement-history screens, and the document type and expiry fields on the asset attachment upload.

**Backfilling the reasons for movements that predate the ledger.** They do not exist, and the opening entry says so rather than pretending otherwise.
