### PR TITLE
Bound the page a caller may ask for

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentCreationDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentSimpleDto;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
@@ -62,9 +64,8 @@ public class IssueCommentController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment read or admin authority")
     })
-    public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
-                                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
+    public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageQuery.getPageNo(),pageQuery.getPageSize());
         return ResponseEntity.status(HttpStatus.OK).body(issueComments.getContent());
     }
 

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentCreationDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentSimpleDto;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
@@ -63,9 +65,8 @@ public class IssueCommentControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of comments returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@RequestParam(defaultValue = "0") int pageNo,
-                                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageNo,pageSize);
+    public ResponseEntity<List<IssueCommentDto>> readAllIssueComments(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<IssueCommentDto> issueComments = issueCommentService.getAllIssueComments(pageQuery.getPageNo(),pageQuery.getPageSize());
         return ResponseEntity.status(HttpStatus.OK).body(issueComments.getContent());
     }
 

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.asset.dto.AssetMovementCreationDto;
 import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
 import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
@@ -68,9 +69,8 @@ public class AssetControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<Page<AssetDto>> readAllAssetsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        return new ResponseEntity<>(assetService.getAllAssets(pageNo, pageSize), HttpStatus.OK);
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(assetService.getAllAssets(pageQuery.getPageNo(), pageQuery.getPageSize()), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
@@ -154,9 +154,8 @@ public class AssetControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })
     public ResponseEntity<Page<AssetMovementDto>> readMovements(@PathVariable Long id,
-                                                                @RequestParam(defaultValue = "0") @Min(0) int pageNo,
-                                                                @RequestParam(defaultValue = "20") @Min(1) int pageSize) {
-        return new ResponseEntity<>(assetService.getMovements(id, pageNo, pageSize), HttpStatus.OK);
+                                                                @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(assetService.getMovements(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)), HttpStatus.OK);
     }
 
     @GetMapping("/{id}/placement-history")

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryController.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.category.dto.CategoryCreationDto;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.category.dto.CategorySimpleDto;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
@@ -76,8 +78,7 @@ public class CategoryController {
     /**
      * Retrieves a paginated list of all categories.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of categories per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
@@ -91,9 +92,8 @@ public class CategoryController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of categories returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the category read or admin authority")
     })
-    public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
-                                                          @RequestParam(defaultValue = "10") int pageSize) {
-        Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
+    public ResponseEntity<List<CategoryDto>> readAllCategories(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<CategoryDto> categories = categoryService.getAllCategories(pageQuery.getPageNo(), pageQuery.getPageSize());
         logger.info("All Categories Retrieved Successfully");
         return new ResponseEntity<>(categories.getContent(), HttpStatus.OK);
 

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryControllerWeb.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.category.dto.CategoryCreationDto;
 import org.tornotron.echno_backend.category.dto.CategoryDto;
 import org.tornotron.echno_backend.category.dto.CategorySimpleDto;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
@@ -69,8 +71,7 @@ public class CategoryControllerWeb {
     /**
      * Retrieves a paginated list of all categories.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of categories per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of category DTOs and HTTP status 200 (OK).
      */
     @GetMapping
@@ -84,9 +85,8 @@ public class CategoryControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of categories returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
-    public ResponseEntity<List<CategoryDto>> readAllCategories(@RequestParam(defaultValue = "0") int pageNo,
-                                                          @RequestParam(defaultValue = "10") int pageSize) {
-        Page<CategoryDto> categories = categoryService.getAllCategories(pageNo, pageSize);
+    public ResponseEntity<List<CategoryDto>> readAllCategories(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<CategoryDto> categories = categoryService.getAllCategories(pageQuery.getPageNo(), pageQuery.getPageSize());
         logger.info("All Categories Retrieved Successfully");
         return new ResponseEntity<>(categories.getContent(), HttpStatus.OK);
 

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.chat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import jakarta.servlet.http.HttpServletResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -130,9 +132,8 @@ public class ChatControllerWeb {
     })
     public ResponseEntity<Page<ChatMessageDto>> readMessages(
             @PathVariable Long roomId,
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "30") int pageSize) {
-        return new ResponseEntity<>(chatService.getMessages(roomId, pageNo, pageSize), HttpStatus.OK);
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(chatService.getMessages(roomId, pageQuery.getPageNo(), pageQuery.pageSizeOr(30)), HttpStatus.OK);
     }
 
     @PostMapping(value = "/rooms/web/{roomId}/messages", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
@@ -1,0 +1,107 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springdoc.core.annotations.ParameterObject;
+
+/**
+ * The {@code pageNo} and {@code pageSize} pair every paginated endpoint takes, bound once and
+ * bounded once.
+ *
+ * <p>Both used to arrive as bare {@code int} request parameters on each handler, with nothing
+ * between the caller and {@code PageRequest.of}. A page index below zero and a page size below one
+ * were rejected only by {@code PageRequest} itself, deep inside the call, and a value that is not
+ * a number at all failed during binding and came back as a 500. Nothing bounded the size upwards
+ * at all, so {@code pageSize=1000000} was a legal request: it undoes the ceiling
+ * {@link UnpagedResultCap} puts on the unpaginated listings, and on the endpoints whose mapper
+ * costs a query per row it multiplies the query count rather than merely the response size.
+ *
+ * <p>Binding the pair as one object is what makes the bound apply everywhere rather than on the
+ * handlers somebody remembered. Spring's own model-attribute binding fills it, so no custom
+ * argument resolver is registered and nothing changes about resolver ordering; the constraints
+ * below are checked by the same validator that checks a request body, and a breach is reported by
+ * {@code GlobalExceptionHandler} as a 400 naming {@code pageNo} or {@code pageSize}. The query
+ * parameters keep the names and the meaning they already had, so no caller has to change.
+ *
+ * <p>{@link #getPageSize()} answers the shared default. An endpoint that shipped with a different
+ * default keeps it through {@link #pageSizeOr(int)}, which can tell an absent parameter from one
+ * the caller set to the same value.
+ */
+@ParameterObject
+public class PageQuery {
+
+    /**
+     * Rows per page when the caller names none.
+     *
+     * <p>The default the great majority of these endpoints already declared. It is a default, not
+     * a limit: the limit is {@link UnpagedResultCap#MAX_ROWS}.
+     */
+    public static final int DEFAULT_PAGE_SIZE = 10;
+
+    @Min(value = 0, message = "pageNo must be zero or greater")
+    @Schema(description = "Zero-based page index.",
+            defaultValue = "0",
+            minimum = "0")
+    private int pageNo = 0;
+
+    @Min(value = 1, message = "pageSize must be at least 1")
+    @Max(value = UnpagedResultCap.MAX_ROWS,
+            message = "pageSize must not exceed " + UnpagedResultCap.MAX_ROWS)
+    @Schema(description = "Rows per page.",
+            defaultValue = "" + DEFAULT_PAGE_SIZE,
+            minimum = "1",
+            maximum = "" + UnpagedResultCap.MAX_ROWS)
+    private int pageSize = DEFAULT_PAGE_SIZE;
+
+    /**
+     * Whether the caller sent {@code pageSize} at all.
+     *
+     * <p>Kept because the field carries a default, so its value alone cannot say whether it was
+     * asked for. {@link #pageSizeOr(int)} needs the difference.
+     */
+    private boolean pageSizeGiven;
+
+    /**
+     * The requested page index, zero when the caller named none.
+     *
+     * @return A page index of zero or more.
+     */
+    public int getPageNo() {
+        return pageNo;
+    }
+
+    public void setPageNo(int pageNo) {
+        this.pageNo = pageNo;
+    }
+
+    /**
+     * The requested page size, {@link #DEFAULT_PAGE_SIZE} when the caller named none.
+     *
+     * @return A page size between one and {@link UnpagedResultCap#MAX_ROWS}.
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+        this.pageSizeGiven = true;
+    }
+
+    /**
+     * The requested page size, falling back to this endpoint's own default rather than the shared
+     * one.
+     *
+     * <p>A handful of endpoints shipped with a default of twenty or thirty. Folding them onto the
+     * shared default would quietly shrink the page every caller who omits the parameter already
+     * receives, which is a change to a published contract and has nothing to do with the bound
+     * this class exists to apply.
+     *
+     * @param defaultPageSize Rows per page to use when the caller sent none.
+     * @return The caller's page size, or {@code defaultPageSize} if there was none.
+     */
+    public int pageSizeOr(int defaultPageSize) {
+        return pageSizeGiven ? pageSize : defaultPageSize;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
@@ -138,12 +140,11 @@ public class EmployeeControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<EmployeeDto>> readAllEmployeesPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String department) {
-        return new ResponseEntity<>(employeeService.displayAllEmployees(pageNo, pageSize, search, status, department), HttpStatus.OK);
+        return new ResponseEntity<>(employeeService.displayAllEmployees(pageQuery.getPageNo(), pageQuery.getPageSize(), search, status, department), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/expense/ExpenseControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.expense.dto.ExpenseCreationDto;
 import org.tornotron.echno_backend.expense.dto.ExpenseDto;
@@ -63,11 +65,10 @@ public class ExpenseControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<ExpenseDto>> readAllExpensesPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status) {
-        return new ResponseEntity<>(expenseService.getPaginated(pageNo, pageSize, search, status), HttpStatus.OK);
+        return new ResponseEntity<>(expenseService.getPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), search, status), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/web/JournalEntryControllerWeb.java
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.finance.ledger.dtos.JournalEntryDto;
 import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
 import org.tornotron.echno_backend.finance.ledger.dtos.ReverseJournalRequest;
@@ -77,9 +79,8 @@ public class JournalEntryControllerWeb {
             @ApiResponse(responseCode = "200", description = "Page of journal entries"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<JournalEntryDto>> getAll(@RequestParam(defaultValue = "0") int pageNo,
-                                        @RequestParam(defaultValue = "10") int pageSize) {
-        Page<JournalEntryDto> journalEntries = service.findAll(pageNo,pageSize);
+    public ResponseEntity<List<JournalEntryDto>> getAll(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<JournalEntryDto> journalEntries = service.findAll(pageQuery.getPageNo(),pageQuery.getPageSize());
         return ResponseEntity.status(HttpStatus.OK).body(journalEntries.getContent());
     }
 

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteUpdateDto;
@@ -100,10 +102,9 @@ public class GoodsReceivedNoteController {
             @ApiResponse(responseCode = "403", description = "Caller lacks the grn read or admin authority")
     })
     public ResponseEntity<Page<GoodsReceivedNoteDto>> getAllGrnsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns(pageNo, pageSize);
+        Page<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(grns);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteUpdateDto;
@@ -94,10 +96,9 @@ public class GoodsReceivedNoteControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<GoodsReceivedNoteDto>> getAllGrnsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns(pageNo, pageSize);
+        Page<GoodsReceivedNoteDto> grns = goodsReceivedNoteService.getAllGrns(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(grns);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentController.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -65,10 +67,9 @@ public class IndentController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent read or admin authority")
     })
     public ResponseEntity<List<IndentDto>> getAllIndents(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        return new ResponseEntity<>(indentService.getAllIndents(pageNo, pageSize).getContent(), HttpStatus.OK);
+        return new ResponseEntity<>(indentService.getAllIndents(pageQuery.getPageNo(), pageQuery.getPageSize()).getContent(), HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indent.dto.IndentUpdateDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
@@ -63,10 +65,9 @@ public class IndentControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<IndentDto>> getAllIndents(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        return new ResponseEntity<>(indentService.getAllIndents(pageNo, pageSize).getContent(), HttpStatus.OK);
+        return new ResponseEntity<>(indentService.getAllIndents(pageQuery.getPageNo(), pageQuery.getPageSize()).getContent(), HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -90,8 +92,7 @@ public class IndentItemController {
      * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
      * {@code totalElements}, {@code totalPages} and the page index travel with the content.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the page of indent items.
      */
     @GetMapping("/paginated")
@@ -106,9 +107,8 @@ public class IndentItemController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
     })
     public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize) {
-        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageNo, pageSize));
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -86,8 +88,7 @@ public class IndentItemControllerWeb {
      * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
      * {@code totalElements}, {@code totalPages} and the page index travel with the content.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the page of indent items.
      */
     @GetMapping("/paginated")
@@ -102,9 +103,8 @@ public class IndentItemControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize) {
-        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageNo, pageSize));
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionController.java
@@ -4,12 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryMaterialStockDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialLocationStockDto;
@@ -89,10 +92,9 @@ public class InventoryTransactionController {
             @ApiResponse(responseCode = "403", description = "Caller lacks the inventory-transaction read or admin authority")
     })
     public ResponseEntity<Page<InventoryTransactionDto>> getAllTransactionsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions(pageNo, pageSize);
+        Page<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(transactions);
     }
 
@@ -128,10 +130,9 @@ public class InventoryTransactionController {
     })
     public ResponseEntity<Page<MaterialMovementHistoryDto>> getMaterialMovementHistory(
             @PathVariable Long materialId,
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageNo, pageSize);
+        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(history);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionControllerWeb.java
@@ -3,11 +3,14 @@ package org.tornotron.echno_backend.inventoryTransaction;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryMaterialStockDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.InventoryTransactionDto;
 import org.tornotron.echno_backend.inventoryTransaction.dto.MaterialLocationStockDto;
@@ -81,10 +84,9 @@ public class InventoryTransactionControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<InventoryTransactionDto>> getAllTransactionsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions(pageNo, pageSize);
+        Page<InventoryTransactionDto> transactions = inventoryTransactionService.getAllTransactions(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(transactions);
     }
 
@@ -119,10 +121,9 @@ public class InventoryTransactionControllerWeb {
     })
     public ResponseEntity<Page<MaterialMovementHistoryDto>> getMaterialMovementHistory(
             @PathVariable Long materialId,
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageNo, pageSize);
+        Page<MaterialMovementHistoryDto> history = inventoryTransactionService.getMaterialMovementHistory(materialId, pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(history);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -72,15 +75,14 @@ public class IssueControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<IssueDto>> readAllIssuesPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String type,
             @RequestParam(required = false) Long assigneeId,
             @RequestParam(required = false) Long creatorId) {
-        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageNo, pageSize, projectId, search, status, type, assigneeId, creatorId);
+        Page<IssueDto> issues = issueService.getAllIssuesPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), projectId, search, status, type, assigneeId, creatorId);
         return new ResponseEntity<>(issues, HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/labour/LabourControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/LabourControllerWeb.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.labour.dto.LabourCreationDto;
 import org.tornotron.echno_backend.labour.dto.LabourDto;
@@ -62,9 +64,8 @@ public class LabourControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of labour records returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<LabourDto>> getAllLabours(@RequestParam(defaultValue = "0") int pageNo,
-                                                         @RequestParam(defaultValue = "10") int pageSize) {
-        return ResponseEntity.status(HttpStatus.OK).body(labourService.getAllLabours(pageNo, pageSize).getContent());
+    public ResponseEntity<List<LabourDto>> getAllLabours(@Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.status(HttpStatus.OK).body(labourService.getAllLabours(pageQuery.getPageNo(), pageQuery.getPageSize()).getContent());
     }
 
     @GetMapping("{id}")

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
@@ -104,10 +106,9 @@ public class MaterialController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority")
     })
     public ResponseEntity<Page<MaterialDto>> getAllMaterialsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialDto> materials = materialService.getAllMaterials(pageNo, pageSize);
+        Page<MaterialDto> materials = materialService.getAllMaterials(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(materials);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
@@ -103,10 +105,9 @@ public class MaterialControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<MaterialDto>> getAllMaterialsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialDto> materials = materialService.getAllMaterials(pageNo, pageSize);
+        Page<MaterialDto> materials = materialService.getAllMaterials(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(materials);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionCreationDto;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionDto;
 import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType;
@@ -103,10 +105,9 @@ public class MaterialConsumptionController {
             @ApiResponse(responseCode = "403", description = "Caller lacks the material-consumption read or admin authority")
     })
     public ResponseEntity<Page<MaterialConsumptionDto>> getAllMaterialConsumptionsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions(pageNo, pageSize);
+        Page<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(consumptions);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionControllerWeb.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionCreationDto;
 import org.tornotron.echno_backend.materialConsumption.dto.MaterialConsumptionDto;
 import org.tornotron.echno_backend.materialConsumption.enums.MaterialConsumptionType;
@@ -103,10 +105,9 @@ public class MaterialConsumptionControllerWeb {
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<MaterialConsumptionDto>> getAllMaterialConsumptionsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions(pageNo, pageSize);
+        Page<MaterialConsumptionDto> consumptions = materialConsumptionService.getAllMaterialConsumptions(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(consumptions);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.payable.dto.PayableCreationDto;
 import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.payable.dto.PaymentRecordDto;
@@ -113,10 +115,9 @@ public class PayableController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the payable read or admin authority")
     })
     public ResponseEntity<Page<PayableDto>> getAllPayablesPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<PayableDto> payables = payableService.getAllPayables(pageNo, pageSize);
+        Page<PayableDto> payables = payableService.getAllPayables(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(payables);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.payable.dto.PayableCreationDto;
 import org.tornotron.echno_backend.payable.dto.PayableDto;
 import org.tornotron.echno_backend.payable.dto.PaymentRecordDto;
@@ -112,10 +114,9 @@ public class PayableControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PayableDto>> getAllPayablesPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<PayableDto> payables = payableService.getAllPayables(pageNo, pageSize);
+        Page<PayableDto> payables = payableService.getAllPayables(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(payables);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -87,8 +89,7 @@ public class ProjectController {
     /**
      * Retrieves a paginated list of all projects.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of projects per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of project DTOs and HTTP status 200 (OK).
      */
     @GetMapping
@@ -102,9 +103,8 @@ public class ProjectController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of projects returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project read or admin authority")
     })
-    public ResponseEntity<List<ProjectDto>> readAllProjects(@RequestParam(defaultValue = "0") int pageNo,
-                                                                 @RequestParam(defaultValue = "10") int pageSize) {
-          Page<ProjectDto> projects = service.getAllProjects(pageNo,pageSize);
+    public ResponseEntity<List<ProjectDto>> readAllProjects(@Valid @ParameterObject PageQuery pageQuery) {
+          Page<ProjectDto> projects = service.getAllProjects(pageQuery.getPageNo(),pageQuery.getPageSize());
           logger.info("All Projects Retrieved Successfully");
         return new ResponseEntity<>(projects.getContent(),HttpStatus.OK);
     }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -124,8 +126,7 @@ public class ProjectControllerWeb {
      * itself. Deliberately the same shape as {@code GET /tasks/web/paginated}; consistency between
      * the two listings matters more than either choice would in isolation.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @param search   Optional case-insensitive match on the project name.
      * @return A {@link ResponseEntity} containing the page of project DTOs.
      */
@@ -142,10 +143,9 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<ProjectDto>> readAllProjectsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(service.getProjectsPaginated(pageNo, pageSize, search));
+        return ResponseEntity.ok(service.getProjectsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), search));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrder;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.access.prepost.PreAuthorize;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
@@ -97,10 +99,9 @@ public class PurchaseOrderController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderDto>> getAllPurchaseOrdersPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders(pageNo, pageSize);
+        Page<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(purchaseOrders);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -4,12 +4,14 @@ import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
@@ -96,10 +98,9 @@ public class PurchaseOrderControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderDto>> getAllPurchaseOrdersPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders(pageNo, pageSize);
+        Page<PurchaseOrderDto> purchaseOrders = purchaseOrderService.getAllPurchaseOrders(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(purchaseOrders);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemResponseDto;
@@ -93,8 +95,7 @@ public class PurchaseOrderItemController {
      * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
      * {@code totalElements}, {@code totalPages} and the page index travel with the content.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the page of purchase order items.
      */
     @GetMapping("/paginated")
@@ -109,9 +110,8 @@ public class PurchaseOrderItemController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize) {
-        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageNo, pageSize));
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
     }
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -4,11 +4,13 @@ import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemResponseDto;
@@ -89,8 +91,7 @@ public class PurchaseOrderItemControllerWeb {
      * caller no way to ask for the rest. Here the {@link Page} reaches the response, so
      * {@code totalElements}, {@code totalPages} and the page index travel with the content.
      *
-     * @param pageNo   Zero-based page index.
-     * @param pageSize Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the page of purchase order items.
      */
     @GetMapping("/paginated")
@@ -105,9 +106,8 @@ public class PurchaseOrderItemControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize) {
-        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageNo, pageSize));
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
     }
 
     @GetMapping("/purchase-order/{purchaseOrderId}")

--- a/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/receipt/ReceiptControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.receipt.dto.ReceiptCreationDto;
 import org.tornotron.echno_backend.receipt.dto.ReceiptDto;
@@ -63,11 +65,10 @@ public class ReceiptControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<ReceiptDto>> readAllReceiptsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status) {
-        return new ResponseEntity<>(receiptService.getPaginated(pageNo, pageSize, search, status), HttpStatus.OK);
+        return new ResponseEntity<>(receiptService.getPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), search, status), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
@@ -102,10 +104,9 @@ public class SiteTransferController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer read or admin authority")
     })
     public ResponseEntity<Page<SiteTransferDto>> getAllSiteTransfersPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers(pageNo, pageSize);
+        Page<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(transfers);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
@@ -101,10 +103,9 @@ public class SiteTransferControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<SiteTransferDto>> getAllSiteTransfersPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers(pageNo, pageSize);
+        Page<SiteTransferDto> transfers = siteTransferService.getAllSiteTransfers(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(transfers);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
@@ -65,9 +67,8 @@ public class StockAdjustmentControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
     })
     public ResponseEntity<Page<StockAdjustmentDto>> readAllStockAdjustmentsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        return new ResponseEntity<>(stockAdjustmentService.getAll(pageNo, pageSize), HttpStatus.OK);
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(stockAdjustmentService.getAll(pageQuery.getPageNo(), pageQuery.getPageSize()), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationController.java
@@ -5,12 +5,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationCreationDto;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
@@ -101,9 +103,8 @@ public class StorageLocationController {
             @ApiResponse(responseCode = "403", description = "Caller lacks the storage-location read or admin authority")
     })
     public ResponseEntity<Page<StorageLocationDto>> getAllStorageLocationsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        Page<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations(pageNo, pageSize);
+            @Valid @ParameterObject PageQuery pageQuery) {
+        Page<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(storageLocations);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationCreationDto;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
@@ -101,9 +103,8 @@ public class StorageLocationControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<StorageLocationDto>> getAllStorageLocationsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize) {
-        Page<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations(pageNo, pageSize);
+            @Valid @ParameterObject PageQuery pageQuery) {
+        Page<StorageLocationDto> storageLocations = storageLocationService.getAllStorageLocations(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(storageLocations);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/subcontract/SubContractControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.subcontract.dto.SubContractCreationDto;
 import org.tornotron.echno_backend.subcontract.dto.SubContractDto;
@@ -62,12 +64,11 @@ public class SubContractControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<SubContractDto>> readAllSubContractsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String type) {
-        return new ResponseEntity<>(subContractService.getPaginated(pageNo, pageSize, search, status, type), HttpStatus.OK);
+        return new ResponseEntity<>(subContractService.getPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), search, status, type), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -86,8 +88,7 @@ public class TaskController {
     /**
      * Retrieves a paginated list of all tasks.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of tasks per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of task DTOs and HTTP status 200 (OK).
      */
     @GetMapping
@@ -101,9 +102,8 @@ public class TaskController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of tasks returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task read or admin authority")
     })
-    public ResponseEntity<List<TaskDto>> readAllTasks(@RequestParam(defaultValue = "0") int pageNo,
-                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<TaskDto> tasks = service.getAllTasks(pageNo, pageSize);
+    public ResponseEntity<List<TaskDto>> readAllTasks(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<TaskDto> tasks = service.getAllTasks(pageQuery.getPageNo(), pageQuery.getPageSize());
         logger.info("All Tasks Retrieved Successfully");
         return new ResponseEntity<>(tasks.getContent(), HttpStatus.OK);
     }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -120,8 +122,7 @@ public class TaskControllerWeb {
      * {@code totalPages} and the page index alongside the content, so a truncated result describes
      * itself. Mirrors {@code GET /issues/web/paginated}.
      *
-     * @param pageNo    Zero-based page index.
-     * @param pageSize  Rows per page, clamped to the result cap.
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @param projectId Optional project filter.
      * @param search    Optional case-insensitive match on title or description.
      * @return A {@link ResponseEntity} containing the page of task DTOs.
@@ -139,11 +140,10 @@ public class TaskControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<TaskDto>> readAllTasksPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "20") int pageSize,
+            @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(service.getTasksPaginated(pageNo, pageSize, projectId, search));
+        return ResponseEntity.ok(service.getTasksPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), projectId, search));
     }
 
     @GetMapping("/projectId/{projectId}")

--- a/src/main/java/org/tornotron/echno_backend/user/UserController.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.organization.dto.OrganizationDto;
 import org.tornotron.echno_backend.user.dto.UserCreationDto;
@@ -51,8 +53,7 @@ public class UserController {
     /**
      * Retrieves a paginated list of all users.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of users per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of user DTOs and HTTP status 200 (OK).
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
@@ -66,9 +67,8 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of users returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
-                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<UserDto> users = userService.getAllUsers(pageNo,pageSize);
+    public ResponseEntity<List<UserDto>> readAllUsers(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<UserDto> users = userService.getAllUsers(pageQuery.getPageNo(),pageQuery.getPageSize());
         return new ResponseEntity<>(users.getContent(), HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springdoc.core.annotations.ParameterObject;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -65,8 +67,7 @@ public class UserControllerWeb {
     /**
      * Retrieves a paginated list of all users.
      *
-     * @param pageNo   The page number to retrieve (default is 0).
-     * @param pageSize The number of users per page (default is 10).
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
      * @return A {@link ResponseEntity} containing the list of user DTOs and HTTP status 200 (OK).
      */
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'hr-admin')")
@@ -80,9 +81,8 @@ public class UserControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of users returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<List<UserDto>> readAllUsers(@RequestParam(defaultValue = "0") int pageNo,
-                                                      @RequestParam(defaultValue = "10") int pageSize) {
-        Page<UserDto> users = userService.getAllUsers(pageNo,pageSize);
+    public ResponseEntity<List<UserDto>> readAllUsers(@Valid @ParameterObject PageQuery pageQuery) {
+        Page<UserDto> users = userService.getAllUsers(pageQuery.getPageNo(),pageQuery.getPageSize());
         return new ResponseEntity<>(users.getContent(), HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.vendor.dto.*;
 
@@ -97,10 +99,9 @@ public class VendorController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the vendor read or admin authority")
     })
     public ResponseEntity<Page<VendorDto>> getAllVendorsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<VendorDto> vendors = vendorService.getAllVendors(pageNo, pageSize);
+        Page<VendorDto> vendors = vendorService.getAllVendors(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(vendors);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/VendorControllerWeb.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.vendor.dto.*;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
@@ -96,10 +98,9 @@ public class VendorControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<VendorDto>> getAllVendorsPaginated(
-            @RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageSize
+            @Valid @ParameterObject PageQuery pageQuery
     ) {
-        Page<VendorDto> vendors = vendorService.getAllVendors(pageNo, pageSize);
+        Page<VendorDto> vendors = vendorService.getAllVendors(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(vendors);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -228,6 +228,15 @@ spring:
       # the redis provider booting cleanly with no repository infrastructure.
       repositories:
         enabled: false
+    # The newer endpoints take a Spring Data Pageable rather than the pageNo/pageSize pair,
+    # so their page size is bounded by the resolver rather than by PageQuery. Spring's own
+    # default ceiling is 2000, which is four times the row cap the rest of the API applies;
+    # bringing it down to UnpagedResultCap.MAX_ROWS makes one ceiling hold whichever way an
+    # endpoint declares its paging. The resolver clamps rather than refusing, which is its
+    # behaviour and not ours to change.
+    web:
+      pageable:
+        max-page-size: 500
   cache:
     cache-names:
       - rate-limit-buckets

--- a/src/test/java/org/tornotron/echno_backend/architecture/PaginationParameterBoundTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PaginationParameterBoundTest.java
@@ -1,0 +1,81 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.springframework.stereotype.Controller;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet against an endpoint declaring its own paging parameters: a controller may take the page
+ * bounds only as a {@code PageQuery} or a Spring Data {@code Pageable}, never as a loose
+ * {@code pageNo} or {@code pageSize} of its own.
+ *
+ * <p>Forty-seven endpoints took the pair as bare {@code int} request parameters with nothing
+ * between the caller and {@code PageRequest.of}. A page index below zero and a page size below
+ * one were caught only by {@code PageRequest} itself, a value that is not a number failed during
+ * binding and came back as a 500, and no value at all was too large: {@code pageSize=1000000} was
+ * a legal request, which undoes on the paginated endpoint the row cap
+ * {@code UnpagedResultCap.MAX_ROWS} puts on its unpaginated sibling, and on the endpoints whose
+ * mapper costs a query per row it multiplies the query count and not merely the response size.
+ *
+ * <p>Fixing forty-seven handlers is forty-seven chances to forget, and the forty-eighth is
+ * written by copying one of them. So the bound lives in
+ * {@code org.tornotron.echno_backend.common.pagination.PageQuery}, and this rule bans the
+ * declaration that goes around it. It is the same shape of guard as
+ * {@link MultipartPayloadValidationTest}, for the same reason: the defect spreads by copy, so the
+ * ratchet has to sit on the pattern rather than on the instances.
+ *
+ * <p>Written against reflected parameter names rather than the fluent DSL, which has no predicate
+ * for one. Names survive into the bytecode because the build compiles with {@code -parameters},
+ * which Spring already depends on for binding these very parameters.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's own
+ * cache, which every architecture test in this package shares and which holds it behind a soft
+ * reference. See {@link UnboundedRepositoryReadTest} for why that matters in a 1 GB test JVM.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class PaginationParameterBoundTest {
+
+    /**
+     * Parameter names that mean "the caller chose the page". Matched case-insensitively, so a
+     * {@code pagesize} or {@code PageSize} spelled some other way is caught too.
+     */
+    private static final Set<String> PAGING_PARAMETER_NAMES = Set.of("pageno", "pagesize");
+
+    @ArchTest
+    static void noControllerDeclaresItsOwnPagingParameters(JavaClasses productionClasses) {
+        List<String> offenders = productionClasses.stream()
+                .filter(javaClass -> javaClass.isMetaAnnotatedWith(Controller.class))
+                .map(JavaClass::reflect)
+                .flatMap(controller -> List.of(controller.getDeclaredMethods()).stream())
+                .flatMap(method -> List.of(method.getParameters()).stream()
+                        .filter(parameter -> PAGING_PARAMETER_NAMES.contains(
+                                parameter.getName().toLowerCase()))
+                        .map(parameter -> describe(method, parameter)))
+                .sorted()
+                .toList();
+
+        assertThat(offenders)
+                .as("a paging parameter a controller declares itself is bounded by nothing, which "
+                        + "is how pageSize=1000000 became a legal request on every paginated "
+                        + "endpoint; take the page as a PageQuery, which carries the bounds and "
+                        + "answers a breach with a 400 naming the parameter")
+                .isEmpty();
+    }
+
+    private static String describe(Method method, Parameter parameter) {
+        return method.getDeclaringClass().getName() + "." + method.getName()
+                + " parameter " + parameter.getName();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/PageQueryBindingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/PageQueryBindingTest.java
@@ -1,0 +1,179 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.tornotron.echno_backend.asset.AssetControllerWeb;
+import org.tornotron.echno_backend.asset.AssetService;
+import org.tornotron.echno_backend.asset.dto.AssetDto;
+import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
+import org.tornotron.echno_backend.common.exception.GlobalExceptionHandler;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * What a caller's {@code pageNo} and {@code pageSize} are allowed to be, proved through the real
+ * request pipeline.
+ *
+ * <p>Driven through {@code MockMvc} standalone rather than against {@link PageQuery} directly,
+ * because the part that had to be got right is the binding, not the constraint annotations. A
+ * bound is only worth as much as its reaching the handler, and the ways it can fail to are all in
+ * the wiring: whether Spring's model-attribute binding claims the type at all, whether
+ * {@code @Valid} on it is honoured, and whether what a breach raises is a failure
+ * {@code GlobalExceptionHandler} answers as a 400 naming the field rather than as a 500.
+ *
+ * <p>{@code AssetControllerWeb} is the subject because it carries one endpoint on the shared
+ * default and one that shipped with a default of twenty, so both readings of an absent
+ * {@code pageSize} are pinned here. It also carries {@code @Validated}, which is the arrangement
+ * most of these controllers are in.
+ *
+ * <p>Stubbing is lenient because most of these cases are refusals, where the service is never
+ * reached and its stub is deliberately unused.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PageQueryBindingTest {
+
+    private static final String PAGINATED = "/api/v1/assets/web/paginated";
+
+    /** The movement ledger of asset 7: the endpoint whose own default page size is twenty. */
+    private static final String MOVEMENTS = "/api/v1/assets/web/7/movements";
+
+    @Mock
+    private AssetService assetService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        // An empty page still needs a real PageRequest behind it: Jackson cannot serialise the
+        // Unpaged instance the single-argument PageImpl constructor leaves in place.
+        when(assetService.getAllAssets(anyInt(), anyInt()))
+                .thenReturn(new PageImpl<AssetDto>(List.of(), PageRequest.of(0, 10), 0));
+        when(assetService.getMovements(anyLong(), anyInt(), anyInt()))
+                .thenReturn(new PageImpl<AssetMovementDto>(List.of(), PageRequest.of(0, 10), 0));
+        mockMvc = MockMvcBuilders.standaloneSetup(new AssetControllerWeb(assetService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void bindsTheParametersTheCallerSent() throws Exception {
+        mockMvc.perform(get(PAGINATED).param("pageNo", "3").param("pageSize", "25"))
+                .andExpect(status().isOk());
+
+        verify(assetService).getAllAssets(3, 25);
+    }
+
+    @Test
+    void appliesTheSharedDefaultWhenTheCallerSendsNeither() throws Exception {
+        mockMvc.perform(get(PAGINATED)).andExpect(status().isOk());
+
+        verify(assetService).getAllAssets(0, PageQuery.DEFAULT_PAGE_SIZE);
+    }
+
+    /**
+     * The endpoints that shipped with a default of twenty or thirty keep it. Folding them onto the
+     * shared default would shrink the page every caller who omits the parameter already receives,
+     * which is a change to a published contract and no part of bounding anything.
+     */
+    @Test
+    void keepsAnEndpointsOwnDefaultPageSize() throws Exception {
+        mockMvc.perform(get(MOVEMENTS)).andExpect(status().isOk());
+
+        verify(assetService).getMovements(7L, 0, 20);
+    }
+
+    @Test
+    void refusesAPageSizeAboveTheRowCap() throws Exception {
+        mockMvc.perform(get(PAGINATED)
+                        .param("pageSize", Integer.toString(UnpagedResultCap.MAX_ROWS + 1)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageSize").exists());
+
+        verify(assetService, never()).getAllAssets(anyInt(), anyInt());
+    }
+
+    @Test
+    void acceptsAPageSizeAtTheRowCap() throws Exception {
+        mockMvc.perform(get(PAGINATED)
+                        .param("pageSize", Integer.toString(UnpagedResultCap.MAX_ROWS)))
+                .andExpect(status().isOk());
+
+        verify(assetService).getAllAssets(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    @Test
+    void refusesANegativePageNumber() throws Exception {
+        mockMvc.perform(get(PAGINATED).param("pageNo", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageNo").exists());
+    }
+
+    @Test
+    void refusesAPageSizeOfZero() throws Exception {
+        mockMvc.perform(get(PAGINATED).param("pageSize", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageSize").exists());
+    }
+
+    /**
+     * The case that used to be a 500 rather than merely a wrong answer: a page number that is not
+     * a number failed while binding, and nothing turned that into a refusal the caller could read.
+     */
+    @Test
+    void refusesAPageNumberThatIsNotANumber() throws Exception {
+        mockMvc.perform(get(PAGINATED).param("pageNo", "not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageNo").exists());
+    }
+
+    @Test
+    void refusesAPageSizeTooLargeForAnInt() throws Exception {
+        mockMvc.perform(get(PAGINATED).param("pageSize", "99999999999"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageSize").exists());
+    }
+
+    /**
+     * The bound belongs to the pair, not to the endpoint, so an endpoint with a default of its own
+     * is refused on the same ceiling as every other.
+     */
+    @Test
+    void refusesAnOversizedPageOnAnEndpointWithItsOwnDefault() throws Exception {
+        mockMvc.perform(get(MOVEMENTS).param("pageSize", "1000000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.pageSize").exists());
+
+        verify(assetService, never()).getMovements(anyLong(), anyInt(), anyInt());
+    }
+
+    /**
+     * Nothing about the pair moved: the parameters keep the names the API published, so a caller
+     * already sending them is unaffected.
+     */
+    @Test
+    void stillReadsTheParametersUnderTheirPublishedNames() throws Exception {
+        mockMvc.perform(get(MOVEMENTS).param("pageNo", "2").param("pageSize", "5"))
+                .andExpect(status().isOk());
+
+        verify(assetService).getMovements(7L, 2, 5);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.project.dto.ProjectDto;
 
@@ -151,7 +152,7 @@ class ProjectControllerWebListingTest {
         Page<ProjectDto> page = new PageImpl<>(projects(20), PageRequest.of(1, 20), 137);
         when(service.getProjectsPaginated(eq(1), eq(20), isNull())).thenReturn(page);
 
-        ResponseEntity<Page<ProjectDto>> response = controller.readAllProjectsPaginated(1, 20, null);
+        ResponseEntity<Page<ProjectDto>> response = controller.readAllProjectsPaginated(page(1, 20), null);
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getTotalElements()).isEqualTo(137);
@@ -162,8 +163,16 @@ class ProjectControllerWebListingTest {
     void thePaginatedListingPassesTheSearchFilterThrough() {
         when(service.getProjectsPaginated(anyInt(), anyInt(), any())).thenReturn(Page.empty());
 
-        controller.readAllProjectsPaginated(0, 20, "riverside");
+        controller.readAllProjectsPaginated(page(0, 20), "riverside");
 
         verify(service).getProjectsPaginated(0, 20, "riverside");
+    }
+
+    /** The page the request would have bound, built by hand for a direct controller call. */
+    private static PageQuery page(int pageNo, int pageSize) {
+        PageQuery pageQuery = new PageQuery();
+        pageQuery.setPageNo(pageNo);
+        pageQuery.setPageSize(pageSize);
+        return pageQuery;
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.task.dto.TaskDto;
 
@@ -152,7 +153,7 @@ class TaskControllerWebListingTest {
         Page<TaskDto> page = new PageImpl<>(tasks(20), PageRequest.of(1, 20), 137);
         when(service.getTasksPaginated(eq(1), eq(20), isNull(), isNull())).thenReturn(page);
 
-        ResponseEntity<Page<TaskDto>> response = controller.readAllTasksPaginated(1, 20, null, null);
+        ResponseEntity<Page<TaskDto>> response = controller.readAllTasksPaginated(page(1, 20), null, null);
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getTotalElements()).isEqualTo(137);
@@ -163,8 +164,16 @@ class TaskControllerWebListingTest {
     void thePaginatedListingPassesTheProjectAndSearchFiltersThrough() {
         when(service.getTasksPaginated(anyInt(), anyInt(), any(), any())).thenReturn(Page.empty());
 
-        controller.readAllTasksPaginated(0, 20, 7L, "slab");
+        controller.readAllTasksPaginated(page(0, 20), 7L, "slab");
 
         verify(service).getTasksPaginated(0, 20, 7L, "slab");
+    }
+
+    /** The page the request would have bound, built by hand for a direct controller call. */
+    private static PageQuery page(int pageNo, int pageSize) {
+        PageQuery pageQuery = new PageQuery();
+        pageQuery.setPageNo(pageNo);
+        pageQuery.setPageSize(pageSize);
+        return pageQuery;
     }
 }


### PR DESCRIPTION
Closes #546.

## What was wrong

Forty-seven paginated endpoints took `pageNo` and `pageSize` as bare `int` request parameters with nothing between the caller and `PageRequest.of`:

- a page index below zero and a page size below one were caught only by `PageRequest` itself, deep inside the call;
- a value that is not a number at all failed while binding and came back as a **500** (`pageNo=abc`, `pageSize=99999999999`);
- nothing bounded the size upwards, so `pageSize=1000000` was a legal request. That undoes on the paginated endpoint the row cap `UnpagedResultCap.MAX_ROWS` (500, from #537) puts on its unpaginated sibling, and on the endpoints whose mapper costs a query per row (`MaterialMapper`, `StorageLocationMapper`, `AttachmentMapper`, `IndentItemMapper`, see #522) it multiplies the query count and not merely the response size.

## The mechanism, and why this one

The pair now binds as a single `common/pagination/PageQuery` carrying `@Min(0)` on `pageNo` and `@Min(1) @Max(UnpagedResultCap.MAX_ROWS)` on `pageSize`, taken as `@Valid @ParameterObject PageQuery pageQuery`.

**Why a parameter object and not a `Pageable` argument resolver.** The existing signature is `pageNo`/`pageSize`, not Spring's `page`/`size`, and forty-seven endpoints and both clients publish those names; moving to `Pageable` would rename the wire contract for a hardening change. And a custom `HandlerMethodArgumentResolver` is appended after Spring's built-ins, which is exactly the ordering hazard that bit #525 when it tried the same shape for payload binding. A parameter object registers no resolver at all: Spring's own model-attribute binding claims the type, `@Valid` on it is honoured by the same validator that checks a request body, and a breach raises `MethodArgumentNotValidException`, which `GlobalExceptionHandler` already answers as a **400 naming `pageNo` or `pageSize`** under `errors`.

Nothing about the request contract moves. The parameters keep their names and meaning, and the eight endpoints that shipped with a default of twenty or thirty keep it through `pageSizeOr(int)` rather than being quietly folded onto the shared default of ten, which would shrink the page every caller who omits the parameter already receives.

The newer endpoints (leave, inspection, finance) declare a Spring Data `Pageable` instead, whose ceiling is the resolver's own and defaulted to **2000**, four times the cap the rest of the API applies. `spring.data.web.pageable.max-page-size` is brought down to 500 so one ceiling holds whichever way an endpoint declares its paging. That resolver clamps rather than refusing, which is its behaviour and not ours to change.

## Native queries

**None exposed.** The only `nativeQuery = true` in the tree is `CurrentStockRepository.seedZeroStockRow`, an insert with named parameters and no page. `ReportService` assembles native SQL as a string but takes no paging value into it, and `SearchService` already clamps its own `limit` to `MAX_LIMIT`. So the unclamped value never reached a place where it was worse than a 500.

## Guardrail

`architecture/PaginationParameterBoundTest` fails the build if any `@RestController` method declares a parameter named `pageNo` or `pageSize`, so endpoint forty-eight cannot reintroduce this by copying endpoint forty-seven. It runs under the same `@AnalyzeClasses` spec as `UnboundedRepositoryReadTest`, `MultipartPayloadValidationTest` and `EndpointAuthorizationTest`, so it shares their soft-referenced import cache rather than importing the class graph a fifth time. Parameter names are read by reflection because ArchUnit's `JavaParameter` does not carry one; they survive into the bytecode because the build already compiles with `-parameters`, which is what Spring binds these very parameters by.

`common/pagination/PageQueryBindingTest` proves the behaviour through the real request pipeline with `MockMvc` standalone over `AssetControllerWeb` (which carries both a shared-default endpoint and one defaulting to twenty, and is `@Validated`, the arrangement most of these controllers are in). Driven over HTTP rather than against `PageQuery` directly because the part that had to be got right is the binding, not the annotations.

## Failing-test table

Each new test run against the pre-fix controller, with `PageQuery` present but `AssetControllerWeb` restored to its `int pageNo, int pageSize` signature.

| Test | Without the fix | With the fix |
|---|---|---|
| `PaginationParameterBoundTest.noControllerDeclaresItsOwnPagingParameters` | FAILED, lists all four offending parameters | PASSED |
| `PageQueryBindingTest.refusesAPageSizeAboveTheRowCap` | FAILED, 200 (reached the service) | PASSED |
| `PageQueryBindingTest.refusesAnOversizedPageOnAnEndpointWithItsOwnDefault` | FAILED, 200 | PASSED |
| `PageQueryBindingTest.refusesANegativePageNumber` | FAILED, 200 | PASSED |
| `PageQueryBindingTest.refusesAPageSizeOfZero` | FAILED, 200 | PASSED |
| `PageQueryBindingTest.refusesAPageNumberThatIsNotANumber` | FAILED, **500** | PASSED |
| `PageQueryBindingTest.refusesAPageSizeTooLargeForAnInt` | FAILED, **500** | PASSED |
| `PageQueryBindingTest.bindsTheParametersTheCallerSent` | PASSED | PASSED |
| `PageQueryBindingTest.appliesTheSharedDefaultWhenTheCallerSendsNeither` | PASSED | PASSED |
| `PageQueryBindingTest.keepsAnEndpointsOwnDefaultPageSize` | PASSED | PASSED |
| `PageQueryBindingTest.acceptsAPageSizeAtTheRowCap` | PASSED | PASSED |
| `PageQueryBindingTest.stillReadsTheParametersUnderTheirPublishedNames` | PASSED | PASSED |

The five that pass in both columns are there deliberately: they describe behaviour that must not change, and a fix that broke the contract would turn them red.

Full suite green on the lab build box.

## Client impact

None expected. The query parameter names, their defaults and their meaning are unchanged, and neither `echno-web` nor `echno-core` asks for a page of a hundred rows anywhere, let alone five hundred.