### PR TITLE
Move a site transfer against the balance row it writes

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
@@ -44,13 +44,16 @@ public class InventoryEventListener {
         logger.info("Handling GRN created event for GRN number: {}", grn.getGrnNumber());
 
         for (GrnItem item : grn.getItems()) {
+            // Read the balance this receipt actually credits. With no storage location that is
+            // the project's unlocated row, not the project total.
             Double openingStock;
             if (grn.getStorageLocation() != null) {
                 openingStock = inventoryService.getStockAtLocation(
                         item.getMaterial().getId(), grn.getProject().getId(),
                         grn.getStorageLocation().getId());
             } else {
-                openingStock = inventoryService.getCurrentStock(item.getMaterial().getId(), grn.getProject().getId());
+                openingStock = inventoryService.findUnlocatedStock(
+                        item.getMaterial().getId(), grn.getProject().getId()).orElse(0.0);
             }
             Double quantityChanged = item.getReceivedQuantity().doubleValue();
             Double closingStock = openingStock + quantityChanged;
@@ -136,15 +139,20 @@ public class InventoryEventListener {
         logger.info("Handling site transfer created event for transfer number: {}", transfer.getTransferNumber());
 
         for (SiteTransferItem item : transfer.getItems()) {
-            // TRANSFER_OUT: Stock decreases at sending project
+            // TRANSFER_OUT: Stock decreases at sending project.
+            // Read the balance this movement actually debits. With no sending storage location
+            // that is the sending project's unlocated row, not the project total: the total
+            // would put an opening and closing figure on the ledger entry that the row it
+            // moves never held, and it is a different quantity from the one updateCurrentStock
+            // goes on to write.
             Double sendingOpeningStock;
             if (transfer.getSendingStorageLocation() != null) {
                 sendingOpeningStock = inventoryService.getStockAtLocation(
                         item.getMaterial().getId(), transfer.getSendingProject().getId(),
                         transfer.getSendingStorageLocation().getId());
             } else {
-                sendingOpeningStock = inventoryService.getCurrentStock(
-                        item.getMaterial().getId(), transfer.getSendingProject().getId());
+                sendingOpeningStock = inventoryService.findUnlocatedStock(
+                        item.getMaterial().getId(), transfer.getSendingProject().getId()).orElse(0.0);
             }
             Double sendingQuantityChanged = -item.getSentQuantity().doubleValue();
             Double sendingClosingStock = sendingOpeningStock + sendingQuantityChanged;
@@ -181,14 +189,16 @@ public class InventoryEventListener {
                     item.getMaterial().getId(), transfer.getSendingProject().getId(), sendingQuantityChanged, sendingClosingStock);
 
             // TRANSFER_IN: Stock increases at receiving project (carries avg cost from sender)
+            // Same on the receiving side: the row credited with no location is the receiving
+            // project's unlocated row.
             Double receivingOpeningStock;
             if (transfer.getReceivingStorageLocation() != null) {
                 receivingOpeningStock = inventoryService.getStockAtLocation(
                         item.getMaterial().getId(), transfer.getReceivingProject().getId(),
                         transfer.getReceivingStorageLocation().getId());
             } else {
-                receivingOpeningStock = inventoryService.getCurrentStock(
-                        item.getMaterial().getId(), transfer.getReceivingProject().getId());
+                receivingOpeningStock = inventoryService.findUnlocatedStock(
+                        item.getMaterial().getId(), transfer.getReceivingProject().getId()).orElse(0.0);
             }
             Double receivingQuantityChanged = item.getSentQuantity().doubleValue();
             Double receivingClosingStock = receivingOpeningStock + receivingQuantityChanged;

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
@@ -124,22 +124,6 @@ public class InventoryService {
     }
 
     /**
-     * Returns current stock for several materials at a project in one call.
-     *
-     * @param materialIds The materials to total.
-     * @param projectId The project to total within.
-     * @return A map from material id to quantity on hand at the project.
-     */
-    @Transactional(readOnly = true)
-    public Map<Long, Double> getCurrentStockForMaterials(List<Long> materialIds, Long projectId) {
-        Map<Long, Double> stockMap = new HashMap<>();
-        for (Long materialId : materialIds) {
-            stockMap.put(materialId, getCurrentStock(materialId, projectId));
-        }
-        return stockMap;
-    }
-
-    /**
      * Checks that a project holds at least the required quantity of a material.
      *
      * @param materialId The material to check.
@@ -265,6 +249,54 @@ public class InventoryService {
     }
 
     /**
+     * Checks the project's unlocated balance holds enough of every requested material.
+     *
+     * <p>The multiple-item form of {@link #validateSufficientUnlocatedStock}, for a movement
+     * that names no storage location and so reads and writes the project's unlocated row.
+     * A check that sums every row on the project is deliberately not used here: it would
+     * authorise a draw against stock sitting in storage locations that the unlocated write
+     * never touches, and the balance would go negative.
+     *
+     * <p>All shortfalls are collected so the failure lists every insufficient material
+     * rather than stopping at the first.
+     *
+     * @param requiredQuantities A map from material id to the quantity needed.
+     * @param projectId The project to check within.
+     * @throws InsufficientStockException if any material falls short, naming each shortfall.
+     */
+    public void validateSufficientUnlocatedStockForMultipleItems(Map<Long, Double> requiredQuantities, Long projectId) {
+        List<String> insufficientItems = new ArrayList<>();
+        for (Map.Entry<Long, Double> entry : requiredQuantities.entrySet()) {
+            Long materialId = entry.getKey();
+            Double required = entry.getValue();
+            Optional<Double> balance = findUnlocatedStock(materialId, projectId);
+
+            if (balance.isEmpty() && required > 0) {
+                insufficientItems.add(
+                    String.format("Material ID %d: Required %.2f, none held outside a storage location",
+                        materialId, required)
+                );
+                continue;
+            }
+            Double available = balance.orElse(0.0);
+            if (available < required) {
+                insufficientItems.add(
+                    String.format("Material ID %d: Required %.2f, Available %.2f",
+                        materialId, required, available)
+                );
+            }
+        }
+
+        if (!insufficientItems.isEmpty()) {
+            throw new InsufficientStockException(
+                "Insufficient stock at project ID " + projectId + " outside a storage location for items: "
+                    + String.join("; ", insufficientItems)
+                    + ". Any stock the project holds sits in its storage locations, so name the location to draw from."
+            );
+        }
+    }
+
+    /**
      * Returns the stock of every material held at a storage location, with totals.
      *
      * @param storageLocationId The storage location to report on.
@@ -344,41 +376,6 @@ public class InventoryService {
         result.setTotalStock(totalStock);
         result.setTotalStockValue(totalStockValue);
         return result;
-    }
-
-    /**
-     * Checks that a project holds enough of every requested material across its locations.
-     *
-     * <p>All shortfalls are collected so the failure lists every insufficient material
-     * rather than stopping at the first.
-     *
-     * @param requiredQuantities A map from material id to the quantity needed.
-     * @param projectId The project to check within.
-     * @throws InsufficientStockException if any material falls short, naming each shortfall.
-     */
-    public void validateSufficientStockForMultipleItems(Map<Long, Double> requiredQuantities, Long projectId) {
-        Map<Long, Double> currentStock = getCurrentStockForMaterials(
-                new ArrayList<>(requiredQuantities.keySet()), projectId);
-
-        List<String> insufficientItems = new ArrayList<>();
-        for (Map.Entry<Long, Double> entry : requiredQuantities.entrySet()) {
-            Long materialId = entry.getKey();
-            Double required = entry.getValue();
-            Double available = currentStock.getOrDefault(materialId, 0.0);
-
-            if (available < required) {
-                insufficientItems.add(
-                    String.format("Material ID %d: Required %.2f, Available %.2f",
-                        materialId, required, available)
-                );
-            }
-        }
-
-        if (!insufficientItems.isEmpty()) {
-            throw new InsufficientStockException(
-                "Insufficient stock at project ID " + projectId + " for items: " + String.join("; ", insufficientItems)
-            );
-        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -158,8 +158,11 @@ public class SiteTransferService {
 
         requireTheTransferMovesStock(sendingProject, sendingLocation, receivingProject, receivingLocation);
 
-        // CRITICAL: Validate sufficient stock at the SENDING location for ALL items
-        // Use storage-location-level validation when a sending storage location is specified
+        // Check the sending side for every item, against the balance row the transfer will
+        // actually debit. Named location means that location's row; no location means the
+        // sending project's unlocated row, which is what the listener goes on to write. The
+        // project total would pass a draw against stock sitting in storage locations the
+        // debit never reaches, and take the unlocated row negative.
         Map<Long, Double> requiredQuantities = new HashMap<>();
         for (SiteTransferItemDto itemDto : creationDto.getItems()) {
             requiredQuantities.merge(itemDto.getMaterialId(), itemDto.getSentQuantity().doubleValue(), Double::sum);
@@ -168,7 +171,8 @@ public class SiteTransferService {
             inventoryService.validateSufficientStockForMultipleItemsAtLocation(
                     requiredQuantities, sendingProject.getId(), creationDto.getSendingStorageLocationId());
         } else {
-            inventoryService.validateSufficientStockForMultipleItems(requiredQuantities, sendingProject.getId());
+            inventoryService.validateSufficientUnlocatedStockForMultipleItems(
+                    requiredQuantities, sendingProject.getId());
         }
 
         // Create site transfer

--- a/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerSiteTransferTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerSiteTransferTest.java
@@ -1,0 +1,205 @@
+package org.tornotron.echno_backend.common.events.listeners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The opening and closing figures on a ledger entry have to describe the balance row the
+ * movement actually writes. {@code CurrentStock} is keyed by material, project and storage
+ * location, so a movement naming no location reads and writes the project's unlocated row
+ * and not the project total. Reading the total instead puts a figure on the entry that the
+ * row it moved never held, and on the outbound side it hides the fact that the row is
+ * about to go negative.
+ */
+@ExtendWith(MockitoExtension.class)
+class InventoryEventListenerSiteTransferTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 2L;
+    private static final Long SENDING_PROJECT = 7L;
+    private static final Long RECEIVING_PROJECT = 9L;
+    private static final Long SENDING_LOCATION = 3L;
+    private static final Long RECEIVING_LOCATION = 4L;
+
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private InventoryService inventoryService;
+
+    private InventoryEventListener listener;
+    private Material material;
+    private Project sendingProject;
+    private Project receivingProject;
+    private Organization organization;
+
+    @BeforeEach
+    void setUp() {
+        listener = new InventoryEventListener(inventoryTransactionRepository, inventoryService);
+        material = new Material();
+        material.setId(MATERIAL);
+        sendingProject = new Project();
+        sendingProject.setId(SENDING_PROJECT);
+        sendingProject.setProjectName("Sending site");
+        receivingProject = new Project();
+        receivingProject.setId(RECEIVING_PROJECT);
+        receivingProject.setProjectName("Receiving site");
+        organization = new Organization();
+        organization.setId(ORG);
+    }
+
+    private StorageLocation location(Long id) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        return location;
+    }
+
+    private SiteTransfer transfer(StorageLocation sending, StorageLocation receiving) {
+        SiteTransfer transfer = new SiteTransfer();
+        transfer.setId(51L);
+        transfer.setTransferNumber("TRF-2026-000042");
+        transfer.setIssueDate(LocalDateTime.now());
+        transfer.setSendingProject(sendingProject);
+        transfer.setReceivingProject(receivingProject);
+        transfer.setSendingStorageLocation(sending);
+        transfer.setReceivingStorageLocation(receiving);
+        transfer.setOrganization(organization);
+
+        SiteTransferItem item = new SiteTransferItem();
+        item.setMaterial(material);
+        item.setSentQuantity(4);
+        transfer.setItems(List.of(item));
+        return transfer;
+    }
+
+    private List<InventoryTransaction> savedTransactions() {
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository, times(2)).save(captor.capture());
+        return captor.getAllValues();
+    }
+
+    private InventoryTransaction of(List<InventoryTransaction> saved, InventoryTransactionType type) {
+        return saved.stream()
+                .filter(t -> t.getTransactionType() == type)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No " + type + " entry was written"));
+    }
+
+    @Test
+    void aTransferOutWithNoSendingLocationOpensFromTheSendingProjectsUnlocatedBalance() {
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
+                .thenReturn(BigDecimal.TEN);
+        when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(10.0));
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(0.0));
+
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
+
+        InventoryTransaction out = of(savedTransactions(), InventoryTransactionType.TRANSFER_OUT);
+        assertThat(out.getOpeningStock()).isEqualTo(10.0);
+        assertThat(out.getQuantityChanged()).isEqualTo(-4.0);
+        assertThat(out.getClosingStock()).isEqualTo(6.0);
+        verify(inventoryService, never()).getCurrentStock(any(), any());
+    }
+
+    @Test
+    void aTransferInWithNoReceivingLocationOpensFromTheReceivingProjectsUnlocatedBalance() {
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
+                .thenReturn(BigDecimal.TEN);
+        when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(10.0));
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(2.0));
+
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
+
+        InventoryTransaction in = of(savedTransactions(), InventoryTransactionType.TRANSFER_IN);
+        assertThat(in.getOpeningStock()).isEqualTo(2.0);
+        assertThat(in.getQuantityChanged()).isEqualTo(4.0);
+        assertThat(in.getClosingStock()).isEqualTo(6.0);
+        verify(inventoryService, never()).getCurrentStock(any(), any());
+    }
+
+    @Test
+    void aProjectWithNoUnlocatedRowAtAllOpensFromZeroRatherThanTheProjectTotal() {
+        // The sending project holds its stock inside storage locations, so there is no
+        // unlocated row. The debit seeds one and takes it to -4, and the entry has to say so
+        // rather than report the located stock the transfer never touched.
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
+                .thenReturn(BigDecimal.ZERO);
+        when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.empty());
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.empty());
+
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
+
+        InventoryTransaction out = of(savedTransactions(), InventoryTransactionType.TRANSFER_OUT);
+        assertThat(out.getOpeningStock()).isZero();
+        assertThat(out.getClosingStock()).isEqualTo(-4.0);
+    }
+
+    @Test
+    void aTransferBetweenTwoLocationsStillOpensFromEachLocationsOwnBalance() {
+        StorageLocation sending = location(SENDING_LOCATION);
+        StorageLocation receiving = location(RECEIVING_LOCATION);
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, SENDING_LOCATION))
+                .thenReturn(BigDecimal.TEN);
+        when(inventoryService.getStockAtLocation(MATERIAL, SENDING_PROJECT, SENDING_LOCATION)).thenReturn(10.0);
+        when(inventoryService.getStockAtLocation(MATERIAL, RECEIVING_PROJECT, RECEIVING_LOCATION)).thenReturn(2.0);
+
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(sending, receiving)));
+
+        List<InventoryTransaction> saved = savedTransactions();
+        assertThat(of(saved, InventoryTransactionType.TRANSFER_OUT).getOpeningStock()).isEqualTo(10.0);
+        assertThat(of(saved, InventoryTransactionType.TRANSFER_IN).getOpeningStock()).isEqualTo(2.0);
+        verify(inventoryService, never()).findUnlocatedStock(any(), any());
+    }
+
+    @Test
+    void aGrnWithNoStorageLocationOpensFromTheProjectsUnlocatedBalance() {
+        GoodsReceivedNote grn = new GoodsReceivedNote();
+        grn.setGrnNumber("GRN-2026-000003");
+        grn.setReceivedOn(LocalDateTime.now());
+        grn.setProject(sendingProject);
+        grn.setOrganization(organization);
+        GrnItem item = new GrnItem();
+        item.setMaterial(material);
+        item.setReceivedQuantity(7);
+        item.setUnitCost(BigDecimal.TEN);
+        grn.setItems(List.of(item));
+
+        when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(3.0));
+
+        listener.handleGrnCreated(new GrnCreatedEvent(this, grn));
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getOpeningStock()).isEqualTo(3.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(10.0);
+        verify(inventoryService, never()).getCurrentStock(any(), any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
  * publisher, and the mapper are mocked; the entity graph is built in memory. The focus
  * is the logic this service owns: rejecting a duplicate transfer number, rejecting
  * unknown referenced entities, aggregating the per-material required quantities that feed
- * the sending-side stock check, choosing the location-scoped vs project-scoped variant of
+ * the sending-side stock check, choosing the location-scoped vs unlocated variant of
  * that check, refusing a transfer whose two sides are the same balance row or whose location
  * belongs to another project, and building one transfer item per request line.
  */
@@ -204,7 +204,7 @@ class SiteTransferServiceTest {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Map<Long, Double>> captor = ArgumentCaptor.forClass(Map.class);
-        verify(inventoryService).validateSufficientStockForMultipleItems(captor.capture(), eq(SENDING_PROJECT));
+        verify(inventoryService).validateSufficientUnlocatedStockForMultipleItems(captor.capture(), eq(SENDING_PROJECT));
         assertThat(captor.getValue()).containsEntry(MATERIAL, 10.0);
     }
 
@@ -219,7 +219,7 @@ class SiteTransferServiceTest {
         service.createSiteTransfer(dto);
 
         verify(inventoryService).validateSufficientStockForMultipleItemsAtLocation(any(), eq(SENDING_PROJECT), eq(SENDING_LOCATION));
-        verify(inventoryService, never()).validateSufficientStockForMultipleItems(any(), anyLong());
+        verify(inventoryService, never()).validateSufficientUnlocatedStockForMultipleItems(any(), anyLong());
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
@@ -1,0 +1,232 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.exception.InsufficientStockException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStock;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The sending-side stock check against a real {@link InventoryService} over a mocked stock
+ * repository, so the balance row the check reads is the thing under test rather than a
+ * mock's say-so.
+ *
+ * <p>A transfer that names no sending storage location debits the sending project's
+ * unlocated row. Checking the project total instead authorises a draw against stock sitting
+ * in storage locations the debit never reaches, and the unlocated row goes negative. That is
+ * how {@code current_stock} row 15 on staging reached -30 through the consumption path
+ * before #539.
+ */
+@ExtendWith(MockitoExtension.class)
+class SiteTransferStockScopeTest {
+
+    private static final Long ORG = 100L;
+    private static final Long SENDER = 7L;
+    private static final Long SENDING_PROJECT = 9L;
+    private static final Long RECEIVING_PROJECT = 10L;
+    private static final Long SENDING_LOCATION = 3L;
+    private static final Long MATERIAL = 11L;
+    private static final Long OTHER_MATERIAL = 12L;
+
+    @Mock private SiteTransferRepository siteTransferRepository;
+    @Mock private SiteTransferItemRepository siteTransferItemRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private CurrentStockRepository currentStockRepository;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private SiteTransferMapper siteTransferMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+
+    private SiteTransferService service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        InventoryService inventoryService = new InventoryService(currentStockRepository,
+                inventoryTransactionRepository, materialRepository, storageLocationRepository);
+        service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
+                materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository,
+                documentNumberAllocator, retryTemplate);
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
+
+        Employee sender = new Employee();
+        sender.setId(SENDER);
+        Project sending = new Project();
+        sending.setId(SENDING_PROJECT);
+        Project receiving = new Project();
+        receiving.setId(RECEIVING_PROJECT);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.SITE_TRANSFER, ORG))
+                .thenReturn("TRF-2026-000042");
+        lenient().when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG)).thenReturn(Optional.of(sender));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.of(sending));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(RECEIVING_PROJECT, ORG)).thenReturn(Optional.of(receiving));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(siteTransferRepository.save(any(SiteTransfer.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(materialRepository.findByIdAndOrganization_Id(any(), eq(ORG)))
+                .thenAnswer(inv -> {
+                    Material m = new Material();
+                    m.setId(inv.getArgument(0));
+                    return Optional.of(m);
+                });
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private CurrentStock stockRow(double quantity) {
+        CurrentStock row = new CurrentStock();
+        row.setCurrentQuantity(quantity);
+        return row;
+    }
+
+    private SiteTransferItemDto item(Long materialId, int qty) {
+        SiteTransferItemDto i = new SiteTransferItemDto();
+        i.setMaterialId(materialId);
+        i.setSentQuantity(qty);
+        return i;
+    }
+
+    private SiteTransferCreationDto dto(Long sendingLocationId) {
+        SiteTransferCreationDto dto = new SiteTransferCreationDto();
+        dto.setIssueDate(LocalDateTime.now());
+        dto.setSendingPerson(SENDER);
+        dto.setSendingProjectId(SENDING_PROJECT);
+        dto.setReceivingProjectId(RECEIVING_PROJECT);
+        dto.setSendingStorageLocationId(sendingLocationId);
+        dto.setStatus("PENDING");
+        dto.setItems(List.of(item(MATERIAL, 4)));
+        return dto;
+    }
+
+    private void sendingLocationExists() {
+        StorageLocation location = new StorageLocation();
+        location.setId(SENDING_LOCATION);
+        Project owner = new Project();
+        owner.setId(SENDING_PROJECT);
+        location.setProject(owner);
+        lenient().when(storageLocationRepository.findByIdAndOrganization_Id(SENDING_LOCATION, ORG))
+                .thenReturn(Optional.of(location));
+    }
+
+    @Test
+    void aTransferWithNoSendingLocationIsRefusedWhenTheProjectHoldsItsStockInsideLocations() {
+        // The project total is 60, all of it inside storage locations. The debit writes the
+        // project's unlocated row, which holds nothing.
+        lenient().when(currentStockRepository.sumCurrentQuantityByMaterialAndProject(MATERIAL, SENDING_PROJECT))
+                .thenReturn(60.0);
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, SENDING_PROJECT))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto(null)))
+                .withMessageContaining("outside a storage location")
+                .withMessageContaining("name the location");
+
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void aTransferWithNoSendingLocationIsRefusedWhenTheUnlocatedBalanceIsShort() {
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, SENDING_PROJECT))
+                .thenReturn(Optional.of(stockRow(1.0)));
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto(null)))
+                .withMessageContaining("Required 4.00, Available 1.00");
+
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void aTransferWithNoSendingLocationIsAllowedAgainstTheUnlocatedBalance() {
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, SENDING_PROJECT))
+                .thenReturn(Optional.of(stockRow(4.0)));
+
+        assertThatCode(() -> service.createSiteTransfer(dto(null))).doesNotThrowAnyException();
+
+        verify(siteTransferRepository).save(any());
+    }
+
+    @Test
+    void everyShortMaterialIsNamedRatherThanOnlyTheFirst() {
+        SiteTransferCreationDto dto = dto(null);
+        dto.setItems(List.of(item(MATERIAL, 4), item(OTHER_MATERIAL, 5)));
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(MATERIAL, SENDING_PROJECT))
+                .thenReturn(Optional.of(stockRow(1.0)));
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationIsNull(OTHER_MATERIAL, SENDING_PROJECT))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto))
+                .withMessageContaining("Material ID 11")
+                .withMessageContaining("Material ID 12");
+    }
+
+    @Test
+    void aTransferFromANamedLocationStillReadsThatLocationsBalance() {
+        sendingLocationExists();
+        when(currentStockRepository.findByMaterialIdAndProjectIdAndStorageLocationId(
+                MATERIAL, SENDING_PROJECT, SENDING_LOCATION)).thenReturn(Optional.of(stockRow(4.0)));
+
+        assertThatCode(() -> service.createSiteTransfer(dto(SENDING_LOCATION))).doesNotThrowAnyException();
+
+        verify(siteTransferRepository).save(any());
+        verify(currentStockRepository, never())
+                .findByMaterialIdAndProjectIdAndStorageLocationIsNull(any(), any());
+    }
+}


### PR DESCRIPTION
Closes #556

Found while landing #554. It is the mismatch #539 fixed for consumption, still present on the site transfer path, so this follows what #539 did rather than inventing a second approach.

## What was wrong

`CurrentStock` is keyed by `(material, project, storage location)`, and a null storage location is a row of its own rather than a rollup over the located rows. `InventoryService.findUnlocatedStock` already says so:

> This is the row a movement with no storage location reads and writes. It is not the project total: stock booked into a storage location lives in its own row and is not reachable from here.

`InventoryEventListener.handleSiteTransferCreated` did not follow that. With no sending storage location it read the opening figure from `getCurrentStock`, the project total across every location, and then debited the unlocated row through `updateCurrentStock`. Two different quantities: the `TRANSFER_OUT` entry stated an opening and a closing figure for a balance the movement never touched. The receiving side had the same shape, and so did `handleGrnCreated`.

`SiteTransferService` chose its check off the same branch, calling `validateSufficientStockForMultipleItems`, which sums every row on the project. A project holding 400 in a storage location and nothing outside one passed a check for 30, and the unlocated row it then debited went to -30.

## Where it had already happened

Row 16 of `inventory_transaction` on `echno.in`:

```
 id | transaction_type | material_id | project_id | storage_location_id | opening_stock | quantity_changed | closing_stock | reference_number
 16 | USE              |           8 |           7 |                NULL |           400 |              -30 |           370 | MC-1
```

Material 8 at project 7 held 400 at storage location 2 and nothing outside a location. The entry claims 400 down to 370; the row it actually debited went 0 to -30, and that is `current_stock` id 15, the negative balance reported as item 4 of #529 with no cause identified. This is the cause. It came through consumption, which #539 has since fixed, so nothing needs correcting beyond that one historical row.

No transfer row is wrong yet, only because no transfer has been created without a sending storage location. The web form makes both locations mandatory, which is a property of the current frontend and not a guard. The API accepts a null on either side.

## The change

- Both sides of `handleSiteTransferCreated`, and `handleGrnCreated`, read their opening figure from `findUnlocatedStock(...).orElse(0.0)` when the side names no location, matching what `handleMaterialConsumed` does since #539. A GRN only ever adds so it could not drive a balance negative, but the figure it wrote was still not the row it credited.
- `InventoryService.validateSufficientUnlocatedStockForMultipleItems` is the multiple-item form of `validateSufficientUnlocatedStock`, which existed for exactly this and had no plural version, which is why the site transfer path had nothing correct to call. It collects every shortfall rather than stopping at the first, like the two checks either side of it, and its message carries the same "name the location to draw from" hint as the single-item version.
- `SiteTransferService` calls it on the no-sending-location branch.

`validateSufficientStockForMultipleItems` and `getCurrentStockForMaterials` are deleted. Both are left with no caller by this change, and both encode the project-total scope that is the bug, so leaving them is leaving the next caller a way to reintroduce it. `validateSufficientStock` is also dead, but it was already dead before this change, so it belongs to whatever sweep picks up #473's leftovers rather than here.

The frontend half is echno-web #324, which is deliberately not started: two other agents are in that repo and it is a form-level change.

## Tests

Every new test was run against the fix removed.

| Test | Fix removed | Result without it |
|---|---|---|
| `InventoryEventListenerSiteTransferTest.aTransferOutWithNoSendingLocationOpensFromTheSendingProjectsUnlocatedBalance` | listener opening figures back to `getCurrentStock` | **FAILED** |
| `InventoryEventListenerSiteTransferTest.aTransferInWithNoReceivingLocationOpensFromTheReceivingProjectsUnlocatedBalance` | same | **FAILED** |
| `InventoryEventListenerSiteTransferTest.aProjectWithNoUnlocatedRowAtAllOpensFromZeroRatherThanTheProjectTotal` | same | **FAILED** |
| `InventoryEventListenerSiteTransferTest.aGrnWithNoStorageLocationOpensFromTheProjectsUnlocatedBalance` | same | **FAILED** |
| `SiteTransferStockScopeTest.aTransferWithNoSendingLocationIsRefusedWhenTheProjectHoldsItsStockInsideLocations` | service back to `validateSufficientStockForMultipleItems`, method restored | **FAILED** |
| `SiteTransferStockScopeTest.aTransferWithNoSendingLocationIsRefusedWhenTheUnlocatedBalanceIsShort` | same | **FAILED** |
| `SiteTransferStockScopeTest.aTransferWithNoSendingLocationIsAllowedAgainstTheUnlocatedBalance` | same | **FAILED** |
| `SiteTransferStockScopeTest.everyShortMaterialIsNamedRatherThanOnlyTheFirst` | same | **FAILED** |
| `SiteTransferServiceTest.create_aggregatesQuantitiesOfRepeatedMaterial_forStockCheck` | same | **FAILED** |

Two are controls and pass under the matching revert, which is what they are for: `InventoryEventListenerSiteTransferTest.aTransferBetweenTwoLocationsStillOpensFromEachLocationsOwnBalance` and `SiteTransferStockScopeTest.aTransferFromANamedLocationStillReadsThatLocationsBalance` pin the located branch, which this change does not touch. `SiteTransferServiceTest.create_withSendingLocation_usesLocationScopedStockCheck` also passes under the revert, because its `never()` on the renamed method is vacuously true there.

`SiteTransferStockScopeTest` runs the service over a real `InventoryService` and a mocked `CurrentStockRepository`, following `MaterialConsumptionStockScopeTest` from #539, so the balance row the check reads is the thing under test rather than a mock's say-so.

No changelog in this one. Full suite green on the lab box.
