### PR TITLE
Give an inspection somewhere to keep its evidence

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentOwner.java
+++ b/src/main/java/org/tornotron/echno_backend/common/dto/AttachmentOwner.java
@@ -1,0 +1,59 @@
+package org.tornotron.echno_backend.common.dto;
+
+import java.util.UUID;
+
+/**
+ * The record a file is filed against: its attachment type, and its key.
+ *
+ * <p>Most of the application keys its rows with a {@code Long}, and the attachment table was
+ * built for exactly that. The inspection module keys everything with a {@code UUID}, and a UUID
+ * does not fit a BIGINT, so an inspection had nowhere to put a file. Rather than duplicating the
+ * upload, presign, register and list paths once per key type, each takes one of these and the
+ * key type stops being visible past the boundary.
+ *
+ * <p>Exactly one of the two keys is set, which is the same rule the database enforces with the
+ * {@code ck_attachment_entity_key} check constraint. The two factory methods are the only way to
+ * build one, so the rule holds by construction.
+ *
+ * @param entityType The attachment entity type, for example ISSUE_ATTACHMENTS or INSPECTION_EVIDENCE
+ * @param entityId   The record's numeric id, or null when it is keyed by UUID
+ * @param entityUuid The record's UUID, or null when it is keyed by a numeric id
+ */
+public record AttachmentOwner(String entityType, Long entityId, UUID entityUuid) {
+
+    public AttachmentOwner {
+        if (entityType == null || entityType.isBlank()) {
+            throw new IllegalArgumentException("An attachment must state the type of record it belongs to");
+        }
+        if ((entityId == null) == (entityUuid == null)) {
+            throw new IllegalArgumentException(
+                    "An attachment must be filed against exactly one of a numeric id and a UUID");
+        }
+    }
+
+    /** A record keyed by a numeric id. */
+    public static AttachmentOwner of(String entityType, Long entityId) {
+        return new AttachmentOwner(entityType, entityId, null);
+    }
+
+    /** A record keyed by a UUID. */
+    public static AttachmentOwner of(String entityType, UUID entityUuid) {
+        return new AttachmentOwner(entityType, null, entityUuid);
+    }
+
+    /**
+     * The storage folder files for this record go in: the part of the entity type before the
+     * first underscore, lower-cased. {@code INSPECTION_EVIDENCE} therefore lands under
+     * {@code inspection/} with nothing in the storage layer needing to know it exists.
+     *
+     * @return The folder name
+     */
+    public String folder() {
+        return entityType.split("_", 2)[0].toLowerCase();
+    }
+
+    /** The key as it reads in a message to the caller. */
+    public String keyAsText() {
+        return entityId != null ? entityId.toString() : entityUuid.toString();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/entity/Attachment.java
+++ b/src/main/java/org/tornotron/echno_backend/common/entity/Attachment.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.user.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 /**
  * Generic attachment entity for storing file references across different modules.
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Table(name = "attachment", indexes = {
         @Index(name = "idx_attachment_entity", columnList = "entity_type, entity_id"),
+        @Index(name = "idx_attachment_entity_uuid", columnList = "organization_id, entity_type, entity_uuid"),
         @Index(name = "idx_attachment_expiry", columnList = "organization_id, entity_type, expires_on")
 })
 @Filter(name = "orgFilter", condition = "organization_id = :organizationId")
@@ -46,10 +48,27 @@ public class Attachment implements TenantScopedEntity {
     private String entityType;
 
     /**
-     * The ID of the entity this attachment belongs to.
+     * The numeric id of the entity this attachment belongs to, for the modules keyed that way.
+     *
+     * <p>Null on a file filed against a UUID-keyed record; {@link #entityUuid} carries the key
+     * instead. A database check constraint requires exactly one of the two, so a file cannot
+     * arrive naming neither and become invisible to every read while still occupying storage.
      */
-    @Column(name = "entity_id", nullable = false)
+    @Column(name = "entity_id")
     private Long entityId;
+
+    /**
+     * The UUID of the entity this attachment belongs to, for the modules keyed that way.
+     *
+     * <p>The inspection module is keyed by UUID throughout, and a UUID does not fit the BIGINT
+     * {@link #entityId}, so before this column an inspection had nowhere to file evidence at all.
+     * It sits on the shared table rather than inspections getting an evidence table of their own,
+     * for the reason the document columns do: the upload, presign, register, list and delete
+     * plumbing is already generic, so every UUID-keyed module inherits the fix rather than
+     * reimplementing it.
+     */
+    @Column(name = "entity_uuid")
+    private UUID entityUuid;
 
     /**
      * The unique key/path of the file in the storage bucket.

--- a/src/main/java/org/tornotron/echno_backend/common/repository/AttachmentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/common/repository/AttachmentRepository.java
@@ -9,6 +9,7 @@ import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Repository for managing Attachment entities.
@@ -45,6 +46,28 @@ public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
 
     boolean existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
             String entityType, Long entityId, String originalFilename, Long fileSize);
+
+    /**
+     * Every file filed against a UUID-keyed record, oldest first.
+     *
+     * @param entityType The attachment entity type, for example INSPECTION_EVIDENCE
+     * @param entityUuid The record's UUID
+     * @return The attachments, in the order they were recorded
+     */
+    List<Attachment> findByEntityTypeAndEntityUuidOrderByIdAsc(String entityType, UUID entityUuid);
+
+    /**
+     * Whether a UUID-keyed record already carries a file of this name and size. The same
+     * duplicate guard the numeric path applies, keyed on the other column.
+     *
+     * @param entityType       The attachment entity type
+     * @param entityUuid       The record's UUID
+     * @param originalFilename The uploaded filename
+     * @param fileSize         The uploaded size in bytes
+     * @return true when an identical file is already filed against that record
+     */
+    boolean existsByEntityTypeAndEntityUuidAndOriginalFilenameAndFileSize(
+            String entityType, UUID entityUuid, String originalFilename, Long fileSize);
 
     /**
      * One attachment by id, refusing to cross tenants. The unscoped {@code findById} lets a

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttachmentService.java
@@ -8,6 +8,7 @@ import org.tornotron.echno_backend.common.dto.PresignedUpload;
 import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
 import org.tornotron.echno_backend.common.dto.UploadRequest;
 import org.tornotron.echno_backend.common.dto.AttachmentDocumentMetadataDto;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Service for managing attachments across different modules.
@@ -78,12 +80,25 @@ public class AttachmentService {
      */
     @Transactional
     public List<Attachment> uploadAttachments(List<MultipartFile> files, String entityType, Long entityId, String folder) {
+        return uploadAttachments(files, AttachmentOwner.of(entityType, entityId), folder);
+    }
+
+    /**
+     * Uploads files and creates attachment records against a record identified by either key.
+     *
+     * @param files  The files to upload
+     * @param owner  The record the files belong to
+     * @param folder The storage folder for the files
+     * @return List of created Attachment entities
+     */
+    @Transactional
+    public List<Attachment> uploadAttachments(List<MultipartFile> files, AttachmentOwner owner, String folder) {
         if (files == null || files.isEmpty()) {
             return List.of();
         }
 
         validateNoDuplicateFiles(files);
-        validateNoExistingAttachments(files, entityType, entityId);
+        validateNoExistingAttachments(files, owner);
 
         List<Attachment> attachments = new ArrayList<>();
         List<StoredFile> storedFiles = fileStorageService.uploadFiles(files, folder);
@@ -93,13 +108,12 @@ public class AttachmentService {
             MultipartFile originalFile = files.get(i);
 
             Attachment attachment = new Attachment();
-            attachment.setEntityType(entityType);
-            attachment.setEntityId(entityId);
+            applyOwner(attachment, owner);
             attachment.setStorageKey(storedFile.key());
             attachment.setContentType(storedFile.contentType());
             attachment.setFileSize(storedFile.size());
             attachment.setOriginalFilename(originalFile.getOriginalFilename());
-            linkToEntity(attachment, folder, entityId);
+            linkToEntity(attachment, folder, owner.entityId());
             attachment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
             attachments.add(attachmentRepository.save(attachment));
         }
@@ -118,13 +132,13 @@ public class AttachmentService {
      */
     @Transactional
     public Attachment uploadAttachment(MultipartFile file, String entityType, Long entityId, String folder) {
-        validateNoExistingAttachments(List.of(file), entityType, entityId);
+        AttachmentOwner owner = AttachmentOwner.of(entityType, entityId);
+        validateNoExistingAttachments(List.of(file), owner);
 
         StoredFile storedFile = fileStorageService.uploadFile(file, folder);
 
         Attachment attachment = new Attachment();
-        attachment.setEntityType(entityType);
-        attachment.setEntityId(entityId);
+        applyOwner(attachment, owner);
         attachment.setStorageKey(storedFile.key());
         attachment.setContentType(storedFile.contentType());
         attachment.setFileSize(storedFile.size());
@@ -144,8 +158,23 @@ public class AttachmentService {
      */
     @Transactional(readOnly = true)
     public List<AttachmentDto> getAttachments(String entityType, Long entityId) {
-        return attachmentRepository.findByEntityTypeAndEntityId(entityType, entityId)
-                .stream()
+        return toDtos(attachmentRepository.findByEntityTypeAndEntityId(entityType, entityId));
+    }
+
+    /**
+     * Retrieves all attachments filed against a UUID-keyed record.
+     *
+     * @param entityType The type of entity
+     * @param entityUuid The UUID of the entity
+     * @return List of attachments, oldest first
+     */
+    @Transactional(readOnly = true)
+    public List<AttachmentDto> getAttachments(String entityType, UUID entityUuid) {
+        return toDtos(attachmentRepository.findByEntityTypeAndEntityUuidOrderByIdAsc(entityType, entityUuid));
+    }
+
+    private List<AttachmentDto> toDtos(List<Attachment> attachments) {
+        return attachments.stream()
                 .map(attachment -> {
                     AttachmentDto dto = new AttachmentDto();
                     dto.setId(attachment.getId());
@@ -218,6 +247,35 @@ public class AttachmentService {
             fileStorageService.deleteFile(attachment.getStorageKey());
             attachmentRepository.delete(attachment);
         });
+    }
+
+    /**
+     * Deletes one attachment that is filed against a particular record, including its stored file.
+     *
+     * <p>Stricter than {@link #deleteAttachment(Long)}, which resolves by numeric id alone and so
+     * lets a caller in one organization delete another's file, and lets a caller who may edit one
+     * record delete a file belonging to a different one. This resolves the attachment through the
+     * tenant-scoped finder and then checks it is actually the named record's, so the id in the
+     * path has to agree with the record in the path.
+     *
+     * @param owner        The record the file must belong to
+     * @param attachmentId The attachment to delete
+     * @throws ResourceNotFoundException if no such attachment is filed against that record in the
+     *                                   caller's organization
+     */
+    @Transactional
+    public void deleteAttachmentOf(AttachmentOwner owner, Long attachmentId) {
+        Attachment attachment = attachmentRepository
+                .findByIdAndOrganization_Id(attachmentId, TenantContext.getCurrentOrgId())
+                .filter(candidate -> owner.entityType().equals(candidate.getEntityType()))
+                .filter(candidate -> owner.entityUuid() != null
+                        ? owner.entityUuid().equals(candidate.getEntityUuid())
+                        : owner.entityId().equals(candidate.getEntityId()))
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Attachment with ID " + attachmentId + " is not filed against "
+                                + owner.entityType() + " " + owner.keyAsText()));
+        fileStorageService.deleteFile(attachment.getStorageKey());
+        attachmentRepository.delete(attachment);
     }
 
     /**
@@ -297,6 +355,18 @@ public class AttachmentService {
      * entirely; the client uploads to storage and then calls registerUploads.
      */
     public List<PresignedUpload> presignUploads(List<UploadRequest> requests, String entityType, Long entityId, String folder) {
+        return presignUploads(requests, AttachmentOwner.of(entityType, entityId), folder);
+    }
+
+    /**
+     * Issues pre-signed upload URLs for a record identified by either key.
+     *
+     * @param requests The files the client intends to upload
+     * @param owner    The record the files will belong to
+     * @param folder   The storage folder for the files
+     * @return One short-lived upload URL per declared file
+     */
+    public List<PresignedUpload> presignUploads(List<UploadRequest> requests, AttachmentOwner owner, String folder) {
         if (requests == null || requests.isEmpty()) {
             return List.of();
         }
@@ -312,10 +382,10 @@ public class AttachmentService {
                 throw new IllegalArgumentException(
                         "Upload request contains a duplicate file: '" + request.filename() + "'");
             }
-            if (attachmentRepository.existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
-                    entityType, entityId, request.filename(), request.fileSize())) {
+            if (alreadyFiled(owner, request.filename(), request.fileSize())) {
                 throw new IllegalArgumentException(
-                        "An attachment named '" + request.filename() + "' already exists for this " + entityType.toLowerCase());
+                        "An attachment named '" + request.filename() + "' already exists for this "
+                                + owner.entityType().toLowerCase());
             }
             presigned.add(fileStorageService.generateUploadUrl(
                     folder, request.filename(), request.contentType(), UPLOAD_URL_EXPIRY));
@@ -332,6 +402,18 @@ public class AttachmentService {
      * uploaded.
      */
     public List<Attachment> registerUploads(List<RegisterUploadRequest> requests, String entityType, Long entityId, String folder) {
+        return registerUploads(requests, AttachmentOwner.of(entityType, entityId), folder);
+    }
+
+    /**
+     * Records attachments uploaded directly to storage for a record identified by either key.
+     *
+     * @param requests The storage keys the client says it has uploaded
+     * @param owner    The record the files belong to
+     * @param folder   The storage folder the files went into
+     * @return The recorded attachments
+     */
+    public List<Attachment> registerUploads(List<RegisterUploadRequest> requests, AttachmentOwner owner, String folder) {
         if (requests == null || requests.isEmpty()) {
             return List.of();
         }
@@ -348,24 +430,43 @@ public class AttachmentService {
             }
 
             Attachment attachment = new Attachment();
-            attachment.setEntityType(entityType);
-            attachment.setEntityId(entityId);
+            applyOwner(attachment, owner);
             attachment.setStorageKey(request.key());
             attachment.setContentType(request.contentType());
             attachment.setFileSize(request.fileSize());
             attachment.setOriginalFilename(request.filename());
-            linkToEntity(attachment, folder, entityId);
+            linkToEntity(attachment, folder, owner.entityId());
             attachment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
             attachments.add(attachmentRepository.save(attachment));
         }
         return attachments;
     }
 
-    private void validateNoExistingAttachments(List<MultipartFile> files, String entityType, Long entityId) {
+    /**
+     * Writes the owning record onto an attachment. The single place either key is set, so the
+     * "exactly one of the two" rule the check constraint enforces cannot be broken by a path
+     * that forgets to clear the other.
+     */
+    private static void applyOwner(Attachment attachment, AttachmentOwner owner) {
+        attachment.setEntityType(owner.entityType());
+        attachment.setEntityId(owner.entityId());
+        attachment.setEntityUuid(owner.entityUuid());
+    }
+
+    /** Whether the record already carries a file of this name and size, on whichever key it uses. */
+    private boolean alreadyFiled(AttachmentOwner owner, String filename, Long fileSize) {
+        if (owner.entityUuid() != null) {
+            return attachmentRepository.existsByEntityTypeAndEntityUuidAndOriginalFilenameAndFileSize(
+                    owner.entityType(), owner.entityUuid(), filename, fileSize);
+        }
+        return attachmentRepository.existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
+                owner.entityType(), owner.entityId(), filename, fileSize);
+    }
+
+    private void validateNoExistingAttachments(List<MultipartFile> files, AttachmentOwner owner) {
         List<String> existing = new ArrayList<>();
         for (MultipartFile file : files) {
-            if (attachmentRepository.existsByEntityTypeAndEntityIdAndOriginalFilenameAndFileSize(
-                    entityType, entityId, file.getOriginalFilename(), file.getSize())) {
+            if (alreadyFiled(owner, file.getOriginalFilename(), file.getSize())) {
                 existing.add(file.getOriginalFilename());
             }
         }

--- a/src/main/java/org/tornotron/echno_backend/inspection/InspectionEvidence.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/InspectionEvidence.java
@@ -1,0 +1,33 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
+
+import java.util.UUID;
+
+/**
+ * How an inspection's evidence is filed in the shared attachment table.
+ *
+ * <p>Mirrors {@code AssetDocuments}. The type is the only thing the storage layer needs: the
+ * folder is derived from the part before the first underscore, so evidence lands under
+ * {@code inspection/} with nothing else to configure.
+ */
+public final class InspectionEvidence {
+
+    /**
+     * The attachment entity type evidence is filed under.
+     *
+     * <p>"Evidence" rather than "attachments" because that is what these files are for. A
+     * compliance inspection standing in for a permit, a certificate or a statutory approval is
+     * not a usable audit record without the document itself, and the file is the thing the record
+     * rests on rather than an incidental extra.
+     */
+    public static final String ENTITY_TYPE = "INSPECTION_EVIDENCE";
+
+    private InspectionEvidence() {
+    }
+
+    /** The owner to file an inspection's evidence against. */
+    public static AttachmentOwner ownerOf(UUID inspectionId) {
+        return AttachmentOwner.of(ENTITY_TYPE, inspectionId);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionEvidenceService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/InspectionEvidenceService.java
@@ -1,0 +1,194 @@
+package org.tornotron.echno_backend.inspection.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
+import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
+import org.tornotron.echno_backend.common.dto.UploadRequest;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.inspection.InspectionEvidence;
+import org.tornotron.echno_backend.inspection.InspectionStatus;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * The files an inspection rests on: the permit, the certificate, the test report, the photograph
+ * of the thing that was checked.
+ *
+ * <h2>Why evidence hangs off the inspection and not off a check point or a defect</h2>
+ *
+ * <p>The inspection row is the only stable identity in the aggregate. {@code
+ * InspectionService.update} clears the check items and the defects and rebuilds both from the
+ * payload on every save, with {@code orphanRemoval}, so every child row is deleted and reinserted
+ * under a new UUID each time an inspector presses save. A file keyed on a check item id or a
+ * defect id would be orphaned by the next edit, which is exactly the trap {@code
+ * DefectPhotoAnnotation} had to work around by keying on the photograph rather than on the defect
+ * row. The inspection's own id is never reissued, so evidence filed against it survives every
+ * edit, and the test in {@code InspectionServiceIT} pins that: it records the child ids, updates,
+ * and asserts they all changed while the evidence still resolves.
+ *
+ * <p>That is also the right domain answer for the case this exists for. A compliance inspection
+ * standing in for a statutory approval carries one document that is evidence of the whole
+ * inspection, not of one line on its checklist. Per-check-point and per-defect photographs already
+ * have a home in the {@code photos} element collections, which a rebuild carries through by value,
+ * with {@code DefectPhotoAnnotation} marking them up on top. What did not exist anywhere was a
+ * place for the inspection's own paperwork, with a document type and an expiry on it.
+ *
+ * <h2>What happens to evidence once the inspection has a verdict</h2>
+ *
+ * <p>Evidence may always be added, including after the inspection has passed. The certificate
+ * routinely arrives days after the work was signed off, which is the whole shape of a statutory
+ * approval, and an audit trail you may not complete is not much of an audit trail.
+ *
+ * <p>Evidence may not be removed once the inspection has reached a verdict, that is once it is
+ * passed, passed with remarks, or failed. Those files were part of the record when somebody
+ * reached that conclusion, and deleting one afterwards leaves a verdict whose basis is gone with
+ * nothing to say it ever existed. A file that turns out to be wrong is superseded by uploading the
+ * correct one, in the same spirit as a stock adjustment corrected by a further adjustment rather
+ * than by an edit. Before a verdict, an inspection is still being assembled, so removal is free.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InspectionEvidenceService {
+
+    /**
+     * The states in which the evidence set is frozen against removal: the inspection has been
+     * judged. Cancelled is not among them, because a cancelled inspection concluded nothing and
+     * its files are the basis of no verdict. Completed is not either: the work is done but the
+     * verdict has not been given yet.
+     */
+    private static final Set<InspectionStatus> VERDICT_REACHED = EnumSet.of(
+            InspectionStatus.PASSED,
+            InspectionStatus.PASSED_WITH_REMARKS,
+            InspectionStatus.FAILED);
+
+    private final InspectionRepository inspectionRepo;
+    private final AttachmentService attachmentService;
+    private final AttachmentMapper attachmentMapper;
+
+    /**
+     * The evidence filed against one inspection, oldest first, each with a short-lived download
+     * URL and, where one was recorded, its document type and expiry.
+     *
+     * @param inspectionId The inspection to read.
+     * @throws ResourceNotFoundException if the inspection is not in this tenant.
+     */
+    @Transactional(readOnly = true)
+    public List<AttachmentDto> list(UUID inspectionId) {
+        requireInspection(inspectionId);
+        return attachmentService.getAttachments(InspectionEvidence.ENTITY_TYPE, inspectionId);
+    }
+
+    /**
+     * Uploads evidence straight through the API. Suitable for a scanned certificate; a large site
+     * photograph should go through {@link #presign} and {@link #register} instead.
+     *
+     * @param inspectionId The inspection the files belong to.
+     * @param files        The files to store.
+     * @return The stored evidence.
+     * @throws ResourceNotFoundException if the inspection is not in this tenant.
+     */
+    @Transactional
+    public List<AttachmentDto> upload(UUID inspectionId, List<MultipartFile> files) {
+        Inspection inspection = requireInspection(inspectionId);
+        AttachmentOwner owner = InspectionEvidence.ownerOf(inspectionId);
+        List<AttachmentDto> stored = attachmentService
+                .uploadAttachments(files, owner, owner.folder())
+                .stream()
+                .map(attachmentMapper::toDto)
+                .toList();
+        log.info("Filed {} pieces of evidence against inspection {}",
+                stored.size(), inspection.getInspectionNumber());
+        return stored;
+    }
+
+    /**
+     * Step one of the direct-to-storage path: a short-lived upload URL per declared file.
+     *
+     * @param inspectionId The inspection the files will belong to.
+     * @param uploads      The files the client intends to upload.
+     * @throws ResourceNotFoundException if the inspection is not in this tenant.
+     */
+    @Transactional(readOnly = true)
+    public List<PresignedUpload> presign(UUID inspectionId, List<UploadRequest> uploads) {
+        requireInspection(inspectionId);
+        AttachmentOwner owner = InspectionEvidence.ownerOf(inspectionId);
+        return attachmentService.presignUploads(uploads, owner, owner.folder());
+    }
+
+    /**
+     * Step two of the direct-to-storage path: records the keys the client has finished uploading,
+     * after the storage layer has confirmed each object is really there.
+     *
+     * @param inspectionId The inspection the files belong to.
+     * @param uploads      The storage keys the client says it has written.
+     * @throws ResourceNotFoundException if the inspection is not in this tenant.
+     */
+    @Transactional
+    public List<AttachmentDto> register(UUID inspectionId, List<RegisterUploadRequest> uploads) {
+        Inspection inspection = requireInspection(inspectionId);
+        AttachmentOwner owner = InspectionEvidence.ownerOf(inspectionId);
+        List<AttachmentDto> stored = attachmentService
+                .registerUploads(uploads, owner, owner.folder())
+                .stream()
+                .map(attachmentMapper::toDto)
+                .toList();
+        log.info("Registered {} pieces of evidence against inspection {}",
+                stored.size(), inspection.getInspectionNumber());
+        return stored;
+    }
+
+    /**
+     * Removes one piece of evidence, unless the inspection has already been judged.
+     *
+     * @param inspectionId The inspection the file is filed against.
+     * @param attachmentId The file to remove.
+     * @throws ResourceNotFoundException if the inspection is not in this tenant, or the file is
+     *                                   not filed against it.
+     * @throws InvalidRequestException   if the inspection has reached a verdict.
+     */
+    @Transactional
+    public void delete(UUID inspectionId, Long attachmentId) {
+        Inspection inspection = requireInspection(inspectionId);
+        requireNoVerdictYet(inspection);
+        attachmentService.deleteAttachmentOf(InspectionEvidence.ownerOf(inspectionId), attachmentId);
+        log.info("Removed evidence {} from inspection {}", attachmentId, inspection.getInspectionNumber());
+    }
+
+    /**
+     * Refuses to remove evidence from an inspection that has been judged.
+     *
+     * @param inspection The inspection the file is filed against.
+     * @throws InvalidRequestException if it is passed, passed with remarks, or failed.
+     */
+    private static void requireNoVerdictYet(Inspection inspection) {
+        if (!VERDICT_REACHED.contains(inspection.getStatus())) {
+            return;
+        }
+        throw new InvalidRequestException(
+                "Inspection " + inspection.getInspectionNumber() + " is "
+                        + inspection.getStatus().getValue() + ", so its evidence is part of the "
+                        + "record of that result and cannot be removed. Upload the correct file "
+                        + "instead; further evidence may still be added.");
+    }
+
+    private Inspection requireInspection(UUID inspectionId) {
+        return inspectionRepo.findByIdScoped(inspectionId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Inspection with ID " + inspectionId + " was not found"));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/InspectionControllerWeb.java
@@ -14,6 +14,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.dto.PresignedUpload;
+import org.tornotron.echno_backend.common.dto.RegisterUploadRequest;
+import org.tornotron.echno_backend.common.dto.UploadRequest;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.inspection.InspectionCategory;
 import org.tornotron.echno_backend.inspection.InspectionResult;
 import org.tornotron.echno_backend.inspection.InspectionStatus;
@@ -26,6 +31,7 @@ import org.tornotron.echno_backend.inspection.dtos.ReplaceAnnotationsRequest;
 import org.tornotron.echno_backend.inspection.dtos.UpdateInspectionRequest;
 import org.tornotron.echno_backend.inspection.pdf.InspectionReportPdfService;
 import org.tornotron.echno_backend.inspection.service.DefectAnnotationService;
+import org.tornotron.echno_backend.inspection.service.InspectionEvidenceService;
 import org.tornotron.echno_backend.inspection.service.InspectionService;
 import org.tornotron.echno_backend.pdfGeneration.RenderedReport;
 
@@ -49,6 +55,7 @@ public class InspectionControllerWeb {
 
     private final InspectionService service;
     private final DefectAnnotationService annotationService;
+    private final InspectionEvidenceService evidenceService;
     private final InspectionReportPdfService reportService;
 
     @PostMapping
@@ -188,5 +195,119 @@ public class InspectionControllerWeb {
                         "attachment; filename=\"" + report.documentName() + ".pdf\"")
                 .contentType(MediaType.APPLICATION_PDF)
                 .body(report.content());
+    }
+
+    // Evidence: the paperwork an inspection rests on, filed against the inspection itself.
+    //
+    // These sit here rather than on the generic attachment controller because that one keys on a
+    // numeric entity id and an inspection is keyed by UUID, and because the removal rule below is
+    // an inspection rule, not an attachment rule. Uploading is the same two shapes as everywhere
+    // else: straight through the API for a scanned certificate, presign then register for a large
+    // file that should not pass through the API or the CDN in front of it.
+    //
+    // What kind of document a file is, when it was issued and when it lapses are recorded
+    // afterwards through PATCH /api/v1/attachment/web/attachmentId/{attachmentId}/document, which
+    // already serves every module and needed nothing added for this one.
+
+    @GetMapping("/{id}/evidence")
+    @PreAuthorize("@inspectionSecurity.canRead()")
+    @Operation(
+            summary = "List an inspection's evidence",
+            description = "Returns the files filed against the inspection: the permit, certificate "
+                    + "or approval a compliance inspection stands in for, test reports, and any other "
+                    + "supporting document, each with a time-limited download URL and, where one was "
+                    + "recorded, its document type and expiry. An AI-suggested inspection is a "
+                    + "recommendation and its evidence list being empty is the normal state; a "
+                    + "suggestion is not itself proof of compliance."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Evidence returned"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
+    public List<AttachmentDto> readEvidence(@PathVariable UUID id) {
+        return evidenceService.list(id);
+    }
+
+    @PostMapping(value = "/{id}/evidence", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
+    @Operation(
+            summary = "Attach evidence to an inspection",
+            description = "Uploads one or more files straight through the API and files them against "
+                    + "the inspection. Accepted at any point in the inspection's life, including after "
+                    + "it has passed: a certificate routinely arrives after the work was signed off, "
+                    + "and that is exactly the record this exists to hold."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Evidence attached"),
+            @ApiResponse(responseCode = "400", description = "No files were sent, or one is already attached"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
+    public ResponseEntity<List<AttachmentDto>> attachEvidence(
+            @PathVariable UUID id,
+            @RequestParam("attachments") List<MultipartFile> attachments) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(evidenceService.upload(id, attachments));
+    }
+
+    @PostMapping("/{id}/evidence/presign")
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
+    @Operation(
+            summary = "Presign evidence uploads",
+            description = "Step one of the direct-to-storage path: for each declared file, returns a "
+                    + "short-lived URL the client PUTs it to, bypassing the API and the CDN in front "
+                    + "of it. Site photographs and scanned approvals routinely exceed what the "
+                    + "streaming path allows."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Presigned upload URLs returned"),
+            @ApiResponse(responseCode = "400", description = "A file was declared twice, or is already attached"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
+    public List<PresignedUpload> presignEvidence(
+            @PathVariable UUID id,
+            @RequestBody List<UploadRequest> uploads) {
+        return evidenceService.presign(id, uploads);
+    }
+
+    @PostMapping("/{id}/evidence/register")
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
+    @Operation(
+            summary = "Register presigned evidence uploads",
+            description = "Step two of the direct-to-storage path: confirms the storage keys once "
+                    + "each object is verified present in storage, so a caller cannot record evidence "
+                    + "for a file that was never uploaded."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Evidence registered"),
+            @ApiResponse(responseCode = "400", description = "A referenced object is missing from storage"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No inspection with the given id in the current tenant")
+    })
+    public ResponseEntity<List<AttachmentDto>> registerEvidence(
+            @PathVariable UUID id,
+            @RequestBody List<RegisterUploadRequest> uploads) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(evidenceService.register(id, uploads));
+    }
+
+    @DeleteMapping("/{id}/evidence/{attachmentId}")
+    @PreAuthorize("@inspectionSecurity.canManageInspections()")
+    @Operation(
+            summary = "Remove evidence from an inspection",
+            description = "Deletes one file and its stored object. Refused once the inspection has "
+                    + "reached a verdict, that is once it is passed, passed with remarks or failed: "
+                    + "those files were part of the record when somebody reached that conclusion. A "
+                    + "file that turns out to be wrong is superseded by uploading the correct one."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Evidence removed"),
+            @ApiResponse(responseCode = "400", description = "The inspection has been judged and its evidence is frozen"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No such inspection, or the file is not filed against it")
+    })
+    public ResponseEntity<Void> removeEvidence(@PathVariable UUID id, @PathVariable Long attachmentId) {
+        evidenceService.delete(id, attachmentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -337,4 +337,7 @@
     <!-- v4.0 - Inspection reports: who accepted the corrective work, for the NCR trail -->
     <include file="db/changelog/v4.0/067-add-ncr-verified-by.xml"/>
 
+    <!-- v4.0 - Attachments: a second key, so a UUID-keyed record can carry files too -->
+    <include file="db/changelog/v4.0/068-add-attachment-entity-uuid.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/068-add-attachment-entity-uuid.xml
+++ b/src/main/resources/db/changelog/v4.0/068-add-attachment-entity-uuid.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Somewhere to file a UUID-keyed entity's attachments.
+
+        The attachment table is generic in every way but one: entity_type is free text, the
+        endpoints take the type and the id as path variables, and the storage folder is derived
+        from the type, so a new kind of attachment normally costs nothing. What it is not generic
+        about is the key. entity_id is BIGINT, and the whole inspection module is keyed by UUID
+        (inspections, their check items, their defects, NCRs). A UUID does not fit a BIGINT, so an
+        inspection had literally nowhere to put a file, which is what #535 is.
+
+        entity_uuid is the second key, and the shared table gets it rather than inspections getting
+        an evidence table of their own, for the reason changeset 065 widened this table rather than
+        giving assets a documents table: the storage, presign, register, list and delete plumbing
+        is already here and already generic, and every other UUID-keyed module inherits the fix.
+
+        entity_id therefore stops being mandatory, and a check constraint takes over from NOT NULL:
+        a row must name exactly one of the two. Without it a file could arrive filed against
+        neither, and be invisible to every read path while still occupying storage. Every existing
+        row satisfies it, because every existing row has a numeric id and no UUID.
+    -->
+    <changeSet id="068-add-attachment-entity-uuid" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="attachment" columnName="entity_uuid"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="attachment">
+            <column name="entity_uuid" type="UUID"/>
+        </addColumn>
+
+        <dropNotNullConstraint tableName="attachment"
+                               columnName="entity_id"
+                               columnDataType="BIGINT"/>
+
+        <sql>
+            ALTER TABLE attachment ADD CONSTRAINT ck_attachment_entity_key
+            CHECK ((entity_id IS NOT NULL) != (entity_uuid IS NOT NULL))
+        </sql>
+
+        <createIndex tableName="attachment" indexName="idx_attachment_entity_uuid">
+            <column name="organization_id"/>
+            <column name="entity_type"/>
+            <column name="entity_uuid"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="attachment" indexName="idx_attachment_entity_uuid"/>
+            <sql>ALTER TABLE attachment DROP CONSTRAINT ck_attachment_entity_key</sql>
+            <addNotNullConstraint tableName="attachment"
+                                  columnName="entity_id"
+                                  columnDataType="BIGINT"/>
+            <dropColumn tableName="attachment" columnName="entity_uuid"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/dto/AttachmentOwnerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/dto/AttachmentOwnerTest.java
@@ -1,0 +1,56 @@
+package org.tornotron.echno_backend.common.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The rule that keeps the attachment table's two keys from disagreeing with each other.
+ *
+ * <p>The database says a row must name exactly one of a numeric id and a UUID, with the
+ * {@code ck_attachment_entity_key} check constraint. This is the same rule stated where the value
+ * is built, so a path that gets it wrong fails at the call rather than at the insert.
+ */
+class AttachmentOwnerTest {
+
+    @Test
+    void aRecordIsKeyedByItsNumericIdOrItsUuid_neverBoth() {
+        assertThatThrownBy(() -> new AttachmentOwner("ISSUE_ATTACHMENTS", 4L, UUID.randomUUID()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void aRecordThatNamesNeitherKeyIsRefused() {
+        assertThatThrownBy(() -> new AttachmentOwner("ISSUE_ATTACHMENTS", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void aRecordMustSayWhatKindOfThingItIs() {
+        assertThatThrownBy(() -> AttachmentOwner.of("  ", 4L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void theStorageFolderIsTheTypeBeforeTheFirstUnderscore() {
+        UUID inspectionId = UUID.randomUUID();
+
+        assertThat(AttachmentOwner.of("INSPECTION_EVIDENCE", inspectionId).folder()).isEqualTo("inspection");
+        assertThat(AttachmentOwner.of("ISSUE_ATTACHMENTS", 4L).folder()).isEqualTo("issue");
+        assertThat(AttachmentOwner.of("ORGANIZATION", 4L).folder()).isEqualTo("organization");
+    }
+
+    @Test
+    void eitherKindOfKeyReadsBackInAMessage() {
+        UUID inspectionId = UUID.randomUUID();
+
+        assertThat(AttachmentOwner.of("INSPECTION_EVIDENCE", inspectionId).keyAsText())
+                .isEqualTo(inspectionId.toString());
+        assertThat(AttachmentOwner.of("ISSUE_ATTACHMENTS", 4L).keyAsText()).isEqualTo("4");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/service/AttachmentServiceTenancyTest.java
@@ -1,14 +1,19 @@
 package org.tornotron.echno_backend.common.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
 import org.tornotron.echno_backend.common.dto.StoredFile;
 import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.repository.AttachmentRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
@@ -18,9 +23,16 @@ import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.task.TaskRepository;
 import org.tornotron.echno_backend.user.UserRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -69,5 +81,85 @@ class AttachmentServiceTenancyTest {
         Attachment result = service.uploadAttachment(file, "ISSUE", 1L, "misc");
 
         assertThat(result.getOrganization()).isSameAs(org);
+    }
+
+    /**
+     * The scoped delete, which the inspection evidence path uses. {@code deleteAttachment(Long)}
+     * resolves by numeric id alone, so it lets a caller reach another organization's file and lets
+     * a caller who may edit one record delete a file belonging to a different one. This one has to
+     * agree on the organization, the entity type and the key before it removes anything.
+     */
+    @Nested
+    class ScopedDelete {
+
+        private final UUID inspectionId = UUID.randomUUID();
+
+        @BeforeEach
+        void actAsOrgSeven() {
+            TenantContext.setCurrentOrgId(7L);
+        }
+
+        @AfterEach
+        void stopActing() {
+            TenantContext.clear();
+        }
+
+        private Attachment evidenceOf(UUID owningInspection) {
+            Attachment attachment = new Attachment();
+            attachment.setId(88L);
+            attachment.setEntityType("INSPECTION_EVIDENCE");
+            attachment.setEntityUuid(owningInspection);
+            attachment.setStorageKey("inspection/fire-noc.pdf");
+            return attachment;
+        }
+
+        @Test
+        void removesTheFileAndItsStoredObjectWhenEverythingAgrees() {
+            Attachment attachment = evidenceOf(inspectionId);
+            when(attachmentRepository.findByIdAndOrganization_Id(88L, 7L))
+                    .thenReturn(Optional.of(attachment));
+
+            service.deleteAttachmentOf(AttachmentOwner.of("INSPECTION_EVIDENCE", inspectionId), 88L);
+
+            verify(fileStorageService).deleteFile("inspection/fire-noc.pdf");
+            verify(attachmentRepository).delete(attachment);
+        }
+
+        @Test
+        void refusesAFileFiledAgainstADifferentRecord() {
+            when(attachmentRepository.findByIdAndOrganization_Id(88L, 7L))
+                    .thenReturn(Optional.of(evidenceOf(UUID.randomUUID())));
+
+            assertThatThrownBy(() -> service.deleteAttachmentOf(
+                    AttachmentOwner.of("INSPECTION_EVIDENCE", inspectionId), 88L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+
+            verify(attachmentRepository, never()).delete(any(Attachment.class));
+            verify(fileStorageService, never()).deleteFile(anyString());
+        }
+
+        @Test
+        void refusesAFileFiledUnderADifferentEntityType() {
+            when(attachmentRepository.findByIdAndOrganization_Id(88L, 7L))
+                    .thenReturn(Optional.of(evidenceOf(inspectionId)));
+
+            assertThatThrownBy(() -> service.deleteAttachmentOf(
+                    AttachmentOwner.of("ASSET_DOCUMENTS", inspectionId), 88L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+
+            verify(attachmentRepository, never()).delete(any(Attachment.class));
+        }
+
+        @Test
+        void refusesAFileOfAnotherOrganization() {
+            when(attachmentRepository.findByIdAndOrganization_Id(88L, 7L))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.deleteAttachmentOf(
+                    AttachmentOwner.of("INSPECTION_EVIDENCE", inspectionId), 88L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+
+            verify(fileStorageService, never()).deleteFile(anyString());
+        }
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionEvidenceServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionEvidenceServiceTest.java
@@ -1,0 +1,171 @@
+package org.tornotron.echno_backend.inspection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.dto.AttachmentOwner;
+import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.inspection.domain.Inspection;
+import org.tornotron.echno_backend.inspection.repositories.InspectionRepository;
+import org.tornotron.echno_backend.inspection.service.InspectionEvidenceService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The rules that make an inspection's evidence usable as an audit record: it is filed against the
+ * inspection's own UUID, it may be added at any point in the inspection's life, and it may not be
+ * taken away once the inspection has been judged.
+ *
+ * <p>Plain Mockito with no Spring context, deliberately: the test JVM caches a context per
+ * distinct test configuration and is capped at 1 GB with no fork between classes, so a new
+ * {@code @SpringBootTest} here would be paid for by an unrelated test failing on heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InspectionEvidenceServiceTest {
+
+    @Mock private InspectionRepository inspectionRepo;
+    @Mock private AttachmentService attachmentService;
+    @Mock private AttachmentMapper attachmentMapper;
+
+    private InspectionEvidenceService service;
+    private UUID inspectionId;
+
+    @BeforeEach
+    void setUp() {
+        service = new InspectionEvidenceService(inspectionRepo, attachmentService, attachmentMapper);
+        inspectionId = UUID.randomUUID();
+    }
+
+    private Inspection inspectionWith(InspectionStatus status) {
+        Inspection inspection = new Inspection();
+        inspection.setId(inspectionId);
+        inspection.setInspectionNumber("INSP-0007");
+        inspection.setStatus(status);
+        when(inspectionRepo.findByIdScoped(inspectionId)).thenReturn(Optional.of(inspection));
+        return inspection;
+    }
+
+    private static MultipartFile aFile() {
+        return new MockMultipartFile("attachments", "fire-noc.pdf", "application/pdf", new byte[]{1});
+    }
+
+    @Test
+    void evidenceIsFiledAgainstTheInspectionsUuid() {
+        inspectionWith(InspectionStatus.IN_PROGRESS);
+        when(attachmentService.uploadAttachments(any(), any(AttachmentOwner.class), anyString()))
+                .thenReturn(List.of(new Attachment()));
+        when(attachmentMapper.toDto(any())).thenReturn(new AttachmentDto());
+
+        service.upload(inspectionId, List.of(aFile()));
+
+        ArgumentCaptor<AttachmentOwner> owner = ArgumentCaptor.forClass(AttachmentOwner.class);
+        verify(attachmentService).uploadAttachments(any(), owner.capture(), eq("inspection"));
+        assertThat(owner.getValue().entityUuid()).isEqualTo(inspectionId);
+        assertThat(owner.getValue().entityId()).isNull();
+        assertThat(owner.getValue().entityType()).isEqualTo("INSPECTION_EVIDENCE");
+    }
+
+    @Test
+    void evidenceCanStillBeAddedOnceTheInspectionHasPassed() {
+        inspectionWith(InspectionStatus.PASSED);
+        when(attachmentService.uploadAttachments(any(), any(AttachmentOwner.class), anyString()))
+                .thenReturn(List.of(new Attachment()));
+        when(attachmentMapper.toDto(any())).thenReturn(new AttachmentDto());
+
+        // The certificate a compliance inspection stands in for routinely arrives after the work
+        // was signed off. Freezing additions at the verdict would make the record unfinishable.
+        assertThat(service.upload(inspectionId, List.of(aFile()))).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InspectionStatus.class,
+            names = {"PASSED", "PASSED_WITH_REMARKS", "FAILED"})
+    void evidenceCannotBeRemovedOnceTheInspectionHasBeenJudged(InspectionStatus judged) {
+        inspectionWith(judged);
+
+        assertThatThrownBy(() -> service.delete(inspectionId, 88L))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("INSP-0007")
+                .hasMessageContaining("cannot be removed");
+
+        verify(attachmentService, never()).deleteAttachmentOf(any(), any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InspectionStatus.class,
+            names = {"SUGGESTED", "SCHEDULED", "IN_PROGRESS", "COMPLETED", "CANCELLED"})
+    void evidenceCanBeRemovedBeforeTheInspectionIsJudged(InspectionStatus unjudged) {
+        inspectionWith(unjudged);
+
+        service.delete(inspectionId, 88L);
+
+        ArgumentCaptor<AttachmentOwner> owner = ArgumentCaptor.forClass(AttachmentOwner.class);
+        verify(attachmentService).deleteAttachmentOf(owner.capture(), eq(88L));
+        assertThat(owner.getValue().entityUuid()).isEqualTo(inspectionId);
+    }
+
+    @Test
+    void anInspectionOfAnotherTenantHasNoEvidenceToRead() {
+        when(inspectionRepo.findByIdScoped(inspectionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.list(inspectionId))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(attachmentService, never()).getAttachments(anyString(), any(UUID.class));
+    }
+
+    @Test
+    void evidenceCannotBeAttachedToAnInspectionOfAnotherTenant() {
+        when(inspectionRepo.findByIdScoped(inspectionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.upload(inspectionId, List.of(aFile())))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(attachmentService, never()).uploadAttachments(any(), any(AttachmentOwner.class), anyString());
+    }
+
+    @Test
+    void readingEvidenceAsksForTheInspectionsOwnFiles() {
+        inspectionWith(InspectionStatus.COMPLETED);
+        when(attachmentService.getAttachments("INSPECTION_EVIDENCE", inspectionId))
+                .thenReturn(List.of(new AttachmentDto()));
+
+        assertThat(service.list(inspectionId)).hasSize(1);
+        verify(attachmentService).getAttachments("INSPECTION_EVIDENCE", inspectionId);
+    }
+
+    @Test
+    void presigningEvidenceGoesToTheInspectionFolderUnderTheInspectionsUuid() {
+        inspectionWith(InspectionStatus.SCHEDULED);
+
+        service.presign(inspectionId, List.of());
+
+        ArgumentCaptor<AttachmentOwner> owner = ArgumentCaptor.forClass(AttachmentOwner.class);
+        verify(attachmentService).presignUploads(any(), owner.capture(), eq("inspection"));
+        assertThat(owner.getValue().entityUuid()).isEqualTo(inspectionId);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/InspectionServiceIT.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.repository.AttachmentRepository;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -83,6 +85,11 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
     @Autowired
     private InspectionRepository inspectionRepo;
+
+    // Not in the @Import list: @DataJpaTest enables every Spring Data repository already, so
+    // pulling this in costs no second Spring context in a JVM that caches one per configuration.
+    @Autowired
+    private AttachmentRepository attachmentRepository;
 
     @Autowired
     private ChecklistTemplateService templateService;
@@ -420,6 +427,110 @@ class InspectionServiceIT extends AbstractIntegrationTest {
 
         assertThat(service.update(id, concludeAs(InspectionStatus.SCHEDULED)).status())
                 .isEqualTo(InspectionStatus.SCHEDULED);
+    }
+
+    /**
+     * Why an inspection's evidence hangs off the inspection and not off a check point or a defect.
+     *
+     * <p>Both children are keyed by UUID, and {@code InspectionService.update} clears and rebuilds
+     * both from the payload, so every child row is deleted and reinserted under a fresh id on each
+     * save. This files one attachment against the inspection and one against a check point, and
+     * then edits the inspection: the check point's evidence is left naming a row that no longer
+     * exists, while the inspection's is exactly where it was. It is the same trap
+     * {@code DefectPhotoAnnotation} had to key around, stated as a test so the next person to
+     * reach for a per-check-point attachment finds the reason rather than the crater.
+     */
+    @Test
+    void evidenceFiledAgainstTheInspectionSurvivesAnUpdateThatReissuesEveryChildId() {
+        InspectionCheckItemRequest surfaceLevel = new InspectionCheckItemRequest(
+                "Finishing", "Surface level", "Level within tolerance",
+                CheckItemStatus.PENDING, null, false, null,
+                null, null, null, null, null, "medium");
+
+        InspectionDto created = service.create(
+                scheduleFor(InspectionTrade.PLASTERING, List.of(surfaceLevel)));
+        UUID inspectionId = created.id();
+        UUID originalCheckItemId = created.checkItems().getFirst().id();
+
+        Long evidenceOnInspection = fileEvidenceAgainst(inspectionId, "fire-noc.pdf");
+        Long evidenceOnCheckPoint = fileEvidenceAgainst(originalCheckItemId, "level-survey.pdf");
+
+        // The same check point sent back unchanged, which is what the web client does on a save.
+        service.update(inspectionId, rebuildWith(List.of(surfaceLevel)));
+        entityManager.flush();
+        entityManager.clear();
+
+        // The rebuild reissued the check point's id, so anything keyed on it is orphaned.
+        UUID rebuiltCheckItemId = service.findById(inspectionId).checkItems().getFirst().id();
+        assertThat(rebuiltCheckItemId).isNotEqualTo(originalCheckItemId);
+        assertThat(attachmentRepository.findByEntityTypeAndEntityUuidOrderByIdAsc(
+                InspectionEvidence.ENTITY_TYPE, rebuiltCheckItemId)).isEmpty();
+        assertThat(attachmentRepository.findById(evidenceOnCheckPoint))
+                .get()
+                .extracting(Attachment::getEntityUuid)
+                .isEqualTo(originalCheckItemId);
+
+        // The inspection's own id was never reissued, so its evidence is still filed against it.
+        assertThat(attachmentRepository.findByEntityTypeAndEntityUuidOrderByIdAsc(
+                InspectionEvidence.ENTITY_TYPE, inspectionId))
+                .extracting(Attachment::getId)
+                .containsExactly(evidenceOnInspection);
+    }
+
+    /**
+     * The check constraint that replaced {@code entity_id NOT NULL} when the UUID key arrived.
+     * Without it a file could be filed against neither key, and be invisible to every read path
+     * while still occupying storage.
+     */
+    @Test
+    void anAttachmentMustBeFiledAgainstExactlyOneOfTheTwoKeys() {
+        assertThatThrownBy(() -> insertAttachment("both.pdf", 7L, UUID.randomUUID()))
+                .hasStackTraceContaining("CHECK constraint");
+        assertThatThrownBy(() -> insertAttachment("neither.pdf", null, null))
+                .hasStackTraceContaining("CHECK constraint");
+    }
+
+    /** An update that sends the given check points back, the shape the web client saves in. */
+    private UpdateInspectionRequest rebuildWith(List<InspectionCheckItemRequest> checkItems) {
+        return new UpdateInspectionRequest(
+                "Wall check", InspectionType.QUALITY, null, InspectionTrade.PLASTERING,
+                InspectionStatus.IN_PROGRESS, null, projectId, "Block A", null, null,
+                LocalDate.of(2026, 8, 20), null, null, null, null, 100L, null, null,
+                null, null, null, checkItems, null);
+    }
+
+    /** Stores one piece of evidence against a UUID-keyed record, and returns its id. */
+    private Long fileEvidenceAgainst(UUID entityUuid, String filename) {
+        Attachment attachment = new Attachment();
+        attachment.setEntityType(InspectionEvidence.ENTITY_TYPE);
+        attachment.setEntityUuid(entityUuid);
+        attachment.setStorageKey("inspection/" + filename);
+        attachment.setOriginalFilename(filename);
+        attachment.setContentType("application/pdf");
+        attachment.setFileSize(1024L);
+        attachment.setOrganization(entityManager.getReference(Organization.class, orgAId));
+        entityManager.persist(attachment);
+        entityManager.flush();
+        return attachment.getId();
+    }
+
+    /**
+     * Inserts an attachment row directly, in its own committed transaction so a constraint
+     * violation does not poison the test's transaction.
+     */
+    private void insertAttachment(String filename, Long entityId, UUID entityUuid) {
+        inCommittedTx(() -> entityManager.createNativeQuery(
+                        "INSERT INTO attachment (entity_type, entity_id, entity_uuid, storage_key, "
+                                + "original_filename, organization_id, created_at, updated_at) "
+                                + "VALUES (:type, CAST(:entityId AS BIGINT), CAST(:entityUuid AS UUID), "
+                                + ":key, :name, :org, CAST(now() AS TIMESTAMP), CAST(now() AS TIMESTAMP))")
+                .setParameter("type", InspectionEvidence.ENTITY_TYPE)
+                .setParameter("entityId", entityId)
+                .setParameter("entityUuid", entityUuid == null ? null : entityUuid.toString())
+                .setParameter("key", "inspection/" + filename)
+                .setParameter("name", filename)
+                .setParameter("org", orgAId)
+                .executeUpdate());
     }
 
     private UpdateInspectionRequest concludeAs(InspectionStatus status) {


### PR DESCRIPTION
Closes #535

Anand's 28 Aug QA pass (ClickUp `86d45v86y`) asks for evidence on inspections. The issue expected this to be nearly free, on the strength of what #545 found. Most of it was. One thing was not, and it is the reason inspections had no attachments in the first place.

## What #545 already gave, and what it could not

Checked before assuming, as the issue asked.

**Free, exactly as expected.** `attachment.entity_type` is a free-form `String`, the upload, presign, register, list and delete endpoints all take the type and the id as path variables, and the storage folder is derived as the part of the type before the first underscore. `INSPECTION_EVIDENCE` therefore lands files under `inspection/` with **no change to the storage layer at all**.

**Also free: what a file is and when it lapses.** #545 put `document_type`, `issued_on` and `expires_on` on the **shared** attachment table specifically because inspections wanted them, and `PATCH /api/v1/attachment/web/attachmentId/{id}/document` already records all three for any entity through a tenant-scoped finder. That endpoint serves inspection evidence unchanged; this PR adds nothing to it. The derived `expired` and `daysUntilExpiry` come along too, so a permit that lapsed last week reads as lapsed rather than sitting in the database marked valid.

**Not free, and not mentioned anywhere in the issue: the key.** `attachment.entity_id` is `BIGINT`. `Inspection`, `InspectionCheckItem`, `InspectionDefect` and `Ncr` are all `@GeneratedValue(strategy = UUID)`. A UUID does not fit a BIGINT, so an inspection could not be named as an attachment's owner by any means. That is the actual reason this module has never had attachments, and it is the only schema work here.

## The one migration

`068-add-attachment-entity-uuid.xml`. `entity_uuid UUID` goes on the **shared** table, for the reason #545 widened it rather than giving assets a documents table: the plumbing is already generic, so `Ncr`, checklist templates and every future UUID-keyed record inherit the fix instead of reimplementing it.

`entity_id` therefore stops being `NOT NULL`, and a check constraint takes over from it:

```sql
CHECK ((entity_id IS NOT NULL) != (entity_uuid IS NOT NULL))
```

A row names **exactly one** of the two. Without that, a file could arrive naming neither and be invisible to every read path while still occupying storage, which is strictly worse than the `NOT NULL` it replaces. Every existing row satisfies it on day one, because every existing row has a numeric id and no UUID. The changeset carries a rollback that puts the `NOT NULL` back.

`AttachmentOwner` states the same rule in Java, in a compact constructor, so a path that gets it wrong fails at the call rather than at the insert. It is also the only thing the four upload and read paths now take, so the key type stops being visible past that boundary and the four methods are not duplicated once per key.

## Where evidence attaches, and why not lower

**Against the inspection, and only against the inspection.**

`InspectionService.update` clears the check items and the defects and rebuilds both from the payload, with `orphanRemoval`, so **every child row is deleted and reinserted under a fresh UUID each time an inspector presses save**. A file keyed on a check item id or a defect id would be orphaned by the next edit. This is the trap #543 hit with photo annotations and solved by keying on the photograph rather than the defect row, and the `ncrs` changelog already records it as the reason an NCR keeps a scalar `defectId` rather than a foreign key.

`evidenceFiledAgainstTheInspectionSurvivesAnUpdateThatReissuesEveryChildId` pins it rather than asserting it in a comment: it files one attachment against the inspection and one against a check point, edits the inspection, and shows the check point's evidence left naming a row that no longer exists while the inspection's is untouched. Mutating that test to file the inspection's own evidence against the check point (M9 below) fails it, which is the design decision being tested rather than described.

The domain agrees with the constraint, which is why this is not a workaround. The case the ticket exists for is a compliance inspection standing in for a statutory approval, and its permit is evidence of **the whole inspection**, not of one line on its checklist. Per-check-point and per-defect photographs already have a home in the `photos` element collections, which a rebuild carries through by value and which #543 marks up on top. What did not exist anywhere was a place for the inspection's own paperwork with a document type and an expiry on it.

**Point 6 of the ticket (per-check-point evidence) is therefore not here.** Doing it properly needs the check item to survive a save under a stable identity, which means changing the inspection update contract so the client can name the check points it is re-sending. That is a contract decision, not an implementation detail, and guessing it would be the expensive mistake this PR exists to avoid.

## The assumption about evidence after a pass

Stated rather than blocked on, as asked. **Add always, remove never once judged.**

- **Adding is allowed in every state, including passed.** The certificate a compliance inspection stands in for routinely arrives days after the work was signed off. That is the normal shape of a statutory approval, and freezing additions at the verdict would make the record unfinishable, which defeats the point of the feature.
- **Removal is refused once the inspection is `passed`, `passed-with-remarks` or `failed`.** Those files were part of the record when somebody reached that conclusion; deleting one afterwards leaves a verdict whose basis is gone with nothing to say it ever existed. A file that turns out to be wrong is superseded by uploading the correct one, in the same spirit as #529's stock adjustment corrected by a further adjustment rather than by an edit.
- **`completed` and `cancelled` are deliberately not frozen.** Completed means the work is done but no verdict has been given, and a cancelled inspection concluded nothing, so neither has files that are the basis of anything.

The refusal names the alternative rather than just saying no, matching the convention #545 and #529 settled on.

The other decision the issue raised, **evidence-required compliance types**, is left out: it needs a per-type flag we do not have, and Anand is explicit that attachments are not mandatory in general. Nothing here blocks adding it.

## Endpoints

On the inspection controller, not the generic attachment one, because that controller keys on a numeric entity id and because the removal rule above is an inspection rule rather than an attachment rule.

| | |
|---|---|
| `GET /inspections/web/{id}/evidence` | read, `canRead()` |
| `POST /inspections/web/{id}/evidence` | multipart, `canManageInspections()` |
| `POST /inspections/web/{id}/evidence/presign` | step one of direct-to-storage |
| `POST /inspections/web/{id}/evidence/register` | step two, storage verified before recording |
| `DELETE /inspections/web/{id}/evidence/{attachmentId}` | frozen after a verdict |

Presign and register are included rather than left for later: the deployed frontend already uploads through that path (`use-direct-attachment-upload.ts`, #181), and a scanned approval or a site photograph routinely exceeds what the streaming path allows.

Every one resolves the inspection through `findByIdScoped` first, so a caller in one organization gets a 404 rather than acting on another tenant's record.

**One hole closed while passing through.** `AttachmentService.deleteAttachment(Long)` resolves by numeric id alone, which the file has carried a `NOTE (phase0 authz lockdown)` about since the lockdown: a member of org A can delete org B's attachment by numeric id. The evidence path does not use it. `deleteAttachmentOf(owner, id)` goes through the tenant-scoped finder #545 added and then checks the file is actually the named record's, so the id in the path has to agree with the record in the path. The old method is left alone rather than changed underneath its existing callers.

## Not in this PR

**Web work.** The evidence list and upload on the inspection detail page, and the document type and expiry fields on it. Anand's last point is worth carrying into that as written: an AI-suggested inspection is a recommendation and must not read as proof of compliance, so an empty evidence list on a `suggested` inspection is the normal state and the section should say so rather than leave it implied. The `GET` endpoint's OpenAPI description says as much.

**#532.** Attachment uploads on the compose staging are failing for an unrelated reason, so this cannot be exercised on `echno.in` until that lands. Nothing here depends on it.

## Tests, and that each one fails without its fix

Every new test is plain JUnit and Mockito with no Spring context, except the two added to the **existing** `InspectionServiceIT` so they reuse its cached context rather than building another. That matters in this repo: the test JVM is capped at 1 GB with no `forkEvery`, so a new distinct test configuration is a cached Spring context that makes an unrelated test fail on heap. `AttachmentRepository` is autowired into that class without touching the `@Import` list, because `@DataJpaTest` enables every Spring Data repository already, so the context cache key is unchanged and the four inspection ITs still share one context.

Nine mutations, each applied and reverted around one run on `.116`. Every one is killed.

| # | The fix removed | Test that then fails |
|---|---|---|
| M1 | the "exactly one key" rule on `AttachmentOwner` | `aRecordIsKeyedByItsNumericIdOrItsUuid_neverBoth`, `aRecordThatNamesNeitherKeyIsRefused` |
| M2 | deriving the storage folder from the type before the first underscore | `theStorageFolderIsTheTypeBeforeTheFirstUnderscore`, `evidenceIsFiledAgainstTheInspectionsUuid`, `presigningEvidenceGoesToTheInspectionFolderUnderTheInspectionsUuid` |
| M3 | the refusal to remove evidence from a judged inspection | `evidenceCannotBeRemovedOnceTheInspectionHasBeenJudged`, all three verdicts |
| M4 | treating completed and cancelled as unjudged | `evidenceCanBeRemovedBeforeTheInspectionIsJudged` for `COMPLETED` and `CANCELLED` |
| M5 | allowing evidence to be added after a pass | `evidenceCanStillBeAddedOnceTheInspectionHasPassed` |
| M6 | resolving the inspection through the tenant-scoped finder before touching files | `anInspectionOfAnotherTenantHasNoEvidenceToRead`, `evidenceCannotBeAttachedToAnInspectionOfAnotherTenant` |
| M7 | the owner check on the scoped delete | `refusesAFileFiledAgainstADifferentRecord`, `refusesAFileFiledUnderADifferentEntityType` |
| M8 | the check constraint in changeset 068 | `anAttachmentMustBeFiledAgainstExactlyOneOfTheTwoKeys` |
| M9 | filing evidence against the inspection rather than the check point | `evidenceFiledAgainstTheInspectionSurvivesAnUpdateThatReissuesEveryChildId` |

Full suite green on `.116`. `EndpointAuthorizationTest`, `MultipartPayloadValidationTest`, `UnboundedRepositoryReadTest` and #555's new `PaginationParameterBoundTest` all pass: the evidence list is a bare array like the asset documents one, with no paging parameters of its own, so it declares neither `pageNo` nor `pageSize`.

## Migration number

`068`. `061` was #540, `062` is claimed by #542 (still open), `063` to `067` went in with #545 and #543. Rechecked against `origin/development` and against every open PR's diff immediately before pushing.
