### PR TITLE
Delete dead file-URL builder and three unused exists-by-number methods

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/FileStorageService.java
@@ -358,17 +358,6 @@ public class FileStorageService {
     }
 
     /**
-     * Builds the public URL for a stored file.
-     *
-     * @param key The storage key
-     * @return The public URL
-     */
-    private String buildFileUrl(String key) {
-        String endpoint = cdnEndpoint.endsWith("/") ? cdnEndpoint : cdnEndpoint + "/";
-        return endpoint + key;
-    }
-
-    /**
      * Rolls back uploaded files by deleting them.
      *
      * @param keys The keys of files to delete

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteRepository.java
@@ -15,6 +15,4 @@ public interface GoodsReceivedNoteRepository extends JpaRepository<GoodsReceived
     List<GoodsReceivedNote> findByVendorId(Long vendorId);
 
     List<GoodsReceivedNote> findByReceivedOnBetween(LocalDateTime startDate, LocalDateTime endDate);
-
-    boolean existsByGrnNumber(String grnNumber);
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderRepository.java
@@ -16,7 +16,5 @@ public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Lo
 
     List<PurchaseOrder> findByStatus(PurchaseOrderStatus status);
 
-    boolean existsByPoNumberAndOrganization_Id(String poNumber, Long organizationId);
-
     Optional<PurchaseOrder> findByIdAndOrganization_Id(Long id, Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferRepository.java
@@ -19,7 +19,5 @@ public interface SiteTransferRepository extends JpaRepository<SiteTransfer, Long
 
     List<SiteTransfer> findByIssueDateBetween(LocalDateTime startDate, LocalDateTime endDate);
 
-    boolean existsByTransferNumberAndOrganization_Id(String transferNumber, Long organizationId);
-
     Optional<SiteTransfer> findByIdAndOrganization_Id(Long id, Long organizationId);
 }


### PR DESCRIPTION
Closes #550. Closes #551.

Two small deletions that were verified dead before filing, and re-verified on `development` at `d63a092` before touching anything.

## `FileStorageService.buildFileUrl` (#550)

The method joined the CDN endpoint straight onto the object key with no bucket segment. The object store is addressed path-style, so the URL it produced pointed at a path that does not exist. It was also `private` with no callers.

`grep -rn "buildFileUrl"` over the whole repository returns exactly one line, the declaration itself. Every URL that reaches a browser goes through `generateDownloadUrl` or `generateUploadUrl`, and both build their requests from `bucketName` plus `key` through the SDK, which addresses the bucket correctly. The bucket is private, so a plain object URL would not be readable even if the path were right. Deleted rather than repaired, per the issue's own recommendation.

The `cdnEndpoint` field stays: it is still read at line 229.

## The exists-by-number repository methods (#551)

Deleted:

- `PurchaseOrderRepository.existsByPoNumberAndOrganization_Id`
- `SiteTransferRepository.existsByTransferNumberAndOrganization_Id`
- `GoodsReceivedNoteRepository.existsByGrnNumber`

Each returned exactly one hit across the whole repository, its own declaration. No caller in `src/main`, no stub in `src/test`, no reference from a `@Query`, a specification, or an ArchUnit allowlist.

The third one is the addition the issue did not list. #540 moved **four** document families to server-side allocation (`DocumentNumberType`: `SITE_TRANSFER`, `PURCHASE_ORDER`, `INDENT`, `GOODS_RECEIVED_NOTE`), so the GRN and indent equivalents were worth checking too. The GRN one is dead in the same way, and was not organization-scoped either, so it would have answered across tenants had anyone picked it up.

**The indent equivalent stays.** `IndentRepository.existsByIndentNumberAndOrganization_Id` is still called from `IndentService.updateIndent`, which lets a caller rename an indent and checks the new number for a collision first. That path is live, so the method is not dead.

`StockAdjustmentRepository.existsByAdjustmentNumberAndOrganization_Id` is also unreferenced, but stock adjustments are not one of #540's four families and separate work is open in that package, so it is left alone rather than dragged into an unrelated cleanup.

## Uniqueness is still guaranteed

The issue asked for this to be confirmed rather than assumed. Server-side allocation is a single `INSERT ... ON CONFLICT ... DO UPDATE ... RETURNING` against a counter row per `(organization, document type, year)`, so two committed transactions cannot come away with the same number. Behind that, `po_number`, `transfer_number` and `grn_number` each carry a unique constraint in the changelog. The deleted methods were never the mechanism, and they were not the backstop either.

## Verification

Full `./gradlew build` on a lab node: BUILD SUCCESSFUL, whole test suite including the ArchUnit checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal file-storage and record-management components.
  * Removed unused duplicate-checking operations for purchase orders, goods received notes, and site transfers.
  * Existing file uploads, downloads, storage access, and record workflows remain unchanged.

* **Bug Fixes**
  * No direct user-facing bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->