### PR TITLE
Take the regularization approver from the session, not the query string

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
@@ -41,7 +41,9 @@ public class AttendanceRegularizationController {
     @Operation(
             summary = "Submit a regularization request",
             description = "Files a request to correct an attendance record, naming the missing clock "
-                    + "events and, optionally, the events that should be added in their place."
+                    + "events and, optionally, the events that should be added in their place. The "
+                    + "authenticated caller is recorded as the requester, and cannot then approve the "
+                    + "request themselves unless they hold the system-admin role."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
@@ -50,11 +52,9 @@ public class AttendanceRegularizationController {
             @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
     })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
-            @Valid @RequestBody RegularizationRequestDto dto,
-            @RequestParam String requestedBy,
-            @RequestParam(required = false) Long requestedById) {
+            @Valid @RequestBody RegularizationRequestDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(regularizationService.submitRequest(dto, requestedBy, requestedById));
+                .body(regularizationService.submitRequest(dto));
     }
 
     @PostMapping("/{id}/process")
@@ -62,20 +62,23 @@ public class AttendanceRegularizationController {
     @Operation(
             summary = "Approve or reject a regularization request",
             description = "Sets the status of a pending regularization request. A rejection should carry "
-                    + "a rejectionReason."
+                    + "a rejectionReason. The authenticated caller is recorded as the approver. Whoever "
+                    + "raised the request cannot approve it: an approval is the second pair of eyes on a "
+                    + "change to an attendance record, so it has to come from someone else. A system "
+                    + "administrator is the one exception, and their self-approval is recorded as one on "
+                    + "the corrected clock events. Rejecting your own request is allowed, since it writes "
+                    + "nothing to the attendance record."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Regularization request processed"),
-            @ApiResponse(responseCode = "400", description = "status is missing or invalid"),
+            @ApiResponse(responseCode = "400", description = "status is missing or invalid, the request has already been actioned, or it is being approved by whoever raised it without the system-admin role"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
             @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
     })
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
-            @Valid @RequestBody RegularizationActionDto dto,
-            @RequestParam String approvedBy,
-            @RequestParam(required = false) Long approvedById) {
-        return ResponseEntity.ok(regularizationService.processRegularization(id, dto, approvedBy, approvedById));
+            @Valid @RequestBody RegularizationActionDto dto) {
+        return ResponseEntity.ok(regularizationService.processRegularization(id, dto));
     }
 
     @GetMapping("/pending")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
@@ -41,7 +41,9 @@ public class AttendanceRegularizationControllerWeb {
     @Operation(
             summary = "Submit a regularization request",
             description = "Files a request to correct an attendance record, naming the missing clock "
-                    + "events and, optionally, the events that should be added in their place."
+                    + "events and, optionally, the events that should be added in their place. The "
+                    + "authenticated caller is recorded as the requester, and cannot then approve the "
+                    + "request themselves unless they hold the system-admin role."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
@@ -50,11 +52,9 @@ public class AttendanceRegularizationControllerWeb {
             @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
     })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(
-            @Valid @RequestBody RegularizationRequestDto dto,
-            @RequestParam String requestedBy,
-            @RequestParam(required = false) Long requestedById) {
+            @Valid @RequestBody RegularizationRequestDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(regularizationService.submitRequest(dto, requestedBy, requestedById));
+                .body(regularizationService.submitRequest(dto));
     }
 
     @PostMapping("/{id}/process")
@@ -62,20 +62,23 @@ public class AttendanceRegularizationControllerWeb {
     @Operation(
             summary = "Approve or reject a regularization request",
             description = "Sets the status of a pending regularization request. A rejection should carry "
-                    + "a rejectionReason."
+                    + "a rejectionReason. The authenticated caller is recorded as the approver. Whoever "
+                    + "raised the request cannot approve it: an approval is the second pair of eyes on a "
+                    + "change to an attendance record, so it has to come from someone else. A system "
+                    + "administrator is the one exception, and their self-approval is recorded as one on "
+                    + "the corrected clock events. Rejecting your own request is allowed, since it writes "
+                    + "nothing to the attendance record."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Regularization request processed"),
-            @ApiResponse(responseCode = "400", description = "status is missing or invalid"),
+            @ApiResponse(responseCode = "400", description = "status is missing or invalid, the request has already been actioned, or it is being approved by whoever raised it without the system-admin role"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
             @ApiResponse(responseCode = "404", description = "No regularization request with the given id")
     })
     public ResponseEntity<AttendanceRegularizationDto> process(
             @PathVariable Long id,
-            @Valid @RequestBody RegularizationActionDto dto,
-            @RequestParam String approvedBy,
-            @RequestParam(required = false) Long approvedById) {
-        return ResponseEntity.ok(regularizationService.processRegularization(id, dto, approvedBy, approvedById));
+            @Valid @RequestBody RegularizationActionDto dto) {
+        return ResponseEntity.ok(regularizationService.processRegularization(id, dto));
     }
 
     @GetMapping("/pending")

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -8,10 +8,14 @@ import org.tornotron.echno_backend.attendance.dto.*;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,38 +24,80 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Raising and deciding regularization requests.
+ *
+ * <p>Both the person who raises a request and the person who decides it are read from the
+ * authenticated session, never from the request. They used to arrive as query parameters, which
+ * meant a caller chose the name and id recorded against a corrected attendance record and the
+ * accountability on the correction was whatever they typed.
+ *
+ * <p>Because the two are now trustworthy they can be compared, so an approval goes through
+ * {@link SelfApprovalPolicy}: whoever raised a request is not the person who approves it, with the
+ * one recorded break-glass exception that policy defines.
+ */
 @Service
 public class AttendanceRegularizationService {
+
+    /** Recorded when the caller cannot be resolved to any identity at all. */
+    private static final String SYSTEM_ACTOR = "system";
+
+    /** Note carried by the corrected clock events of a request approved under the break-glass role. */
+    private static final String SELF_APPROVAL_NOTE =
+            " (self-approved: raised and approved by the same person)";
 
     private final AttendanceRegularizationRepository regularizationRepository;
     private final AttendanceRepository attendanceRepository;
     private final OrganizationRepository organizationRepository;
+    private final EmployeeRepository employeeRepository;
     private final AttendanceSettingsService settingsService;
     private final AttendanceCalculationService calculationService;
     private final AttendanceRegularizationMapper regularizationMapper;
+    private final UserContextService userContextService;
+    private final SelfApprovalPolicy selfApprovalPolicy;
 
     public AttendanceRegularizationService(AttendanceRegularizationRepository regularizationRepository,
                                             AttendanceRepository attendanceRepository,
                                             OrganizationRepository organizationRepository,
+                                            EmployeeRepository employeeRepository,
                                             AttendanceSettingsService settingsService,
                                             AttendanceCalculationService calculationService,
-                                            AttendanceRegularizationMapper regularizationMapper) {
+                                            AttendanceRegularizationMapper regularizationMapper,
+                                            UserContextService userContextService,
+                                            SelfApprovalPolicy selfApprovalPolicy) {
         this.regularizationRepository = regularizationRepository;
         this.attendanceRepository = attendanceRepository;
         this.organizationRepository = organizationRepository;
+        this.employeeRepository = employeeRepository;
         this.settingsService = settingsService;
         this.calculationService = calculationService;
         this.regularizationMapper = regularizationMapper;
+        this.userContextService = userContextService;
+        this.selfApprovalPolicy = selfApprovalPolicy;
     }
 
-    @Transactional
-    public AttendanceRegularizationDto submitRequest(RegularizationRequestDto dto, String requestedBy) {
-        return submitRequest(dto, requestedBy, null);
+    /** Who the authenticated caller is, as recorded on a request: a display name and, when the
+     *  caller has an employee record in this tenant, that employee's id. */
+    private record Actor(String name, Long employeeId) {
     }
 
+    /**
+     * Files a regularization request against an attendance record.
+     *
+     * <p>The requester is taken from the session. It is what the approval is later checked
+     * against, so a caller naming someone else as the requester would clear their own way to
+     * approve it, and it is also what the monthly cap is counted by.
+     *
+     * @param dto The attendance record, the reason, the missing events and any corrections.
+     * @return The stored request as a DTO.
+     * @throws ResourceNotFoundException if the organization or the attendance record is not found.
+     * @throws ValidationException if self-service regularization is off for the project, the
+     *         monthly cap is reached, or a request is already pending for that record.
+     */
     @Transactional
-    public AttendanceRegularizationDto submitRequest(RegularizationRequestDto dto, String requestedBy,
-                                                     Long requestedById) {
+    public AttendanceRegularizationDto submitRequest(RegularizationRequestDto dto) {
+        Actor requester = resolveCurrentActor();
+        String requestedBy = requester.name();
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -95,7 +141,7 @@ public class AttendanceRegularizationService {
                 .attendance(attendance)
                 .reason(dto.getReason())
                 .requestedBy(requestedBy)
-                .requestedById(requestedById)
+                .requestedById(requester.employeeId())
                 .status(settings.getRegularizationApprovalRequired()
                         ? RegularizationStatus.PENDING : RegularizationStatus.APPROVED)
                 .missingEvents(regularizationMapper.serializeMissingEvents(dto.getMissingEvents()))
@@ -106,8 +152,11 @@ public class AttendanceRegularizationService {
                 .build();
 
         // Auto-approving projects take effect immediately, so the corrections are written now.
+        // This path is deliberately outside the self-approval rule: a project configured not to
+        // require an approval is the tenant's own standing decision that these corrections do not
+        // need a second person, which is exactly the case the setting exists for.
         if (!settings.getRegularizationApprovalRequired()) {
-            applyCorrectedEvents(attendance, dto.getCorrectedEvents(), org);
+            applyCorrectedEvents(attendance, dto.getCorrectedEvents(), org, false);
             if (attendance.getShiftTiming() != null) {
                 calculationService.recalculate(attendance, attendance.getShiftTiming());
             }
@@ -117,18 +166,33 @@ public class AttendanceRegularizationService {
         return regularizationMapper.toDto(regularizationRepository.save(regularization));
     }
 
+    /**
+     * Approves or rejects a pending regularization request.
+     *
+     * <p>The approver is taken from the session, so the record says who actually decided it. An
+     * approval then goes through {@link SelfApprovalPolicy}: an approval is the second pair of eyes
+     * on a change to an attendance record, so it has to come from someone other than whoever raised
+     * the request, unless the approver holds the break-glass role, in which case the corrected clock
+     * events carry a note saying the correction was self-approved.
+     *
+     * <p>A rejection is left outside the rule on purpose. It writes nothing to the attendance
+     * record, and refusing a self-rejection would leave an employee unable to withdraw a request
+     * they raised by mistake.
+     *
+     * <p>Requests stored before the requester was stamped from the session name nobody, so there is
+     * nothing to compare them against and they are let through.
+     *
+     * @param regularizationId The request to decide.
+     * @param dto The decision and, on a rejection, the reason.
+     * @return The decided request as a DTO.
+     * @throws ResourceNotFoundException if no such request exists in this organization.
+     * @throws ValidationException if the request is no longer pending.
+     * @throws org.tornotron.echno_backend.common.exception.InvalidRequestException if the approver
+     *         raised the request and does not hold the break-glass role.
+     */
     @Transactional
     public AttendanceRegularizationDto processRegularization(Long regularizationId,
-                                                              RegularizationActionDto dto,
-                                                              String approvedBy) {
-        return processRegularization(regularizationId, dto, approvedBy, null);
-    }
-
-    @Transactional
-    public AttendanceRegularizationDto processRegularization(Long regularizationId,
-                                                              RegularizationActionDto dto,
-                                                              String approvedBy,
-                                                              Long approvedById) {
+                                                              RegularizationActionDto dto) {
         AttendanceRegularization regularization = regularizationRepository.findByIdAndOrganization_Id(regularizationId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Regularization request with ID " + regularizationId + " was not found"));
@@ -140,9 +204,16 @@ public class AttendanceRegularizationService {
                             + " and can no longer be actioned");
         }
 
+        Actor approver = resolveCurrentActor();
+        boolean selfApproved = dto.getStatus() == RegularizationStatus.APPROVED
+                && selfApprovalPolicy.checkSelfApproval(
+                        regularization.getRequestedById(),
+                        approver.employeeId(),
+                        "Regularization request with ID " + regularizationId);
+
         regularization.setStatus(dto.getStatus());
-        regularization.setApprovedBy(approvedBy);
-        regularization.setApprovedById(approvedById);
+        regularization.setApprovedBy(approver.name());
+        regularization.setApprovedById(approver.employeeId());
         regularization.setApprovedAt(LocalDateTime.now());
         regularization.setRejectionReason(dto.getRejectionReason());
 
@@ -154,7 +225,8 @@ public class AttendanceRegularizationService {
             applyCorrectedEvents(
                     attendance,
                     regularizationMapper.deserializeRequestedEvents(regularization.getRequestedEvents()),
-                    regularization.getOrganization());
+                    regularization.getOrganization(),
+                    selfApproved);
             if (attendance.getShiftTiming() != null) {
                 calculationService.recalculate(attendance, attendance.getShiftTiming());
             }
@@ -187,13 +259,20 @@ public class AttendanceRegularizationService {
      * missing, not to overwrite a real clock event, and skipping duplicates keeps the operation safe
      * to reach twice, for instance when a rejected request is resubmitted and then approved.
      *
+     * <p>A correction let through under the break-glass role says so on every event it writes. The
+     * request already records the requester and the approver side by side, but the clock event is
+     * what a corrected day is read from, so a correction nobody independent agreed to says so where
+     * the day is explained.
+     *
      * @param attendance      the record being corrected
      * @param correctedEvents the events to add; {@code null} or empty is a no-op
      * @param org             the owning organization, stamped onto each new event
+     * @param selfApproved    whether the approval was a break-glass self-approval
      */
     private void applyCorrectedEvents(Attendance attendance,
                                        List<ClockEventCreationDto> correctedEvents,
-                                       Organization org) {
+                                       Organization org,
+                                       boolean selfApproved) {
         if (correctedEvents == null || correctedEvents.isEmpty()) {
             return;
         }
@@ -217,12 +296,34 @@ public class AttendanceRegularizationService {
                     .projectId(attendance.getProjectId())
                     .projectName(attendance.getProjectName())
                     .isRegularized(true)
-                    .regularizationReason("Self-regularized")
+                    .regularizationReason("Self-regularized" + (selfApproved ? SELF_APPROVAL_NOTE : ""))
                     .isWithinGeofence(false)
                     .distanceFromProject(0.0)
                     .organization(org)
                     .build();
             attendance.getClockEvents().add(event);
         }
+    }
+
+    /**
+     * Resolves the authenticated caller into what gets recorded on a request.
+     *
+     * <p>The caller's employee record in the current organization is preferred, because the
+     * employee id is what the self-approval rule compares and what the web client links a
+     * requester by. A caller with no employee record in this tenant, for instance a bootstrap
+     * administrator, still gets a stable identity: their authenticated username, which is not
+     * something they can choose per request. Only a caller with no identity at all falls back to
+     * {@value #SYSTEM_ACTOR}, which the endpoint's authorization rules already rule out.
+     */
+    private Actor resolveCurrentActor() {
+        Long userId = userContextService.getCurrentUserId();
+        Employee employee = userId == null ? null
+                : employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
+                        .orElse(null);
+        if (employee != null) {
+            return new Actor(employee.getEmployeeName(), employee.getId());
+        }
+        String username = userContextService.getCurrentUsername();
+        return new Actor(username == null || username.isBlank() ? SYSTEM_ACTOR : username, null);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationApproverParamTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationApproverParamTest.java
@@ -1,0 +1,126 @@
+package org.tornotron.echno_backend.attendance;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.service.AttendanceRegularizationService;
+import org.tornotron.echno_backend.common.exception.GlobalExceptionHandler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * What happens to a caller that still sends {@code requestedBy} and {@code approvedBy} on the query
+ * string, proved through the real request pipeline.
+ *
+ * <p>Both parameters used to be how the requester and the approver were recorded, and removing them
+ * is a contract change on parameters a request body's "unknown properties are ignored" rule does not
+ * cover. The deployed web client sends them on every call, so what matters is that Spring drops a
+ * query parameter no handler declares rather than refusing the request. That is what lets the fix
+ * ship on its own instead of having to land with a frontend release.
+ *
+ * <p>Driven through {@code MockMvc} standalone, because the question is about the binding rather
+ * than anything the service does: no Spring context is started, so this adds none to the cached set
+ * the test JVM holds.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AttendanceRegularizationApproverParamTest {
+
+    private static final String WEB = "/api/v1/attendance-regularizations/web";
+    private static final String PLAIN = "/api/v1/attendance-regularizations";
+
+    private static final String REQUEST_BODY =
+            "{\"attendanceId\":42,\"reason\":\"Forgot to clock out\",\"missingEvents\":[\"EVENING_CLOCK_OUT\"]}";
+    private static final String ACTION_BODY = "{\"status\":\"APPROVED\"}";
+
+    @Mock
+    private AttendanceRegularizationService regularizationService;
+
+    private MockMvc mockMvc(Object controller) {
+        when(regularizationService.submitRequest(any(RegularizationRequestDto.class)))
+                .thenReturn(AttendanceRegularizationDto.builder().build());
+        when(regularizationService.processRegularization(anyLong(), any(RegularizationActionDto.class)))
+                .thenReturn(AttendanceRegularizationDto.builder().build());
+        return MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void theWebTwinIgnoresAnApprovedByTheCallerStillSends() throws Exception {
+        mockMvc(new AttendanceRegularizationControllerWeb(regularizationService))
+                .perform(post(WEB + "/7/process")
+                        .param("approvedBy", "Somebody Else")
+                        .param("approvedById", "99")
+                        .contentType(APPLICATION_JSON)
+                        .content(ACTION_BODY))
+                .andExpect(status().isOk());
+
+        verify(regularizationService).processRegularization(anyLong(), any(RegularizationActionDto.class));
+    }
+
+    @Test
+    void theOtherTwinIgnoresAnApprovedByTheCallerStillSends() throws Exception {
+        mockMvc(new AttendanceRegularizationController(regularizationService))
+                .perform(post(PLAIN + "/7/process")
+                        .param("approvedBy", "Somebody Else")
+                        .param("approvedById", "99")
+                        .contentType(APPLICATION_JSON)
+                        .content(ACTION_BODY))
+                .andExpect(status().isOk());
+
+        verify(regularizationService).processRegularization(anyLong(), any(RegularizationActionDto.class));
+    }
+
+    @Test
+    void theWebTwinIgnoresARequestedByTheCallerStillSends() throws Exception {
+        mockMvc(new AttendanceRegularizationControllerWeb(regularizationService))
+                .perform(post(WEB + "/request")
+                        .param("requestedBy", "Somebody Else")
+                        .param("requestedById", "99")
+                        .contentType(APPLICATION_JSON)
+                        .content(REQUEST_BODY))
+                .andExpect(status().isCreated());
+
+        verify(regularizationService).submitRequest(any(RegularizationRequestDto.class));
+    }
+
+    @Test
+    void theOtherTwinIgnoresARequestedByTheCallerStillSends() throws Exception {
+        mockMvc(new AttendanceRegularizationController(regularizationService))
+                .perform(post(PLAIN + "/request")
+                        .param("requestedBy", "Somebody Else")
+                        .param("requestedById", "99")
+                        .contentType(APPLICATION_JSON)
+                        .content(REQUEST_BODY))
+                .andExpect(status().isCreated());
+
+        verify(regularizationService).submitRequest(any(RegularizationRequestDto.class));
+    }
+
+    /** A caller that has been updated and sends neither is served the same way. */
+    @Test
+    void aCallerThatSendsNeitherIsServedTheSame() throws Exception {
+        mockMvc(new AttendanceRegularizationControllerWeb(regularizationService))
+                .perform(post(WEB + "/7/process")
+                        .contentType(APPLICATION_JSON)
+                        .content(ACTION_BODY))
+                .andExpect(status().isOk());
+
+        verify(regularizationService).processRegularization(anyLong(), any(RegularizationActionDto.class));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -22,10 +22,15 @@ import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,7 +53,9 @@ import static org.mockito.Mockito.when;
  * processing gates the service owns: refusing self-service when disabled, enforcing the
  * monthly cap, blocking a duplicate pending request, choosing PENDING vs auto-APPROVED from
  * the settings, carrying the submitted corrections through to approval, and refusing to
- * re-action a request that is no longer PENDING (recalculating attendance only on approval).
+ * re-action a request that is no longer PENDING (recalculating attendance only on approval),
+ * and the identity rules: the requester and the approver come from the session, and an approval
+ * by whoever raised the request is refused unless they hold the break-glass role.
  */
 @ExtendWith(MockitoExtension.class)
 class AttendanceRegularizationServiceTest {
@@ -57,14 +64,20 @@ class AttendanceRegularizationServiceTest {
     private static final Long ATT_ID = 42L;
     private static final Long REG_ID = 7L;
     private static final String REQUESTER = "user-abc";
+    private static final Long REQUESTER_EMP_ID = 11L;
     private static final String APPROVER = "manager-xyz";
+    private static final Long APPROVER_EMP_ID = 12L;
+    private static final Long USER_ID = 500L;
 
     @Mock private AttendanceRegularizationRepository regularizationRepository;
     @Mock private AttendanceRepository attendanceRepository;
     @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
     @Mock private AttendanceSettingsService settingsService;
     @Mock private AttendanceCalculationService calculationService;
     @Mock private AttendanceRegularizationMapper regularizationMapper;
+    @Mock private UserContextService userContextService;
+    @Mock private SelfApprovalPolicy selfApprovalPolicy;
 
     private AttendanceRegularizationService service;
 
@@ -72,7 +85,28 @@ class AttendanceRegularizationServiceTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
-                organizationRepository, settingsService, calculationService, regularizationMapper);
+                organizationRepository, employeeRepository, settingsService, calculationService,
+                regularizationMapper, userContextService, selfApprovalPolicy);
+        // The session is the requesting employee unless a test says otherwise.
+        signedInAs(REQUESTER_EMP_ID, REQUESTER);
+    }
+
+    /** Puts an employee of this tenant in the security context, as the service resolves it. */
+    private void signedInAs(Long employeeId, String employeeName) {
+        Employee employee = new Employee();
+        employee.setId(employeeId);
+        employee.setEmployeeName(employeeName);
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG))
+                .thenReturn(Optional.of(employee));
+    }
+
+    /** Puts an authenticated caller with no employee record of this tenant in the context. */
+    private void signedInWithNoEmployeeRecord(String username) {
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG))
+                .thenReturn(Optional.empty());
+        lenient().when(userContextService.getCurrentUsername()).thenReturn(username);
     }
 
     @AfterEach
@@ -120,7 +154,7 @@ class AttendanceRegularizationServiceTest {
         when(organizationRepository.findById(ORG)).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+                .isThrownBy(() -> service.submitRequest(requestDto()));
     }
 
     @Test
@@ -129,7 +163,7 @@ class AttendanceRegularizationServiceTest {
         when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG)).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+                .isThrownBy(() -> service.submitRequest(requestDto()));
     }
 
     @Test
@@ -139,7 +173,7 @@ class AttendanceRegularizationServiceTest {
                 .thenReturn(settings(false, true, 3));
 
         assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+                .isThrownBy(() -> service.submitRequest(requestDto()));
         verify(regularizationRepository, never()).save(any());
     }
 
@@ -152,7 +186,7 @@ class AttendanceRegularizationServiceTest {
                 .thenReturn(2L);
 
         assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+                .isThrownBy(() -> service.submitRequest(requestDto()));
         verify(regularizationRepository, never()).save(any());
     }
 
@@ -168,7 +202,7 @@ class AttendanceRegularizationServiceTest {
         when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.of(pending));
 
         assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> service.submitRequest(requestDto(), REQUESTER));
+                .isThrownBy(() -> service.submitRequest(requestDto()));
         verify(regularizationRepository, never()).save(any());
     }
 
@@ -184,7 +218,7 @@ class AttendanceRegularizationServiceTest {
                 .thenAnswer(inv -> inv.getArgument(0));
         when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
 
-        service.submitRequest(requestDto(), REQUESTER);
+        service.submitRequest(requestDto());
 
         ArgumentCaptor<AttendanceRegularization> captor =
                 ArgumentCaptor.forClass(AttendanceRegularization.class);
@@ -206,7 +240,7 @@ class AttendanceRegularizationServiceTest {
                 .thenAnswer(inv -> inv.getArgument(0));
         when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
 
-        service.submitRequest(requestDto(), REQUESTER);
+        service.submitRequest(requestDto());
 
         ArgumentCaptor<AttendanceRegularization> captor =
                 ArgumentCaptor.forClass(AttendanceRegularization.class);
@@ -222,7 +256,7 @@ class AttendanceRegularizationServiceTest {
         action.setStatus(RegularizationStatus.APPROVED);
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> service.processRegularization(REG_ID, action, APPROVER));
+                .isThrownBy(() -> service.processRegularization(REG_ID, action));
     }
 
     @Test
@@ -236,12 +270,13 @@ class AttendanceRegularizationServiceTest {
         action.setStatus(RegularizationStatus.APPROVED);
 
         assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> service.processRegularization(REG_ID, action, APPROVER));
+                .isThrownBy(() -> service.processRegularization(REG_ID, action));
         verify(calculationService, never()).recalculate(any(), any());
     }
 
     @Test
     void processRegularization_approveWithShift_recalculatesAttendance() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         AttendanceRegularization pending = AttendanceRegularization.builder()
@@ -255,7 +290,7 @@ class AttendanceRegularizationServiceTest {
         RegularizationActionDto action = new RegularizationActionDto();
         action.setStatus(RegularizationStatus.APPROVED);
 
-        service.processRegularization(REG_ID, action, APPROVER);
+        service.processRegularization(REG_ID, action);
 
         verify(calculationService).recalculate(eq(attendance), any(ShiftTiming.class));
         verify(attendanceRepository).save(attendance);
@@ -293,7 +328,7 @@ class AttendanceRegularizationServiceTest {
                 List.of(correctedEvent(ClockEventType.MORNING_CLOCK_IN, 9));
         dto.setCorrectedEvents(corrections);
 
-        service.submitRequest(dto, REQUESTER);
+        service.submitRequest(dto);
 
         verify(regularizationMapper).serializeRequestedEvents(corrections);
         ArgumentCaptor<AttendanceRegularization> captor =
@@ -309,6 +344,7 @@ class AttendanceRegularizationServiceTest {
      */
     @Test
     void processRegularization_approve_appliesTheStoredCorrections() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         attendance.setClockEvents(new ArrayList<>());
@@ -330,7 +366,7 @@ class AttendanceRegularizationServiceTest {
         RegularizationActionDto action = new RegularizationActionDto();
         action.setStatus(RegularizationStatus.APPROVED);
 
-        service.processRegularization(REG_ID, action, APPROVER);
+        service.processRegularization(REG_ID, action);
 
         assertThat(attendance.getClockEvents())
                 .extracting(ClockEvent::getEventType)
@@ -351,6 +387,7 @@ class AttendanceRegularizationServiceTest {
      */
     @Test
     void processRegularization_approve_leavesAnExistingEventAlone() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         ClockEvent real = ClockEvent.builder()
@@ -376,7 +413,7 @@ class AttendanceRegularizationServiceTest {
         RegularizationActionDto action = new RegularizationActionDto();
         action.setStatus(RegularizationStatus.APPROVED);
 
-        service.processRegularization(REG_ID, action, APPROVER);
+        service.processRegularization(REG_ID, action);
 
         assertThat(attendance.getClockEvents()).hasSize(2);
         assertThat(attendance.getClockEvents().get(0).getEventTimestamp())
@@ -387,6 +424,7 @@ class AttendanceRegularizationServiceTest {
 
     @Test
     void processRegularization_reject_doesNotRecalculate() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         AttendanceRegularization pending = AttendanceRegularization.builder()
@@ -401,10 +439,225 @@ class AttendanceRegularizationServiceTest {
         action.setStatus(RegularizationStatus.REJECTED);
         action.setRejectionReason("Insufficient evidence");
 
-        service.processRegularization(REG_ID, action, APPROVER);
+        service.processRegularization(REG_ID, action);
 
         verify(calculationService, never()).recalculate(any(), any());
         verify(attendanceRepository, never()).save(any());
         assertThat(pending.getRejectionReason()).isEqualTo("Insufficient evidence");
+    }
+
+    // ─── Who is recorded, and who may approve ────────────────────────────────────────────────
+
+    /**
+     * The requester used to arrive as a query parameter, so a caller could file a request under
+     * anyone's name. It now comes from the session, which is also what the monthly cap counts by.
+     */
+    @Test
+    void submitRequest_recordsTheSignedInEmployeeAsTheRequester() {
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(REQUESTER), any(), any()))
+                .thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.submitRequest(requestDto());
+
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getRequestedBy()).isEqualTo(REQUESTER);
+        assertThat(captor.getValue().getRequestedById()).isEqualTo(REQUESTER_EMP_ID);
+    }
+
+    /**
+     * A caller with no employee record in this tenant, for instance a bootstrap administrator, is
+     * still recorded by a name they cannot choose per request, and carries no employee id.
+     */
+    @Test
+    void submitRequest_recordsTheAuthenticatedUsernameWhenTheCallerIsNotAnEmployeeHere() {
+        signedInWithNoEmployeeRecord("admin@echno.com");
+        stubOrgAndAttendance(attendance());
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
+                .thenReturn(settings(true, true, 3));
+        when(regularizationRepository.countApprovedRegularizationsInMonth(
+                eq("admin@echno.com"), any(), any())).thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.submitRequest(requestDto());
+
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getRequestedBy()).isEqualTo("admin@echno.com");
+        assertThat(captor.getValue().getRequestedById()).isNull();
+    }
+
+    /**
+     * The approver used to arrive as a query parameter, so the record said whatever the caller
+     * typed. It now comes from the session.
+     */
+    @Test
+    void processRegularization_recordsTheSignedInEmployeeAsTheApprover() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
+        AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
+        pending.setAttendance(attendance());
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        assertThat(pending.getApprovedBy()).isEqualTo(APPROVER);
+        assertThat(pending.getApprovedById()).isEqualTo(APPROVER_EMP_ID);
+    }
+
+    /** The rule: the request is checked against the person approving it, and a refusal stands. */
+    @Test
+    void processRegularization_theSamePersonCannotRaiseAndApproveAndNothingIsCorrected() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        attendance.setClockEvents(new ArrayList<>());
+        AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
+        pending.setAttendance(attendance);
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(selfApprovalPolicy.checkSelfApproval(REQUESTER_EMP_ID, REQUESTER_EMP_ID,
+                "Regularization request with ID " + REG_ID))
+                .thenThrow(new InvalidRequestException("raised by the same person"));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED)));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.PENDING);
+        assertThat(attendance.getClockEvents()).isEmpty();
+        verify(calculationService, never()).recalculate(any(), any());
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    /**
+     * The break-glass exception goes through, and the clock events it writes say the correction was
+     * self-approved: the clock event is what a corrected day is read from.
+     */
+    @Test
+    void processRegularization_aBreakGlassSelfApprovalIsAppliedAndTheClockEventsSaySo() {
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        attendance.setClockEvents(new ArrayList<>());
+        AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
+        pending.setAttendance(attendance);
+        pending.setOrganization(organization());
+        pending.setRequestedEvents("[stored]");
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(selfApprovalPolicy.checkSelfApproval(REQUESTER_EMP_ID, REQUESTER_EMP_ID,
+                "Regularization request with ID " + REG_ID)).thenReturn(true);
+        when(regularizationMapper.deserializeRequestedEvents("[stored]"))
+                .thenReturn(List.of(correctedEvent(ClockEventType.EVENING_CLOCK_OUT, 18)));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+        assertThat(attendance.getClockEvents())
+                .singleElement()
+                .extracting(ClockEvent::getRegularizationReason)
+                .isEqualTo("Self-regularized (self-approved: raised and approved by the same person)");
+    }
+
+    /** Negative control: an approval by someone else is an ordinary approval and says nothing extra. */
+    @Test
+    void processRegularization_anApprovalBySomeoneElseIsNotMarkedAsSelfApproved() {
+        signedInAs(APPROVER_EMP_ID, APPROVER);
+        Attendance attendance = attendance();
+        attendance.setShiftTiming(new ShiftTiming());
+        attendance.setClockEvents(new ArrayList<>());
+        AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
+        pending.setAttendance(attendance);
+        pending.setOrganization(organization());
+        pending.setRequestedEvents("[stored]");
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationMapper.deserializeRequestedEvents("[stored]"))
+                .thenReturn(List.of(correctedEvent(ClockEventType.EVENING_CLOCK_OUT, 18)));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        verify(selfApprovalPolicy).checkSelfApproval(REQUESTER_EMP_ID, APPROVER_EMP_ID,
+                "Regularization request with ID " + REG_ID);
+        assertThat(attendance.getClockEvents())
+                .singleElement()
+                .extracting(ClockEvent::getRegularizationReason)
+                .isEqualTo("Self-regularized");
+    }
+
+    /**
+     * Rejecting your own request is left alone. It writes nothing to the attendance record, and
+     * refusing it would leave an employee unable to withdraw a request raised by mistake.
+     */
+    @Test
+    void processRegularization_rejectingYourOwnRequestIsNotSubjectToTheRule() {
+        AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
+        pending.setAttendance(attendance());
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        RegularizationActionDto action = action(RegularizationStatus.REJECTED);
+        action.setRejectionReason("Filed by mistake");
+        service.processRegularization(REG_ID, action);
+
+        verify(selfApprovalPolicy, never()).checkSelfApproval(any(), any(), any());
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.REJECTED);
+    }
+
+    /**
+     * Requests stored before the requester was stamped from the session name nobody, so there is
+     * nothing to compare them against. They stay approvable rather than becoming stuck.
+     */
+    @Test
+    void processRegularization_aRequestWithNoRecordedRequesterIdIsStillApprovable() {
+        AttendanceRegularization pending = pendingRaisedBy(null);
+        pending.setAttendance(attendance());
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        verify(selfApprovalPolicy).checkSelfApproval(null, REQUESTER_EMP_ID,
+                "Regularization request with ID " + REG_ID);
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+    }
+
+    private AttendanceRegularization pendingRaisedBy(Long requestedById) {
+        return AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING)
+                .requestedBy(REQUESTER)
+                .requestedById(requestedById)
+                .build();
+    }
+
+    private RegularizationActionDto action(RegularizationStatus status) {
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(status);
+        return action;
     }
 }


### PR DESCRIPTION
Closes #562.

## What changed

Both regularization controllers took the approver off the query string and passed it straight to the service, so the record said whoever the caller typed had approved a correction to an attendance record. The approver now comes from the authenticated session on both twins, and `approvedBy` / `approvedById` are gone from the signature.

The caller is resolved to their employee record in the current tenant, which is the same resolution `AttendanceService.approveAttendance` already uses next door, so `approvedById` keeps meaning what it means on an attendance record and the web client's "requested by" link still resolves. A caller with no employee record here, a bootstrap administrator for instance, is recorded by their authenticated username instead: still not something they choose per request. Only a caller with no identity at all falls back to `system`, which the endpoint's authorization already rules out.

## The requester had to move too

The rule the issue asks for compares the raiser against the approver, and on this entity the raiser was as forgeable as the approver. Worse: **the web client never sent `requestedById` at all**, so every row written through the UI carries a null requester id and a rule comparing the two would never have fired once. It would have been a control in name only.

So `requestedBy` and `requestedById` are stamped from the session on submit as well, which is the same precondition #559 had to satisfy on `StockAdjustment.submittedBy`. The monthly cap already counted by `requestedBy`, and the value the web client sends for it today is the signed-in employee's name, the same string the session now supplies, so the cap keeps counting the same rows and needs no migration.

## Then the rule, from the shared policy

`common/approval/SelfApprovalPolicy` unchanged, called the way `StockAdjustmentService.approve` calls it: refused outright for an ordinary approver, allowed and logged for `system-admin`. A break-glass self-approval writes its note onto every corrected clock event (`Self-regularized (self-approved: raised and approved by the same person)`). That is this module's equivalent of #559 putting the note in the ledger remarks: the ledger is what a stock figure is explained from, and the clock event is what a corrected day is read from.

Two paths are outside the rule on purpose:

- **Rejection.** It writes nothing to the attendance record, and refusing a self-rejection would leave an employee unable to withdraw a request they filed by mistake.
- **The auto-approve path** inside `submitRequest`, where `regularizationApprovalRequired` is off. A project configured not to require an approval is the tenant's own standing decision that these corrections do not need a second person, which is exactly the case that setting exists for. Same exemption, and same reasoning, as #559 gave the invoice approval threshold.

Requests stored before this name no requester, so there is nothing to compare and they are let through rather than becoming unapprovable.

## Does `echno-web` send these today, and is a coordinated deploy needed?

**It sends them, and no coordinated deploy is needed.** Verified in the clone rather than assumed.

`echno-core`'s `attendanceRegularizationService` puts the identity on the query string on both calls (`src/services/attendance-regularization-service.ts`): `request(dto, requestedBy)` sends `{ requestedBy }`, `process(id, status, approvedBy, rejectionReason)` sends `{ approvedBy }`. Both call sites in `echno-web` (`features/attendance/components/attendance-regularization-card.tsx` and `regularization-management.tsx`) pass `currentEmployee?.name ?? currentEmployee?.employeeId ?? ''`. Neither ever sends `requestedById` or `approvedById`.

The direction of the break matters. A query parameter no handler declares is dropped by Spring, so the deployed client keeps working and the value it sends is simply ignored. What would have broken is the reverse case, a client that stopped sending `approvedBy` while the parameter was still `@RequestParam` and required: that is a 400. Backend first is therefore the safe order, and the frontend can drop the arguments whenever it likes.

This is pinned rather than asserted: `AttendanceRegularizationApproverParamTest` drives both twins through MockMvc with `?approvedBy=Somebody Else&approvedById=99` still attached and expects the same 200 the updated client gets, and the same for `requestedBy` on submit. The one case in that file that fails against the old code is a caller sending neither, which the old contract answered with a 400.

## Two byte-identical controllers: what I chose

**Kept both, and did not merge them.** The shared implementation already exists and it is the service: after this change the controllers hold no logic at all beyond delegation, so the rule lands on both twins whether or not the pair is ever collapsed. Collapsing 32 controller-twin pairs is #522's analysis and is decision-gated on the `@PreAuthorize` question, since the two twins can carry different guards and a shared base class has to settle which one wins. Doing it here, in a security fix, would put that question in the diff that has to be reviewed for something else. The duplication that remains is two annotation blocks, and it is now duplication of documentation rather than of behaviour.

## What the live data shows

Read-only against the compose staging on `.116`. One regularization exists:

| id | requested_by | requested_by_id | approved_by | approved_by_id | requested_at | approved_at |
|---|---|---|---|---|---|---|
| 1 | Echno Admin | 4 | Echno Admin | 4 | 2026-06-02 12:59:07 | 2026-06-02 13:03:18 |

So the one row on staging is a self-approval, four minutes apart: employee 4 raised it against their own attendance record (`attendance.employee_id = 4`) and approved it. There is no orphan approver: id 4 resolves to a real employee, "Echno Admin", of organization 2, and every other regularization column is consistent.

Whether this PR would have refused it comes down to the break-glass role. `employee_org_roles` gives employee 4 `SYSTEM_ADMIN`, so on that evidence it would have gone through as a recorded self-approval rather than being refused. Worth stating precisely: the gate `SelfApprovalPolicy` reads is the Keycloak org group (`ORG_2_ROLE_system-admin`), not that table, so the table is strong evidence and not proof. Either way there is nothing to migrate and no existing record to reinterpret.

## Failing-test table

Each new test run against a reverted baseline (the three main-source files restored to `origin/development`, the tests' call sites given back the query parameters the old contract accepted, sending a forged `"Somebody Else"` / `99L` exactly as the endpoint allowed), then against the fix.

| Test | Without the fix | With the fix |
|---|---|---|
| `submitRequest_recordsTheSignedInEmployeeAsTheRequester` | FAILED | PASSED |
| `submitRequest_recordsTheAuthenticatedUsernameWhenTheCallerIsNotAnEmployeeHere` | FAILED | PASSED |
| `processRegularization_recordsTheSignedInEmployeeAsTheApprover` | FAILED | PASSED |
| `processRegularization_theSamePersonCannotRaiseAndApproveAndNothingIsCorrected` | FAILED | PASSED |
| `processRegularization_aBreakGlassSelfApprovalIsAppliedAndTheClockEventsSaySo` | FAILED | PASSED |
| `processRegularization_anApprovalBySomeoneElseIsNotMarkedAsSelfApproved` | FAILED | PASSED |
| `processRegularization_aRequestWithNoRecordedRequesterIdIsStillApprovable` | FAILED | PASSED |
| `AttendanceRegularizationApproverParamTest.aCallerThatSendsNeitherIsServedTheSame` | FAILED | PASSED |

Two further new tests pass either way by design, and are there to pin what must not change:

- `processRegularization_rejectingYourOwnRequestIsNotSubjectToTheRule` (the rule must not fire on a rejection)
- the three `...IgnoresA{Requested,Approved}ByTheCallerStillSends` cases, which are the compatibility controls: they have to pass on both sides, because that is the whole claim about the deployed client.

Full suite on `lab-node-116-f`: **BUILD SUCCESSFUL**, 1243 tests, 0 failures, 0 errors, branched from `origin/development` at `ef15dad`.

No Liquibase changeset. `requested_by`, `requested_by_id`, `approved_by` and `approved_by_id` all already exist on `attendance_regularization`, and this changes only where their values come from. No new Spring context either: the controller test is `MockMvcBuilders.standaloneSetup`, and the service test is plain Mockito, so the cached-context position in the test JVM is unchanged.

## If you would rather have it another way

If self-rejection should also be refused, move the policy call above the `status` check in `processRegularization` and drop the `APPROVED` condition; one line, and one test flips. If the auto-approve path should be subject to the rule, that belongs in `submitRequest` rather than here, and it would mean a project that auto-approves can no longer auto-approve anything, which is why I did not.
