### PR TITLE
Make the compliance AI timeouts configuration like everything around them

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/ComplianceAiProperties.java
@@ -76,4 +76,28 @@ public class ComplianceAiProperties {
 
     /** Proxy port used only when {@code proxyHost} is set. */
     private int proxyPort = 3128;
+
+    /**
+     * How long to wait for the TCP connection to the inference endpoint, in seconds.
+     *
+     * <p>Ten seconds is generous for a connect: either the endpoint answers the handshake
+     * quickly or something is wrong with the route. It is configuration rather than a
+     * constant because the route is not always direct. Where egress goes through a forward
+     * proxy the connect is to the proxy, and a loaded proxy can be slower to accept than the
+     * endpoint behind it.
+     */
+    private int connectTimeoutSeconds = 10;
+
+    /**
+     * How long to wait for the endpoint's response after the request is sent, in seconds.
+     *
+     * <p>Sixty is sized against {@code batchSize}, not against the catalogue: a run costs
+     * about 1.7 seconds a rule, so the default ten-rule batch takes roughly 20 seconds and
+     * sits at a third of this. That margin is the whole reason this value can stay still
+     * while the catalogue grows, and it is also why the two numbers have to move together.
+     * Raising {@code batchSize} to twenty puts a batch at about 34 seconds, over half the
+     * budget; past thirty rules a batch no longer fits at all. A slower endpoint moves the
+     * same line without anyone touching the batch size.
+     */
+    private int readTimeoutSeconds = 60;
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceService.java
@@ -331,8 +331,8 @@ public class OpenAiCompatibleComplianceService {
 
     private SimpleClientHttpRequestFactory requestFactory() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(10));
-        factory.setReadTimeout(Duration.ofSeconds(60));
+        factory.setConnectTimeout(Duration.ofSeconds(props.getConnectTimeoutSeconds()));
+        factory.setReadTimeout(Duration.ofSeconds(props.getReadTimeoutSeconds()));
         String proxyHost = props.getProxyHost();
         if (proxyHost != null && !proxyHost.isBlank()) {
             int proxyPort = props.getProxyPort();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,13 @@ compliance:
     # Set both when the backend has no direct internet, e.g. the IITM lab host proxy.
     proxy-host: ${COMPLIANCE_AI_PROXY_HOST:}
     proxy-port: ${COMPLIANCE_AI_PROXY_PORT:3128}
+    # HTTP timeouts for the inference call. read-timeout-seconds is sized against
+    # batch-size, not the catalogue: at ~1.7 s per rule a ten-rule batch takes ~20 s, a
+    # third of the 60 s budget. Raise batch-size and this has to move with it (twenty
+    # rules is ~34 s, past thirty a batch no longer fits). A slower endpoint or a loaded
+    # forward proxy moves the same line without the batch size changing.
+    connect-timeout-seconds: ${COMPLIANCE_AI_CONNECT_TIMEOUT_SECONDS:10}
+    read-timeout-seconds: ${COMPLIANCE_AI_READ_TIMEOUT_SECONDS:60}
   # The generation queue. Every replica polls and claims with a conditional update, so
   # there is no leader. enabled: false still accepts jobs but runs none, which is what a
   # replica that should serve requests and do no background work wants.

--- a/src/test/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ai/OpenAiCompatibleComplianceServiceTest.java
@@ -1,20 +1,27 @@
 package org.tornotron.echno_backend.compliance.ai;
 
 import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.common.exception.ComplianceAiException;
 import org.tornotron.echno_backend.compliance.CompliancePhase;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.enums.ProjectType;
 
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The compliance AI must be safe to run without a configured endpoint: when disabled
- * or missing an API key it returns no suggestions rather than attempting a call. These
- * are pure unit tests; they never touch the network.
+ * or missing an API key it returns no suggestions rather than attempting a call.
+ *
+ * <p>No test here reaches an external endpoint. The timeout test is the only one that opens
+ * a socket at all, and it is a loopback listener the test owns and closes.
  */
 class OpenAiCompatibleComplianceServiceTest {
 
@@ -69,6 +76,59 @@ class OpenAiCompatibleComplianceServiceTest {
 
         assertThat(props.getProxyHost()).isEmpty();
         assertThat(props.getProxyPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void timeoutsDefaultToThePreviouslyHardcodedValues() {
+        ComplianceAiProperties props = new ComplianceAiProperties();
+
+        assertThat(props.getConnectTimeoutSeconds()).isEqualTo(10);
+        assertThat(props.getReadTimeoutSeconds()).isEqualTo(60);
+    }
+
+    /**
+     * The read timeout has to come from config, not from a constant. This is asserted
+     * behaviourally rather than by reading the field back, because what matters is that the
+     * value reaches the request factory: a property nothing consumes would satisfy a getter
+     * test and change nothing about the call.
+     *
+     * <p>The server here accepts the connection and then never writes a byte, which is the
+     * shape of a hung endpoint. With the timeout configured to one second the call fails in
+     * about one second; against a hardcoded sixty it sits there for a minute, so the elapsed
+     * bound is what separates the two.
+     */
+    @Test
+    void readTimeoutComesFromConfiguration() throws Exception {
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Thread accepter = new Thread(() -> {
+                try {
+                    // Hold the accepted socket open and silent until the test closes the server.
+                    Socket accepted = server.accept();
+                    Thread.sleep(120_000);
+                    accepted.close();
+                } catch (Exception ignored) {
+                    // Closing the server socket at the end of the test lands here.
+                }
+            });
+            accepter.setDaemon(true);
+            accepter.start();
+
+            ComplianceAiProperties props = new ComplianceAiProperties();
+            props.setEnabled(true);
+            props.setApiKey("sk-test");
+            props.setBaseUrl("http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/v1");
+            props.setReadTimeoutSeconds(1);
+            OpenAiCompatibleComplianceService service = new OpenAiCompatibleComplianceService(props);
+
+            long startedAt = System.nanoTime();
+            assertThatThrownBy(() -> service.callModel(sampleProject(), "Tamil Nadu", sampleRules()))
+                    .isInstanceOf(ComplianceAiException.class);
+            long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000;
+
+            assertThat(elapsedMillis)
+                    .as("read timeout of 1s must be honoured, not the 60s default")
+                    .isLessThan(15_000);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #552.

## What changed

`requestFactory()` had the connect and read timeouts as literals while every other knob in the same method came from `ComplianceAiProperties`, `props.getProxyHost()` and `props.getProxyPort()` two lines below them. Both are now properties with the values they already had, exposed as `COMPLIANCE_AI_CONNECT_TIMEOUT_SECONDS` and `COMPLIANCE_AI_READ_TIMEOUT_SECONDS`. Behaviour is unchanged unless someone sets them.

## Why the read timeout is the one worth moving

It is sized against `batch-size`, not against the catalogue. At roughly 1.7 seconds a rule the default ten-rule batch takes about 20 seconds and sits at a third of the 60-second budget, which is exactly why the value can stay still while the catalogue grows. The two numbers have to move together, though: twenty rules in a batch is about 34 seconds, over half the budget, and past thirty a batch no longer fits at all. A slower endpoint moves the same line without anyone touching the batch size, and we already switch between DO Gradient and the lab-proxied route. Neither case should need a rebuild.

The connect timeout is less interesting but has the same shape: where egress goes through a forward proxy the connect is to the proxy, and a loaded proxy can be slower to accept than the endpoint behind it.

## Test

`readTimeoutComesFromConfiguration` is behavioural rather than a getter assertion, deliberately. A property nothing consumes would satisfy a getter test and change nothing about the call, so the test has to observe the value reaching the request factory. It points the client at a loopback listener that accepts the connection and then never writes a byte, sets the read timeout to one second, and bounds the elapsed time.

| Test | Without the fix | With the fix |
|---|---|---|
| `readTimeoutComesFromConfiguration` | FAILED, 78 s build (the call sat on the hardcoded 60 s, elapsed bound of 15 s missed) | PASSED, ~1 s |
| `timeoutsDefaultToThePreviouslyHardcodedValues` | n/a (property did not exist) | PASSED |

Verified on `lab-node-116-f` by reverting only the `setReadTimeout` line in the service and re-running.

No changelog in this PR.
