### PR TITLE
Let a stock adjustment correct a balance on another project's location

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -32,6 +32,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Stock-adjustment documents: draft, browse, edit, and post to the stock ledger.
@@ -199,6 +200,13 @@ public class StockAdjustmentService {
      * document, unless they hold the break-glass role, in which case the posting is allowed and
      * the ledger entries say they were self-approved. See {@link SelfApprovalPolicy}.
      *
+     * <p>The location on a line is scoped through
+     * {@link StorageLocationScope#requireUsableForBalanceCorrection}, not the strict rule the
+     * other stock paths use. A location belonging to another project is still refused, unless a
+     * balance row already sits at that (material, project, location), which is the one pairing an
+     * adjustment exists to correct: the strict rule is written for a new movement, and applying it
+     * here would leave a wrongly located balance with no route back at all.
+     *
      * <p>Every posted line writes an {@code ADJUST} {@link InventoryTransaction} whose
      * remarks carry the reason, so the balance stays explainable, and only then moves the
      * balance. Both happen in this transaction: an approval that recorded no movement is the
@@ -208,7 +216,7 @@ public class StockAdjustmentService {
      * @param id The document to approve and post.
      * @return The posted document as a DTO.
      * @throws ResourceNotFoundException if no such document exists in this organization.
-     * @throws InvalidRequestException if the document is already posted, is being approved by whoever raised it without the break-glass role, names no project, has no lines, or a line is missing a material, a reason, or a quantity, or would drive a balance negative.
+     * @throws InvalidRequestException if the document is already posted, is being approved by whoever raised it without the break-glass role, names no project, has no lines, or a line is missing a material, a reason, or a quantity, names a location on another project that holds no balance for it, or would drive a balance negative.
      */
     @Transactional
     public StockAdjustmentDto approve(Long id) {
@@ -251,12 +259,13 @@ public class StockAdjustmentService {
             StorageLocation location = line.getLocation() != null
                     ? line.getLocation()
                     : stockAdjustment.getLocation();
-            StorageLocationScope.requireUsableFromProject(location, project.getId());
 
-            Double balance = (location != null
+            Optional<Double> existingBalance = location != null
                     ? inventoryService.findStockAtLocation(material.getId(), project.getId(), location.getId())
-                    : inventoryService.findUnlocatedStock(material.getId(), project.getId()))
-                    .orElse(0.0);
+                    : inventoryService.findUnlocatedStock(material.getId(), project.getId());
+            StorageLocationScope.requireUsableForBalanceCorrection(location, project.getId(),
+                    existingBalance::isPresent);
+            Double balance = existingBalance.orElse(0.0);
             Double movement = resolveMovement(line, balance, material, id);
 
             // Record what was actually posted, so the document and the ledger agree.

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationScope.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationScope.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.storageLocation;
 
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 
+import java.util.function.BooleanSupplier;
+
 /**
  * The rule deciding which projects a storage location may be booked against.
  *
@@ -19,6 +21,15 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
  * <p>The web client applies the same rule when it fills the location dropdown
  * ({@code features/material-consumptions/storage-location-scope.ts}), so a change here
  * has to be made there too.
+ *
+ * <p><strong>Correcting an existing balance is the one exception</strong>, and it has its
+ * own entry point, {@link #requireUsableForBalanceCorrection}. The strict rule is written
+ * for a <em>new</em> movement, where a wrong (project, location) pairing is a mistake being
+ * made. A stock adjustment correcting a balance that already sits on such a pairing is the
+ * one case where the wrong pairing is the thing being fixed, so refusing it removes the
+ * only tool. That entry point accepts a location the balance row already exists at, and
+ * nothing else: it permits correcting a pairing that is already there and still refuses
+ * inventing a new one.
  */
 public final class StorageLocationScope {
 
@@ -53,6 +64,40 @@ public final class StorageLocationScope {
         throw new InvalidRequestException(String.format(
                 "Storage location with ID %d belongs to project with ID %d and cannot be used from "
                         + "project with ID %d. Choose a location on this project, or an "
+                        + "organisation-level location, which belongs to no project and is available "
+                        + "from every one.",
+                location.getId(), location.getProject().getId(), projectId));
+    }
+
+    /**
+     * Refuses a location that belongs to a different project, unless a balance already sits there.
+     *
+     * <p>This is the rule for the stock-adjustment path alone, which is why it is a separate
+     * method rather than a flag on {@link #requireUsableFromProject}: the strict rule stays
+     * the default everywhere, and relaxing it has to be asked for by name. The relaxation is
+     * deliberately narrow. It is not "any location in the organization": the location must
+     * already hold a balance row for this material and project, which is exactly the pairing
+     * an adjustment exists to correct. A location holding nothing is still refused, so an
+     * adjustment cannot invent a cross-project pairing that was never there.
+     *
+     * @param location The storage location, or null when no location is named.
+     * @param projectId The project the adjustment is booked against.
+     * @param balanceRowExists Whether a balance row already exists for this material, project and
+     *                         location. Consulted only when the strict rule would refuse, so the
+     *                         caller can pass a lookup without paying for it on the common path.
+     * @throws InvalidRequestException if the location belongs to another project and holds no balance.
+     */
+    public static void requireUsableForBalanceCorrection(StorageLocation location, Long projectId,
+                                                         BooleanSupplier balanceRowExists) {
+        if (isUsableFromProject(location, projectId) || balanceRowExists.getAsBoolean()) {
+            return;
+        }
+        throw new InvalidRequestException(String.format(
+                "Storage location with ID %d belongs to project with ID %d and holds no balance for "
+                        + "this material on project with ID %d, so there is no figure here to correct. "
+                        + "An adjustment may correct a balance that already sits on a location owned by "
+                        + "another project, but it cannot create one. Choose a location this project "
+                        + "already holds this material at, a location on this project, or an "
                         + "organisation-level location, which belongs to no project and is available "
                         + "from every one.",
                 location.getId(), location.getProject().getId(), projectId));

--- a/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/materialConsumption/MaterialConsumptionStockScopeTest.java
@@ -156,8 +156,14 @@ class MaterialConsumptionStockScopeTest {
     }
 
     @Test
-    void aStorageLocationBelongingToAnotherProjectIsRefused() {
+    void aStorageLocationBelongingToAnotherProjectIsRefusedEvenWhenItAlreadyHoldsABalance() {
+        // The stock-adjustment path accepts a location a balance already sits at, because
+        // correcting that pairing is what an adjustment is for. Recording a new consumption is
+        // not, so the strict rule still applies here whether a balance row exists or not.
         location(LOCATION, OTHER_PROJECT);
+        lenient().when(currentStockRepository
+                        .findByMaterialIdAndProjectIdAndStorageLocationId(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(stockRow(60.0)));
 
         assertThatExceptionOfType(InvalidRequestException.class)
                 .isThrownBy(() -> service.createMaterialConsumption(dto(LOCATION)))

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
@@ -10,6 +10,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.exception.InsufficientStockException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
@@ -161,6 +162,29 @@ class SiteTransferStockScopeTest {
         location.setProject(owner);
         lenient().when(storageLocationRepository.findByIdAndOrganization_Id(SENDING_LOCATION, ORG))
                 .thenReturn(Optional.of(location));
+    }
+
+    @Test
+    void aSendingLocationBelongingToAnotherProjectIsRefusedEvenWhenItAlreadyHoldsABalance() {
+        // The stock-adjustment path accepts a location a balance already sits at, because
+        // correcting that pairing is what an adjustment is for. A transfer records a new
+        // movement, so the strict rule still applies here whether a balance row exists or not.
+        StorageLocation location = new StorageLocation();
+        location.setId(SENDING_LOCATION);
+        Project owner = new Project();
+        owner.setId(RECEIVING_PROJECT);
+        location.setProject(owner);
+        when(storageLocationRepository.findByIdAndOrganization_Id(SENDING_LOCATION, ORG))
+                .thenReturn(Optional.of(location));
+        lenient().when(currentStockRepository
+                        .findByMaterialIdAndProjectIdAndStorageLocationId(MATERIAL, SENDING_PROJECT, SENDING_LOCATION))
+                .thenReturn(Optional.of(stockRow(60.0)));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.createSiteTransfer(dto(SENDING_LOCATION)))
+                .withMessageContaining("belongs to project with ID " + RECEIVING_PROJECT);
+
+        verify(siteTransferRepository, never()).save(any());
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -46,8 +46,10 @@ import static org.mockito.Mockito.when;
  * what that has to guarantee: a ledger entry carrying the reason is written before the
  * balance moves, a physical count lands the balance on the counted figure, a movement with
  * no stated reason is refused, an adjustment cannot be posted twice or edited afterwards,
- * and it cannot be used to book stock onto a location belonging to another project or to
- * push a balance below zero. Segregation of duties is covered here too: the person who
+ * and it cannot be used to book stock onto a location belonging to another project that
+ * holds no balance for it, or to push a balance below zero. The one relaxation the
+ * adjustment path carries is covered too: a balance that already sits on another project's
+ * location can be corrected, because that pairing is what the document exists to fix. Segregation of duties is covered here too: the person who
  * raised the document cannot approve it, and a system administrator who does is recorded
  * as having self-approved on the ledger entry itself.
  */
@@ -224,15 +226,45 @@ class StockAdjustmentApprovalTest {
     }
 
     @Test
-    void aLineOnALocationBelongingToAnotherProjectIsRefused() {
+    void aLineOnAnotherProjectsLocationHoldingNoBalanceIsRefused() {
+        // Nothing has ever been booked here, so there is no wrong pairing to correct and the
+        // adjustment would be inventing one. The strict rule still applies.
         StockAdjustment adjustment = adjustment(location(LOCATION, OTHER_PROJECT));
         line(adjustment, null, -5.0, "damage");
+        when(inventoryService.findStockAtLocation(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.empty());
 
         assertThatExceptionOfType(InvalidRequestException.class)
                 .isThrownBy(() -> service.approve(ADJUSTMENT))
-                .withMessageContaining("belongs to project with ID 9");
+                .withMessageContaining("belongs to project with ID 9")
+                .withMessageContaining("holds no balance");
 
         verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void aBalanceAlreadySittingOnAnotherProjectsLocationCanBeCorrected() {
+        // Issue #563. current_stock row 6 on staging is material 8 at project 7, storage
+        // location 2, holding 400; location 2 belongs to project 3. The wrong pairing is the
+        // thing being fixed, so the adjustment path has to reach it. MC-1 took 30 out of it,
+        // so the true figure is 370.
+        StockAdjustment adjustment = adjustment(null);
+        StockAdjustmentLineItem line = line(adjustment, 370.0, null, "Data correction");
+        line.setLocation(location(LOCATION, OTHER_PROJECT));
+        balanceAtLocation(400.0);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        InventoryTransaction posted = captor.getValue();
+        assertThat(posted.getOpeningStock()).isEqualTo(400.0);
+        assertThat(posted.getQuantityChanged()).isEqualTo(-30.0);
+        assertThat(posted.getClosingStock()).isEqualTo(370.0);
+        assertThat(posted.getStorageLocation().getId()).isEqualTo(LOCATION);
+        verify(inventoryService).updateCurrentStock(eq(material), eq(project), any(StorageLocation.class),
+                eq(organization), eq(-30.0), isNull());
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationScopeTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.project.Project;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -14,6 +16,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * stock. The rule: no project means an organisation-level store, usable from every
  * project; a named project means that project alone. The web client holds the same rule
  * in {@code features/material-consumptions/storage-location-scope.ts}.
+ *
+ * <p>The stock-adjustment exception is pinned here too: correcting a balance that already
+ * sits on a location owned by another project is allowed, and inventing one is not.
  */
 class StorageLocationScopeTest {
 
@@ -60,6 +65,41 @@ class StorageLocationScopeTest {
                 .withMessageContaining("Storage location with ID 7")
                 .withMessageContaining("belongs to project with ID 9")
                 .withMessageContaining("project with ID 3");
+    }
+
+    @Test
+    void aBalanceAlreadySittingOnAnotherProjectsLocationCanBeCorrected() {
+        StorageLocation site = location(7L, OTHER_PROJECT);
+
+        assertThatCode(() -> StorageLocationScope
+                .requireUsableForBalanceCorrection(site, PROJECT, () -> true))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void anAdjustmentCannotInventABalanceOnAnotherProjectsLocation() {
+        StorageLocation site = location(7L, OTHER_PROJECT);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> StorageLocationScope
+                        .requireUsableForBalanceCorrection(site, PROJECT, () -> false))
+                .withMessageContaining("Storage location with ID 7")
+                .withMessageContaining("belongs to project with ID 9")
+                .withMessageContaining("holds no balance")
+                .withMessageContaining("cannot create one");
+    }
+
+    @Test
+    void aLocationTheStrictRuleAlreadyAllowsIsNotLookedUpAtAll() {
+        StorageLocation site = location(7L, PROJECT);
+        AtomicBoolean lookedUp = new AtomicBoolean(false);
+
+        assertThatCode(() -> StorageLocationScope.requireUsableForBalanceCorrection(site, PROJECT, () -> {
+            lookedUp.set(true);
+            return false;
+        })).doesNotThrowAnyException();
+
+        assertThat(lookedUp).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Closes the blocker on #563.

## The problem

`StockAdjustmentService.approve` scopes every line through
`StorageLocationScope.requireUsableFromProject`, which refuses a line naming a storage
location whose `project_id` differs from the adjustment's project. That rule is right for a
**new** movement, which is what it was written for. An adjustment correcting an existing
balance is the one case where the wrong pairing is the thing being fixed, so refusing it
removes the only tool.

Twelve of the twenty `current_stock` rows on staging sit at exactly that pairing, listed in
#563. #529 built the adjustment path as the route back for balances no goods receipt can
explain, and the scope rule closed it against the legacy rows that most need it. Both landed
in the same commit, `5973899`, so it has never worked for these.

## The narrowed rule

On the adjustment path, a location is accepted when a balance row already exists at that
`(material, project, location)`. That is the precise condition and it is deliberately narrow:
it permits correcting a pairing that is already there and still refuses inventing a new one.
It is not "any location in the org", and the check is not disabled.

## How the relaxed path is made explicit

A second entry point on `StorageLocationScope`, not a flag on the existing one:

```java
public static void requireUsableForBalanceCorrection(StorageLocation location, Long projectId,
                                                     BooleanSupplier balanceRowExists)
```

- The strict `requireUsableFromProject` stays untouched and stays the default. Consumption,
  goods receipt and site transfer still call it.
- Relaxing has to be asked for by name at the call site, so no future caller can opt into it
  by passing a boolean into the method it already uses.
- The third argument is a fact about the data, not a mode switch, and it is a `BooleanSupplier`
  consulted only when the strict rule would refuse, so the common path pays nothing for it.
  `approve` already reads the balance, so it passes `existingBalance::isPresent` and there is
  no extra query.
- The refusal message says why: the location holds no balance for this material and project,
  so there is no figure here to correct, and an adjustment cannot create one.

## Tests

Both directions, each proved to fail without the fix.

| Test | What it pins | Without the fix |
|------|--------------|-----------------|
| `StockAdjustmentApprovalTest.aBalanceAlreadySittingOnAnotherProjectsLocationCanBeCorrected` | The #563 shape: 400 at a location owned by another project, counted at 370, posts a -30 `ADJUST` against that location | FAILS: `InvalidRequestException: Storage location with ID 14 belongs to project with ID 9 and cannot be used from project with ID 7` |
| `StockAdjustmentApprovalTest.aLineOnAnotherProjectsLocationHoldingNoBalanceIsRefused` | An adjustment still cannot invent a cross-project pairing; nothing is posted | FAILS: refused by the strict rule with the wrong message, so it is not exercising the new path |
| `StorageLocationScopeTest.aBalanceAlreadySittingOnAnotherProjectsLocationCanBeCorrected` | The rule itself, in one place | FAILS to compile: method does not exist |
| `StorageLocationScopeTest.anAdjustmentCannotInventABalanceOnAnotherProjectsLocation` | The refusal and its message | FAILS to compile: method does not exist |
| `StorageLocationScopeTest.aLocationTheStrictRuleAlreadyAllowsIsNotLookedUpAtAll` | The lookup is not run when the strict rule already passes | FAILS to compile: method does not exist |
| `MaterialConsumptionStockScopeTest.aStorageLocationBelongingToAnotherProjectIsRefusedEvenWhenItAlreadyHoldsABalance` | Leak guard: consumption is still strict with a balance row present | Passes before and after, by design. It fails only if the relaxation is later moved onto the shared rule |
| `SiteTransferStockScopeTest.aSendingLocationBelongingToAnotherProjectIsRefusedEvenWhenItAlreadyHoldsABalance` | Leak guard: transfer is still strict with a balance row present | Same |

The two leak guards are regression guards rather than red-then-green tests, and they are
stated that way on purpose: they hold the strict rule down on the paths that record a new
movement, and both would have passed on the old code because the old code was strict
everywhere.

Full `./gradlew test` green on the lab build box.

## Note for the web client

`StorageLocationScope`'s doc points at `features/material-consumptions/storage-location-scope.ts`,
which applies the strict rule to the location dropdown. That is not changed here and does not
need to be for correctness: it narrows what can be picked, not what can be posted. It does mean
the adjustment screen will not offer such a location until it is widened. Worth pairing with the
separate gap #563 records, that `echno-web` and `@tornotron/echno-core` carry no call to
`POST /stock-adjustments/web/{id}/approve` at all, so a draft can be raised in the UI and never
posted.