### PR TITLE
Refuse a site transfer that ends where it started

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.retry.SqlStateDetector;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
@@ -31,6 +32,7 @@ import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.user.User;
 import org.tornotron.echno_backend.user.UserRepository;
 
@@ -39,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -49,6 +52,14 @@ import java.util.stream.Collectors;
  * sending project), persists the transfer and its items, then publishes a
  * {@link SiteTransferCreatedEvent} so the ledger draws stock down at the source and raises it
  * at the destination in the same transaction.
+ *
+ * <p>A transfer has to move stock from one balance row to another. Balances are held per
+ * (material, project, storage location), with a location of none being its own row rather
+ * than a project total, so the two sides are the same row exactly when they name the same
+ * project and the same location. Such a transfer is refused: it moved nothing and would
+ * leave an out and a matching in that cancel, sitting in the movement history looking like
+ * real movement. Two locations inside one project are two rows, so a store-to-store move
+ * within a project is a real transfer and is allowed.
  */
 @Service
 public class SiteTransferService {
@@ -98,10 +109,12 @@ public class SiteTransferService {
     /**
      * Creates a site transfer with its items after checking sending-side stock.
      *
-     * <p>Allocates the transfer number and resolves the sending person and the sending and
-     * receiving projects (plus optional storage locations). Requested quantities are totalled
-     * per material and validated against the sending side. After saving the transfer and its
-     * items, a {@link SiteTransferCreatedEvent} is published so inventory moves.
+     * <p>Resolves the sending person, both projects and both optional storage locations,
+     * refuses a pair of sides that resolve to the same balance row, then totals the requested
+     * quantities per material and validates them against the sending side. The transfer
+     * number is allocated only once all of that has passed, so a rejected request does not
+     * spend one. After saving the transfer and its items, a {@link SiteTransferCreatedEvent}
+     * is published so inventory moves.
      *
      * <p>The transaction is restarted on a serialization abort, and also on a unique
      * violation: the counter behind the transfer number is the row two concurrent creates
@@ -112,6 +125,7 @@ public class SiteTransferService {
      * @param creationDto The transfer header fields and the list of items to move.
      * @return The created site transfer as a DTO.
      * @throws ResourceNotFoundException if the sending person, either project, a storage location, or a line's material is not found in this organization.
+     * @throws InvalidRequestException if both sides name the same project and the same storage location, so nothing would move, or if a storage location belongs to a project other than the one it is used from.
      * @throws org.tornotron.echno_backend.common.exception.InsufficientStockException if the sending side does not hold enough of any requested material.
      */
     public SiteTransferDto createSiteTransfer(SiteTransferCreationDto creationDto) {
@@ -132,6 +146,17 @@ public class SiteTransferService {
         // Validate receiving project
         Project receivingProject = projectRepository.findByIdAndOrganization_Id(creationDto.getReceivingProjectId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Receiving project with ID " + creationDto.getReceivingProjectId() + " was not found in this organization"));
+
+        // Resolve both storage locations here, before anything is decided. They are what say
+        // which balance rows this transfer draws from and credits, and that is needed twice
+        // over: to refuse a transfer whose two sides are the same row, and to know which row
+        // the stock check has to read.
+        StorageLocation sendingLocation = resolveStorageLocation(
+                creationDto.getSendingStorageLocationId(), sendingProject, "Sending");
+        StorageLocation receivingLocation = resolveStorageLocation(
+                creationDto.getReceivingStorageLocationId(), receivingProject, "Receiving");
+
+        requireTheTransferMovesStock(sendingProject, sendingLocation, receivingProject, receivingLocation);
 
         // CRITICAL: Validate sufficient stock at the SENDING location for ALL items
         // Use storage-location-level validation when a sending storage location is specified
@@ -154,22 +179,8 @@ public class SiteTransferService {
         transfer.setSendingPerson(sendingPerson);
         transfer.setSendingProject(sendingProject);
         transfer.setReceivingProject(receivingProject);
-
-        // Validate and set storage locations (optional)
-        if (creationDto.getSendingStorageLocationId() != null) {
-            StorageLocation sendingLocation = storageLocationRepository.findByIdAndOrganization_Id(
-                            creationDto.getSendingStorageLocationId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "Sending storage location with ID " + creationDto.getSendingStorageLocationId() + " was not found in this organization"));
-            transfer.setSendingStorageLocation(sendingLocation);
-        }
-        if (creationDto.getReceivingStorageLocationId() != null) {
-            StorageLocation receivingLocation = storageLocationRepository.findByIdAndOrganization_Id(
-                            creationDto.getReceivingStorageLocationId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException(
-                            "Receiving storage location with ID " + creationDto.getReceivingStorageLocationId() + " was not found in this organization"));
-            transfer.setReceivingStorageLocation(receivingLocation);
-        }
+        transfer.setSendingStorageLocation(sendingLocation);
+        transfer.setReceivingStorageLocation(receivingLocation);
 
         transfer.setStatus(SiteTransferStatus.valueOf(creationDto.getStatus()));
         transfer.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
@@ -200,6 +211,68 @@ public class SiteTransferService {
         eventPublisher.publishEvent(new SiteTransferCreatedEvent(this, transfer));
 
         return siteTransferMapper.toDto(transfer);
+    }
+
+    /**
+     * Resolves one side's optional storage location and checks it may be used from that side's project.
+     *
+     * @param storageLocationId The requested storage location id, or null when the side names no location.
+     * @param project The project the location will be booked against.
+     * @param side Either Sending or Receiving, used to say which end of the transfer a message is about.
+     * @return The resolved storage location, or null when none was requested.
+     * @throws ResourceNotFoundException if the id names no location in this organization.
+     * @throws InvalidRequestException if the location belongs to a different project.
+     */
+    private StorageLocation resolveStorageLocation(Long storageLocationId, Project project, String side) {
+        if (storageLocationId == null) {
+            return null;
+        }
+        StorageLocation location = storageLocationRepository
+                .findByIdAndOrganization_Id(storageLocationId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        side + " storage location with ID " + storageLocationId + " was not found in this organization"));
+        // A location on another project names a balance row this side can never reach, so the
+        // transfer would be written against a row that cannot exist. Same rule as consumption.
+        StorageLocationScope.requireUsableFromProject(location, project.getId());
+        return location;
+    }
+
+    /**
+     * Refuses a transfer whose two sides are the same balance row, so nothing would move.
+     *
+     * <p>Balances are held per (material, project, storage location), and a movement with no
+     * location writes the project's unlocated row rather than a project total. The two sides
+     * are therefore the same row exactly when the projects match and the locations match,
+     * counting no location on both sides as a match. Everything else moves stock between two
+     * distinct rows and is a real transfer, including two locations inside one project and
+     * one organisation-level store used from two different projects.
+     *
+     * @param sendingProject The project stock is drawn from.
+     * @param sendingLocation The location stock is drawn from, or null for the project's unlocated balance.
+     * @param receivingProject The project stock is credited to.
+     * @param receivingLocation The location stock is credited to, or null for the project's unlocated balance.
+     * @throws InvalidRequestException if both sides resolve to the same balance row.
+     */
+    private void requireTheTransferMovesStock(Project sendingProject, StorageLocation sendingLocation,
+                                              Project receivingProject, StorageLocation receivingLocation) {
+        if (!Objects.equals(sendingProject.getId(), receivingProject.getId())) {
+            return;
+        }
+        Long sendingLocationId = sendingLocation != null ? sendingLocation.getId() : null;
+        Long receivingLocationId = receivingLocation != null ? receivingLocation.getId() : null;
+        if (!Objects.equals(sendingLocationId, receivingLocationId)) {
+            return;
+        }
+
+        String where = sendingLocationId != null
+                ? "storage location with ID " + sendingLocationId + " in project with ID " + sendingProject.getId()
+                : "project with ID " + sendingProject.getId() + ", against no storage location";
+        throw new InvalidRequestException(
+                "This transfer sends stock from " + where + " straight back to the same place, so nothing "
+                        + "moves and the movement history would carry an out and a matching in that cancel. "
+                        + "To move stock between two stores on one project, name a different receiving "
+                        + "storage location; to move it to another site, name a different receiving project; "
+                        + "to correct a balance that is wrong, raise a stock adjustment instead.");
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
@@ -12,7 +12,10 @@ import java.util.List;
 
 @Schema(description = "Payload to create a site transfer moving materials from a sending project "
         + "to a receiving project. The transfer number is allocated by the server and returned on "
-        + "the created transfer; it is not part of this payload.")
+        + "the created transfer; it is not part of this payload. The two sides must differ: a "
+        + "transfer naming the same project and the same storage location on both sides moves "
+        + "nothing and is refused, while two storage locations inside one project is a real move "
+        + "and is accepted.")
 @Data
 public class SiteTransferCreationDto {
 
@@ -29,8 +32,10 @@ public class SiteTransferCreationDto {
     private Long sendingProjectId;
 
     @Schema(description = "Id of the specific storage location within the sending project to draw stock "
-            + "from, for example Main Site Store. Optional; when omitted, stock is validated at the "
-            + "project level instead of a single location.", example = "7")
+            + "from, for example Main Site Store. Must either belong to the sending project or belong to "
+            + "no project, which makes it an organisation-level store available from every project. "
+            + "Optional; when omitted, stock is validated at the project level instead of a single "
+            + "location.", example = "7")
     private Long sendingStorageLocationId;
 
     @Schema(description = "Id of the project the materials are being sent to.", example = "9")
@@ -38,7 +43,10 @@ public class SiteTransferCreationDto {
     private Long receivingProjectId;
 
     @Schema(description = "Id of the specific storage location within the receiving project to credit the "
-            + "materials to, for example Site B Yard. Optional.", example = "15")
+            + "materials to, for example Site B Yard. Must either belong to the receiving project or belong "
+            + "to no project. When the receiving project is also the sending project this must name a "
+            + "different location from the sending one, since a transfer that ends where it started moves "
+            + "nothing. Optional.", example = "15")
     private Long receivingStorageLocationId;
 
     @Schema(description = "Initial status of the transfer.", example = "PENDING")

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -57,7 +58,8 @@ import static org.mockito.Mockito.when;
  * is the logic this service owns: rejecting a duplicate transfer number, rejecting
  * unknown referenced entities, aggregating the per-material required quantities that feed
  * the sending-side stock check, choosing the location-scoped vs project-scoped variant of
- * that check, and building one transfer item per request line.
+ * that check, refusing a transfer whose two sides are the same balance row or whose location
+ * belongs to another project, and building one transfer item per request line.
  */
 @ExtendWith(MockitoExtension.class)
 class SiteTransferServiceTest {
@@ -67,6 +69,8 @@ class SiteTransferServiceTest {
     private static final Long SENDING_PROJECT = 9L;
     private static final Long RECEIVING_PROJECT = 10L;
     private static final Long SENDING_LOCATION = 3L;
+    private static final Long RECEIVING_LOCATION = 4L;
+    private static final Long OTHER_PROJECT = 12L;
     private static final Long MATERIAL = 11L;
 
     @Mock private SiteTransferRepository siteTransferRepository;
@@ -125,6 +129,26 @@ class SiteTransferServiceTest {
                     m.setId(MATERIAL);
                     return Optional.of(m);
                 });
+    }
+
+    /**
+     * Registers a storage location the service can resolve.
+     *
+     * @param id The location id the request will name.
+     * @param owningProjectId The project the location belongs to, or null for an organisation-level store.
+     * @return The location, already stubbed on the repository.
+     */
+    private StorageLocation location(Long id, Long owningProjectId) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        if (owningProjectId != null) {
+            Project owner = new Project();
+            owner.setId(owningProjectId);
+            location.setProject(owner);
+        }
+        lenient().when(storageLocationRepository.findByIdAndOrganization_Id(id, ORG))
+                .thenReturn(Optional.of(location));
+        return location;
     }
 
     private SiteTransferItemDto item(Long materialId, int qty) {
@@ -187,9 +211,7 @@ class SiteTransferServiceTest {
     @Test
     void create_withSendingLocation_usesLocationScopedStockCheck() {
         stubMasterLookups();
-        StorageLocation location = new StorageLocation();
-        location.setId(SENDING_LOCATION);
-        when(storageLocationRepository.findByIdAndOrganization_Id(SENDING_LOCATION, ORG)).thenReturn(Optional.of(location));
+        location(SENDING_LOCATION, SENDING_PROJECT);
 
         SiteTransferCreationDto dto = baseDto();
         dto.setSendingStorageLocationId(SENDING_LOCATION);
@@ -219,6 +241,138 @@ class SiteTransferServiceTest {
         assertThat(items.get(0).getSiteTransfer()).isNotNull();
 
         verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_sameProjectAndSameStorageLocation_isRefused() {
+        stubMasterLookups();
+        location(SENDING_LOCATION, SENDING_PROJECT);
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+        dto.setReceivingStorageLocationId(SENDING_LOCATION);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto))
+                .withMessageContaining("nothing")
+                .withMessageContaining("stock adjustment");
+
+        verify(siteTransferRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_sameProjectAndNoLocationOnEitherSide_isRefused() {
+        stubMasterLookups();
+
+        // No location on either side is not "unscoped", it is the project's own unlocated
+        // balance row, so this ends exactly where it started.
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto));
+
+        verify(siteTransferRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_refusedTransfer_doesNotSpendATransferNumber() {
+        stubMasterLookups();
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto));
+
+        verify(documentNumberAllocator, never()).allocate(any(), anyLong());
+    }
+
+    @Test
+    void create_sameProjectButTwoDifferentStores_isAllowed() {
+        stubMasterLookups();
+        location(SENDING_LOCATION, SENDING_PROJECT);
+        location(RECEIVING_LOCATION, SENDING_PROJECT);
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+        dto.setReceivingStorageLocationId(RECEIVING_LOCATION);
+
+        service.createSiteTransfer(dto);
+
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getSendingStorageLocation().getId()).isEqualTo(SENDING_LOCATION);
+        assertThat(captor.getValue().getReceivingStorageLocation().getId()).isEqualTo(RECEIVING_LOCATION);
+        verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_sameProjectFromUnlocatedStockIntoAStore_isAllowed() {
+        stubMasterLookups();
+        location(RECEIVING_LOCATION, SENDING_PROJECT);
+
+        // The project's unlocated balance and one of its stores are two different rows, so
+        // putting stock away into a store is a real movement.
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+        dto.setReceivingStorageLocationId(RECEIVING_LOCATION);
+
+        service.createSiteTransfer(dto);
+
+        verify(siteTransferRepository).save(any(SiteTransfer.class));
+        verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_oneOrganisationLevelStoreUsedFromTwoProjects_isAllowed() {
+        stubMasterLookups();
+        location(SENDING_LOCATION, null);
+
+        // A central yard belongs to no project, so the same location id on both sides still
+        // names two different balance rows when the projects differ.
+        SiteTransferCreationDto dto = baseDto();
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+        dto.setReceivingStorageLocationId(SENDING_LOCATION);
+
+        service.createSiteTransfer(dto);
+
+        verify(siteTransferRepository).save(any(SiteTransfer.class));
+        verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_sendingLocationOnAnotherProject_isRefused() {
+        stubMasterLookups();
+        location(SENDING_LOCATION, OTHER_PROJECT);
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto))
+                .withMessageContaining("cannot be used from");
+
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void create_receivingLocationOnAnotherProject_isRefused() {
+        stubMasterLookups();
+        location(RECEIVING_LOCATION, OTHER_PROJECT);
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingStorageLocationId(RECEIVING_LOCATION);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto))
+                .withMessageContaining("cannot be used from");
+
+        verify(siteTransferRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
Closes #533

## What was wrong

`SiteTransferService.createSiteTransfer` resolved the two projects independently and never compared them, and the same for the two storage locations. So `Test 2` to `Test 2`, `Godown` to `Godown`, was accepted. It then published `SiteTransferCreatedEvent`, and `InventoryEventListener.handleSiteTransferCreated` wrote a `TRANSFER_OUT` and a `TRANSFER_IN` against the same balance row: a pair that nets to zero and sits in the movement history looking like real movement.

## The rule, and why it is not "block same-project"

Anand's ticket assumes a same-project transfer should be blocked. That is one step too strong, and the balance model says why.

Balances are held per `(material, project, storage location)`, and a movement with **no** location writes the project's own unlocated row rather than a project total. `InventoryService.findUnlocatedStock` says so in as many words: *"It is not the project total: stock booked into a storage location lives in its own row and is not reachable from here."*

So the two sides of a transfer are the **same row** exactly when the projects match and the locations match, counting no-location on both sides as a match. That, and only that, is the transfer that moves nothing. It is now refused. Everything else moves stock from one row to another and is a real transfer:

| Sending | Receiving | Verdict | Why |
|---|---|---|---|
| project A, store 3 | project A, store 3 | **refused** | one row, in and out cancel |
| project A, no location | project A, no location | **refused** | one row, the project's unlocated balance on both sides |
| project A, store 3 | project A, store 4 | allowed | two rows, an ordinary move between stores on one site |
| project A, no location | project A, store 4 | allowed | two rows, putting unlocated stock away into a store |
| project A, store 3 | project B, store 3 | allowed | an organisation-level store is a different row per project |
| project A, anything | project B, anything | allowed | unchanged |

The message names the alternative, as the inventory work has done since #530: *"To move stock between two stores on one project, name a different receiving storage location; to move it to another site, name a different receiving project; to correct a balance that is wrong, raise a stock adjustment instead."*

## Also, because it falls out of the same reordering

Both locations are now resolved **before** anything is decided, which they have to be: they are what say which rows the transfer touches. Two things follow.

- Each location is checked against its own side's project with `StorageLocationScope.requireUsableFromProject`, the rule #529 settled for consumption. A location on another project names a balance row that side can never reach. A location on **no** project stays an organisation-level store selectable from everywhere, which matters here because seven of the thirteen locations on staging have `project_id = NULL`.
- A bad location id is now found before a transfer number is allocated rather than after, so a request that was always going to 404 no longer spends a number from the #530 sequence.

## No schema change, and deliberately no CHECK constraint

The rule is not carried into the database. A `CHECK` would refuse to install on any database that already holds a degenerate row, and the movement history is append-only by design: whatever it recorded is what happened, and #539's convention is to correct with a new entry rather than to rewrite or invalidate an old one. The service is the one place transfers are created, and the check sits in it.

**Existing data, checked read-only on `echno.in`:** one site transfer in total, project 2 store 1 to project 6 store 4, a genuine cross-project move. Zero transfers with matching sides, and joining `TRANSFER_OUT` to `TRANSFER_IN` on reference number and material finds zero pairs sharing a project and a location. So there is nothing to clean up there, and no cleanup migration is proposed. The k8s staging was not checked (reading its kubeconfig needs a sudo password), and the query to repeat is:

```sql
SELECT o.reference_number, o.project_id, o.storage_location_id
FROM inventory_transaction o JOIN inventory_transaction i
  ON o.reference_number = i.reference_number AND o.material_id = i.material_id
WHERE o.transaction_type = 'TRANSFER_OUT' AND i.transaction_type = 'TRANSFER_IN'
  AND o.project_id = i.project_id
  AND o.storage_location_id IS NOT DISTINCT FROM i.storage_location_id;
```

If a future environment does turn any up, the recommendation is to leave the rows and let the corrected balance stand: they already net to zero, so no balance is wrong, and deleting from an append-only ledger is the thing #545 built its repository to make impossible.

## Tests

Every new test was run with the fix reverted. The three that pass under the revert are marked as such rather than dressed up as red.

| Test | Fix removed | Result without it |
|---|---|---|
| `create_sameProjectAndSameStorageLocation_isRefused` | service restored to its `development` state | **FAILED**, the transfer was accepted and saved |
| `create_sameProjectAndNoLocationOnEitherSide_isRefused` | same | **FAILED** |
| `create_refusedTransfer_doesNotSpendATransferNumber` | same | **FAILED**, a number was allocated for a request that should never have got that far |
| `create_sendingLocationOnAnotherProject_isRefused` | same | **FAILED** |
| `create_receivingLocationOnAnotherProject_isRefused` | same | **FAILED** |
| `create_sameProjectButTwoDifferentStores_isAllowed` | same | passed, it pins what must **not** break |
| `create_sameProjectFromUnlocatedStockIntoAStore_isAllowed` | same | passed, same reason |
| `create_oneOrganisationLevelStoreUsedFromTwoProjects_isAllowed` | same | passed, same reason |

`SiteTransferServiceTest` is 15 of 15 green with the fix, and the full `test` task is green on the lab box.

## Follow-up for the frontend, not done here

`site-transfer-form.tsx` still shows an **organisation-aggregate** stock figure and two **unfiltered** location dropdowns, left out of echno-web #314 because each side needs its own scope. The backend now settles what correct looks like, so it can be written without another decision:

- Each dropdown lists the locations of **its own** project plus every location with no project, which is `StorageLocationScope.isUsableFromProject` and already exists on the web side as `features/material-consumptions/storage-location-scope.ts`.
- Changing a project resets that side's location.
- When both projects are the same, the receiving dropdown excludes the location the sending side has chosen. That is the whole of this rule expressed in the UI, and it stops the user reaching a 400 rather than explaining one.
- The stock figure should be read at the **sending** project and, when one is chosen, the sending location, which is the balance the server actually checks.

An in-transit quantity and a receive-with-variance step, the larger request in `86d45vqh8`, is still a separate piece of design and is not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented transfers between the same project and storage location.
  * Added validation to ensure storage locations belong to the selected projects or are organization-level locations.
  * Improved stock validation for project-level and location-specific transfers.
  * Transfer numbers are now assigned only after all validation succeeds.

* **Documentation**
  * Clarified transfer rules and storage-location requirements in the transfer form documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->