### PR TITLE
Ban database I/O from mapping hooks, and enforce it

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
@@ -27,13 +27,17 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemUpdateDto;
 import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
 import org.tornotron.echno_backend.indent.enums.IndentStatus;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * CRUD for material indents and their line items.
@@ -56,13 +60,14 @@ public class IndentService {
     private final IndentItemMapper indentItemMapper;
     private final DocumentNumberAllocator documentNumberAllocator;
     private final TransactionRetryTemplate retryTemplate;
+    private final InventoryService inventoryService;
 
     public IndentService(IndentRepository indentRepository, IndentItemRepository indentItemRepository,
                          MaterialRepository materialRepository, IndentMapper indentMapper,
                          TenantEntityHelper tenantEntityHelper, EmployeeRepository employeeRepository,
                          ProjectRepository projectRepository, IndentItemMapper indentItemMapper,
                          DocumentNumberAllocator documentNumberAllocator,
-                         TransactionRetryTemplate retryTemplate) {
+                         TransactionRetryTemplate retryTemplate, InventoryService inventoryService) {
         this.indentRepository = indentRepository;
         this.indentItemRepository = indentItemRepository;
         this.materialRepository = materialRepository;
@@ -73,6 +78,7 @@ public class IndentService {
         this.indentItemMapper = indentItemMapper;
         this.documentNumberAllocator = documentNumberAllocator;
         this.retryTemplate = retryTemplate;
+        this.inventoryService = inventoryService;
     }
 
     // ==================== Indent CRUD ====================
@@ -125,7 +131,8 @@ public class IndentService {
             indent.setRemarks(indentDto.getRemarks());
         }
 
-        return indentMapper.toDto(indentRepository.save(indent));
+        Indent saved = indentRepository.save(indent);
+        return indentMapper.toDto(saved, stockForIndents(List.of(saved)));
     }
 
     /**
@@ -176,7 +183,8 @@ public class IndentService {
             }
         }
 
-        return indentMapper.toDto(indentRepository.save(indent));
+        Indent saved = indentRepository.save(indent);
+        return indentMapper.toDto(saved, stockForIndents(List.of(saved)));
     }
 
     /**
@@ -189,8 +197,9 @@ public class IndentService {
     @Transactional(readOnly = true)
     public Page<IndentDto> getAllIndents(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "id"));
-        return indentRepository.findAll(pageable)
-                .map(indent -> indentMapper.toDto(indent));
+        Page<Indent> indents = indentRepository.findAll(pageable);
+        MaterialStockLookup stock = stockForIndents(indents.getContent());
+        return indents.map(indent -> indentMapper.toDto(indent, stock));
     }
 
 
@@ -204,7 +213,7 @@ public class IndentService {
     @Transactional(readOnly = true)
     public IndentDto getAnIndent(Long id) {
         return indentRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
-                .map(indent -> indentMapper.toDto(indent))
+                .map(indent -> indentMapper.toDto(indent, stockForIndents(List.of(indent))))
                 .orElseThrow(() -> new ResourceNotFoundException("Indent with ID " + id + " was not found in this organization"));
     }
 
@@ -234,9 +243,11 @@ public class IndentService {
     @Transactional(readOnly = true)
     public List<IndentItemDto> getItemsByIndentId(Long indentId) {
         findIndentById(indentId);
-        return indentItemRepository.findByIndentId(indentId).stream()
-                .map(item -> indentItemMapper.toDto(item))
-                .collect(Collectors.toList());
+        List<IndentItem> items = indentItemRepository.findByIndentId(indentId);
+        MaterialStockLookup stock = stockForItems(items);
+        return items.stream()
+                .map(item -> indentItemMapper.toDto(item, stock))
+                .toList();
     }
 
     /**
@@ -254,7 +265,7 @@ public class IndentService {
         item.setOrganization(indent.getOrganization());
         indent.addItem(item);
         indentRepository.save(indent);
-        return indentItemMapper.toDto(item);
+        return indentItemMapper.toDto(item, stockForItems(List.of(item)));
     }
 
     /**
@@ -301,7 +312,7 @@ public class IndentService {
         }
 
         item = indentItemRepository.save(item);
-        return indentItemMapper.toDto(item);
+        return indentItemMapper.toDto(item, stockForItems(List.of(item)));
     }
 
     /**
@@ -344,5 +355,35 @@ public class IndentService {
         item.setRemarks(dto.getRemarks());
         item.setConvertedToPurchaseOrder(false);
         return item;
+    }
+
+    /**
+     * Reads the aggregate stock for every material on the given indents, in one query.
+     *
+     * <p>An indent line carries a full material DTO, so while the material mapper fetched its own
+     * stock a ten-line indent cost twenty aggregate reads and a page of indents multiplied that by
+     * the page size. One call now covers the page.
+     *
+     * @param indents The indents being converted.
+     * @return The stock for their materials, with anything unstocked reading as zero.
+     */
+    private MaterialStockLookup stockForIndents(Collection<Indent> indents) {
+        return stockForItems(indents.stream()
+                .flatMap(indent -> indent.getItems() == null ? Stream.<IndentItem>empty() : indent.getItems().stream())
+                .toList());
+    }
+
+    /**
+     * Reads the aggregate stock for the materials on the given indent lines, in one query.
+     *
+     * @param items The lines being converted.
+     * @return The stock for their materials, with anything unstocked reading as zero.
+     */
+    private MaterialStockLookup stockForItems(Collection<IndentItem> items) {
+        return inventoryService.aggregateStockFor(items.stream()
+                .map(IndentItem::getMaterial)
+                .filter(Objects::nonNull)
+                .map(Material::getId)
+                .toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/indent/mapper/IndentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/mapper/IndentMapper.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.indent.mapper;
 import java.util.Collections;
 
 import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -10,19 +11,30 @@ import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.indent.Indent;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 
 /**
  * Maps {@link Indent} to its DTO. createdBy maps through {@link EmployeeMapper}, the
  * item lines through {@link IndentItemMapper}, and the project flattens to id + name.
  * The old converter set an empty list when the indent had no items, so
  * {@link #emptyItemsIfNull} restores that (MapStruct would otherwise leave it null).
+ *
+ * <p>The stock lookup is carried through to the line items, which carry it on to the material.
  */
 @Mapper(componentModel = "spring", uses = {EmployeeMapper.class, IndentItemMapper.class})
 public interface IndentMapper {
 
-    @Mapping(source = "project.id", target = "projectId")
-    @Mapping(source = "project.projectName", target = "projectName")
-    IndentDto toDto(Indent indent);
+    /**
+     * Converts an indent and its lines.
+     *
+     * @param indent The indent to convert.
+     * @param stock The stock read for every material on this indent, or on the whole page of
+     *              indents being mapped.
+     * @return The indent DTO.
+     */
+    @Mapping(source = "indent.project.id", target = "projectId")
+    @Mapping(source = "indent.project.projectName", target = "projectName")
+    IndentDto toDto(Indent indent, @Context MaterialStockLookup stock);
 
     @AfterMapping
     default void emptyItemsIfNull(@MappingTarget IndentDto dto) {

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemService.java
@@ -16,10 +16,13 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 import org.tornotron.echno_backend.indent.Indent;
 import org.tornotron.echno_backend.indent.IndentRepository;
 import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 import org.tornotron.echno_backend.material.MaterialRepository;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 @Service
 public class IndentItemService {
@@ -29,16 +32,19 @@ public class IndentItemService {
     private final MaterialRepository materialRepository;
     private final TenantEntityHelper tenantEntityHelper;
     private final IndentItemMapper indentItemMapper;
+    private final InventoryService inventoryService;
 
     public IndentItemService(IndentItemRepository indentItemRepository,
                              IndentRepository indentRepository,
                              MaterialRepository materialRepository,
-                             TenantEntityHelper tenantEntityHelper, IndentItemMapper indentItemMapper) {
+                             TenantEntityHelper tenantEntityHelper, IndentItemMapper indentItemMapper,
+                             InventoryService inventoryService) {
         this.indentItemRepository = indentItemRepository;
         this.indentRepository = indentRepository;
         this.materialRepository = materialRepository;
         this.tenantEntityHelper = tenantEntityHelper;
         this.indentItemMapper = indentItemMapper;
+        this.inventoryService = inventoryService;
     }
 
     @Transactional
@@ -60,14 +66,14 @@ public class IndentItemService {
         indentItem.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         indentItem = indentItemRepository.save(indentItem);
-        return indentItemMapper.toDto(indentItem);
+        return indentItemMapper.toDto(indentItem, stockFor(List.of(indentItem)));
     }
 
     @Transactional(readOnly = true)
     public IndentItemDto getIndentItemById(Long id) {
         IndentItem indentItem = indentItemRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Indent item with ID " + id + " was not found in this organization"));
-        return indentItemMapper.toDto(indentItem);
+        return indentItemMapper.toDto(indentItem, stockFor(List.of(indentItem)));
     }
 
     /**
@@ -82,8 +88,9 @@ public class IndentItemService {
      */
     @Transactional(readOnly = true)
     public Page<IndentItemDto> getAllIndentItems(Pageable pageable) {
-        return indentItemRepository.findAll(pageable)
-                .map(indentItem -> indentItemMapper.toDto(indentItem));
+        Page<IndentItem> items = indentItemRepository.findAll(pageable);
+        MaterialStockLookup stock = stockFor(items.getContent());
+        return items.map(indentItem -> indentItemMapper.toDto(indentItem, stock));
     }
 
     /**
@@ -112,23 +119,17 @@ public class IndentItemService {
 
     @Transactional(readOnly = true)
     public List<IndentItemDto> getIndentItemsByIndentId(Long indentId) {
-        return indentItemRepository.findByIndentId(indentId).stream()
-                .map(indentItem -> indentItemMapper.toDto(indentItem))
-                .collect(Collectors.toList());
+        return toDtos(indentItemRepository.findByIndentId(indentId));
     }
 
     @Transactional(readOnly = true)
     public List<IndentItemDto> getIndentItemsByMaterialId(Long materialId) {
-        return indentItemRepository.findByMaterialId(materialId).stream()
-                .map(indentItem -> indentItemMapper.toDto(indentItem))
-                .collect(Collectors.toList());
+        return toDtos(indentItemRepository.findByMaterialId(materialId));
     }
 
     @Transactional(readOnly = true)
     public List<IndentItemDto> getIndentItemsByConversionStatus(Boolean converted) {
-        return indentItemRepository.findByConvertedToPurchaseOrder(converted).stream()
-                .map(indentItem -> indentItemMapper.toDto(indentItem))
-                .collect(Collectors.toList());
+        return toDtos(indentItemRepository.findByConvertedToPurchaseOrder(converted));
     }
 
     @Transactional
@@ -150,7 +151,7 @@ public class IndentItemService {
         indentItem.setRemarks(updateDto.getRemarks());
 
         indentItem = indentItemRepository.save(indentItem);
-        return indentItemMapper.toDto(indentItem);
+        return indentItemMapper.toDto(indentItem, stockFor(List.of(indentItem)));
     }
 
     @Transactional
@@ -170,6 +171,36 @@ public class IndentItemService {
         indentItem.setLinkedPurchaseOrderNumber(purchaseOrderNumber);
 
         indentItem = indentItemRepository.save(indentItem);
-        return indentItemMapper.toDto(indentItem);
+        return indentItemMapper.toDto(indentItem, stockFor(List.of(indentItem)));
+    }
+
+    /**
+     * Converts a list of indent lines, reading the stock for all their materials once.
+     *
+     * @param items The lines to convert.
+     * @return The lines as DTOs.
+     */
+    private List<IndentItemDto> toDtos(List<IndentItem> items) {
+        MaterialStockLookup stock = stockFor(items);
+        return items.stream()
+                .map(indentItem -> indentItemMapper.toDto(indentItem, stock))
+                .toList();
+    }
+
+    /**
+     * Reads the aggregate stock for the materials on the given lines, in one query.
+     *
+     * <p>An indent line carries a full material DTO. While the material mapper fetched its own
+     * stock, every line on a page cost two aggregate reads and nothing in the listing code said so.
+     *
+     * @param items The lines being converted.
+     * @return The stock for their materials, with anything unstocked reading as zero.
+     */
+    private MaterialStockLookup stockFor(Collection<IndentItem> items) {
+        return inventoryService.aggregateStockFor(items.stream()
+                .map(IndentItem::getMaterial)
+                .filter(Objects::nonNull)
+                .map(Material::getId)
+                .toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/indentItem/mapper/IndentItemMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/mapper/IndentItemMapper.java
@@ -1,13 +1,30 @@
 package org.tornotron.echno_backend.indentItem.mapper;
 
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.tornotron.echno_backend.indentItem.IndentItem;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 import org.tornotron.echno_backend.material.mapper.MaterialMapper;
 
-/** Maps {@link IndentItem} to its DTO; the material maps through {@link MaterialMapper}. */
+/**
+ * Maps {@link IndentItem} to its DTO; the material maps through {@link MaterialMapper}.
+ *
+ * <p>The stock lookup is carried through rather than used here. {@link IndentItemDto} holds a
+ * full material DTO, so while the material mapper fetched its own stock a ten-line indent cost
+ * twenty aggregate queries and a page of indents multiplied that by the page size. The caller
+ * reads the stock for every material on the page once and it travels down as a
+ * {@code @Context}.
+ */
 @Mapper(componentModel = "spring", uses = MaterialMapper.class)
 public interface IndentItemMapper {
 
-    IndentItemDto toDto(IndentItem item);
+    /**
+     * Converts an indent line.
+     *
+     * @param item The line to convert.
+     * @param stock The stock read for every material being mapped in this request.
+     * @return The indent item DTO.
+     */
+    IndentItemDto toDto(IndentItem item, @Context MaterialStockLookup stock);
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,11 +79,47 @@ public interface CurrentStockRepository extends JpaRepository<CurrentStock, Long
     @Query("SELECT COALESCE(SUM(cs.stockValue), 0) FROM CurrentStock cs WHERE cs.material.id = :materialId")
     BigDecimal sumStockValueByMaterial(@Param("materialId") Long materialId);
 
+    /**
+     * Totals quantity and value for many materials in one grouped read.
+     *
+     * <p>The batched form of {@link #sumCurrentQuantityByMaterial} and
+     * {@link #sumStockValueByMaterial}, which cost two queries per material and were being called
+     * once per row from inside a mapper. Both aggregates come back together because a caller that
+     * wants one always wants the other.
+     *
+     * <p>A material with no stock row produces no group, so the caller supplies the zero. Pass a
+     * non-empty collection: {@code IN ()} is not valid SQL.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.inventoryTransaction.MaterialStockTotals(
+                       cs.material.id,
+                       COALESCE(SUM(cs.currentQuantity), 0.0),
+                       COALESCE(SUM(cs.stockValue), 0))
+            FROM CurrentStock cs
+            WHERE cs.material.id IN :materialIds
+            GROUP BY cs.material.id
+            """)
+    List<MaterialStockTotals> sumStockByMaterialIds(@Param("materialIds") Collection<Long> materialIds);
+
+    /**
+     * Counts distinct materials for many storage locations in one grouped read.
+     *
+     * <p>Replaces a per-location count that ran once per row on four listing paths. A location
+     * holding nothing produces no group, so the caller supplies the zero. Pass a non-empty
+     * collection: {@code IN ()} is not valid SQL.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.inventoryTransaction.StorageLocationItemCount(
+                       cs.storageLocation.id, COUNT(DISTINCT cs.material.id))
+            FROM CurrentStock cs
+            WHERE cs.storageLocation.id IN :storageLocationIds AND cs.organization.id = :organizationId
+            GROUP BY cs.storageLocation.id
+            """)
+    List<StorageLocationItemCount> countDistinctMaterialsByStorageLocationIds(
+            @Param("storageLocationIds") Collection<Long> storageLocationIds,
+            @Param("organizationId") Long organizationId);
+
     List<CurrentStock> findByMaterialIdAndOrganization_Id(Long materialId, Long organizationId);
 
     List<CurrentStock> findByProjectId(Long projectId);
-
-    @Query("SELECT COUNT(DISTINCT cs.material.id) FROM CurrentStock cs WHERE cs.storageLocation.id = :storageLocationId AND cs.organization.id = :organizationId")
-    Long countDistinctMaterialsByStorageLocationIdAndOrganizationId(
-            @Param("storageLocationId") Long storageLocationId, @Param("organizationId") Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryService.java
@@ -491,6 +491,55 @@ public class InventoryService {
     }
 
     /**
+     * Reads the aggregate stock for a whole set of materials in one query.
+     *
+     * <p>This is what a caller uses before mapping a page. {@link #getAggregateStock} and
+     * {@link #getAggregateStockValue} answer for one material and cost two queries doing it, so
+     * asking them once per row is what turned a fifty-material page into a hundred reads. Both
+     * aggregates come back in a single grouped read here, and materials that hold no stock read
+     * as zero rather than being missing.
+     *
+     * @param materialIds The materials about to be mapped; duplicates and nulls are ignored.
+     * @return A lookup over their totals, empty when no ids were given.
+     */
+    @Transactional(readOnly = true)
+    public MaterialStockLookup aggregateStockFor(Collection<Long> materialIds) {
+        Set<Long> ids = distinctIds(materialIds);
+        if (ids.isEmpty()) {
+            return MaterialStockLookup.none();
+        }
+        return MaterialStockLookup.of(currentStockRepository.sumStockByMaterialIds(ids));
+    }
+
+    /**
+     * Reads the distinct-material count for a whole set of storage locations in one query.
+     *
+     * <p>The storage-location counterpart to {@link #aggregateStockFor}, for the same reason: the
+     * count used to run once per row on every location listing.
+     *
+     * @param storageLocationIds The locations about to be mapped; duplicates and nulls are ignored.
+     * @return A lookup over their counts, empty when no ids were given.
+     */
+    @Transactional(readOnly = true)
+    public StorageLocationItemCounts itemCountsAt(Collection<Long> storageLocationIds) {
+        Set<Long> ids = distinctIds(storageLocationIds);
+        if (ids.isEmpty()) {
+            return StorageLocationItemCounts.none();
+        }
+        return StorageLocationItemCounts.of(currentStockRepository
+                .countDistinctMaterialsByStorageLocationIds(ids, TenantContext.getCurrentOrgId()));
+    }
+
+    private static Set<Long> distinctIds(Collection<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Set.of();
+        }
+        Set<Long> distinct = new HashSet<>(ids);
+        distinct.remove(null);
+        return distinct;
+    }
+
+    /**
      * Returns the stock value for a material at one storage location.
      *
      * @param materialId The material to value.

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/MaterialStockLookup.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/MaterialStockLookup.java
@@ -1,0 +1,99 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The aggregate stock figures for a whole set of materials, read once and handed to the mapper.
+ *
+ * <p>This is the shape that keeps stock out of the conversion path. A mapper that has to ask for
+ * a material's stock costs two queries per row and shows nothing at the call site, so a page of
+ * fifty materials quietly costs a hundred reads. The caller instead collects the material ids it
+ * is about to map, asks {@link InventoryService#aggregateStockFor} for all of them in one grouped
+ * query, and passes the answer down as a MapStruct {@code @Context}. Every nested mapper on the
+ * way (an indent line carries a material, an indent carries its lines) receives the same instance,
+ * so the depth of the DTO no longer multiplies the query count.
+ *
+ * <p>A material with no stock row anywhere is absent from the grouped result. The two accessors
+ * return zero for it, which is what the per-material {@code COALESCE(SUM(...), 0)} reads returned
+ * and what the response has always carried.
+ */
+public final class MaterialStockLookup {
+
+    private static final MaterialStockLookup EMPTY = new MaterialStockLookup(Map.of());
+
+    private final Map<Long, MaterialStockTotals> byMaterialId;
+
+    private MaterialStockLookup(Map<Long, MaterialStockTotals> byMaterialId) {
+        this.byMaterialId = byMaterialId;
+    }
+
+    /**
+     * A lookup holding nothing, so every material reads as zero stock.
+     *
+     * <p>For the paths that map a material which cannot have stock yet, and for tests. It is not
+     * a fallback for a caller that forgot to fetch: that would silently zero a real balance.
+     *
+     * @return The empty lookup.
+     */
+    public static MaterialStockLookup none() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a lookup from the rows of a grouped read.
+     *
+     * @param totals The per-material totals, at most one row per material.
+     * @return A lookup over those totals.
+     */
+    public static MaterialStockLookup of(Collection<MaterialStockTotals> totals) {
+        if (totals == null || totals.isEmpty()) {
+            return EMPTY;
+        }
+        return new MaterialStockLookup(totals.stream()
+                .filter(row -> row.materialId() != null)
+                .collect(Collectors.toMap(MaterialStockTotals::materialId, Function.identity(),
+                        (first, second) -> first)));
+    }
+
+    /**
+     * The quantity on hand for a material.
+     *
+     * @param materialId The material to read, which may be null for an entity not yet persisted.
+     * @return The quantity on hand, or zero where the material holds no stock.
+     */
+    public Double currentStockOf(Long materialId) {
+        MaterialStockTotals totals = byMaterialId.get(materialId);
+        return totals == null || totals.currentStock() == null ? 0.0 : totals.currentStock();
+    }
+
+    /**
+     * The value of the stock on hand for a material.
+     *
+     * @param materialId The material to read, which may be null for an entity not yet persisted.
+     * @return The stock value, or zero where the material holds no stock.
+     */
+    public BigDecimal stockValueOf(Long materialId) {
+        MaterialStockTotals totals = byMaterialId.get(materialId);
+        return totals == null || totals.stockValue() == null ? BigDecimal.ZERO : totals.stockValue();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof MaterialStockLookup lookup && byMaterialId.equals(lookup.byMaterialId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(byMaterialId);
+    }
+
+    @Override
+    public String toString() {
+        return "MaterialStockLookup" + byMaterialId.keySet();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/MaterialStockTotals.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/MaterialStockTotals.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import java.math.BigDecimal;
+
+/**
+ * One material's aggregate quantity and value on hand, as returned by the grouped read in
+ * {@link CurrentStockRepository#sumStockByMaterialIds}.
+ *
+ * <p>A row exists only for a material that has at least one {@code CurrentStock} row, so a
+ * material with no stock anywhere is absent from the result rather than present with a zero.
+ * {@link MaterialStockLookup} is what turns that absence back into the zero the single-material
+ * reads have always returned.
+ *
+ * @param materialId The material these totals belong to.
+ * @param currentStock The quantity on hand across every project and storage location.
+ * @param stockValue That quantity valued at its running weighted-average unit cost.
+ */
+public record MaterialStockTotals(Long materialId, Double currentStock, BigDecimal stockValue) {
+}

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/StorageLocationItemCount.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/StorageLocationItemCount.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+/**
+ * How many distinct materials are stocked at one storage location, as returned by the grouped
+ * read in {@link CurrentStockRepository#countDistinctMaterialsByStorageLocationIds}.
+ *
+ * <p>As with {@link MaterialStockTotals}, a location holding nothing produces no row;
+ * {@link StorageLocationItemCounts} supplies the zero.
+ *
+ * @param storageLocationId The storage location this count belongs to.
+ * @param itemCount The number of distinct materials with a stock row at that location.
+ */
+public record StorageLocationItemCount(Long storageLocationId, Long itemCount) {
+}

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/StorageLocationItemCounts.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/StorageLocationItemCounts.java
@@ -1,0 +1,81 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * The distinct-material count for a whole set of storage locations, read once and handed to the
+ * mapper.
+ *
+ * <p>The counterpart to {@link MaterialStockLookup}, for the same reason: counting the materials
+ * at a location inside the conversion cost one {@code COUNT DISTINCT} per row across four listing
+ * paths, and nothing at the call site said so. The caller now asks
+ * {@link InventoryService#itemCountsAt} for every location on the page at once.
+ *
+ * <p>A location holding nothing is absent from the grouped result and reads as zero, which is what
+ * the per-row {@code COUNT} returned.
+ */
+public final class StorageLocationItemCounts {
+
+    private static final StorageLocationItemCounts EMPTY = new StorageLocationItemCounts(Map.of());
+
+    private final Map<Long, Long> byStorageLocationId;
+
+    private StorageLocationItemCounts(Map<Long, Long> byStorageLocationId) {
+        this.byStorageLocationId = byStorageLocationId;
+    }
+
+    /**
+     * A lookup holding nothing, so every location reads as zero items.
+     *
+     * @return The empty lookup.
+     */
+    public static StorageLocationItemCounts none() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a lookup from the rows of a grouped read.
+     *
+     * @param counts The per-location counts, at most one row per location.
+     * @return A lookup over those counts.
+     */
+    public static StorageLocationItemCounts of(Collection<StorageLocationItemCount> counts) {
+        if (counts == null || counts.isEmpty()) {
+            return EMPTY;
+        }
+        return new StorageLocationItemCounts(counts.stream()
+                .filter(row -> row.storageLocationId() != null)
+                .collect(Collectors.toMap(StorageLocationItemCount::storageLocationId,
+                        row -> row.itemCount() == null ? 0L : row.itemCount(),
+                        (first, second) -> first)));
+    }
+
+    /**
+     * How many distinct materials are stocked at a location.
+     *
+     * @param storageLocationId The location to read, which may be null for an entity not yet persisted.
+     * @return The count, or zero where the location holds nothing.
+     */
+    public Long itemCountOf(Long storageLocationId) {
+        return byStorageLocationId.getOrDefault(storageLocationId, 0L);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof StorageLocationItemCounts counts
+                && byStorageLocationId.equals(counts.byStorageLocationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(byStorageLocationId);
+    }
+
+    @Override
+    public String toString() {
+        return "StorageLocationItemCounts" + byStorageLocationId.keySet();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
@@ -27,8 +28,8 @@ import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * CRUD and stock-aware reads for the material catalogue.
@@ -152,7 +153,7 @@ public class MaterialService {
                     material.getOrganization(), quantity, unitCost);
         }
 
-        return materialMapper.toDto(material);
+        return materialMapper.toDto(material, stockFor(List.of(material)));
     }
 
     /**
@@ -166,7 +167,7 @@ public class MaterialService {
     public MaterialDto getMaterialById(Long id) {
         Material material = materialRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Material with ID " + id + " was not found in this organization"));
-        return materialMapper.toDto(material);
+        return materialMapper.toDto(material, stockFor(List.of(material)));
     }
 
 
@@ -180,8 +181,9 @@ public class MaterialService {
     @Transactional(readOnly = true)
     public Page<MaterialDto> getAllMaterials(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "materialName"));
-        return materialRepository.findAll(pageable)
-                .map(material -> materialMapper.toDto(material));
+        Page<Material> materials = materialRepository.findAll(pageable);
+        MaterialStockLookup stock = stockFor(materials.getContent());
+        return materials.map(material -> materialMapper.toDto(material, stock));
     }
 
     /**
@@ -192,9 +194,11 @@ public class MaterialService {
      */
     @Transactional(readOnly = true)
     public List<MaterialDto> searchMaterialsByName(String name) {
-        return materialRepository.findByMaterialNameContainingIgnoreCase(name).stream()
-                .map(material -> materialMapper.toDto(material))
-                .collect(Collectors.toList());
+        List<Material> materials = materialRepository.findByMaterialNameContainingIgnoreCase(name);
+        MaterialStockLookup stock = stockFor(materials);
+        return materials.stream()
+                .map(material -> materialMapper.toDto(material, stock))
+                .toList();
     }
 
     /**
@@ -263,7 +267,7 @@ public class MaterialService {
         }
 
         material = materialRepository.save(material);
-        return materialMapper.toDto(material);
+        return materialMapper.toDto(material, stockFor(List.of(material)));
     }
 
     /**
@@ -332,5 +336,18 @@ public class MaterialService {
         Double currentStock = inventoryService.getStockAtLocation(id, projectId, storageLocationId);
         BigDecimal stockValue = inventoryService.getStockValueAtLocation(id, projectId, storageLocationId);
         return materialMapper.toWithStockDto(material, currentStock, stockValue);
+    }
+
+    /**
+     * Reads the aggregate stock for every material about to be mapped, in one query.
+     *
+     * <p>This is the batched read that replaced the per-material fetch the mapper used to do for
+     * itself. One call covers a whole page, so the query count no longer follows the row count.
+     *
+     * @param materials The materials being converted.
+     * @return Their stock figures, with anything unstocked reading as zero.
+     */
+    private MaterialStockLookup stockFor(Collection<Material> materials) {
+        return inventoryService.aggregateStockFor(materials.stream().map(Material::getId).toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/material/mapper/MaterialMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/material/mapper/MaterialMapper.java
@@ -1,38 +1,46 @@
 package org.tornotron.echno_backend.material.mapper;
 
-import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
 
+import java.math.BigDecimal;
+
 /**
- * Maps {@link Material} to its DTOs. createdBy maps through {@link EmployeeMapper};
- * the aggregate current stock and stock value are pulled from {@link InventoryService}
- * in an {@code @AfterMapping} hook. The with-stock DTO takes an externally supplied
- * stock and value (the caller already has them).
+ * Maps {@link Material} to its DTOs. createdBy maps through {@link EmployeeMapper}; the
+ * aggregate current stock and stock value are read from the {@link MaterialStockLookup} the
+ * caller hands in.
+ *
+ * <p>The stock used to be fetched here, from {@link InventoryService}, in an
+ * {@code @AfterMapping} hook. That cost two aggregate queries for every material mapped and
+ * nothing at the call site showed it, so a page of fifty materials cost a hundred extra reads
+ * and an indent paid the same again on every line. The caller now reads the whole page's stock
+ * in one grouped query and passes it down, which is the shape {@link #toWithStockDto} has always
+ * had. The lookup travels as a MapStruct {@code @Context}, so the mappers that nest this one
+ * (an indent line carries a material) pass the same instance through rather than each fetching
+ * their own.
  */
 @Mapper(componentModel = "spring", uses = EmployeeMapper.class)
-public abstract class MaterialMapper {
+public interface MaterialMapper {
 
-    @Autowired
-    protected InventoryService inventoryService;
-
-    @Mapping(target = "currentStock", ignore = true) // filled in fillStock
-    @Mapping(target = "stockValue", ignore = true)   // filled in fillStock
-    public abstract MaterialDto toDto(Material material);
-
-    @AfterMapping
-    protected void fillStock(Material material, @MappingTarget MaterialDto dto) {
-        dto.setCurrentStock(inventoryService.getAggregateStock(material.getId()));
-        dto.setStockValue(inventoryService.getAggregateStockValue(material.getId()));
-    }
+    /**
+     * Converts a material, taking its stock figures from the supplied lookup.
+     *
+     * @param material The material to convert.
+     * @param stock The stock read for the whole set of materials being mapped. A material absent
+     *              from it reads as zero, which is what the per-material query returned.
+     * @return The material DTO.
+     */
+    @Mapping(target = "currentStock", expression = "java(stock.currentStockOf(material.getId()))")
+    @Mapping(target = "stockValue", expression = "java(stock.stockValueOf(material.getId()))")
+    MaterialDto toDto(Material material, @Context MaterialStockLookup stock);
 
     @Mapping(target = "currentStock", expression = "java(currentStock != null ? currentStock : 0.0)")
-    public abstract MaterialWithStockDto toWithStockDto(Material material, Double currentStock, java.math.BigDecimal stockValue);
+    MaterialWithStockDto toWithStockDto(Material material, Double currentStock, BigDecimal stockValue);
 }

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
@@ -11,6 +11,8 @@ import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.StorageLocationItemCounts;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationCreationDto;
@@ -18,8 +20,8 @@ import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationUpdateDto;
 import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class StorageLocationService {
@@ -28,14 +30,17 @@ public class StorageLocationService {
     private final ProjectRepository projectRepository;
     private final TenantEntityHelper tenantEntityHelper;
     private final StorageLocationMapper storageLocationMapper;
+    private final InventoryService inventoryService;
 
     public StorageLocationService(StorageLocationRepository storageLocationRepository,
                                   ProjectRepository projectRepository,
-                                  TenantEntityHelper tenantEntityHelper, StorageLocationMapper storageLocationMapper) {
+                                  TenantEntityHelper tenantEntityHelper, StorageLocationMapper storageLocationMapper,
+                                  InventoryService inventoryService) {
         this.storageLocationRepository = storageLocationRepository;
         this.projectRepository = projectRepository;
         this.tenantEntityHelper = tenantEntityHelper;
         this.storageLocationMapper = storageLocationMapper;
+        this.inventoryService = inventoryService;
     }
 
     @Transactional
@@ -67,36 +72,33 @@ public class StorageLocationService {
         }
 
         storageLocation = storageLocationRepository.save(storageLocation);
-        return storageLocationMapper.toDto(storageLocation);
+        return storageLocationMapper.toDto(storageLocation, itemCountsFor(List.of(storageLocation)));
     }
 
     @Transactional(readOnly = true)
     public StorageLocationDto getStorageLocationById(Long id) {
         StorageLocation storageLocation = storageLocationRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID " + id + " was not found in this organization"));
-        return storageLocationMapper.toDto(storageLocation);
+        return storageLocationMapper.toDto(storageLocation, itemCountsFor(List.of(storageLocation)));
     }
 
 
     @Transactional(readOnly = true)
     public Page<StorageLocationDto> getAllStorageLocations(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "locationName"));
-        return storageLocationRepository.findAll(pageable)
-                .map(storageLocation -> storageLocationMapper.toDto(storageLocation));
+        Page<StorageLocation> locations = storageLocationRepository.findAll(pageable);
+        StorageLocationItemCounts itemCounts = itemCountsFor(locations.getContent());
+        return locations.map(storageLocation -> storageLocationMapper.toDto(storageLocation, itemCounts));
     }
 
     @Transactional(readOnly = true)
     public List<StorageLocationDto> getStorageLocationsByProject(Long projectId) {
-        return storageLocationRepository.findByProjectId(projectId).stream()
-                .map(storageLocation -> storageLocationMapper.toDto(storageLocation))
-                .collect(Collectors.toList());
+        return toDtos(storageLocationRepository.findByProjectId(projectId));
     }
 
     @Transactional(readOnly = true)
     public List<StorageLocationDto> getStorageLocationsByType(StorageLocationType locationType) {
-        return storageLocationRepository.findByLocationType(locationType).stream()
-                .map(storageLocation -> storageLocationMapper.toDto(storageLocation))
-                .collect(Collectors.toList());
+        return toDtos(storageLocationRepository.findByLocationType(locationType));
     }
 
     @Transactional
@@ -148,7 +150,7 @@ public class StorageLocationService {
         }
 
         storageLocation = storageLocationRepository.save(storageLocation);
-        return storageLocationMapper.toDto(storageLocation);
+        return storageLocationMapper.toDto(storageLocation, itemCountsFor(List.of(storageLocation)));
     }
 
     @Transactional
@@ -156,5 +158,31 @@ public class StorageLocationService {
         StorageLocation storageLocation = storageLocationRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID " + id + " was not found in this organization"));
         storageLocationRepository.delete(storageLocation);
+    }
+
+    /**
+     * Converts a list of storage locations, counting the materials at all of them once.
+     *
+     * @param locations The locations to convert.
+     * @return The locations as DTOs.
+     */
+    private List<StorageLocationDto> toDtos(List<StorageLocation> locations) {
+        StorageLocationItemCounts itemCounts = itemCountsFor(locations);
+        return locations.stream()
+                .map(storageLocation -> storageLocationMapper.toDto(storageLocation, itemCounts))
+                .toList();
+    }
+
+    /**
+     * Counts the distinct materials at every location about to be mapped, in one query.
+     *
+     * <p>This is the batched read that replaced the count the mapper used to issue for itself,
+     * once per row, on each of the listing paths above.
+     *
+     * @param locations The locations being converted.
+     * @return Their item counts, with anything unstocked reading as zero.
+     */
+    private StorageLocationItemCounts itemCountsFor(Collection<StorageLocation> locations) {
+        return inventoryService.itemCountsAt(locations.stream().map(StorageLocation::getId).toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/mapper/StorageLocationMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/mapper/StorageLocationMapper.java
@@ -1,34 +1,35 @@
 package org.tornotron.echno_backend.storageLocation.mapper;
 
-import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.tornotron.echno_backend.common.multitenancy.TenantContext;
-import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.inventoryTransaction.StorageLocationItemCounts;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
 
 /**
  * Maps {@link StorageLocation} to its DTO. Project is flattened to id + name; the
- * distinct-materials count is computed from {@link CurrentStockRepository} for the
- * current tenant in an {@code @AfterMapping} hook, matching the previous converter.
+ * distinct-materials count is read from the {@link StorageLocationItemCounts} the caller hands in.
+ *
+ * <p>The count used to be issued here, one {@code COUNT DISTINCT} per row, from an
+ * {@code @AfterMapping} hook holding the stock repository. Four listing paths went through it, so
+ * every location on a page cost a query that the listing code gave no sign of. The caller now
+ * counts the whole page in one grouped read.
  */
 @Mapper(componentModel = "spring")
-public abstract class StorageLocationMapper {
+public interface StorageLocationMapper {
 
-    @Autowired
-    protected CurrentStockRepository currentStockRepository;
-
-    @Mapping(source = "project.id", target = "projectId")
-    @Mapping(source = "project.projectName", target = "projectName")
-    @Mapping(target = "storageItemsCount", ignore = true) // computed in fillItemsCount
-    public abstract StorageLocationDto toDto(StorageLocation storageLocation);
-
-    @AfterMapping
-    protected void fillItemsCount(StorageLocation source, @MappingTarget StorageLocationDto dto) {
-        dto.setStorageItemsCount(currentStockRepository
-                .countDistinctMaterialsByStorageLocationIdAndOrganizationId(source.getId(), TenantContext.getCurrentOrgId()));
-    }
+    /**
+     * Converts a storage location, taking its item count from the supplied lookup.
+     *
+     * @param storageLocation The location to convert.
+     * @param itemCounts The counts read for the whole set of locations being mapped. A location
+     *                   absent from it reads as zero, which is what the per-row count returned.
+     * @return The storage location DTO.
+     */
+    @Mapping(source = "storageLocation.project.id", target = "projectId")
+    @Mapping(source = "storageLocation.project.projectName", target = "projectName")
+    @Mapping(target = "storageItemsCount",
+            expression = "java(itemCounts.itemCountOf(storageLocation.getId()))")
+    StorageLocationDto toDto(StorageLocation storageLocation, @Context StorageLocationItemCounts itemCounts);
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/MapperDatabaseAccessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/MapperDatabaseAccessTest.java
@@ -1,0 +1,187 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import jakarta.persistence.EntityManager;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.Mapper;
+import org.springframework.data.repository.Repository;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.tngtech.archunit.base.DescribedPredicate.describe;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet against database reads inside a MapStruct hook: a mapper converts the object it was
+ * handed and asks nobody anything.
+ *
+ * <p>A {@code @BeforeMapping} or {@code @AfterMapping} method runs once for every object mapped,
+ * and the generated mapper calls it from inside the per-row loop. A query in there therefore costs
+ * one round trip per row, multiplied again for every DTO that nests the mapped one, and the call
+ * site shows none of it: the service reads {@code page.map(mapper::toDto)}, which looks free. That
+ * is how {@code MaterialMapper} came to charge two aggregate queries per material, so a page of
+ * fifty cost a hundred extra reads and a ten-line indent cost twenty, and how
+ * {@code StorageLocationMapper} came to count its stock rows once per row across four listings.
+ *
+ * <p>{@code hibernate.default_batch_fetch_size} does not soften this. It batches lazy
+ * <em>association</em> loads; a hook calling a repository issues explicit statements the setting
+ * cannot see. So unlike an N+1 over a mapped collection, this one does not get cheaper on its own.
+ *
+ * <p>The fix is always the same shape and it already existed in the codebase before this rule did:
+ * whatever the mapper cannot reach from the object it was given, the caller reads once for the
+ * whole page and passes in. {@code MaterialMapper.toWithStockDto} took its aggregates as arguments
+ * and cost nothing; {@code toDto} fetched its own and cost everything. A MapStruct
+ * {@code @Context} parameter carries the batch through nested mappers, so depth stops multiplying
+ * query count.
+ *
+ * <p>The rule follows calls transitively rather than only looking for a repository named directly
+ * in the hook, because neither offender named one: {@code MaterialMapper} went through
+ * {@code InventoryService}. A direct-call rule would have passed the very code it exists to
+ * prevent. Reachability is computed over method calls only and only through this codebase's own
+ * classes, which keeps it precise: work a hook delegates to something that never touches the
+ * database, such as signing a storage URL, is not a database read and is not reported.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class MapperDatabaseAccessTest {
+
+    private static final String PRODUCTION_PACKAGE = "org.tornotron.echno_backend.";
+
+    /**
+     * What counts as touching the database. A Spring Data repository covers every query the
+     * codebase issues today; {@link EntityManager} is there so dropping to JPA directly is not a
+     * way around the rule.
+     */
+    private static final DescribedPredicate<JavaClass> DATABASE_ACCESS =
+            describe("a database access point",
+                    javaClass -> javaClass.isAssignableTo(Repository.class)
+                            || javaClass.isAssignableTo(EntityManager.class));
+
+    /**
+     * Guards the direct case: a mapper has no business holding a repository at all.
+     *
+     * <p>Cheaper and blunter than the reachability check below, and it fails at the field rather
+     * than at the hook, which is the line a reviewer would rather see. It is not a substitute:
+     * a mapper that injects a service instead slips straight past it.
+     */
+    @ArchTest
+    static final ArchRule noMapperHoldsARepository = noClasses()
+            .that().areAnnotatedWith(Mapper.class)
+            .should().dependOnClassesThat(assignableTo(Repository.class))
+            .because("a mapper converts what it is handed; whatever it cannot reach from that "
+                    + "object is read once for the whole page by the caller and passed in");
+
+    /**
+     * The real rule: nothing a mapping hook calls may end in a database read.
+     *
+     * <p>Written as a plain assertion rather than as an {@code ArchRule} because the useful part
+     * of the failure is the path, and a condition that reports only the offending method leaves
+     * the reader to find the query themselves.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void noMappingHookReachesTheDatabase(JavaClasses productionClasses) {
+        Map<String, List<String>> offenders = new LinkedHashMap<>();
+
+        for (JavaClass javaClass : productionClasses) {
+            for (JavaMethod method : javaClass.getMethods()) {
+                if (!isMappingHook(method)) {
+                    continue;
+                }
+                pathToDatabase(method).ifPresent(path ->
+                        offenders.put(javaClass.getSimpleName() + "." + method.getName(), path));
+            }
+        }
+
+        assertThat(offenders)
+                .as("a @BeforeMapping or @AfterMapping hook runs once per mapped row, so a query "
+                        + "reached from one costs a round trip per row and the call site shows "
+                        + "nothing; read it once for the whole page in the caller and pass it in, "
+                        + "through a MapStruct @Context where the mapper is nested")
+                .isEmpty();
+    }
+
+    private static boolean isMappingHook(JavaMethod method) {
+        return method.isAnnotatedWith(AfterMapping.class) || method.isAnnotatedWith(BeforeMapping.class);
+    }
+
+    /**
+     * Walks the method-call graph out of a hook, looking for a database read.
+     *
+     * <p>Breadth first, so the reported path is the shortest one, which is the one that reads as
+     * an explanation. Only calls landing in this codebase are followed: a framework method is a
+     * leaf, either a database read or of no interest.
+     *
+     * @param hook The mapping hook to walk out from.
+     * @return The call path from the hook to a database read, or empty where there is none.
+     */
+    private static Optional<List<String>> pathToDatabase(JavaMethod hook) {
+        Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom = new LinkedHashMap<>();
+        Set<JavaCodeUnit> seen = new HashSet<>();
+        Deque<JavaCodeUnit> queue = new ArrayDeque<>();
+
+        seen.add(hook);
+        queue.add(hook);
+
+        while (!queue.isEmpty()) {
+            JavaCodeUnit current = queue.poll();
+            for (JavaMethodCall call : current.getMethodCallsFromSelf()) {
+                if (DATABASE_ACCESS.test(call.getTargetOwner())) {
+                    return Optional.of(describePath(hook, current, arrivedFrom, call));
+                }
+                if (!isOurs(call.getTargetOwner())) {
+                    continue;
+                }
+                Optional<JavaMethod> called = call.getTarget().resolveMember();
+                if (called.isEmpty() || !seen.add(called.get())) {
+                    continue;
+                }
+                arrivedFrom.put(called.get(), current);
+                queue.add(called.get());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<String> describePath(JavaMethod hook, JavaCodeUnit lastHop,
+                                             Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom,
+                                             JavaMethodCall databaseCall) {
+        List<String> path = new ArrayList<>();
+        path.add(name(databaseCall.getTargetOwner(), databaseCall.getName()));
+        for (JavaCodeUnit step = lastHop; step != null && !step.equals(hook); step = arrivedFrom.get(step)) {
+            path.add(0, name(step.getOwner(), step.getName()));
+        }
+        path.add(0, name(hook.getOwner(), hook.getName()));
+        return path;
+    }
+
+    private static String name(JavaClass owner, String member) {
+        return owner.getSimpleName() + "." + member;
+    }
+
+    private static boolean isOurs(JavaClass javaClass) {
+        return javaClass.getName().startsWith(PRODUCTION_PACKAGE);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/indent/IndentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/indent/IndentServiceTest.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.enums.IndentStatus;
 import org.tornotron.echno_backend.indent.mapper.IndentMapper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
 import org.tornotron.echno_backend.indentItem.IndentItemRepository;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
 import org.tornotron.echno_backend.material.MaterialRepository;
@@ -53,6 +54,7 @@ class IndentServiceTest {
     @Mock private IndentItemMapper indentItemMapper;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private InventoryService inventoryService;
 
     private IndentService service;
 
@@ -62,7 +64,7 @@ class IndentServiceTest {
         TenantContext.setCurrentOrgId(ORG);
         service = new IndentService(indentRepository, indentItemRepository, materialRepository,
                 indentMapper, tenantEntityHelper, employeeRepository, projectRepository,
-                indentItemMapper, documentNumberAllocator, retryTemplate);
+                indentItemMapper, documentNumberAllocator, retryTemplate, inventoryService);
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }

--- a/src/test/java/org/tornotron/echno_backend/indentItem/IndentItemServicePaginationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/indentItem/IndentItemServicePaginationTest.java
@@ -13,6 +13,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.indent.IndentRepository;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
 import org.tornotron.echno_backend.material.MaterialRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +46,9 @@ class IndentItemServicePaginationTest {
 
     @Mock
     private IndentItemMapper indentItemMapper;
+
+    @Mock
+    private InventoryService inventoryService;
 
     @InjectMocks
     private IndentItemService service;

--- a/src/test/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockBatchReadIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockBatchReadIT.java
@@ -1,0 +1,177 @@
+package org.tornotron.echno_backend.inventoryTransaction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks the two grouped reads that replaced the per-row aggregates against a real CockroachDB.
+ *
+ * <p>The mappers used to ask for one material's stock, or one location's item count, once per row
+ * they converted. Those reads are now issued once for the whole page, which is only safe if the
+ * grouped form returns exactly what the per-row form returned, including for the row that has no
+ * stock at all and so produces no group. That equivalence is what this pins, and it needs the real
+ * database because the constructor expression and the {@code GROUP BY} are the parts a mock cannot
+ * check.
+ *
+ * <p>Runs on the same {@code @DataJpaTest} configuration as {@link InventoryValuationIT}, so it
+ * shares that Spring context rather than adding one to a cache the suite is already tight on.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(InventoryService.class)
+class CurrentStockBatchReadIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private CurrentStockRepository currentStockRepository;
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Organization org;
+    private Project project;
+    private Material cement;
+    private Material steel;
+    private Material unstocked;
+    private StorageLocation siteStore;
+    private StorageLocation warehouse;
+    private StorageLocation emptyGodown;
+
+    @BeforeEach
+    void seed() {
+        org = new Organization();
+        org.setOrganizationName("Batch Read Org");
+        org.setOrganizationAddress("addr");
+        org.setOrganizationEmail("batchread@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+
+        project = new Project();
+        project.setProjectName("Batch Read Project");
+        project.setOrganization(org);
+        entityManager.persist(project);
+
+        cement = material("Cement");
+        steel = material("Steel");
+        unstocked = material("Never stocked");
+
+        siteStore = location("Site store");
+        warehouse = location("Warehouse");
+        emptyGodown = location("Empty godown");
+
+        // Cement sits in two places, so its total only comes out right if the group sums both.
+        stock(cement, siteStore, 40.0, "400.00");
+        stock(cement, warehouse, 60.0, "600.00");
+        stock(steel, siteStore, 15.0, "1500.00");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        TenantContext.setCurrentOrgId(org.getId());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void theGroupedStockReadMatchesTheOneItReplaced() {
+        List<MaterialStockTotals> totals = currentStockRepository.sumStockByMaterialIds(
+                List.of(cement.getId(), steel.getId(), unstocked.getId()));
+
+        assertThat(totals).hasSize(2);
+        for (MaterialStockTotals row : totals) {
+            assertThat(row.currentStock())
+                    .isEqualTo(currentStockRepository.sumCurrentQuantityByMaterial(row.materialId()));
+            assertThat(row.stockValue())
+                    .isEqualByComparingTo(currentStockRepository.sumStockValueByMaterial(row.materialId()));
+        }
+        // The material with no stock row produces no group, which is the one difference from the
+        // per-material read and the reason the lookup supplies the zero.
+        assertThat(totals).noneMatch(row -> row.materialId().equals(unstocked.getId()));
+    }
+
+    @Test
+    void theLookupReportsZeroForAMaterialThatHoldsNoStock() {
+        MaterialStockLookup lookup = inventoryService.aggregateStockFor(
+                List.of(cement.getId(), steel.getId(), unstocked.getId()));
+
+        assertThat(lookup.currentStockOf(cement.getId())).isEqualTo(100.0);
+        assertThat(lookup.stockValueOf(cement.getId())).isEqualByComparingTo("1000.00");
+        assertThat(lookup.currentStockOf(steel.getId())).isEqualTo(15.0);
+
+        assertThat(lookup.currentStockOf(unstocked.getId()))
+                .isEqualTo(currentStockRepository.sumCurrentQuantityByMaterial(unstocked.getId()));
+        assertThat(lookup.stockValueOf(unstocked.getId()))
+                .isEqualByComparingTo(currentStockRepository.sumStockValueByMaterial(unstocked.getId()));
+    }
+
+    @Test
+    void theGroupedItemCountMatchesTheOneItReplaced() {
+        StorageLocationItemCounts counts = inventoryService.itemCountsAt(
+                List.of(siteStore.getId(), warehouse.getId(), emptyGodown.getId()));
+
+        assertThat(counts.itemCountOf(siteStore.getId())).isEqualTo(2L);
+        assertThat(counts.itemCountOf(warehouse.getId())).isEqualTo(1L);
+        assertThat(counts.itemCountOf(emptyGodown.getId())).isZero();
+    }
+
+    @Test
+    void anEmptySetOfIdsAsksTheDatabaseNothing() {
+        // IN () is not valid SQL, so the guard matters; it also keeps a page of nothing free.
+        assertThat(inventoryService.aggregateStockFor(List.of()).currentStockOf(1L)).isEqualTo(0.0);
+        assertThat(inventoryService.itemCountsAt(List.of()).itemCountOf(1L)).isZero();
+    }
+
+    private Material material(String name) {
+        Material material = new Material();
+        material.setMaterialName(name);
+        material.setUnit("bag");
+        material.setOrganization(org);
+        entityManager.persist(material);
+        return material;
+    }
+
+    private StorageLocation location(String name) {
+        StorageLocation location = new StorageLocation();
+        location.setLocationName(name);
+        location.setLocationType(StorageLocationType.WAREHOUSE);
+        location.setOrganization(org);
+        location.setProject(project);
+        entityManager.persist(location);
+        return location;
+    }
+
+    private void stock(Material material, StorageLocation location, double quantity, String value) {
+        CurrentStock row = new CurrentStock();
+        row.setOrganization(org);
+        row.setProject(project);
+        row.setMaterial(material);
+        row.setStorageLocation(location);
+        row.setCurrentQuantity(quantity);
+        row.setStockValue(new BigDecimal(value));
+        entityManager.persist(row);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/material/mapper/MaterialMapperCostTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/mapper/MaterialMapperCostTest.java
@@ -1,57 +1,123 @@
 package org.tornotron.echno_backend.material.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.indentItem.IndentItem;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.indentItem.IndentItemService;
+import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapperImpl;
+import org.tornotron.echno_backend.indent.IndentRepository;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockTotals;
 import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.material.MaterialService;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 /**
- * Records what {@link MaterialMapper} costs per row, in database round trips.
+ * Records what the material conversion path costs per row, in database round trips.
  *
- * <p>This is a cost record, not a statement of desired behaviour. {@code fillStock} is an
- * {@code @AfterMapping} hook that asks {@link InventoryService} for two aggregates keyed on the
- * material id, so the cost is per mapped material rather than per request, and it is invisible at
- * the call site: a service that maps a page of materials in a stream reads as free and is not.
- * Hibernate's {@code default_batch_fetch_size} does not help here, because these are explicit
- * repository calls and not lazy association loads.
+ * <p>It used to cost two aggregate reads per material. {@code fillStock} was an
+ * {@code @AfterMapping} hook that asked {@link InventoryService} for the quantity and the value on
+ * hand keyed on the material id, so the cost followed the row count rather than the request, and
+ * nothing at the call site showed it: a service mapping a page in a stream reads as free and was
+ * not. Hibernate's {@code default_batch_fetch_size} could not soften it either, because these are
+ * explicit repository calls rather than lazy association loads.
  *
- * <p>The numbers asserted below are the ones quoted in the converter audit on issue #522. When the
- * aggregates move to a single batched lookup per page, these assertions are what change, and the
- * change is then visible in the diff rather than only in a query log.
+ * <p>The stock is now read once for the whole set of materials being mapped and handed to the
+ * mapper, which is the shape {@link MaterialMapper#toWithStockDto} always had. The counts below
+ * are the same measurements the converter audit on issue #522 quoted, taken again after the
+ * change: what was two reads for one material, a hundred for a page of fifty and twenty for a
+ * ten-line indent is one read in each case.
+ *
+ * <p>Reads are counted on {@link CurrentStockRepository} rather than on the service in front of
+ * it, so the number really is the number of statements the request issues.
  */
 class MaterialMapperCostTest {
 
+    private static final long ORG_ID = 7L;
+
+    private CurrentStockRepository currentStockRepository;
     private InventoryService inventoryService;
     private MaterialMapper materialMapper;
+    private IndentItemMapper indentItemMapper;
+    private MaterialRepository materialRepository;
+    private MaterialService materialService;
+    private IndentItemRepository indentItemRepository;
+    private IndentItemService indentItemService;
 
     @BeforeEach
     void setUp() {
-        inventoryService = mock(InventoryService.class);
-        when(inventoryService.getAggregateStock(anyLong())).thenReturn(10.0);
-        when(inventoryService.getAggregateStockValue(anyLong())).thenReturn(new BigDecimal("100.00"));
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        currentStockRepository = mock(CurrentStockRepository.class);
+        when(currentStockRepository.sumStockByMaterialIds(any())).thenAnswer(invocation -> {
+            Collection<Long> ids = invocation.getArgument(0);
+            return ids.stream()
+                    .map(id -> new MaterialStockTotals(id, 10.0, new BigDecimal("100.00")))
+                    .toList();
+        });
+
+        inventoryService = new InventoryService(currentStockRepository,
+                mock(InventoryTransactionRepository.class), mock(MaterialRepository.class),
+                mock(StorageLocationRepository.class));
 
         materialMapper = new MaterialMapperImpl();
-        ReflectionTestUtils.setField(materialMapper, "inventoryService", inventoryService);
         // The generated impl delegates createdBy unconditionally, so the collaborator has to exist
         // even when the field is null.
         ReflectionTestUtils.setField(materialMapper, "employeeMapper", mock(EmployeeMapper.class));
+
+        indentItemMapper = new IndentItemMapperImpl();
+        ReflectionTestUtils.setField(indentItemMapper, "materialMapper", materialMapper);
+
+        materialRepository = mock(MaterialRepository.class);
+        materialService = new MaterialService(materialRepository, inventoryService,
+                mock(InventoryTransactionRepository.class), mock(TenantEntityHelper.class),
+                mock(EmployeeRepository.class), mock(ProjectRepository.class),
+                mock(StorageLocationRepository.class), materialMapper, mock(UserContextService.class));
+
+        indentItemRepository = mock(IndentItemRepository.class);
+        indentItemService = new IndentItemService(indentItemRepository, mock(IndentRepository.class),
+                mock(MaterialRepository.class), mock(TenantEntityHelper.class), indentItemMapper,
+                inventoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
     }
 
     private static Material material(long id) {
@@ -63,57 +129,77 @@ class MaterialMapperCostTest {
         return material;
     }
 
+    private static IndentItem line(long id) {
+        IndentItem line = new IndentItem();
+        line.setId(id);
+        line.setMaterial(material(id));
+        line.setRequestedQuantity(5);
+        return line;
+    }
+
     @Test
-    void mappingOneMaterialCostsTwoAggregateReads() {
-        MaterialDto dto = materialMapper.toDto(material(1L));
+    void readingOneMaterialCostsOneAggregateRead() {
+        when(materialRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(material(1L)));
+
+        MaterialDto dto = materialService.getMaterialById(1L);
 
         assertThat(dto.getCurrentStock()).isEqualTo(10.0);
         assertThat(dto.getStockValue()).isEqualByComparingTo("100.00");
 
-        verify(inventoryService, times(1)).getAggregateStock(1L);
-        verify(inventoryService, times(1)).getAggregateStockValue(1L);
+        // Was two: one sum for the quantity and one for the value, both issued from the mapper.
+        verify(currentStockRepository, times(1)).sumStockByMaterialIds(any());
+        verify(currentStockRepository, never()).sumCurrentQuantityByMaterial(anyLong());
+        verify(currentStockRepository, never()).sumStockValueByMaterial(anyLong());
     }
 
     @Test
-    void mappingAPageOfFiftyMaterialsCostsOneHundredAggregateReads() {
-        List<MaterialDto> dtos = new ArrayList<>();
+    void readingAPageOfFiftyMaterialsCostsOneAggregateRead() {
+        List<Material> materials = new ArrayList<>();
         for (long id = 1; id <= 50; id++) {
-            dtos.add(materialMapper.toDto(material(id)));
+            materials.add(material(id));
         }
+        when(materialRepository.findAll(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(materials));
 
-        assertThat(dtos).hasSize(50);
-        // One page query, then two aggregate reads for every row on the page.
-        verify(inventoryService, times(50)).getAggregateStock(anyLong());
-        verify(inventoryService, times(50)).getAggregateStockValue(anyLong());
+        Page<MaterialDto> page = materialService.getAllMaterials(0, 50);
+
+        assertThat(page.getContent()).hasSize(50);
+        assertThat(page.getContent()).allSatisfy(dto -> assertThat(dto.getCurrentStock()).isEqualTo(10.0));
+
+        // Was a hundred: two per row. One grouped read now covers the page, whatever its size.
+        verify(currentStockRepository, times(1)).sumStockByMaterialIds(any());
     }
 
     @Test
-    void theCostFollowsMaterialDtoIntoAnIndentLine() {
-        // IndentItemMapper delegates the material to MaterialMapper, and IndentMapper delegates the
-        // lines to IndentItemMapper, so an indent pays the per-material cost once per line item.
-        IndentItemMapper indentItemMapper = new IndentItemMapperImpl();
-        ReflectionTestUtils.setField(indentItemMapper, "materialMapper", materialMapper);
-
+    void theCostNoLongerFollowsMaterialDtoIntoAnIndentLine() {
+        // IndentItemDto carries a full MaterialDto, so while the material mapper fetched its own
+        // stock a ten-line indent paid the per-material cost once per line.
+        List<IndentItem> lines = new ArrayList<>();
         for (long id = 1; id <= 10; id++) {
-            IndentItem line = new IndentItem();
-            line.setId(id);
-            line.setMaterial(material(id));
-            line.setRequestedQuantity(5);
-            indentItemMapper.toDto(line);
+            lines.add(line(id));
         }
+        when(indentItemRepository.findByIndentId(anyLong())).thenReturn(lines);
 
-        // Ten lines on one indent, before the page multiplies it by the number of indents.
-        verify(inventoryService, times(10)).getAggregateStock(anyLong());
-        verify(inventoryService, times(10)).getAggregateStockValue(anyLong());
+        List<IndentItemDto> dtos = indentItemService.getIndentItemsByIndentId(99L);
+
+        assertThat(dtos).hasSize(10);
+        assertThat(dtos).allSatisfy(dto -> assertThat(dto.getMaterial().getCurrentStock()).isEqualTo(10.0));
+
+        // Was twenty, before the page multiplied it by the number of indents.
+        verify(currentStockRepository, times(1)).sumStockByMaterialIds(any());
     }
 
     @Test
-    void theWithStockVariantTakesTheAggregatesFromTheCaller() {
-        // The batched shape already exists on this mapper and is used by three call sites in
-        // MaterialService. It costs nothing per row, which is the target for toDto as well.
-        materialMapper.toWithStockDto(material(1L), 42.0, new BigDecimal("500.00"));
+    void theMapperItselfReadsNothing() {
+        // The point of the change: the conversion is a conversion again. Handed a lookup, it asks
+        // nobody anything, so nesting it inside another DTO cannot multiply a query count.
+        MaterialDto dto = materialMapper.toDto(material(1L), MaterialStockLookup.none());
+        indentItemMapper.toDto(line(2L), MaterialStockLookup.none());
+        materialMapper.toWithStockDto(material(3L), 42.0, new BigDecimal("500.00"));
 
-        verify(inventoryService, times(0)).getAggregateStock(anyLong());
-        verify(inventoryService, times(0)).getAggregateStockValue(anyLong());
+        assertThat(dto.getCurrentStock()).isEqualTo(0.0);
+        assertThat(dto.getStockValue()).isEqualByComparingTo("0");
+        verifyNoInteractions(currentStockRepository);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/material/mapper/MaterialMapperCostTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/mapper/MaterialMapperCostTest.java
@@ -1,0 +1,119 @@
+package org.tornotron.echno_backend.material.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.indentItem.IndentItem;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapperImpl;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.dto.MaterialDto;
+
+/**
+ * Records what {@link MaterialMapper} costs per row, in database round trips.
+ *
+ * <p>This is a cost record, not a statement of desired behaviour. {@code fillStock} is an
+ * {@code @AfterMapping} hook that asks {@link InventoryService} for two aggregates keyed on the
+ * material id, so the cost is per mapped material rather than per request, and it is invisible at
+ * the call site: a service that maps a page of materials in a stream reads as free and is not.
+ * Hibernate's {@code default_batch_fetch_size} does not help here, because these are explicit
+ * repository calls and not lazy association loads.
+ *
+ * <p>The numbers asserted below are the ones quoted in the converter audit on issue #522. When the
+ * aggregates move to a single batched lookup per page, these assertions are what change, and the
+ * change is then visible in the diff rather than only in a query log.
+ */
+class MaterialMapperCostTest {
+
+    private InventoryService inventoryService;
+    private MaterialMapper materialMapper;
+
+    @BeforeEach
+    void setUp() {
+        inventoryService = mock(InventoryService.class);
+        when(inventoryService.getAggregateStock(anyLong())).thenReturn(10.0);
+        when(inventoryService.getAggregateStockValue(anyLong())).thenReturn(new BigDecimal("100.00"));
+
+        materialMapper = new MaterialMapperImpl();
+        ReflectionTestUtils.setField(materialMapper, "inventoryService", inventoryService);
+        // The generated impl delegates createdBy unconditionally, so the collaborator has to exist
+        // even when the field is null.
+        ReflectionTestUtils.setField(materialMapper, "employeeMapper", mock(EmployeeMapper.class));
+    }
+
+    private static Material material(long id) {
+        Material material = new Material();
+        material.setId(id);
+        material.setSku("SKU-" + id);
+        material.setMaterialName("Material " + id);
+        material.setUnit("bags");
+        return material;
+    }
+
+    @Test
+    void mappingOneMaterialCostsTwoAggregateReads() {
+        MaterialDto dto = materialMapper.toDto(material(1L));
+
+        assertThat(dto.getCurrentStock()).isEqualTo(10.0);
+        assertThat(dto.getStockValue()).isEqualByComparingTo("100.00");
+
+        verify(inventoryService, times(1)).getAggregateStock(1L);
+        verify(inventoryService, times(1)).getAggregateStockValue(1L);
+    }
+
+    @Test
+    void mappingAPageOfFiftyMaterialsCostsOneHundredAggregateReads() {
+        List<MaterialDto> dtos = new ArrayList<>();
+        for (long id = 1; id <= 50; id++) {
+            dtos.add(materialMapper.toDto(material(id)));
+        }
+
+        assertThat(dtos).hasSize(50);
+        // One page query, then two aggregate reads for every row on the page.
+        verify(inventoryService, times(50)).getAggregateStock(anyLong());
+        verify(inventoryService, times(50)).getAggregateStockValue(anyLong());
+    }
+
+    @Test
+    void theCostFollowsMaterialDtoIntoAnIndentLine() {
+        // IndentItemMapper delegates the material to MaterialMapper, and IndentMapper delegates the
+        // lines to IndentItemMapper, so an indent pays the per-material cost once per line item.
+        IndentItemMapper indentItemMapper = new IndentItemMapperImpl();
+        ReflectionTestUtils.setField(indentItemMapper, "materialMapper", materialMapper);
+
+        for (long id = 1; id <= 10; id++) {
+            IndentItem line = new IndentItem();
+            line.setId(id);
+            line.setMaterial(material(id));
+            line.setRequestedQuantity(5);
+            indentItemMapper.toDto(line);
+        }
+
+        // Ten lines on one indent, before the page multiplies it by the number of indents.
+        verify(inventoryService, times(10)).getAggregateStock(anyLong());
+        verify(inventoryService, times(10)).getAggregateStockValue(anyLong());
+    }
+
+    @Test
+    void theWithStockVariantTakesTheAggregatesFromTheCaller() {
+        // The batched shape already exists on this mapper and is used by three call sites in
+        // MaterialService. It costs nothing per row, which is the target for toDto as well.
+        materialMapper.toWithStockDto(material(1L), 42.0, new BigDecimal("500.00"));
+
+        verify(inventoryService, times(0)).getAggregateStock(anyLong());
+        verify(inventoryService, times(0)).getAggregateStockValue(anyLong());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/mapper/StorageLocationMapperCostTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/mapper/StorageLocationMapperCostTest.java
@@ -1,0 +1,127 @@
+package org.tornotron.echno_backend.storageLocation.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.inventoryTransaction.StorageLocationItemCount;
+import org.tornotron.echno_backend.inventoryTransaction.StorageLocationItemCounts;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationService;
+import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
+
+/**
+ * Records what the storage-location conversion path costs per row.
+ *
+ * <p>It used to cost one {@code COUNT DISTINCT} per location, issued from an
+ * {@code @AfterMapping} hook that held the stock repository, on each of the four listing paths
+ * through {@code StorageLocationService}. The count is now read for the whole page in one grouped
+ * query and passed to the mapper.
+ *
+ * <p>Reads are counted on {@link CurrentStockRepository} so the number is the number of statements
+ * the request issues.
+ */
+class StorageLocationMapperCostTest {
+
+    private static final long ORG_ID = 7L;
+
+    private CurrentStockRepository currentStockRepository;
+    private StorageLocationMapper storageLocationMapper;
+    private StorageLocationRepository storageLocationRepository;
+    private StorageLocationService storageLocationService;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        currentStockRepository = mock(CurrentStockRepository.class);
+        when(currentStockRepository.countDistinctMaterialsByStorageLocationIds(any(), anyLong()))
+                .thenAnswer(invocation -> {
+                    Collection<Long> ids = invocation.getArgument(0);
+                    return ids.stream().map(id -> new StorageLocationItemCount(id, 3L)).toList();
+                });
+
+        InventoryService inventoryService = new InventoryService(currentStockRepository,
+                mock(InventoryTransactionRepository.class), mock(MaterialRepository.class),
+                mock(StorageLocationRepository.class));
+
+        storageLocationMapper = new StorageLocationMapperImpl();
+        storageLocationRepository = mock(StorageLocationRepository.class);
+        storageLocationService = new StorageLocationService(storageLocationRepository,
+                mock(ProjectRepository.class), mock(TenantEntityHelper.class), storageLocationMapper,
+                inventoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private static StorageLocation location(long id) {
+        StorageLocation location = new StorageLocation();
+        location.setId(id);
+        location.setLocationName("Store " + id);
+        return location;
+    }
+
+    @Test
+    void readingAPageOfFiftyLocationsCostsOneCount() {
+        List<StorageLocation> locations = new ArrayList<>();
+        for (long id = 1; id <= 50; id++) {
+            locations.add(location(id));
+        }
+        when(storageLocationRepository.findAll(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(locations));
+
+        Page<StorageLocationDto> page = storageLocationService.getAllStorageLocations(0, 50);
+
+        assertThat(page.getContent()).hasSize(50);
+        assertThat(page.getContent()).allSatisfy(dto -> assertThat(dto.getStorageItemsCount()).isEqualTo(3L));
+
+        // Was fifty, one per row.
+        verify(currentStockRepository, times(1)).countDistinctMaterialsByStorageLocationIds(any(), anyLong());
+    }
+
+    @Test
+    void listingByProjectCostsOneCount() {
+        when(storageLocationRepository.findByProjectId(anyLong()))
+                .thenReturn(List.of(location(1L), location(2L), location(3L)));
+
+        List<StorageLocationDto> dtos = storageLocationService.getStorageLocationsByProject(12L);
+
+        assertThat(dtos).hasSize(3);
+        // Was three.
+        verify(currentStockRepository, times(1)).countDistinctMaterialsByStorageLocationIds(any(), anyLong());
+    }
+
+    @Test
+    void theMapperItselfReadsNothing() {
+        StorageLocationDto dto = storageLocationMapper.toDto(location(1L), StorageLocationItemCounts.none());
+
+        assertThat(dto.getStorageItemsCount()).isZero();
+        verifyNoInteractions(currentStockRepository);
+    }
+}


### PR DESCRIPTION
Item A of #522, and only item A.

The audit on that issue concluded the converter component does not need reworking: the hand-rolled-or-mapper question was settled by the MapStruct migration, there is no per-request reflection anywhere on the conversion path, and finance and inspection, which the issue names as the place to start, are the two cleanest modules in the repo. What is real is three mappers doing per-row database I/O inside an `@AfterMapping` hook, which is invisible at the call site because the mapper looks like a pure conversion. That is what this changes.

## What it cost

`MaterialMapper.fillStock` asked `InventoryService` for two aggregates keyed on the material id. The generated mapper calls the hook once per mapped material, so the cost followed the row count and not the request, and a service mapping a page in a stream read as free:

```java
return materialRepository.findAll(pageable)
        .map(material -> materialMapper.toDto(material));
```

`IndentItemDto` carries a full `MaterialDto` and `IndentItemMapper` declares `uses = MaterialMapper.class`, so an indent paid the same cost once per line, and a page of indents multiplied that by the page size. `StorageLocationMapper` did the same thing with a `COUNT DISTINCT`, once per location, on four listing paths.

`hibernate.default_batch_fetch_size` does not soften any of it. It batches lazy association loads; these were explicit repository calls it cannot see. #537 capped `GET /materials` at 500 rows, which bounds the row count but not the per-row cost.

## What it costs now

Counted at `CurrentStockRepository`, so the number is statements issued, not service calls:

| Path | Before | After |
|---|---|---|
| one material | 2 | 1 |
| page of 50 materials | 100 | 1 |
| ten-line indent | 20 | 1 |
| page of 50 storage locations | 50 | 1 |

Two grouped reads replace the per-row ones: one totalling quantity and value per material, one counting distinct materials per location. The result is handed to the mapper as a MapStruct `@Context`, which is the shape `MaterialMapper.toWithStockDto` always had and which three call sites in `MaterialService` already used. Because it is a context, `IndentItemMapper` and `IndentMapper` pass the same instance down rather than each fetching their own, so DTO depth stops multiplying query count.

A material or a location that holds nothing produces no group. The lookup supplies the zero the per-row `COALESCE(SUM(...), 0)` used to return, so that case is unchanged too.

`countDistinctMaterialsByStorageLocationIdAndOrganizationId` had no caller left and is gone with it. That overlaps #550 by one method; happy to drop it from here if it is easier to take there.

## No response changed shape

This touches DTO-producing code that a lot of endpoints run through, and `echno-core` maintains its contract by hand with no codegen, so a shape change would not fail to compile anywhere. I checked it rather than reasoning about it: compiling `origin/development` and this branch and diffing all 52 generated mapper implementations, the entire difference is the threaded parameter and where three values come from.

```
-        fillStock( material, materialDto );
+        materialDto.setCurrentStock( stock.currentStockOf(material.getId()) );
+        materialDto.setStockValue( stock.stockValueOf(material.getId()) );

-        fillItemsCount( storageLocation, storageLocationDto );
+        storageLocationDto.setStorageItemsCount( itemCounts.itemCountOf(storageLocation.getId()) );
```

Every other line is the parameter being passed along. No field was added, removed, renamed or retyped, and every field is still set from the same source in the same order. `CurrentStockBatchReadIT` then checks against a real CockroachDB that the grouped reads agree with the per-row reads they replaced, for the stocked case and the unstocked one.

## The guardrail

Neither mapper had anything in the repo saying it should not do this, which is why the pattern survived both the MapStruct migration and the unbounded-read sweep. `MapperDatabaseAccessTest` makes it a build failure, sharing the existing `@AnalyzeClasses` import with the other architecture tests so no second class graph sits in the capped test heap.

Two checks. The first is cheap and blunt: a `@Mapper` class may not depend on a Spring Data repository at all, which fails at the field rather than at the hook. The second walks the method-call graph out of every `@BeforeMapping` and `@AfterMapping` and fails where a database access is reachable, reporting the shortest path. Transitive rather than direct, because neither offender named a repository in the hook: `MaterialMapper` went through `InventoryService`, so a direct-call rule would have passed the code it exists to prevent. Reachability follows method calls only and only through this codebase's classes, which keeps it precise; `AttachmentMapper` signs a storage URL from its hook and is correctly not reported, because signing is not a database read.

Run against the code as it stood before the fix, both fail:

```
Field <StorageLocationMapper.currentStockRepository> has type <CurrentStockRepository>

Expecting empty but was:
  MaterialMapper.fillStock
      -> InventoryService.getAggregateStock
      -> CurrentStockRepository.sumCurrentQuantityByMaterial
  StorageLocationMapper.fillItemsCount
      -> CurrentStockRepository.countDistinctMaterialsByStorageLocationIdAndOrganizationId
```

## Draft #538

Folded in and superseded. Its commit is the first of the three here, so the measurement lands as it was written and the next commit flips the assertions, which is what that PR said should happen when item A landed. #538 can be closed unmerged.

## Still open on #522

Items B, C and D are not in here and the issue stays open for them: list projections for `OrganizationDto`, `ProjectDto` and `IndentDto`; the seven remaining hand-written mappers; and the 28 hand-parsed request bodies, which is the one that pays off soonest because it is the half the published spec cannot describe today.

`AttachmentMapper` is also untouched. It presigns once per attachment and is a `uses` dependency of six mappers, so it fans out further than anything here, but it costs CPU rather than queries and moving it means changing six mappers and their whole call chain. It is not item A and it is not what the guardrail bans.

## Verification

Full suite on lab `.116`: 1138 tests, 0 failures, including the Testcontainers integration tests against CockroachDB v26.2.4.
