### PR TITLE
Close the API docs by default instead of at one edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Once the service is running, the live, generated API reference is available at `
 (OpenAPI JSON at `/v3/api-docs`). Controllers and DTOs carry OpenAPI annotations, so the Swagger UI
 groups endpoints by module and documents request and response fields.
 
+Those paths are closed to unauthenticated callers by default, because the OpenAPI document is the
+whole endpoint surface in one file. Set `SWAGGER_PUBLIC_ACCESS=true` to open them for an environment
+where the docs are wanted, such as your own run:
+
+```bash
+SWAGGER_PUBLIC_ACCESS=true ./gradlew bootRun
+```
+
 ## Getting Started
 
 ### Prerequisites

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
@@ -37,6 +37,13 @@ public class SecurityConfig {
     @Value("${keycloak.frontend.web-origin}")
     private List<String> allowedOrigins;
 
+    /**
+     * Whether the API docs are served to an unauthenticated caller. Closed unless an
+     * environment opts in (SWAGGER_PUBLIC_ACCESS=true), because the OpenAPI document is
+     * the entire endpoint surface in one download. Both the fallback here and the value
+     * shipped in application.yml are false, so an ingress that reaches this application
+     * without passing an edge rule still gets 401 on the docs paths. See issue #569.
+     */
     @Value("${springdoc.swagger-ui.public-access:false}")
     private boolean swaggerPublicAccess;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,15 @@ management:
     prometheus:
       access: unrestricted
     health:
-      show-details: always
+      # /actuator is permitAll (kubelet probes and the compose healthcheck reach it
+      # without a credential), so whatever this value is, it is served to whoever can
+      # reach the port. "always" would put every component's detail there: database
+      # url, disk paths, broker addresses. "when_authorized" keeps the aggregate
+      # status the probes need and withholds the breakdown from an anonymous caller.
+      # Both deployed environments already set this to when_authorized by env var; the
+      # shipped default now matches, so a developer run and any future deployment
+      # shape inherit it too.
+      show-details: ${MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS:when_authorized}
   endpoints:
     web:
       exposure:
@@ -312,7 +320,23 @@ spring:
 
 springdoc:
   swagger-ui:
-    public-access: true
+    # Whether /swagger-ui/**, /swagger-ui.html and /v3/api-docs/** are served to an
+    # unauthenticated caller. Off by default: the OpenAPI document is the whole
+    # endpoint surface, every path, parameter and DTO schema in one download, which is
+    # the reconnaissance step for finding the endpoint whose authorization is weakest.
+    #
+    # This used to ship as true, and what kept it private was a rule on the compose
+    # edge vhost that 404s the docs paths. That rule is still there and still right,
+    # but it only ever covered one ingress: the k8s ingress carries no equivalent, so
+    # for as long as it has existed the document has been a public download on
+    # backend-k8s.echno.in. The default belongs here, where every ingress inherits it,
+    # rather than in a rule each new front door has to remember. See issue #569.
+    #
+    # Turn it on where the docs are wanted (a developer's own run, or a staging the
+    # team reads them on) by setting SWAGGER_PUBLIC_ACCESS=true for that environment.
+    # With it off, the paths answer 401 rather than 404: springdoc still builds the
+    # document, Spring Security just refuses to hand it to an anonymous caller.
+    public-access: ${SWAGGER_PUBLIC_ACCESS:false}
 
 server:
   tomcat:

--- a/src/test/java/org/tornotron/echno_backend/architecture/ShippedConfigurationDefaultTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ShippedConfigurationDefaultTest.java
@@ -1,0 +1,86 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Guards the two shipped configuration values that decide what an unauthenticated caller
+ * can read, by evaluating them the way an environment that sets nothing would.
+ *
+ * <p>The point is the default rather than any one deployment. Both of these were once
+ * permissive in application.yml and safe only because something outside this repository
+ * closed them: the compose edge vhost returned 404 for the docs paths, and both
+ * deployments set the health detail level by environment variable. That held until a
+ * second ingress arrived. The k8s ingress carries no equivalent rule, so the OpenAPI
+ * document, the full endpoint surface, was a public download on backend-k8s.echno.in for
+ * as long as that host existed. A default that leans closed would have covered it without
+ * anyone remembering to. See issue #569.
+ *
+ * <p>Reading the file rather than starting a context is deliberate: the question is what
+ * application.yml ships, and a test that booted Spring would answer it for whatever
+ * profile and property sources the test harness happens to supply. It also costs no test
+ * context, which matters in a 1 GB test JVM (see {@link UnboundedRepositoryReadTest}).
+ */
+class ShippedConfigurationDefaultTest {
+
+    /** Resolves {@code ${NAME:default}} the way an environment supplying nothing would. */
+    private static final PropertyPlaceholderHelper UNSET_ENVIRONMENT =
+            new PropertyPlaceholderHelper("${", "}", ":", '\\', true);
+
+    @Test
+    @DisplayName("the API docs are closed unless an environment asks for them")
+    void apiDocsAreNotPublicByDefault() {
+        String shipped = shippedValue("springdoc", "swagger-ui", "public-access");
+
+        assertThat(Boolean.parseBoolean(resolveWithNothingSet(shipped)))
+                .as("springdoc.swagger-ui.public-access in application.yml, evaluated with no "
+                        + "environment set. True here serves the whole OpenAPI document to an "
+                        + "unauthenticated caller on every ingress that does not separately block "
+                        + "it. Open it per environment with SWAGGER_PUBLIC_ACCESS=true instead.")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("health details are withheld from an anonymous caller unless an environment asks")
+    void healthDetailsAreNotAlwaysShownByDefault() {
+        String shipped = shippedValue("management", "endpoint", "health", "show-details");
+
+        assertThat(resolveWithNothingSet(shipped))
+                .as("management.endpoint.health.show-details in application.yml, evaluated with no "
+                        + "environment set. /actuator is permitAll so the kubelet probes and the "
+                        + "compose healthcheck can reach it, which means \"always\" hands every "
+                        + "component's detail to anyone who can reach the port.")
+                .isNotEqualTo("always");
+    }
+
+    private static String resolveWithNothingSet(String value) {
+        return UNSET_ENVIRONMENT.replacePlaceholders(value, name -> null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String shippedValue(String... path) {
+        try (InputStream in = ShippedConfigurationDefaultTest.class
+                .getClassLoader().getResourceAsStream("application.yml")) {
+            assertThat(in).as("application.yml on the classpath").isNotNull();
+
+            Object node = new Yaml().load(in);
+            for (String key : path) {
+                if (!(node instanceof Map<?, ?> map) || !map.containsKey(key)) {
+                    return fail("application.yml has no " + String.join(".", path));
+                }
+                node = ((Map<String, Object>) map).get(key);
+            }
+            return String.valueOf(node);
+        } catch (Exception e) {
+            return fail("could not read application.yml", e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #569.

## What was wrong

`application.yml` shipped `springdoc.swagger-ui.public-access: true`. `SecurityConfig` reads it as `${springdoc.swagger-ui.public-access:false}`, so the code default was already the safe one; the shipped value is what turned the docs on everywhere.

What kept them private was a rule in `echno-deployment`, `ansible/roles/edge/templates/vhost.conf.j2`, which returns 404 for `actuator|swagger-ui|swagger-resources|webjars|v3/api-docs` on the backend vhost. That rule is correct and stays. It covers one ingress. The k8s ingress carries no equivalent, so the exposure the issue predicted is not latent, it is live.

Probed unauthenticated, from outside the network, before this change:

| URL | `backend.echno.in` (compose) | `backend-k8s.echno.in` (k8s) |
|---|---|---|
| `/v3/api-docs` | 404 | **200, 1,466,410 bytes** |
| `/swagger-ui/index.html` | 404 | **200** |
| `/actuator/health` | 404 | **200** |

The complete API specification is a public 1.4 MB download today. Nothing here reaches the database (springdoc reads Spring's own request-mapping metadata), so this is not a data exposure. It is the whole endpoint map, which is the reconnaissance step for finding the endpoint whose authorization is weakest.

## What this changes

- `springdoc.swagger-ui.public-access: ${SWAGGER_PUBLIC_ACCESS:false}`. Closed by default, switchable per environment.
- `management.endpoint.health.show-details: ${MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS:when_authorized}`, same shape. See the correction below: this one is not currently broken anywhere.
- `ShippedConfigurationDefaultTest` evaluates both values the way an environment setting nothing would, and fails the build if either goes back to being permissive. Verified both directions: it passes on the new values and fails on the old ones. It parses the file rather than booting a context, so it costs nothing in the 1 GB test JVM.
- README says the docs are closed by default and how to open them.

## Correction to the issue: health details do not reproduce

The issue also flagged `management.endpoint.health.show-details: always`. It is not in effect on either host. `backend-k8s.echno.in/actuator/health` returns

```json
{"status":"UP","groups":["liveness","readiness"]}
```

with no component detail, because both deployments already set `MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS=when_authorized` by environment variable (`ansible/roles/apps/templates/backend.env.j2` and `k8s/scripts/create-app-secrets.sh`). So nothing is being fixed there. The change is alignment: the shipped default now says what both environments already say, which makes it a literal no-op in deployment and closes the same gap for a developer run and for any future deployment shape. If you would rather this PR touched only springdoc, say so and I will drop that hunk.

## Does this take away something the team uses

On compose staging the docs have always been 404 at the edge, so nothing changes there. On k8s staging they were reachable and will now answer 401. I have no evidence anyone was reading them there (Apidog is the team's collection), but it is a real capability being withdrawn, so it should be a decision rather than a side effect.

To turn them back on for an environment, set `SWAGGER_PUBLIC_ACCESS=true`:

- k8s: one more entry in the backend `env` list in `k8s/helm/echno/templates/backend.yaml`, or in `echno-backend-env`.
- compose: one line in `ansible/roles/apps/templates/backend.env.j2`. Note the edge rule would still 404 them, so the vhost rule would have to be relaxed too.
- locally: `SWAGGER_PUBLIC_ACCESS=true ./gradlew bootRun`.

## Two decisions, recorded rather than assumed

**The k8s ingress does not get the equivalent block.** The compose parallel is tempting, but ingress-nginx 4.11 ships `allow-snippet-annotations: false` (default since controller 1.9), so `server-snippet` is the only way to express `return 404` there and it would mean flipping that flag, plus the annotations risk level, on the shared controller. That lets anything able to create an Ingress in any namespace inject nginx configuration: a cluster-wide relaxation bought to close a host-specific gap that this PR now closes at the application, on every ingress at once, present and future. The application default is the durable control here; a third place to remember is what produced this issue in the first place.

**`/actuator/**` is a separate problem and is not in this PR.** It is unconditionally `permitAll` in `SecurityConfig` and cannot simply be authenticated: the kubelet probes and the compose healthcheck reach it with no credential. On k8s that leaves `/actuator` (the link listing), `/actuator/info` and `/actuator/prometheus` (470 lines of metrics, including per-URI request timings) publicly readable. The disclosure is small but real, and neither lever used here reaches it: the application cannot close it without breaking the probes, and the ingress cannot without the snippet relaxation above. The clean fix is `management.server.port`, moving actuator to its own port that the ingress does not route to while kubelet and the PodMonitor keep scraping the pod directly. That touches probes, the PodMonitor, the compose healthcheck and the blackbox check, so it belongs in its own change. Filed as a follow-up.

## Verification

Before and after probes on both hosts are in the issue thread once this reaches staging.