### PR TITLE
Refuse a status a create could not have transitioned into

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -3,8 +3,6 @@ package org.tornotron.echno_backend.employee.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 
@@ -40,11 +38,10 @@ public class EmployeeCreationDto {
     @Schema(description = "Id of the structured shift timing to assign to the employee.", example = "5")
     private Long shiftTimingId;
 
-    @Schema(description = "Employment status.", example = "active")
-    @NotBlank(message = "status is required")
-    @Size(min = 3, max = 50, message = "status must be between 3 and 50 characters")
-    @Enumerated(EnumType.STRING)
-    private String status;
+    // No status field. It was declared here and required, then discarded by the mapper that
+    // builds the employee, so a caller was made to send a value nothing ever read and a caller
+    // that left it out was refused for it. An employee's status is set through the employee
+    // update endpoint, which is the one place that writes it.
 
     @Schema(description = "Full name of the employee.", example = "Ravi Kumar")
     @NotBlank(message = "employeeName is required")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -64,6 +64,13 @@ import java.util.stream.Collectors;
 @Service
 public class SiteTransferService {
 
+    /**
+     * The state a transfer starts in, and the only one create accepts. It is what the web
+     * client's transfer form already sends, and what {@code echno-core} documents as the
+     * typical initial value.
+     */
+    private static final SiteTransferStatus CREATION_STATUS = SiteTransferStatus.PENDING;
+
     private final SiteTransferRepository siteTransferRepository;
     private final SiteTransferItemRepository siteTransferItemRepository;
     private final UserRepository userRepository;
@@ -109,6 +116,9 @@ public class SiteTransferService {
     /**
      * Creates a site transfer with its items after checking sending-side stock.
      *
+     * <p>The transfer starts {@link SiteTransferStatus#PENDING}, whether the payload says so or
+     * says nothing, and any other starting value is refused: see {@link #requireCreatableStatus}.
+     *
      * <p>Resolves the sending person, both projects and both optional storage locations,
      * refuses a pair of sides that resolve to the same balance row, then totals the requested
      * quantities per material and validates them against the sending side. The transfer
@@ -125,10 +135,13 @@ public class SiteTransferService {
      * @param creationDto The transfer header fields and the list of items to move.
      * @return The created site transfer as a DTO.
      * @throws ResourceNotFoundException if the sending person, either project, a storage location, or a line's material is not found in this organization.
-     * @throws InvalidRequestException if both sides name the same project and the same storage location, so nothing would move, or if a storage location belongs to a project other than the one it is used from.
+     * @throws InvalidRequestException if both sides name the same project and the same storage location, so nothing would move, or if a storage location belongs to a project other than the one it is used from, or if the payload asks for a status other than PENDING.
      * @throws org.tornotron.echno_backend.common.exception.InsufficientStockException if the sending side does not hold enough of any requested material.
      */
     public SiteTransferDto createSiteTransfer(SiteTransferCreationDto creationDto) {
+        // Checked before the retry rather than inside it: a refused status is the caller's to
+        // correct, and retrying it would only refuse it again.
+        requireCreatableStatus(creationDto.getStatus());
         return retryTemplate.execute(
                 "SiteTransferService.createSiteTransfer",
                 failure -> SqlStateDetector.carriesSqlState(failure, SqlStateDetector.UNIQUE_VIOLATION),
@@ -186,7 +199,7 @@ public class SiteTransferService {
         transfer.setSendingStorageLocation(sendingLocation);
         transfer.setReceivingStorageLocation(receivingLocation);
 
-        transfer.setStatus(SiteTransferStatus.valueOf(creationDto.getStatus()));
+        transfer.setStatus(CREATION_STATUS);
         transfer.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         // Save transfer first
@@ -215,6 +228,36 @@ public class SiteTransferService {
         eventPublisher.publishEvent(new SiteTransferCreatedEvent(this, transfer));
 
         return siteTransferMapper.toDto(transfer);
+    }
+
+    /**
+     * Refuses a transfer asked to be created in any state but {@link #CREATION_STATUS}.
+     *
+     * <p>The other two states both say the receiving site has taken delivery, and taking
+     * delivery is recorded through {@code PATCH /site-transfers/{id}/status}. That endpoint is
+     * held by a different authority from create on the token-authority controller
+     * ({@code site-transfer:update} against {@code site-transfer:create}), so a create that
+     * copied the payload's status let a caller who may only raise transfers record their own
+     * receipt of one. Stock moves on creation either way, through
+     * {@link SiteTransferCreatedEvent}, so what a transfer issued as {@code COMPLETED} leaves
+     * behind is a movement that stands as confirmed by nobody.
+     *
+     * <p>This is the rule {@code ProjectService.addProject} and
+     * {@code PurchaseOrderService.createPurchaseOrder} apply: a create may not reach a state
+     * whose transition carries a check or an event. Here the status endpoint gates both of the
+     * later states, so {@code PENDING} is all that is left.
+     *
+     * @param status The status the create payload asked for, or null when it asked for none.
+     * @throws InvalidRequestException if that status is anything but {@link #CREATION_STATUS}.
+     */
+    private void requireCreatableStatus(SiteTransferStatus status) {
+        if (status != null && status != CREATION_STATUS) {
+            throw new InvalidRequestException(
+                    "A site transfer is issued as " + CREATION_STATUS + " and cannot be created as "
+                            + status + ". Issue it first, then record what the receiving site took "
+                            + "delivery of with PATCH /site-transfers/{id}/status, which is where "
+                            + "the authority to say a transfer has been received is checked.");
+        }
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
@@ -2,10 +2,10 @@ package org.tornotron.echno_backend.siteTransfer.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,9 +49,19 @@ public class SiteTransferCreationDto {
             + "nothing. Optional.", example = "15")
     private Long receivingStorageLocationId;
 
-    @Schema(description = "Initial status of the transfer.", example = "PENDING")
-    @NotBlank(message = "status is required")
-    private String status;
+    /**
+     * The state the transfer starts in. Optional, and {@code PENDING} is the only value
+     * accepted: the other two say the far end has received the materials, and that is recorded
+     * through the transfer's own status endpoint. See {@code SiteTransferService.createSiteTransfer}.
+     */
+    @Schema(description = "State the transfer starts in. Optional, and PENDING is the only value "
+            + "accepted, so leaving it out is the same as sending PENDING. "
+            + "PARTIALLY_TRANSFERRED and COMPLETED say the receiving site has taken delivery, "
+            + "which is recorded through PATCH /{id}/status; that endpoint wants a different "
+            + "authority from create, and a transfer issued as COMPLETED would stand as received "
+            + "with nobody having confirmed receipt.",
+            example = "PENDING", allowableValues = {"PENDING"})
+    private SiteTransferStatus status;
 
     @Schema(description = "Line items listing each material and quantity being transferred. Must contain "
             + "at least one item.")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -95,12 +95,31 @@ public class StockAdjustmentService {
     static final String POSTED_STATUS = "processed";
 
     /**
+     * Status a document carries until it is approved, and the only one a request body may ask
+     * for. Compared case-insensitively, since the status column holds the frontend's own
+     * lower-case vocabulary rather than an enum.
+     */
+    static final String DRAFT_STATUS = "draft";
+
+    /**
      * Below this, a line's movement is treated as none at all. A count matching the balance
      * to the last decimal place can still leave floating-point residue, and a ledger entry
      * for a movement of 1e-16 is a phantom row claiming stock moved when it did not.
      */
     private static final double NO_MOVEMENT = 1e-9;
 
+    /**
+     * Raises a stock-adjustment document as a draft, with its line items.
+     *
+     * <p>The document is a {@link #DRAFT_STATUS} whether the payload says so or says nothing,
+     * and any other status is refused: see {@link #requireDraftStatus}. Nothing is posted here;
+     * {@link #approve} is what moves the balance.
+     *
+     * @param creationDto The header fields and line items of the document.
+     * @return The created document as a DTO.
+     * @throws InvalidRequestException if the payload asks for a status other than draft.
+     * @throws ResourceNotFoundException if the location, the project or a line's material is not found in this organization.
+     */
     @Transactional
     public StockAdjustmentDto create(StockAdjustmentCreationDto creationDto) {
         Organization organization = tenantEntityHelper.resolveCurrentOrganization();
@@ -141,7 +160,7 @@ public class StockAdjustmentService {
      * @param creationDto The replacement header and lines.
      * @return The updated document as a DTO.
      * @throws ResourceNotFoundException if the document, or anything it references, is not in this organization.
-     * @throws InvalidRequestException if the document has already been posted to the stock ledger.
+     * @throws InvalidRequestException if the document has already been posted to the stock ledger, or if the payload asks for a status other than draft.
      */
     @Transactional
     public StockAdjustmentDto update(Long id, StockAdjustmentCreationDto creationDto) {
@@ -321,6 +340,39 @@ public class StockAdjustmentService {
         return selfApproved ? " (self-approved: raised and approved by the same person)" : "";
     }
 
+    /**
+     * Refuses a document asked to be written in any state but {@link #DRAFT_STATUS}.
+     *
+     * <p>A stock adjustment has one transition, and everything this module exists for hangs off
+     * it: {@link #approve} refuses an approval by whoever raised the document unless they hold
+     * the break-glass role, writes an {@link InventoryTransaction} per line, moves the balance,
+     * and stamps the approver and the posting time. A body that set the status itself reached
+     * the posted state with none of that: no approver on record, no ledger entries, and the
+     * balance untouched, while every list and detail view reads the document as dealt with. The
+     * self-approval control added for that transition would be sidestepped by simply not using
+     * the transition.
+     *
+     * <p>Applied to the update path as well as create, because the two write the same header
+     * and a document can be edited right up until it is posted, so gating only create would
+     * leave the same door one call further along.
+     *
+     * <p>This is the rule {@code ProjectService.addProject} and
+     * {@code PurchaseOrderService.createPurchaseOrder} apply: a create may not reach a state
+     * whose transition carries a check or an event.
+     *
+     * @param status The status the request body asked for, or null when it asked for none.
+     * @throws InvalidRequestException if that status is anything but {@link #DRAFT_STATUS}.
+     */
+    private void requireDraftStatus(String status) {
+        if (status != null && !status.isBlank() && !DRAFT_STATUS.equalsIgnoreCase(status.trim())) {
+            throw new InvalidRequestException(
+                    "A stock adjustment is raised as a " + DRAFT_STATUS + " and cannot be given the status "
+                            + status + ". Post it with POST /stock-adjustments/{id}/approve, which is "
+                            + "what checks who is approving it, writes the stock-ledger entries and "
+                            + "moves the balance.");
+        }
+    }
+
     /** Refuses to change a document whose movements are already on the ledger. */
     private void requireNotPosted(StockAdjustment stockAdjustment, String action) {
         if (stockAdjustment.getProcessedAt() != null) {
@@ -375,11 +427,16 @@ public class StockAdjustmentService {
      * Deliberately does not touch {@code submittedBy}: it is stamped from the session in
      * {@link #create} and left alone by {@link #update}, so an edit cannot move the document
      * onto a different raiser and clear the way for its own approval.
+     *
+     * <p>The status is not copied either. It is written here as {@link #DRAFT_STATUS} and moved
+     * only by {@link #approve}; a body naming any other status is refused rather than ignored,
+     * so a caller who believed they were posting a document finds out that they were not.
      */
     private void applyHeaderFields(StockAdjustment stockAdjustment, StockAdjustmentCreationDto dto) {
+        requireDraftStatus(dto.getStatus());
         stockAdjustment.setAdjustmentNumber(dto.getAdjustmentNumber());
         stockAdjustment.setType(dto.getType());
-        stockAdjustment.setStatus(dto.getStatus());
+        stockAdjustment.setStatus(DRAFT_STATUS);
         stockAdjustment.setAdjustmentDate(dto.getAdjustmentDate());
         stockAdjustment.setEffectiveDate(dto.getEffectiveDate());
         stockAdjustment.setTotalAdjustmentValue(dto.getTotalAdjustmentValue());

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -18,7 +18,18 @@ public class StockAdjustmentCreationDto {
     @Schema(description = "Type of adjustment.", example = "PHYSICAL_COUNT")
     private String type;
 
-    @Schema(description = "Status of the adjustment document.", example = "DRAFT")
+    /**
+     * The state the document is in. Optional, and {@code draft} is the only value accepted:
+     * the posted state is reached by approving the document, which is what checks who is
+     * approving it and writes the ledger entries. See {@code StockAdjustmentService.create}.
+     */
+    @Schema(description = "State of the adjustment document. Optional, and draft is the only "
+            + "value accepted, so leaving it out is the same as sending draft. A document "
+            + "reaches its posted state through POST /{id}/approve, which is what refuses an "
+            + "approval by whoever raised it and writes the stock-ledger entries; a document "
+            + "created or edited into that state would carry neither, and would read as approved "
+            + "with nobody on record as having approved it and no movement behind it.",
+            example = "draft", allowableValues = {"draft"})
     private String status;
 
     @Schema(description = "Id of the storage location the adjustment applies to.", example = "7")

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeCreationDtoTest.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeCreationDtoTest.java
@@ -1,0 +1,86 @@
+package org.tornotron.echno_backend.employee;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.tornotron.echno_backend.employee.dto.EmployeeCreationDto;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * The create payload carried a required {@code status} that the mapper building the employee
+ * then threw away, so a caller was made to send a value nothing read and a caller that left it
+ * out was refused for it. It is gone. An employee's status is written through the employee
+ * update endpoint, which is the one place that sets it.
+ */
+class EmployeeCreationDtoTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private EmployeeCreationDto validDto() {
+        EmployeeCreationDto dto = new EmployeeCreationDto();
+        dto.setDesignation("Site Engineer");
+        dto.setDepartment("Civil");
+        dto.setEmployeeName("Ravi Kumar");
+        dto.setGender("male");
+        dto.setPhoneNumber("9847012345");
+        dto.setEmailAddress("ravi.kumar@example.com");
+        dto.setDateOfBirth(LocalDateTime.of(1994, 3, 22, 0, 0));
+        return dto;
+    }
+
+    @Test
+    void aPayloadThatNamesNoStatusIsValid() {
+        assertThat(validator.validate(validDto())).isEmpty();
+    }
+
+    @Test
+    void aPayloadThatStillSendsAStatusIsStillAccepted() {
+        // Nothing here refuses a client that has not caught up: the application's mapper is the
+        // one Spring Boot builds, which ignores a property the DTO no longer declares. So an old
+        // caller keeps working and this change needs no deploy coordinated with the clients.
+        ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json()
+                .modules(new JavaTimeModule())
+                .build();
+        String json = """
+                {
+                  "designation": "Site Engineer",
+                  "department": "Civil",
+                  "employeeName": "Ravi Kumar",
+                  "gender": "male",
+                  "phoneNumber": "9847012345",
+                  "emailAddress": "ravi.kumar@example.com",
+                  "dateOfBirth": "1994-03-22T00:00:00",
+                  "status": "active"
+                }
+                """;
+
+        assertThatCode(() -> {
+            EmployeeCreationDto dto = objectMapper.readValue(json, EmployeeCreationDto.class);
+            assertThat(validator.validate(dto)).isEmpty();
+        }).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferCreateStatusTest.java
@@ -1,0 +1,194 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * A transfer is issued as PENDING and nothing else. The other two states say the receiving
+ * site has taken delivery, which is recorded through the transfer's own status endpoint, and
+ * that endpoint is held by a different authority from create. Stock moves on creation either
+ * way, so a transfer issued as COMPLETED would stand as a movement confirmed by nobody.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class SiteTransferCreateStatusTest {
+
+    private static final Long ORG = 100L;
+    private static final Long SENDER = 7L;
+    private static final Long SENDING_PROJECT = 9L;
+    private static final Long RECEIVING_PROJECT = 10L;
+    private static final Long MATERIAL = 11L;
+
+    @Mock private SiteTransferRepository siteTransferRepository;
+    @Mock private SiteTransferItemRepository siteTransferItemRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private SiteTransferMapper siteTransferMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+
+    private SiteTransferService service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
+                materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository,
+                documentNumberAllocator, retryTemplate);
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private void stubMasterLookups() {
+        Employee sender = new Employee();
+        sender.setId(SENDER);
+        Project sending = new Project();
+        sending.setId(SENDING_PROJECT);
+        Project receiving = new Project();
+        receiving.setId(RECEIVING_PROJECT);
+        Organization org = new Organization();
+        org.setId(ORG);
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.SITE_TRANSFER, ORG))
+                .thenReturn("TRF-2026-000042");
+        lenient().when(employeeRepository.findByIdAndOrganizationId(SENDER, ORG)).thenReturn(Optional.of(sender));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(SENDING_PROJECT, ORG)).thenReturn(Optional.of(sending));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(RECEIVING_PROJECT, ORG)).thenReturn(Optional.of(receiving));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(org);
+        lenient().when(siteTransferRepository.save(any(SiteTransfer.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(materialRepository.findByIdAndOrganization_Id(eq(MATERIAL), eq(ORG)))
+                .thenAnswer(inv -> {
+                    Material material = new Material();
+                    material.setId(MATERIAL);
+                    return Optional.of(material);
+                });
+    }
+
+    private SiteTransferCreationDto dto(SiteTransferStatus status) {
+        SiteTransferCreationDto dto = new SiteTransferCreationDto();
+        dto.setIssueDate(LocalDateTime.now());
+        dto.setSendingPerson(SENDER);
+        dto.setSendingProjectId(SENDING_PROJECT);
+        dto.setReceivingProjectId(RECEIVING_PROJECT);
+        dto.setStatus(status);
+        SiteTransferItemDto item = new SiteTransferItemDto();
+        item.setMaterialId(MATERIAL);
+        item.setSentQuantity(4);
+        dto.setItems(List.of(item));
+        return dto;
+    }
+
+    @Test
+    void create_refusesATransferIssuedAlreadyCompleted() {
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto(SiteTransferStatus.COMPLETED)))
+                .withMessageContaining("cannot be created as COMPLETED");
+
+        verify(siteTransferRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_refusesATransferIssuedAlreadyPartiallyTransferred() {
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto(SiteTransferStatus.PARTIALLY_TRANSFERRED)))
+                .withMessageContaining("cannot be created as PARTIALLY_TRANSFERRED");
+
+        verify(siteTransferRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+
+    @Test
+    void create_refusesEveryStartingStateButPending() {
+        // Both later states are recorded through PATCH /{id}/status, so neither is a state the
+        // caller raising the transfer could have reached by asking for it.
+        for (SiteTransferStatus status : SiteTransferStatus.values()) {
+            if (status == SiteTransferStatus.PENDING) {
+                continue;
+            }
+            assertThatExceptionOfType(InvalidRequestException.class)
+                    .isThrownBy(() -> service.createSiteTransfer(dto(status)))
+                    .withMessageContaining("cannot be created as " + status);
+        }
+        verify(siteTransferRepository, never()).save(any());
+    }
+
+    @Test
+    void create_withNoStatusInThePayload_startsPending() {
+        stubMasterLookups();
+
+        service.createSiteTransfer(dto(null));
+
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+    }
+
+    @Test
+    void create_withPendingInThePayload_isAccepted() {
+        stubMasterLookups();
+
+        service.createSiteTransfer(dto(SiteTransferStatus.PENDING));
+
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+        verify(eventPublisher).publishEvent(any(SiteTransferCreatedEvent.class));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -164,7 +164,7 @@ class SiteTransferServiceTest {
         dto.setSendingPerson(SENDER);
         dto.setSendingProjectId(SENDING_PROJECT);
         dto.setReceivingProjectId(RECEIVING_PROJECT);
-        dto.setStatus("PENDING");
+        dto.setStatus(SiteTransferStatus.PENDING);
         dto.setItems(List.of(item(MATERIAL, 4)));
         return dto;
     }

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
@@ -26,6 +26,7 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
@@ -148,7 +149,7 @@ class SiteTransferStockScopeTest {
         dto.setSendingProjectId(SENDING_PROJECT);
         dto.setReceivingProjectId(RECEIVING_PROJECT);
         dto.setSendingStorageLocationId(sendingLocationId);
-        dto.setStatus("PENDING");
+        dto.setStatus(SiteTransferStatus.PENDING);
         dto.setItems(List.of(item(MATERIAL, 4)));
         return dto;
     }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
@@ -1,0 +1,147 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * A stock adjustment is raised as a draft and reaches its posted state only through
+ * {@code approve}, which is what refuses an approval by whoever raised the document, writes
+ * the stock-ledger entries and moves the balance. A body that set the status itself would
+ * reach that state with none of it: no approver on record, no ledger entries, no movement, and
+ * the document reading as dealt with. These pin that the status may only be draft, on the
+ * create path and on the update path that writes the same header.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentCreateStatusTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private StockAdjustmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(call -> {
+            Organization org = new Organization();
+            org.setId(ORG);
+            return org;
+        });
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private StockAdjustmentCreationDto dto(String status) {
+        StockAdjustmentCreationDto dto = new StockAdjustmentCreationDto();
+        dto.setAdjustmentNumber("ADJ-001");
+        dto.setType("write_off");
+        dto.setJustification("Quarterly count found a shortfall in River Sand");
+        dto.setStatus(status);
+        return dto;
+    }
+
+    @Test
+    void create_refusesADocumentRaisedAlreadyApproved() {
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.create(dto("APPROVED")))
+                .withMessageContaining("cannot be given the status APPROVED");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void create_refusesADocumentRaisedInThePostedState() {
+        // The state approve() stamps once the movements are on the ledger. Reaching it here
+        // would leave a document that reads as posted with nothing posted behind it.
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.create(dto(StockAdjustmentService.POSTED_STATUS)))
+                .withMessageContaining("cannot be given the status processed");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void create_withNoStatusInTheBody_raisesADraft() {
+        service.create(dto(null));
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(StockAdjustmentService.DRAFT_STATUS);
+    }
+
+    @Test
+    void create_withDraftInTheBody_isAcceptedWhateverItsCase() {
+        service.create(dto("Draft"));
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(StockAdjustmentService.DRAFT_STATUS);
+    }
+
+    @Test
+    void update_refusesToMoveADocumentIntoThePostedState() {
+        // The document can be edited right up until it is posted, so gating only create would
+        // leave the same door one call further along.
+        StockAdjustment existing = new StockAdjustment();
+        existing.setId(4L);
+        existing.setStatus(StockAdjustmentService.DRAFT_STATUS);
+        lenient().when(stockAdjustmentRepository.findByIdAndOrganization_Id(4L, ORG))
+                .thenReturn(Optional.of(existing));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(4L, dto(StockAdjustmentService.POSTED_STATUS)))
+                .withMessageContaining("cannot be given the status processed");
+
+        assertThat(existing.getStatus()).isEqualTo(StockAdjustmentService.DRAFT_STATUS);
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+}


### PR DESCRIPTION
Continues #541. #544 closed the two entries that were not hygiene; this closes the rest of the survey, under the same rule and with no second mechanism: a create may not reach a state whose transition carries a check or an event, the field stays on the payload typed as its enum and optional, and the schema's `allowableValues` names what is real.

## Refused

| Entity | What create takes now | What is behind the state it can no longer reach |
|---|---|---|
| StockAdjustment | `draft` only, on create **and** update | `approve` refuses a self-approval (#559), writes an `InventoryTransaction` per line, moves the balance, and stamps the approver and the posting time |
| SiteTransfer | `PENDING` only, and defaults to it | `PATCH /{id}/status` records what the receiving site took delivery of, and a different authority holds it |

**StockAdjustment (rank 3).** Its status was a free string copied straight onto the entity by both create and update. `"APPROVED"` on create is the case the issue names, and #559 makes it more than untidy: the self-approval check it added guards the one transition, so a body that wrote the status itself sidestepped the control by not using the transition. The posted state is worse still, because `POSTED_STATUS` is what every list and detail view reads as dealt with, while `processedAt` (which is what actually freezes the document) stayed null: a document reading as posted with no approver on record, no ledger entries and the balance untouched.

Applied to `update` as well as `create`, because both write the same header through `applyHeaderFields` and a document can be edited right up until it is posted. Gating only create would have left the same door one call further along.

The status stays a `String` rather than becoming an enum. The column deliberately holds the frontend's own lower-case vocabulary (documented on the entity, alongside `write_off` and `physical_count`), the module has exactly two producers of the value, and the issue's suggestion of an enum plus a status endpoint is a build rather than a guard. `draft` is matched case-insensitively.

**SiteTransfer (rank 4).** `PARTIALLY_TRANSFERRED` and `COMPLETED` both say the far end has received the materials, which is recorded through `PATCH /site-transfers/{id}/status`. On the token-authority controller that endpoint wants `site-transfer:update` while create wants `site-transfer:create`, so a caller who may only raise transfers could record their own receipt of one. Stock moves on creation either way, through `SiteTransferCreatedEvent`, so what a transfer issued as `COMPLETED` left behind was a movement standing as confirmed by nobody.

The field is now typed as `SiteTransferStatus` and optional, defaulting to `PENDING`, which is what the web form already sends and what `echno-core` documents as the typical initial value.

## Deleted

**`EmployeeCreationDto.status` (rank 7).** Verified still correct: `EmployeeService.EmployeeObjectMapper` does not read it, and nothing else does. It was `@NotBlank`, so a caller was made to send a value nothing read and a caller who left it out was refused for it, which is also why `echno-core`'s `createEmployeeToJson` (which sends no status) would have been rejected by this endpoint. An employee's status is written through the employee patch path, which is the one place that sets it. Deleting relaxes the contract in both directions.

## Left alone, deliberately

Not narrowing a field just because it can be narrowed is the other half of #544's rule, so these are stated rather than quietly skipped.

| Entity | Why it stays as it is |
|---|---|
| Expense, Receipt, SubContract, Asset (rank 5) | Free strings with no enum, no state machine, no status endpoint and no event. Written by create and update under the same role, and read only as a list filter. Refusing values would take away frontend-defined vocabulary for no safety gained. The day a workflow goes behind one of them, its create has to be gated in the same change. |
| `ConstructionPaymentService.update` (the adjacent item) | `ConstructionPaymentVoucherStatus` states carry no journal entry on any transition (stated on the enum itself), the only guard is that `CANCELLED` is terminal, and `update` already enforces that. There is no status endpoint, so update is the only way a payment can be recorded as completed at all: refusing the field there would make `COMPLETED` unreachable rather than gated. `create` already forces `PENDING`. |
| Task, WBS, Indent, Vendor, Labour, Employee join-org, InviteCode (rank 6) | Checked again: plain `setStatus` on create and on update, the same role gate on both, and the only status-related events in the codebase are `ProjectApprovedEvent` (closed by #544) and `SiteTransferCreatedEvent` (which fires on create whatever the status). Nothing sits behind any of their terminal values. |

## Deploy ordering

None of this needs a coordinated deploy, for the same reason #544 gave. A refused value fails loudly with a message naming the endpoint to use instead, rather than being silently written or silently dropped. Beyond that:

- Stock adjustments have no client at all: the module appears nowhere in `echno-core` or `echno-web`, so nothing sends a status to refuse. Staging holds one row, a draft.
- The site-transfer create page already hardcodes `SiteTransferStatus.pending`, so the tightened endpoint refuses nothing the client sends. tornotron/echno-web#320 needs no follow-up for this, and neither does anything else in the app; the status control on the transfer form is on the detail page, which goes through the status endpoint.
- Deleting `EmployeeCreationDto.status` cannot break a client that still sends it: the application's mapper ignores an undeclared property, pinned by a test.

## Failing-test table

Each new test run against a reverted baseline (the guards removed and the status copied from the body again, `EmployeeCreationDto.status` restored), then against the fix.

| Test | Without the fix | With the fix |
|---|---|---|
| `SiteTransferCreateStatusTest.create_refusesATransferIssuedAlreadyCompleted` | FAILED | PASSED |
| `SiteTransferCreateStatusTest.create_refusesATransferIssuedAlreadyPartiallyTransferred` | FAILED | PASSED |
| `SiteTransferCreateStatusTest.create_refusesEveryStartingStateButPending` | FAILED | PASSED |
| `SiteTransferCreateStatusTest.create_withNoStatusInThePayload_startsPending` | FAILED | PASSED |
| `StockAdjustmentCreateStatusTest.create_refusesADocumentRaisedAlreadyApproved` | FAILED | PASSED |
| `StockAdjustmentCreateStatusTest.create_refusesADocumentRaisedInThePostedState` | FAILED | PASSED |
| `StockAdjustmentCreateStatusTest.create_withNoStatusInTheBody_raisesADraft` | FAILED | PASSED |
| `StockAdjustmentCreateStatusTest.create_withDraftInTheBody_isAcceptedWhateverItsCase` | FAILED | PASSED |
| `StockAdjustmentCreateStatusTest.update_refusesToMoveADocumentIntoThePostedState` | FAILED | PASSED |
| `EmployeeCreationDtoTest.aPayloadThatNamesNoStatusIsValid` | FAILED | PASSED |

Two further new tests are negative controls and pass either way by design: `SiteTransferCreateStatusTest.create_withPendingInThePayload_isAccepted` (the legitimate value still goes through and still publishes the stock event) and `EmployeeCreationDtoTest.aPayloadThatStillSendsAStatusIsStillAccepted` (an old client is not broken).

Full suite on `lab-node-116-f`: **BUILD SUCCESSFUL**, 1242 tests, 0 failures, on `ef15dad`. Plain JUnit and Mockito throughout, no new Spring context, so no change to the test-heap position. No Liquibase changeset: nothing about the stored data changes.
