### PR TITLE
Require someone else to approve what you raised

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicy.java
+++ b/src/main/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicy.java
@@ -1,0 +1,69 @@
+package org.tornotron.echno_backend.common.approval;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+/**
+ * Segregation of duties on the approvals that post an entry: whoever raised a document is not
+ * the person who approves it.
+ *
+ * <p>An approval is the second pair of eyes on the entry it writes. Where the same account both
+ * raises and approves a document, that entry has been reviewed by nobody, and the record shows
+ * an approver without showing that anyone independent agreed. The role gate on the endpoint does
+ * not supply this: every approver may also draft, so a single role holder can do both halves in
+ * two requests.
+ *
+ * <p>The rule applied here is a refusal with one recorded exception. An ordinary approver is
+ * refused outright. A {@value #BREAK_GLASS_ROLE} may approve their own document, because a small
+ * tenant can genuinely have one person with the authority to correct anything and a rule that
+ * cannot be satisfied would leave a wrong figure standing with no route back. That exception is
+ * logged and stays visible on the document, where the raiser and the approver are both recorded
+ * and can be compared.
+ *
+ * <p>A document that names nobody as its raiser cannot be compared against anything, so it is
+ * allowed through. That is the case only for rows written before the raiser was stamped from the
+ * session, since every path that creates one now records who did it.
+ */
+@Slf4j
+@Component
+public class SelfApprovalPolicy {
+
+    /** The one role that may approve its own document, and only as a recorded exception. */
+    public static final String BREAK_GLASS_ROLE = "system-admin";
+
+    private final OrganizationSecurityService orgSecurity;
+
+    public SelfApprovalPolicy(OrganizationSecurityService orgSecurity) {
+        this.orgSecurity = orgSecurity;
+    }
+
+    /**
+     * Applies the rule to one approval, and reports whether it went through as a self-approval.
+     *
+     * @param raisedBy The user who raised the document, or null when the document does not say.
+     * @param approver The user approving it now.
+     * @param document How to name the document in the refusal, for example "Stock adjustment with ID 5".
+     * @return true when the approver is approving their own document under the break-glass role,
+     *         so the caller can record the approval as one; false when the two are different
+     *         people, which is the ordinary case.
+     * @throws InvalidRequestException if the approver raised the document and does not hold the
+     *         break-glass role.
+     */
+    public boolean checkSelfApproval(Long raisedBy, Long approver, String document) {
+        if (raisedBy == null || approver == null || !raisedBy.equals(approver)) {
+            return false;
+        }
+        if (!orgSecurity.hasAnyOrgRoleForCurrentTenant(BREAK_GLASS_ROLE)) {
+            throw new InvalidRequestException(document + " was raised by the same person who is now "
+                    + "approving it. An approval is the second pair of eyes on the entry it posts, so it "
+                    + "has to come from someone other than whoever raised the document. Ask another "
+                    + "approver to review it, or have a system administrator approve it, which is "
+                    + "recorded as a self-approval.");
+        }
+        log.warn("Self-approval: {} was raised and approved by user {}, allowed under the {} role",
+                document, approver, BREAK_GLASS_ROLE);
+        return true;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -89,6 +90,7 @@ public class ConstructionInvoiceService {
     private final CostCategoryRepository costCategoryRepository;
     private final CustomerRepository customerRepository;
     private final InvoiceService invoiceService;
+    private final SelfApprovalPolicy selfApprovalPolicy;
 
     @Transactional(readOnly = true)
     public ConstructionInvoiceDto findById(UUID id) {
@@ -199,6 +201,11 @@ public class ConstructionInvoiceService {
      * is approved and posted straight away through the same path as {@link #approve}, rather than
      * left waiting in PENDING. A null effective threshold means every invoice needs manual approval,
      * which is the original behaviour.
+     *
+     * <p>The threshold path is the one approval that is allowed to be the submitter's own: the
+     * threshold is a standing decision by the tenant that invoices under it are not worth a second
+     * pair of eyes. Above it, and where no threshold is set, the invoice goes to
+     * {@link #approve}, which requires a different person.
      */
     @Transactional
     public ConstructionInvoiceDto submit(UUID id) {
@@ -227,6 +234,13 @@ public class ConstructionInvoiceService {
     /**
      * Approve a pending invoice: PENDING -> APPROVED, and post the journal entry.
      *
+     * <p>Whoever submitted the invoice cannot approve it, on the same rule as every other
+     * approval that posts an entry: see {@link SelfApprovalPolicy}. The auto-approval inside
+     * {@link #submit} is deliberately not subject to it, because a threshold set on the
+     * organization or the project is the tenant's own recorded decision that invoices below that
+     * figure do not need a second person, and passing the submitter's own invoice through it is
+     * exactly what it was configured for.
+     *
      * <p>Posting is invoice-level to the accounts resolved for each posting role (a per-org mapping
      * where set, else the configured default account):
      * <ul>
@@ -246,6 +260,9 @@ public class ConstructionInvoiceService {
                     "Only PENDING construction invoices can be approved; invoice "
                             + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
         }
+        selfApprovalPolicy.checkSelfApproval(inv.getSubmittedBy(),
+                userContextService.getCurrentUserId(),
+                "Construction invoice " + inv.getInvoiceNumber());
         postAndApprove(inv);
         return mapper.toDto(inv);
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -157,11 +157,15 @@ public class ConstructionInvoiceControllerWeb {
     @Operation(
             summary = "Approve a submitted invoice",
             description = "Approves a submitted invoice and posts the matching journal entry to the ledger. "
-                    + "Once approved the invoice is eligible for payment."
+                    + "Once approved the invoice is eligible for payment. Whoever submitted the invoice "
+                    + "cannot approve it: the approval is the second pair of eyes on the entry it posts. "
+                    + "A system administrator is the one exception, and it is logged as a self-approval. "
+                    + "Invoices auto-approved on submit under a configured threshold are not affected, "
+                    + "since that threshold is the tenant's own decision to skip the second reviewer."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Invoice approved and posted"),
-            @ApiResponse(responseCode = "400", description = "Invoice is not in a state that can be approved"),
+            @ApiResponse(responseCode = "400", description = "Invoice is not in a state that can be approved, or the caller submitted it and does not hold the system-admin role"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
     })

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -31,7 +31,8 @@ import java.util.List;
                 + "resulting figure stays explainable. Endpoints cover creating, updating, browsing, "
                 + "approving and deleting stock adjustment documents for the caller's current tenant. "
                 + "Read endpoints require tenant membership; write and approval endpoints require the "
-                + "system-admin or project-manager role."
+                + "system-admin or project-manager role, and approval additionally has to come from "
+                + "someone other than whoever raised the document."
 )
 public class StockAdjustmentControllerWeb {
 
@@ -93,7 +94,9 @@ public class StockAdjustmentControllerWeb {
             summary = "Create a stock adjustment",
             description = "Records a stock adjustment document capturing the counted and system quantities, "
                     + "variance and justification for one or more materials at a location. The document is "
-                    + "created as a draft: it does not change any stock balance until it is approved."
+                    + "created as a draft: it does not change any stock balance until it is approved. "
+                    + "The caller is recorded as the user who raised it, and cannot then approve it "
+                    + "themselves unless they hold the system-admin role."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Stock adjustment created"),
@@ -136,12 +139,16 @@ public class StockAdjustmentControllerWeb {
                     + "or the document must give a primary reason to fall back on, because the reason is "
                     + "what the resulting balance is explained by. This is the only path that sets or "
                     + "corrects a balance, and it is restricted to the system-admin and project-manager "
-                    + "roles. It runs once: an approved document is frozen against further posting, "
-                    + "editing and deletion, and a mistake is corrected by raising another adjustment."
+                    + "roles. Whoever raised the document cannot approve it: an approval is the second "
+                    + "pair of eyes on the movement it posts, so it has to come from someone else. A "
+                    + "system administrator is the one exception, and their self-approval is recorded as "
+                    + "one on the ledger entries. It runs once: an approved document is frozen against "
+                    + "further posting, editing and deletion, and a mistake is corrected by raising "
+                    + "another adjustment."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment approved and posted"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The adjustment is already posted, names no project, has no lines, or a line is missing a material, a reason or a quantity, or would take a balance below zero"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The adjustment is already posted, is being approved by whoever raised it without the system-admin role, names no project, has no lines, or a line is missing a material, a reason or a quantity, or would take a balance below zero"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
     })

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -48,6 +49,11 @@ import java.util.List;
  * through {@link #approve}, and a posted document is then frozen: edits and deletes are
  * refused, because changing the lines afterwards would leave the ledger describing a
  * document that no longer exists.
+ *
+ * <p>Because approval is what moves the balance, it is also where segregation of duties
+ * applies: {@link #create} records who raised the document from the session, and
+ * {@link #approve} refuses an approval by that same person unless they hold the break-glass
+ * role. See {@link SelfApprovalPolicy}.
  */
 @Service
 public class StockAdjustmentService {
@@ -61,6 +67,7 @@ public class StockAdjustmentService {
     private final InventoryService inventoryService;
     private final InventoryTransactionRepository inventoryTransactionRepository;
     private final UserContextService userContextService;
+    private final SelfApprovalPolicy selfApprovalPolicy;
 
     public StockAdjustmentService(StockAdjustmentRepository stockAdjustmentRepository,
                                   StockAdjustmentMapper stockAdjustmentMapper,
@@ -70,7 +77,8 @@ public class StockAdjustmentService {
                                   ProjectRepository projectRepository,
                                   InventoryService inventoryService,
                                   InventoryTransactionRepository inventoryTransactionRepository,
-                                  UserContextService userContextService) {
+                                  UserContextService userContextService,
+                                  SelfApprovalPolicy selfApprovalPolicy) {
         this.stockAdjustmentRepository = stockAdjustmentRepository;
         this.stockAdjustmentMapper = stockAdjustmentMapper;
         this.tenantEntityHelper = tenantEntityHelper;
@@ -80,6 +88,7 @@ public class StockAdjustmentService {
         this.inventoryService = inventoryService;
         this.inventoryTransactionRepository = inventoryTransactionRepository;
         this.userContextService = userContextService;
+        this.selfApprovalPolicy = selfApprovalPolicy;
     }
 
     /** Status a document carries once its movements are on the ledger. */
@@ -98,6 +107,11 @@ public class StockAdjustmentService {
         StockAdjustment stockAdjustment = new StockAdjustment();
         stockAdjustment.setOrganization(organization);
         applyHeaderFields(stockAdjustment, creationDto);
+        // Who raised the document is taken from the session, never from the request body: it is
+        // what approval is checked against, so a caller naming someone else as the raiser would
+        // clear their own way to approve it.
+        stockAdjustment.setSubmittedBy(userContextService.getCurrentUserId());
+        stockAdjustment.setSubmittedAt(LocalDateTime.now());
         applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
         return stockAdjustmentMapper.toDto(saved);
@@ -181,6 +195,10 @@ public class StockAdjustmentService {
      * its signed {@code adjustmentQuantity}. Lines that come out at no movement are skipped
      * rather than writing a ledger row that changes nothing.
      *
+     * <p>The approval is refused up front when the person approving is the one who raised the
+     * document, unless they hold the break-glass role, in which case the posting is allowed and
+     * the ledger entries say they were self-approved. See {@link SelfApprovalPolicy}.
+     *
      * <p>Every posted line writes an {@code ADJUST} {@link InventoryTransaction} whose
      * remarks carry the reason, so the balance stays explainable, and only then moves the
      * balance. Both happen in this transaction: an approval that recorded no movement is the
@@ -190,7 +208,7 @@ public class StockAdjustmentService {
      * @param id The document to approve and post.
      * @return The posted document as a DTO.
      * @throws ResourceNotFoundException if no such document exists in this organization.
-     * @throws InvalidRequestException if the document is already posted, names no project, has no lines, or a line is missing a material, a reason, or a quantity, or would drive a balance negative.
+     * @throws InvalidRequestException if the document is already posted, is being approved by whoever raised it without the break-glass role, names no project, has no lines, or a line is missing a material, a reason, or a quantity, or would drive a balance negative.
      */
     @Transactional
     public StockAdjustmentDto approve(Long id) {
@@ -199,6 +217,10 @@ public class StockAdjustmentService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "posted again");
+
+        Long approver = userContextService.getCurrentUserId();
+        boolean selfApproved = selfApprovalPolicy.checkSelfApproval(
+                stockAdjustment.getSubmittedBy(), approver, "Stock adjustment with ID " + id);
 
         Project project = stockAdjustment.getProject();
         if (project == null) {
@@ -266,7 +288,7 @@ public class StockAdjustmentService {
             transaction.setClosingStock(closing);
             transaction.setTransactionType(InventoryTransactionType.ADJUST);
             transaction.setReferenceNumber(referenceNumber);
-            transaction.setRemarks("Stock adjustment - " + reason);
+            transaction.setRemarks("Stock adjustment - " + reason + selfApprovalNote(selfApproved));
             transaction.setProject(project);
             transaction.setStorageLocation(location);
             transaction.setOrganization(organization);
@@ -279,7 +301,6 @@ public class StockAdjustmentService {
             totalVariance += movement;
         }
 
-        Long approver = userContextService.getCurrentUserId();
         stockAdjustment.setTotalVarianceQuantity(totalVariance);
         stockAdjustment.setStatus(POSTED_STATUS);
         stockAdjustment.setApprovedBy(approver);
@@ -289,6 +310,15 @@ public class StockAdjustmentService {
 
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
         return stockAdjustmentMapper.toDto(saved);
+    }
+
+    /**
+     * What a self-approved posting carries in the ledger. The document already records the raiser
+     * and the approver side by side, but the ledger entry is what a stock figure is explained
+     * from, so a movement nobody independent agreed to says so where the figure is read.
+     */
+    private String selfApprovalNote(boolean selfApproved) {
+        return selfApproved ? " (self-approved: raised and approved by the same person)" : "";
     }
 
     /** Refuses to change a document whose movements are already on the ledger. */
@@ -340,7 +370,12 @@ public class StockAdjustmentService {
         return value != null && !value.isBlank();
     }
 
-    /** Copies the header scalars from the creation DTO, resolving the location and project. */
+    /**
+     * Copies the header scalars from the creation DTO, resolving the location and project.
+     * Deliberately does not touch {@code submittedBy}: it is stamped from the session in
+     * {@link #create} and left alone by {@link #update}, so an edit cannot move the document
+     * onto a different raiser and clear the way for its own approval.
+     */
     private void applyHeaderFields(StockAdjustment stockAdjustment, StockAdjustmentCreationDto dto) {
         stockAdjustment.setAdjustmentNumber(dto.getAdjustmentNumber());
         stockAdjustment.setType(dto.getType());
@@ -353,7 +388,6 @@ public class StockAdjustmentService {
         stockAdjustment.setPhysicalCountDate(dto.getPhysicalCountDate());
         stockAdjustment.setPhysicalCountBy(dto.getPhysicalCountBy());
         stockAdjustment.setCountMethod(dto.getCountMethod());
-        stockAdjustment.setSubmittedBy(dto.getSubmittedBy());
         stockAdjustment.setTotalVarianceQuantity(dto.getTotalVarianceQuantity());
 
         stockAdjustment.setLocation(resolveLocation(dto.getLocationId()));

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -52,7 +52,10 @@ public class StockAdjustmentCreationDto {
     @Schema(description = "Method used to perform the physical count.", example = "FULL_COUNT")
     private String countMethod;
 
-    @Schema(description = "Id of the employee who submitted the adjustment.", example = "18")
+    @Schema(description = "Read-only. The user who raised the document is recorded from the "
+            + "authenticated session, because approval is checked against it. Any value sent here "
+            + "is ignored.",
+            accessMode = Schema.AccessMode.READ_ONLY, example = "18")
     private Long submittedBy;
 
     @Schema(description = "Total variance quantity across all line items.", example = "-120.0")

--- a/src/test/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicyTest.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.common.approval;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The rule itself, away from any document: two different people is the ordinary case and passes
+ * silently, one person doing both halves is refused, a system administrator doing both halves is
+ * allowed and reported back as a self-approval so the caller can record it, and a document that
+ * names nobody as its raiser has nothing to compare and is let through.
+ */
+@ExtendWith(MockitoExtension.class)
+class SelfApprovalPolicyTest {
+
+    private static final Long DRAFTER = 11L;
+    private static final Long APPROVER = 12L;
+    private static final String DOCUMENT = "Stock adjustment with ID 5";
+
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private SelfApprovalPolicy policy() {
+        return new SelfApprovalPolicy(orgSecurity);
+    }
+
+    @Test
+    void twoDifferentPeopleIsNotASelfApprovalAndNeedsNoRoleAtAll() {
+        assertThat(policy().checkSelfApproval(DRAFTER, APPROVER, DOCUMENT)).isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+
+    @Test
+    void approvingYourOwnDocumentIsRefused() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> policy().checkSelfApproval(DRAFTER, DRAFTER, DOCUMENT))
+                .withMessageContaining(DOCUMENT)
+                .withMessageContaining("someone other than whoever raised the document");
+    }
+
+    @Test
+    void aSystemAdministratorMayApproveTheirOwnDocumentAndItComesBackAsASelfApproval() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+
+        assertThat(policy().checkSelfApproval(DRAFTER, DRAFTER, DOCUMENT)).isTrue();
+    }
+
+    @Test
+    void aDocumentThatNamesNoRaiserHasNothingToCompareAndIsLetThrough() {
+        assertThat(policy().checkSelfApproval(null, APPROVER, DOCUMENT)).isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+
+    @Test
+    void anUnresolvedApproverIsNotTreatedAsAMatchAgainstAnUnresolvedRaiser() {
+        assertThat(policy().checkSelfApproval(null, null, DOCUMENT)).isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
@@ -15,9 +15,11 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
@@ -57,7 +59,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
-        PostingAccountResolver.class, FinanceSettingsService.class})
+        PostingAccountResolver.class, FinanceSettingsService.class,
+        SelfApprovalPolicy.class, OrganizationSecurityService.class})
 class ConstructionInvoiceAutoApprovalIT extends AbstractIntegrationTest {
 
     // Total of the built invoice: 10 * 100 = 1000 subtotal, 18% tax = 180, gross 1180.

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -19,9 +19,11 @@ import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
@@ -73,7 +75,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
         org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
-        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class})
+        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class,
+        SelfApprovalPolicy.class, OrganizationSecurityService.class})
 class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
 
     private static final long PROJECT_ID = 4001L;

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -16,10 +16,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.construction.ConstructionPostingProperties;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionInvoiceRequest;
@@ -57,7 +59,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class,
         org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
-        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class})
+        org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class,
+        SelfApprovalPolicy.class, OrganizationSecurityService.class})
 class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -79,6 +80,7 @@ class ConstructionInvoiceArMaterializationTest {
     @Mock private CostCategoryRepository costCategoryRepository;
     @Mock private CustomerRepository customerRepository;
     @Mock private InvoiceService invoiceService;
+    @Mock private SelfApprovalPolicy selfApprovalPolicy;
 
     private ConstructionInvoiceService service;
 
@@ -93,7 +95,7 @@ class ConstructionInvoiceArMaterializationTest {
         service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
                 journalRepo, postingService, postingAccountResolver, financeSettingsService,
                 projectRepository, userContextService, costCategoryRepository, customerRepository,
-                invoiceService);
+                invoiceService, selfApprovalPolicy);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceSelfApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceSelfApprovalTest.java
@@ -1,0 +1,170 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
+import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+import org.tornotron.echno_backend.finance.ledger.domain.Account;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.dtos.PostJournalRequest;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.PostingRole;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Segregation of duties on the construction-invoice approval, which posts a journal entry and is
+ * the other half of the same rule the stock adjustment carries: whoever submitted the invoice
+ * cannot approve it, a system administrator may as a recorded exception, and anybody else
+ * approves as normal. The auto-approval inside submit is deliberately outside the rule and is
+ * covered by ConstructionInvoiceAutoApprovalIT.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionInvoiceSelfApprovalTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long SUBMITTER = 31L;
+    private static final long OTHER_APPROVER = 32L;
+
+    @Mock private ConstructionInvoiceRepository invoiceRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private ConstructionInvoiceMapper mapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private JournalEntryRepository journalRepo;
+    @Mock private JournalPostingService postingService;
+    @Mock private PostingAccountResolver postingAccountResolver;
+    @Mock private FinanceSettingsService financeSettingsService;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private CostCategoryRepository costCategoryRepository;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private InvoiceService invoiceService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private ConstructionInvoiceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
+                journalRepo, postingService, postingAccountResolver, financeSettingsService,
+                projectRepository, userContextService, costCategoryRepository, customerRepository,
+                invoiceService, new SelfApprovalPolicy(orgSecurity));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void theSubmitterCannotApproveTheirOwnInvoiceAndNoEntryIsPosted() {
+        ConstructionInvoice inv = pendingPurchaseInvoice();
+        when(userContextService.getCurrentUserId()).thenReturn(SUBMITTER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(inv.getId()))
+                .withMessageContaining(inv.getInvoiceNumber())
+                .withMessageContaining("someone other than whoever raised the document");
+
+        verify(postingService, never()).postInternal(any(), anyString(), any());
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.PENDING);
+        assertThat(inv.getApprovedBy()).isNull();
+    }
+
+    @Test
+    void aSystemAdministratorMayApproveTheirOwnInvoice() {
+        ConstructionInvoice inv = pendingPurchaseInvoice();
+        when(userContextService.getCurrentUserId()).thenReturn(SUBMITTER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+        givenPostingAccounts();
+
+        service.approve(inv.getId());
+
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(inv.getApprovedBy()).isEqualTo(SUBMITTER);
+    }
+
+    @Test
+    void anotherApproverIsUnaffected() {
+        ConstructionInvoice inv = pendingPurchaseInvoice();
+        when(userContextService.getCurrentUserId()).thenReturn(OTHER_APPROVER);
+        givenPostingAccounts();
+
+        service.approve(inv.getId());
+
+        assertThat(inv.getStatus()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
+        assertThat(inv.getApprovedBy()).isEqualTo(OTHER_APPROVER);
+        verify(orgSecurity, never()).hasAnyOrgRoleForCurrentTenant(anyString());
+    }
+
+    private ConstructionInvoice pendingPurchaseInvoice() {
+        ConstructionInvoice inv = new ConstructionInvoice();
+        inv.setId(UUID.randomUUID());
+        inv.setInvoiceNumber("CINV-2026-0007");
+        inv.setType(ConstructionInvoiceType.PURCHASE);
+        inv.setStatus(ConstructionInvoiceStatus.PENDING);
+        inv.setIssueDate(LocalDate.of(2026, 8, 1));
+        inv.setDueDate(LocalDate.of(2026, 8, 31));
+        inv.setSubtotal(new BigDecimal("1000"));
+        inv.setTaxAmount(BigDecimal.ZERO);
+        inv.setDiscountAmount(BigDecimal.ZERO);
+        inv.setTotalAmount(new BigDecimal("1000"));
+        inv.setSubmittedBy(SUBMITTER);
+        when(invoiceRepo.findByIdWithLines(inv.getId())).thenReturn(Optional.of(inv));
+        return inv;
+    }
+
+    private void givenPostingAccounts() {
+        lenient().when(postingAccountResolver.resolve(any(PostingRole.class)))
+                .thenAnswer(call -> account());
+        JournalEntry je = new JournalEntry();
+        je.setId(UUID.randomUUID());
+        je.setEntryNumber("JE-2026-0100");
+        when(postingService.postInternal(any(PostJournalRequest.class), anyString(), any()))
+                .thenReturn(je);
+    }
+
+    private Account account() {
+        Account account = new Account();
+        account.setId(UUID.randomUUID());
+        account.setCode("5000");
+        return account;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
@@ -45,7 +47,9 @@ import static org.mockito.Mockito.when;
  * balance moves, a physical count lands the balance on the counted figure, a movement with
  * no stated reason is refused, an adjustment cannot be posted twice or edited afterwards,
  * and it cannot be used to book stock onto a location belonging to another project or to
- * push a balance below zero.
+ * push a balance below zero. Segregation of duties is covered here too: the person who
+ * raised the document cannot approve it, and a system administrator who does is recorded
+ * as having self-approved on the ledger entry itself.
  */
 @ExtendWith(MockitoExtension.class)
 class StockAdjustmentApprovalTest {
@@ -57,6 +61,7 @@ class StockAdjustmentApprovalTest {
     private static final Long LOCATION = 14L;
     private static final Long OTHER_PROJECT = 9L;
     private static final Long APPROVER = 42L;
+    private static final Long DRAFTER = 43L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
@@ -67,6 +72,7 @@ class StockAdjustmentApprovalTest {
     @Mock private InventoryService inventoryService;
     @Mock private InventoryTransactionRepository inventoryTransactionRepository;
     @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
 
     private StockAdjustmentService service;
     private Organization organization;
@@ -78,7 +84,8 @@ class StockAdjustmentApprovalTest {
         TenantContext.setCurrentOrgId(ORG);
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
-                inventoryService, inventoryTransactionRepository, userContextService);
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity));
 
         organization = new Organization();
         organization.setId(ORG);
@@ -283,5 +290,70 @@ class StockAdjustmentApprovalTest {
 
         verify(inventoryTransactionRepository, never()).save(any());
         verify(stockAdjustmentRepository, never()).delete(any());
+    }
+
+    @Test
+    void theSamePersonCannotRaiseAndApproveTheDocumentAndNothingIsPosted() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setSubmittedBy(APPROVER);
+        line(adjustment, 46.0, null, "damage");
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("someone other than whoever raised the document");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+        assertThat(adjustment.getProcessedAt()).isNull();
+        assertThat(adjustment.getApprovedBy()).isNull();
+        assertThat(adjustment.getStatus()).isNotEqualTo("processed");
+    }
+
+    @Test
+    void aSystemAdministratorApprovingTheirOwnDocumentPostsAndTheLedgerEntrySaysSo() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setSubmittedBy(APPROVER);
+        line(adjustment, 46.0, null, "damage");
+        balanceAtLocation(48.0);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getRemarks()).contains("damage").contains("self-approved");
+        assertThat(adjustment.getApprovedBy()).isEqualTo(APPROVER);
+        assertThat(adjustment.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    void anApprovalByAnyoneOtherThanTheRaiserPostsWithNoSelfApprovalOnTheLedger() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setSubmittedBy(DRAFTER);
+        line(adjustment, 46.0, null, "damage");
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getRemarks()).doesNotContain("self-approved");
+        assertThat(adjustment.getApprovedBy()).isEqualTo(APPROVER);
+    }
+
+    @Test
+    void aDocumentRaisedBeforeTheRaiserWasRecordedCanStillBeApproved() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setSubmittedBy(null);
+        line(adjustment, 46.0, null, "damage");
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        verify(inventoryTransactionRepository).save(any(InventoryTransaction.class));
+        assertThat(adjustment.getApprovedBy()).isEqualTo(APPROVER);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
 import org.tornotron.echno_backend.material.Material;
@@ -39,9 +41,10 @@ import static org.mockito.Mockito.when;
  * Unit tests for the drafting half of StockAdjustmentService: an id that names nothing in
  * the current tenant is rejected, a null id resolves to no association rather than an
  * error, line items are wired to their parent and stamped with the organization, and an
- * update replaces the whole line-item collection. The repositories, mapper, and tenant
- * helper are mocked; assertions read the entity captured on saveAndFlush. Posting to the
- * stock ledger is covered by {@link StockAdjustmentApprovalTest}.
+ * update replaces the whole line-item collection, and the user who raised the document is
+ * taken from the session rather than from the request body. The repositories, mapper, and
+ * tenant helper are mocked; assertions read the entity captured on saveAndFlush. Posting to
+ * the stock ledger is covered by {@link StockAdjustmentApprovalTest}.
  */
 @ExtendWith(MockitoExtension.class)
 class StockAdjustmentServiceTest {
@@ -50,6 +53,7 @@ class StockAdjustmentServiceTest {
     private static final Long MATERIAL = 11L;
     private static final Long LOCATION = 3L;
     private static final Long PROJECT = 9L;
+    private static final Long SESSION_USER = 77L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
@@ -60,6 +64,7 @@ class StockAdjustmentServiceTest {
     @Mock private InventoryService inventoryService;
     @Mock private InventoryTransactionRepository inventoryTransactionRepository;
     @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
 
     private StockAdjustmentService service;
 
@@ -68,7 +73,8 @@ class StockAdjustmentServiceTest {
         TenantContext.setCurrentOrgId(ORG);
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
-                inventoryService, inventoryTransactionRepository, userContextService);
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity));
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
             Organization org = new Organization();
             org.setId(ORG);
@@ -212,5 +218,39 @@ class StockAdjustmentServiceTest {
         service.delete(5L);
 
         verify(stockAdjustmentRepository).delete(existing);
+    }
+
+    @Test
+    void create_recordsTheSessionUserAsTheRaiserAndIgnoresTheOneInTheBody() {
+        stubReferenceLookups();
+        when(userContextService.getCurrentUserId()).thenReturn(SESSION_USER);
+        StockAdjustmentCreationDto dto = baseDto();
+        // A caller naming somebody else as the raiser would otherwise clear their own way to
+        // approve the document, since approval is checked against this field.
+        dto.setSubmittedBy(999L);
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        StockAdjustment saved = captor.getValue();
+        assertThat(saved.getSubmittedBy()).isEqualTo(SESSION_USER);
+        assertThat(saved.getSubmittedAt()).isNotNull();
+    }
+
+    @Test
+    void update_leavesTheRecordedRaiserAloneWhateverTheBodySays() {
+        stubReferenceLookups();
+        StockAdjustment existing = new StockAdjustment();
+        existing.setId(4L);
+        existing.setSubmittedBy(SESSION_USER);
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(4L, ORG))
+                .thenReturn(Optional.of(existing));
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setSubmittedBy(999L);
+
+        service.update(4L, dto);
+
+        assertThat(existing.getSubmittedBy()).isEqualTo(SESSION_USER);
     }
 }


### PR DESCRIPTION
Closes #548.

## The rule I chose, and why

**Refuse a self-approval, with one recorded exception for `system-admin`.** Not a hard four-eyes rule, and not a per-organisation setting.

The three options were: refuse outright, refuse by default with a per-organisation opt-out, or allow it and stamp it for the audit. I ruled out each of the other two for a concrete reason.

Refusing outright is unsafe here in a way it would not be elsewhere. A stock adjustment is the only path that can correct a balance, which is why #539 built it: staging held a `-30` row nothing could fix. A tenant with one person who has the authority to correct stock would then have a wrong figure and no route back, which is the exact failure the module exists to remove.

A per-organisation setting would work, and the codebase already has the shape for it (`FinanceSettings.approvalThreshold` is a per-tenant knob that relaxes an approval control). I did not take it because it buys nothing the role does not already give. The relaxation has to be a deliberate act by someone with authority over the tenant either way, and `system-admin` is that someone. A setting adds a table, an endpoint, a migration and a value that can be switched on once and forgotten, in exchange for the same outcome.

Recording rather than refusing is too weak on its own: the issue is a missing control, and a note in an audit trail is not a control. So the recording is folded into the refusal instead. When a system administrator does approve their own document it is logged at WARN, the document shows the raiser and the approver side by side (both are already on the DTO), and every ledger entry the adjustment writes carries `(self-approved: raised and approved by the same person)` in its remarks. The ledger is what a stock figure is explained from, so that is where a movement nobody independent agreed to should say so.

## What the check needed first

The rule is worth nothing while the raiser is whatever the request body claims. `StockAdjustmentService.applyHeaderFields` copied `submittedBy` straight off the creation DTO, so a drafter could name somebody else and clear their own way to approve. The document now records the raiser (and `submittedAt`) from the session on create, and `update` leaves the field alone. `StockAdjustmentCreationDto.submittedBy` is documented and marked read-only rather than deleted, so the web client keeps compiling; the value sent is ignored.

That is the same weakness #541 surveys for `status`. This PR fixes only `submittedBy` on this one entity, because it is a precondition for the check; `status` is untouched and stays #541's.

Rows written before this carry no raiser. There is nothing to compare, so they are allowed through rather than becoming unapprovable. Documented on the policy.

## Construction invoices

Same rule, same object, applied to `ConstructionInvoiceService.approve`. The issue is right that two approval paths behaving differently for no stated reason would be worse than either, so the check lives in one `common/approval/SelfApprovalPolicy` that both call. Invoices already record `submittedBy` from the session in `submit`, so nothing else was needed there.

**One deliberate exemption, stated because it is a real difference:** the auto-approval inside `submit` is not subject to the rule. A threshold set on the organisation or the project is the tenant's own standing decision that invoices below that figure do not need a second person, and passing the submitter's own invoice through it is exactly what it was configured for. Subjecting it to the rule would make the threshold unreachable for its most common case. Above the threshold, and where no threshold is set, the invoice goes to `approve`, which requires a different person.

Attendance approval is out of scope. It is a different risk class (approving a timesheet does not post to a ledger) and its two controllers take the approver as a request parameter rather than from the session, so the same check would need that path fixed first. Worth its own issue.

## What the live data shows

Staging has one real self-approval. `CINV-2027-000002` was submitted by user 1 and approved by user 1, `submitted_at 08:19:15`, `approved_at 08:19:48`, 33 seconds apart. `finance_settings.approval_threshold` is NULL, so no auto-approval was involved: it was a manual self-approval through `POST /{id}/approve`. This PR would have refused it unless that user held `system-admin`.

Stock adjustments on staging: one row, still a draft, never approved. Nothing to migrate and no existing posting to reinterpret.

## Failing-test table

Each new test run against a reverted baseline (`checkSelfApproval` stubbed to `return false`, `submittedBy` restored to the request body), then against the fix.

| Test | Without the fix | With the fix |
|---|---|---|
| `SelfApprovalPolicyTest.approvingYourOwnDocumentIsRefused` | FAILED | PASSED |
| `SelfApprovalPolicyTest.aSystemAdministratorMayApproveTheirOwnDocumentAndItComesBackAsASelfApproval` | FAILED | PASSED |
| `StockAdjustmentApprovalTest.theSamePersonCannotRaiseAndApproveTheDocumentAndNothingIsPosted` | FAILED | PASSED |
| `StockAdjustmentApprovalTest.aSystemAdministratorApprovingTheirOwnDocumentPostsAndTheLedgerEntrySaysSo` | FAILED | PASSED |
| `StockAdjustmentServiceTest.create_recordsTheSessionUserAsTheRaiserAndIgnoresTheOneInTheBody` | FAILED | PASSED |
| `StockAdjustmentServiceTest.update_leavesTheRecordedRaiserAloneWhateverTheBodySays` | FAILED | PASSED |
| `ConstructionInvoiceSelfApprovalTest.theSubmitterCannotApproveTheirOwnInvoiceAndNoEntryIsPosted` | FAILED | PASSED |
| `ConstructionInvoiceSelfApprovalTest.aSystemAdministratorMayApproveTheirOwnInvoice` | FAILED | PASSED |

Six further new tests are negative controls and pass either way by design, since they pin that the rule does **not** fire where it should not: a different approver, a document with no recorded raiser, an unresolved approver, and the invoice equivalent.

Full suite on `lab-node-116-f`: **BUILD SUCCESSFUL**, 1127 tests, 0 failures, rebased onto `origin/development` at `2385513` (after #555). No Liquibase changeset: `approved_by` and `submitted_by` already exist on both tables, and self-approval is derivable from them, so a redundant boolean column that can disagree with the two id columns was not worth adding.

The three construction-invoice ITs use sliced `@DataJpaTest` contexts and needed `SelfApprovalPolicy` and `OrganizationSecurityService` added to their `@Import` lists. No new contexts are created, so no change to the test-heap position.

## If you would rather have it another way

If you want the per-organisation setting instead, the shape is a boolean on `finance_settings` (or its own `approval_settings` row on the same get-or-create idiom) read inside `SelfApprovalPolicy`. Only that one class changes; neither service and none of the tests would move. If you want it stricter, drop the `system-admin` exception: delete the role check, and `checkSelfApproval` becomes an unconditional refusal. Either way the decision stays in one place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added segregation-of-duties controls for invoice and stock adjustment approvals.
  * Submitters cannot approve their own documents unless they have the system-admin break-glass role.
  * Approval records now capture the authenticated submitter, ignoring client-provided values.
  * Break-glass self-approvals are clearly marked in ledger remarks.

* **Documentation**
  * Updated API documentation to explain approval restrictions, exceptions, and validation errors.

* **Tests**
  * Added coverage for standard, self-approval, break-glass, auto-approval, and legacy-record scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->