### PR TITLE
Give compliance rules a change timestamp, and a sweep that reads it

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/domain/ComplianceRule.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/domain/ComplianceRule.java
@@ -4,9 +4,12 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.compliance.CompliancePhase;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -68,4 +71,55 @@ public class ComplianceRule {
 
     @Column(name = "active", nullable = false)
     private boolean active = true;
+
+    /** When this row first appeared. Audit only; nothing schedules off it. */
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** When this row was last written, for any reason at all. Audit only. */
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * When the rule came into force, as the catalogue's curator states it. This is the only
+     * timestamp the nightly sweep reads, and the distinction from {@link #updatedAt} is the
+     * whole reason it exists.
+     *
+     * <p>{@code updatedAt} moves on every write, including a corrected typo in
+     * {@link #description} and including a bulk re-seed that rewrites rows whose content did
+     * not change. A sweep keyed on it would treat a comma fix across the catalogue as the
+     * whole catalogue changing, and re-assess every approved project in every tenant against
+     * rules whose meaning is identical. That is expensive and it is also wrong: nothing about
+     * the answer changed.
+     *
+     * <p>So this one is deliberately inert. It is set once, to the insert time, by
+     * {@link #defaultEffectiveFrom()} when the caller has not set it, and the application never
+     * touches it again. Re-dating it forward is a curator's decision that says "this rule is
+     * materially different, assess projects against it again", and it is the only thing that
+     * makes an already-assessed project stale.
+     *
+     * <p>Two cases worth stating because they are easy to get wrong. Reactivating a rule by
+     * flipping {@link #active} back to true does not by itself re-date it, so a rule switched
+     * off and on again reaches only projects that were never assessed; move this forward as
+     * well if the intent is that everyone re-assesses. And a rule loaded with a back-dated
+     * {@code effectiveFrom} reaches nobody who has already been assessed, which is the right
+     * behaviour for recording history and the wrong one for a rule that is new to us.
+     */
+    @Column(name = "effective_from", nullable = false)
+    private LocalDateTime effectiveFrom;
+
+    /**
+     * Gives a new rule an {@code effectiveFrom} of now unless one was supplied. A rule the
+     * curator says nothing about is in force from when we learned of it, which is the only
+     * defensible default: dating it earlier would hide it from every project already assessed,
+     * and that is the exact failure this column exists to prevent.
+     */
+    @PrePersist
+    void defaultEffectiveFrom() {
+        if (effectiveFrom == null) {
+            effectiveFrom = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
@@ -179,6 +179,65 @@ public interface ComplianceGenerationJobRepository extends JpaRepository<Complia
             + "FROM compliance_generation_jobs WHERE id = :id", nativeQuery = true)
     Optional<DispatchRow> findDispatchRow(@Param("id") UUID id);
 
+    /**
+     * Approved projects across every tenant, each with the last time compliance was actually
+     * assessed for it. The nightly sweep's one scan.
+     *
+     * <p>Cross-tenant and scalars only, for the same reason the dispatcher queries above are:
+     * the caller has no tenant, because its whole job is to work out which tenants have
+     * something to do. It establishes one per project before anything is enqueued.
+     *
+     * <p>"Assessed" means a run that reached the model and came back, which is {@code SUCCEEDED}
+     * or {@code NOTHING_TO_REPORT}. The second of those matters: a run that assessed every rule
+     * and found none applicable did the work, and treating it as never-assessed would put the
+     * project back in the queue every night for ever. {@code FAILED} deliberately does not
+     * count, because a failed run assessed nothing, and {@code QUEUED} and {@code RUNNING} do
+     * not count because they have not finished; a project with one in flight is filtered out
+     * later by the job table's own one-active-job-per-project index, not here.
+     *
+     * <p>A null {@code lastAssessedAt} is a project that has never had a completed run at all,
+     * which is exactly the backlog this exists for: everything approved before generation was
+     * wired up, and everything whose approval-time run failed silently. Ordering nulls first
+     * puts that backlog at the front of a capped pass.
+     *
+     * <p>The project's jurisdiction is returned raw rather than matched here. Resolving a state
+     * from a free-text address is Java, so the comparison against the rule catalogue happens in
+     * the caller; this query's job is only to bound what the caller looks at.
+     */
+    @Query(value = "SELECT p.id AS \"projectId\", "
+            + "p.organization_id AS \"organizationId\", "
+            + "p.project_state AS \"projectState\", "
+            + "p.project_address AS \"projectAddress\", "
+            + "p.project_type AS \"projectType\", "
+            + "j.last_finished_at AS \"lastAssessedAt\" "
+            + "FROM project p "
+            + "LEFT JOIN (SELECT project_id, organization_id, max(finished_at) AS last_finished_at "
+            + "           FROM compliance_generation_jobs "
+            + "           WHERE status IN ('SUCCEEDED', 'NOTHING_TO_REPORT') "
+            + "           GROUP BY project_id, organization_id) j "
+            + "  ON j.project_id = p.id AND j.organization_id = p.organization_id "
+            + "WHERE p.status = 'approved' "
+            + "  AND p.organization_id IS NOT NULL "
+            + "  AND p.project_type IS NOT NULL "
+            + "ORDER BY j.last_finished_at ASC NULLS FIRST, p.id ASC "
+            + "LIMIT :limit", nativeQuery = true)
+    List<SweepCandidate> findSweepCandidates(@Param("limit") int limit);
+
+    /** One approved project the sweep has to decide about. */
+    interface SweepCandidate {
+        Long getProjectId();
+
+        Long getOrganizationId();
+
+        String getProjectState();
+
+        String getProjectAddress();
+
+        String getProjectType();
+
+        LocalDateTime getLastAssessedAt();
+    }
+
     /** What a worker needs off a claimed row before it can establish the tenant and start. */
     interface DispatchRow {
         Long getOrganizationId();

--- a/src/main/java/org/tornotron/echno_backend/compliance/repository/ComplianceRuleRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/repository/ComplianceRuleRepository.java
@@ -1,10 +1,12 @@
 package org.tornotron.echno_backend.compliance.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
 import org.tornotron.echno_backend.project.enums.ProjectType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,4 +24,32 @@ public interface ComplianceRuleRepository extends JpaRepository<ComplianceRule, 
      */
     List<ComplianceRule> findByStateIgnoreCaseAndProjectTypeAndActiveTrue(String state,
                                                                           ProjectType projectType);
+
+    /**
+     * The newest {@code effectiveFrom} in each jurisdiction, over active rules only.
+     *
+     * <p>This is the whole of what the sweep needs from the catalogue, and it is one query for
+     * every project rather than one per project. The table is global reference data measured in
+     * tens of rows, so the grouped result is small enough to hold in memory for a pass and
+     * compare against each candidate, which is what keeps the sweep from issuing a query per
+     * project across every tenant.
+     *
+     * <p>Inactive rules are excluded because a rule that is switched off cannot make anything
+     * stale: generation would not consider it, so re-assessing a project on account of it would
+     * spend a model call to produce the answer the project already has.
+     */
+    @Query("SELECT r.state AS state, r.projectType AS projectType, "
+            + "MAX(r.effectiveFrom) AS newestEffectiveFrom "
+            + "FROM ComplianceRule r WHERE r.active = true "
+            + "GROUP BY r.state, r.projectType")
+    List<JurisdictionChange> findNewestEffectiveFromByJurisdiction();
+
+    /** One jurisdiction and the most recent moment anything in it came into force. */
+    interface JurisdictionChange {
+        String getState();
+
+        ProjectType getProjectType();
+
+        LocalDateTime getNewestEffectiveFrom();
+    }
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweep.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweep.java
@@ -1,0 +1,279 @@
+package org.tornotron.echno_backend.compliance.sweep;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.IndianStateResolver;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Finds approved projects that were never assessed against the compliance rules now in force,
+ * and queues a generation run for each.
+ *
+ * <h2>The gap this closes</h2>
+ *
+ * <p>Compliance is generated when a project is approved, and only then. That is fine for a
+ * project approved into a catalogue that already covers it, and silently wrong for every other
+ * case. A project approved before its jurisdiction had any rules gets nothing and is never
+ * revisited. A project approved while its state was unset is refused at accept time, correctly,
+ * and nothing retries it once the state is filled in. And the moment a curated catalogue lands,
+ * every project approved before it is permanently missing compliances that nobody knows are
+ * missing, which is discovered by someone noticing an empty list.
+ *
+ * <h2>What makes a project stale</h2>
+ *
+ * <p>One comparison: the newest {@code effectiveFrom} among the active rules for the project's
+ * jurisdiction, against the last time a run for that project actually finished. Never assessed
+ * is stale by definition.
+ *
+ * <p>{@code effectiveFrom} rather than {@code updatedAt} is the entire design of this. The two
+ * are easy to conflate and the difference is the difference between a sweep that costs almost
+ * nothing and one that re-assesses the world: {@code updatedAt} moves when someone fixes a
+ * typo, and it moves on every row of a bulk re-seed whose content did not change, so a sweep
+ * keyed on it would spend a model call per approved project per tenant to re-derive answers
+ * that did not change. {@code effectiveFrom} moves only when a curator says the rule is
+ * materially different. See {@code ComplianceRule#effectiveFrom}.
+ *
+ * <h2>It queues, it does not generate</h2>
+ *
+ * <p>Every stale project goes through {@link ComplianceGenerationJobService#submit}, the same
+ * entry point the approval listener and the manual endpoint use. That is not tidiness. Calling
+ * generation inline from here would put a model call per project on the scheduler thread,
+ * outside any lease, with no record that it was attempted, no progress for anyone watching, and
+ * nothing to recover it when the replica restarts halfway through, which is the whole of what
+ * the job queue was built to fix. Going through the queue also means the one-active-job-per-
+ * project index does the obvious right thing: a project with a run already in flight is handed
+ * back that run instead of getting a second one.
+ *
+ * <h2>Pacing</h2>
+ *
+ * <p>The thundering herd this could be is prevented by the queue rather than by anything here.
+ * Enqueueing is an insert; {@code compliance.job.max-in-flight} decides how many runs are ever
+ * in flight against the inference endpoint, so a pass that queues 25 jobs produces a queue that
+ * drains two at a time, not 25 simultaneous calls to a rate-limited endpoint. On top of that
+ * this pass bounds both what it reads ({@code scanLimit}) and what it spends
+ * ({@code maxProjectsPerRun}), and takes candidates oldest-assessed first so a capped pass
+ * still makes deterministic progress and the next one continues behind it.
+ *
+ * <h2>Off by default</h2>
+ *
+ * <p>{@code compliance.sweep.enabled} is false, so this bean does not exist unless someone
+ * turns it on. The mechanism is settled; three things about the policy are not, and none of
+ * them is a call this code can make. Whether re-dating a rule is the right way to ask for
+ * re-assessment, or whether some narrower notion of "changed" is wanted. How often a pass
+ * should run. And whether a tenant should be able to decline it, since the spend is real and
+ * lands on whoever owns the inference key.
+ *
+ * <p>One question is deliberately left answered a particular way, and it is worth being
+ * explicit about. A project whose state still cannot be resolved is skipped quietly every pass
+ * rather than retried against the model, because there is nothing to retry: the precondition
+ * fails before any call is made, so retrying costs nothing and achieves nothing. Skipping it
+ * silently for ever would be its own version of this bug, so the pass counts them and logs the
+ * count. Surfacing that on the project itself, where somebody would see it, is a UI change and
+ * is left for whoever picks that up.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "compliance.sweep.enabled", havingValue = "true")
+public class ComplianceRuleSweep {
+
+    private final ComplianceRuleRepository ruleRepository;
+    private final ComplianceGenerationJobRepository jobRepository;
+    private final ComplianceGenerationJobService jobService;
+    private final TenantScopedJobRunner tenantScopedJobRunner;
+    private final TransactionRetryTemplate retryTemplate;
+    private final ComplianceSweepProperties properties;
+
+    /**
+     * One pass.
+     *
+     * <p>Nothing here throws. A pass that fails must not stop the schedule, because Spring stops
+     * rescheduling a {@code @Scheduled} method that throws and a catch-up sweep that quietly
+     * stopped catching up is the failure this class exists to remove, one level up.
+     */
+    @Scheduled(cron = "${compliance.sweep.cron:0 0 2 * * *}", zone = "${compliance.sweep.zone:UTC}")
+    @WithoutTenant("The sweep belongs to no organization: it exists to find which organizations "
+            + "have projects to re-assess, reads scalars only across tenants, and establishes a "
+            + "tenant per project before anything is enqueued")
+    public void sweep() {
+        try {
+            runPass();
+        } catch (Exception e) {
+            log.error("Compliance sweep pass failed: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * The pass itself. Package-private so a test can run it and assert on what it did, without
+     * waiting on a cron.
+     */
+    void runPass() {
+        Map<String, LocalDateTime> newestByJurisdiction = loadJurisdictionChanges();
+        if (newestByJurisdiction.isEmpty()) {
+            log.debug("Compliance sweep found no active rules; nothing to compare projects against");
+            return;
+        }
+
+        List<ComplianceGenerationJobRepository.SweepCandidate> candidates = retryTemplate.execute(
+                "ComplianceRuleSweep.findCandidates",
+                () -> jobRepository.findSweepCandidates(Math.max(1, properties.getScanLimit())));
+
+        int cap = Math.max(0, properties.getMaxProjectsPerRun());
+        int enqueued = 0;
+        int alreadyRunning = 0;
+        int notAssessable = 0;
+        int upToDate = 0;
+
+        for (ComplianceGenerationJobRepository.SweepCandidate candidate : candidates) {
+            if (enqueued >= cap) {
+                log.info("Compliance sweep stopped at its per-run cap of {} project(s); the rest "
+                        + "are picked up by the next pass", cap);
+                break;
+            }
+
+            LocalDateTime newest = newestFor(candidate, newestByJurisdiction);
+            if (newest == null) {
+                // No jurisdiction we could resolve, or no active rules for it. Generation would
+                // refuse this project anyway, so there is nothing to queue.
+                notAssessable++;
+                continue;
+            }
+
+            LocalDateTime lastAssessed = candidate.getLastAssessedAt();
+            if (lastAssessed != null && !newest.isAfter(lastAssessed)) {
+                upToDate++;
+                continue;
+            }
+
+            switch (submit(candidate)) {
+                case ENQUEUED -> enqueued++;
+                case ALREADY_RUNNING -> alreadyRunning++;
+                case NOT_ASSESSABLE -> notAssessable++;
+            }
+        }
+
+        log.info("Compliance sweep looked at {} approved project(s): queued {}, {} already running, "
+                        + "{} up to date, {} not assessable yet",
+                candidates.size(), enqueued, alreadyRunning, upToDate, notAssessable);
+    }
+
+    /** What happened to one candidate. */
+    private enum Outcome { ENQUEUED, ALREADY_RUNNING, NOT_ASSESSABLE }
+
+    /**
+     * Queues a run for one project, under that project's tenant.
+     *
+     * <p>The two expected exceptions are caught and counted rather than logged as faults. A
+     * project with no resolvable state, or none registered for its jurisdiction, is a normal
+     * state of affairs on this path and not something an operator should be woken for. Anything
+     * else is logged and the pass carries on, because one bad project must not cost every other
+     * project its night.
+     */
+    private Outcome submit(ComplianceGenerationJobRepository.SweepCandidate candidate) {
+        Long projectId = candidate.getProjectId();
+        Long orgId = candidate.getOrganizationId();
+        try {
+            ComplianceGenerationJobService.Accepted accepted = tenantScopedJobRunner.callForTenant(
+                    orgId, () -> jobService.submit(projectId, orgId));
+            if (accepted.created()) {
+                log.info("Compliance sweep queued generation for project {} in organization {}",
+                        projectId, orgId);
+                return Outcome.ENQUEUED;
+            }
+            return Outcome.ALREADY_RUNNING;
+        } catch (InvalidRequestException | ResourceNotFoundException e) {
+            log.debug("Compliance sweep skipped project {} in organization {}: {}",
+                    projectId, orgId, e.getMessage());
+            return Outcome.NOT_ASSESSABLE;
+        } catch (Exception e) {
+            log.error("Compliance sweep could not queue generation for project {} in organization "
+                    + "{}: {}", projectId, orgId, e.getMessage(), e);
+            return Outcome.NOT_ASSESSABLE;
+        }
+    }
+
+    /**
+     * The newest moment anything came into force in each jurisdiction, keyed the way the
+     * generation query matches rules: state case-insensitively, plus project type.
+     */
+    private Map<String, LocalDateTime> loadJurisdictionChanges() {
+        List<ComplianceRuleRepository.JurisdictionChange> changes = retryTemplate.execute(
+                "ComplianceRuleSweep.loadJurisdictionChanges",
+                ruleRepository::findNewestEffectiveFromByJurisdiction);
+
+        Map<String, LocalDateTime> byJurisdiction = new HashMap<>();
+        for (ComplianceRuleRepository.JurisdictionChange change : changes) {
+            if (change.getState() == null || change.getProjectType() == null
+                    || change.getNewestEffectiveFrom() == null) {
+                continue;
+            }
+            byJurisdiction.merge(key(change.getState(), change.getProjectType()),
+                    change.getNewestEffectiveFrom(),
+                    (a, b) -> a.isAfter(b) ? a : b);
+        }
+        return byJurisdiction;
+    }
+
+    /**
+     * The newest applicable rule change for one project, or null if it has no jurisdiction we
+     * can resolve or no active rules in it.
+     *
+     * <p>The state is resolved exactly as generation resolves it, including the free-text
+     * address fallback, so the sweep cannot decide a project is stale on a jurisdiction that
+     * generation would then refuse to use.
+     */
+    private LocalDateTime newestFor(ComplianceGenerationJobRepository.SweepCandidate candidate,
+                                    Map<String, LocalDateTime> newestByJurisdiction) {
+        String state = IndianStateResolver.forProject(
+                candidate.getProjectState(), candidate.getProjectAddress());
+        if (state == null) {
+            return null;
+        }
+
+        ProjectType projectType = parseProjectType(candidate.getProjectType());
+        if (projectType == null) {
+            return null;
+        }
+
+        return newestByJurisdiction.get(key(state, projectType));
+    }
+
+    /**
+     * The project type as an enum. It arrives as text because the candidate query is native, and
+     * a value this build does not know is treated as no type at all rather than crashing the
+     * pass over one row.
+     */
+    private ProjectType parseProjectType(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return ProjectType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            log.warn("Compliance sweep does not recognise project type '{}'; skipping that project",
+                    value);
+            return null;
+        }
+    }
+
+    private String key(String state, ProjectType projectType) {
+        return state.toLowerCase(Locale.ROOT) + "|" + projectType.name();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceSweepProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceSweepProperties.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.compliance.sweep;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * How the catch-up sweep behaves. Bound from the {@code compliance.sweep.*} block in
+ * application.yml.
+ *
+ * <p>It is off by default, which is a deliberate choice rather than caution about the code.
+ * Three questions here are product decisions and none of them can be answered from the
+ * codebase: which changes to the catalogue should count as worth re-assessing a project for,
+ * how often the sweep should run, and whether a tenant should be able to decline it. The
+ * mechanism is built and the answers are configuration, so whoever settles them turns it on
+ * without a build.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "compliance.sweep")
+public class ComplianceSweepProperties {
+
+    /**
+     * Master switch. False, so nothing runs until someone decides it should.
+     *
+     * <p>Turning it on is safe in the sense that the queue paces the work and the generation
+     * path is idempotent, but it does spend money on inference for every project it finds
+     * stale, and how much depends entirely on what the catalogue looks like by then.
+     */
+    private boolean enabled = false;
+
+    /**
+     * When the pass runs, as a Spring cron expression. Two in the morning by default, because
+     * the work is inference against a shared endpoint and the cheapest time to contend for it
+     * is when nobody is using the application.
+     */
+    private String cron = "0 0 2 * * *";
+
+    /**
+     * Time zone the cron is read in. UTC rather than the server's zone, so the schedule does
+     * not move when a host's zone is set differently, and does not shift twice a year.
+     */
+    private String zone = "UTC";
+
+    /**
+     * How many approved projects one pass looks at.
+     *
+     * <p>This bounds the scan, not the spend. It exists because the query runs across every
+     * tenant with no organization filter, and an unbounded scan of every approved project in
+     * the database is the kind of query that is fine at today's 29 projects and is not fine
+     * later. Candidates come back oldest-assessed first, so a pass that hits this ceiling
+     * still makes deterministic progress and the next one continues from where it left off.
+     */
+    private int scanLimit = 500;
+
+    /**
+     * How many jobs one pass may enqueue.
+     *
+     * <p>The real pacing is the queue, not this: {@code compliance.job.max-in-flight} decides
+     * how many runs are ever in flight at once, so enqueueing 200 jobs does not make 200
+     * simultaneous calls to the inference endpoint, it makes a queue two deep that drains over
+     * the night. This cap is the second bound, on total spend rather than on concurrency. At
+     * the measured 1.7 seconds and 57 completion tokens per rule, 25 projects over a 21-rule
+     * catalogue is about nine minutes of wall clock at the default two in flight, and it is
+     * the number to raise once someone has looked at a real bill.
+     */
+    private int maxProjectsPerRun = 25;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,19 @@ compliance:
     max-in-flight: ${COMPLIANCE_JOB_MAX_IN_FLIGHT:2}
     lease-duration: 5m
     max-attempts: 3
+  # The catch-up sweep for projects approved before the rules that apply to them existed.
+  # OFF by default and deliberately so: the mechanism is settled, the policy is not. Which
+  # catalogue changes should count as worth re-assessing for, how often a pass should run,
+  # and whether a tenant may decline it are product decisions, and all three are config.
+  # Turning it on spends inference for every project it finds stale. It paces itself through
+  # the queue above, so max-projects-per-run bounds the spend while job.max-in-flight bounds
+  # how many runs ever hit the endpoint at once.
+  sweep:
+    enabled: ${COMPLIANCE_SWEEP_ENABLED:false}
+    cron: ${COMPLIANCE_SWEEP_CRON:0 0 2 * * *}
+    zone: ${COMPLIANCE_SWEEP_ZONE:UTC}
+    scan-limit: ${COMPLIANCE_SWEEP_SCAN_LIMIT:500}
+    max-projects-per-run: ${COMPLIANCE_SWEEP_MAX_PROJECTS_PER_RUN:25}
 
 
 # Chart-of-accounts auto numbering. level-steps is the gap between sibling codes

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -340,4 +340,7 @@
     <!-- v4.0 - Attachments: a second key, so a UUID-keyed record can carry files too -->
     <include file="db/changelog/v4.0/068-add-attachment-entity-uuid.xml"/>
 
+    <!-- v4.0 - Compliance rules: when a rule was written, and when it came into force -->
+    <include file="db/changelog/v4.0/069-add-compliance-rule-timestamps.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/069-add-compliance-rule-timestamps.xml
+++ b/src/main/resources/db/changelog/v4.0/069-add-compliance-rule-timestamps.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="069-add-compliance-rule-timestamps" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="compliance_rules" columnName="effective_from"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            compliance_rules recorded nothing about when a rule appeared or changed, so there was
+            no way to ask which rules a project has not yet been assessed against. Three columns
+            rather than two, because "when the row was written" and "when the rule came into
+            force" are different facts and a sweep that confuses them re-assesses every project
+            for a corrected typo.
+
+            created_at and updated_at are ordinary audit columns, written by Hibernate on every
+            insert and every update respectively. Nothing reads them for scheduling.
+
+            effective_from is the curated one and the only input to the sweep. It is set to the
+            insert time for a new rule and is never touched again by the application: correcting
+            a rule's wording moves updated_at and leaves effective_from alone, so no project is
+            re-assessed. A rule that genuinely changed, or whose scope widened, is re-dated by
+            whoever curates the catalogue, and that deliberate act is what asks for re-assessment.
+        </comment>
+
+        <addColumn tableName="compliance_rules">
+            <column name="created_at" type="TIMESTAMP"/>
+            <column name="updated_at" type="TIMESTAMP"/>
+            <column name="effective_from" type="TIMESTAMP"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="069-backfill-compliance-rule-timestamps" author="echno">
+        <comment>
+            Existing rows are dated to when the seed actually ran, read out of Liquibase's own
+            databasechangelog, rather than to now().
+
+            This is the difference between the first sweep doing nothing and the first sweep
+            enqueueing a job for every approved project in every tenant. The 21 seeded rules have
+            been in force since 037 applied (2026-08-21 on IITM staging). Dating them to now()
+            would make every one of them newer than every assessment ever done, so every approved
+            project would read as stale on the first pass, spend a model call each and create
+            nothing, because those projects were already assessed against exactly these rules.
+            Dating them to the seed says what is true, and the only projects the first pass then
+            picks up are the ones that genuinely were never assessed.
+
+            The coalesce chain degrades safely: the changeset id first, the filename second for a
+            database whose changelog was rewritten by a baseline, and the column default last for
+            anything else. A row that ends up at now() costs one wasted model call, not a wrong
+            answer, so the fallback does not need to be clever.
+        </comment>
+
+        <sql>
+            UPDATE compliance_rules
+            SET effective_from = COALESCE(
+                    (SELECT min(dateexecuted) FROM databasechangelog
+                      WHERE id = '037-seed-compliance-rules'),
+                    (SELECT min(dateexecuted) FROM databasechangelog
+                      WHERE filename LIKE '%037-create-and-seed-compliance-rules%'),
+                    current_timestamp)
+            WHERE effective_from IS NULL;
+
+            UPDATE compliance_rules
+            SET created_at = effective_from
+            WHERE created_at IS NULL;
+
+            UPDATE compliance_rules
+            SET updated_at = effective_from
+            WHERE updated_at IS NULL;
+        </sql>
+
+        <rollback>
+            <comment>
+                Nothing to undo: the columns these statements fill are dropped by rolling back
+                the previous changeset.
+            </comment>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="069-compliance-rule-timestamps-not-null" author="echno">
+        <comment>
+            Made NOT NULL only after the backfill, so the constraint cannot fail on existing rows.
+            Every one is now a fact the sweep can rely on rather than a null it has to interpret.
+        </comment>
+
+        <addNotNullConstraint tableName="compliance_rules" columnName="created_at"
+                              columnDataType="TIMESTAMP"/>
+        <addNotNullConstraint tableName="compliance_rules" columnName="updated_at"
+                              columnDataType="TIMESTAMP"/>
+        <addNotNullConstraint tableName="compliance_rules" columnName="effective_from"
+                              columnDataType="TIMESTAMP"/>
+    </changeSet>
+
+    <changeSet id="069-compliance-rule-effective-from-index" author="echno">
+        <comment>
+            The sweep's one query over this table asks for the newest effective_from per
+            (state, project_type) among active rules. The existing idx_compliance_rule_state_type
+            covers the grouping; this carries effective_from alongside it so the answer comes from
+            the index rather than from the rows. The table is small today, and the point is that
+            it stays cheap when the curated catalogue is not.
+        </comment>
+
+        <sql>
+            CREATE INDEX IF NOT EXISTS idx_compliance_rule_jurisdiction_effective
+            ON compliance_rules (state, project_type, effective_from)
+            WHERE active = true;
+        </sql>
+
+        <rollback>
+            DROP INDEX IF EXISTS compliance_rules@idx_compliance_rule_jurisdiction_effective;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -26,6 +26,7 @@ import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
 import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
 import org.tornotron.echno_backend.compliance.job.ComplianceJobStatus;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
 import org.tornotron.echno_backend.compliance.ai.ComplianceSuggestion;
 import org.tornotron.echno_backend.inspection.ComplianceRiskLevel;
 import org.tornotron.echno_backend.inspection.InspectionOrigin;
@@ -94,6 +95,9 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
 
     @Autowired
     private ComplianceGenerationJobRepository jobRepository;
+
+    @Autowired
+    private ComplianceRuleRepository ruleRepository;
 
     private Long orgAId;
     private Long projectId;
@@ -362,6 +366,118 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     }
 
     /** Inserts a job row directly, so what is under test is the schema and not the service. */
+    // -------------------------------------------------------------------------------
+    // The sweep's two queries. Both are only really testable here.
+    // -------------------------------------------------------------------------------
+
+    /**
+     * The catalogue side of the sweep, against the migration-seeded rules. This is also the
+     * only assertion that the {@code 069} backfill did its job: every seeded rule was written
+     * long before the column existed, and a null {@code effectiveFrom} would leave the grouped
+     * maximum null and make the sweep unable to tell whether anything had changed.
+     */
+    @Test
+    void reportsWhenEachJurisdictionLastChanged() {
+        List<ComplianceRuleRepository.JurisdictionChange> changes =
+                ruleRepository.findNewestEffectiveFromByJurisdiction();
+
+        assertThat(changes).isNotEmpty();
+        assertThat(changes).allSatisfy(change ->
+                assertThat(change.getNewestEffectiveFrom()).isNotNull());
+        assertThat(changes)
+                .filteredOn(change -> "Tamil Nadu".equalsIgnoreCase(change.getState())
+                        && change.getProjectType() == ProjectType.RESIDENTIAL)
+                .singleElement()
+                .satisfies(change -> assertThat(change.getNewestEffectiveFrom()).isNotNull());
+    }
+
+    /**
+     * The project side, which is native SQL over a table this repository does not own and a
+     * left join whose null is load bearing. A never-assessed project has to come back with a
+     * null {@code lastAssessedAt}, because that null is what the sweep reads as "this is the
+     * backlog".
+     */
+    @Test
+    void findsAnApprovedProjectThatWasNeverAssessed() {
+        List<ComplianceGenerationJobRepository.SweepCandidate> candidates =
+                jobRepository.findSweepCandidates(200);
+
+        assertThat(candidates)
+                .filteredOn(candidate -> projectId.equals(candidate.getProjectId()))
+                .singleElement()
+                .satisfies(candidate -> {
+                    assertThat(candidate.getOrganizationId()).isEqualTo(orgAId);
+                    assertThat(candidate.getProjectType()).isEqualTo(ProjectType.RESIDENTIAL.name());
+                    assertThat(candidate.getProjectAddress()).contains("Tamil Nadu");
+                    assertThat(candidate.getLastAssessedAt()).isNull();
+                });
+    }
+
+    /**
+     * A successful run is what makes a project assessed, and the timestamp the sweep compares
+     * against is that run's {@code finished_at}.
+     *
+     * <p>Each of these three does exactly one committed write and then one read, deliberately.
+     * The surrounding test transaction takes its snapshot at its first statement, so a second
+     * committed write made after a read in the same test would be invisible to the next read
+     * and the test would fail for a reason that has nothing to do with the query.
+     */
+    @Test
+    void countsASucceededRunAsAnAssessment() {
+        LocalDateTime finishedAt = LocalDateTime.now().withNano(0);
+        inCommittedTx(() -> insertFinishedJob(ComplianceJobStatus.SUCCEEDED, finishedAt));
+
+        assertThat(sweepCandidateForSeededProject().getLastAssessedAt()).isNotNull();
+    }
+
+    /**
+     * A failed run assessed nothing, so it must not make the project look done. A project whose
+     * only run failed belongs in the backlog, which is where the sweep will find it.
+     */
+    @Test
+    void doesNotCountAFailedRunAsAnAssessment() {
+        inCommittedTx(() -> insertFinishedJob(ComplianceJobStatus.FAILED, LocalDateTime.now()));
+
+        assertThat(sweepCandidateForSeededProject().getLastAssessedAt()).isNull();
+    }
+
+    /**
+     * A run that assessed every rule and found none applicable did the work. Treating it as
+     * never-assessed would put the project back in the queue every night for ever, spending a
+     * model call each time to re-derive the same empty answer.
+     */
+    @Test
+    void countsARunThatFoundNothingApplicableAsAnAssessment() {
+        LocalDateTime finishedAt = LocalDateTime.now().withNano(0);
+        inCommittedTx(() -> insertFinishedJob(ComplianceJobStatus.NOTHING_TO_REPORT, finishedAt));
+
+        assertThat(sweepCandidateForSeededProject().getLastAssessedAt()).isNotNull();
+    }
+
+    private ComplianceGenerationJobRepository.SweepCandidate sweepCandidateForSeededProject() {
+        return jobRepository.findSweepCandidates(200).stream()
+                .filter(candidate -> projectId.equals(candidate.getProjectId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "the seeded approved project was not returned as a sweep candidate"));
+    }
+
+    private void insertFinishedJob(ComplianceJobStatus status, LocalDateTime finishedAt) {
+        entityManager.createNativeQuery(
+                        "INSERT INTO compliance_generation_jobs (id, organization_id, project_id, "
+                                + "status, rules_total, rules_assessed, batches_total, batches_done, "
+                                + "created_count, attempt, max_attempts, finished_at, created_at, "
+                                + "updated_at) VALUES "
+                                + "(:id, :org, :project, :status, 6, 6, 1, 1, 0, 1, 3, :finishedAt, "
+                                + "now()::timestamp, now()::timestamp)")
+                .setParameter("id", UUID.randomUUID())
+                .setParameter("org", orgAId)
+                .setParameter("project", projectId)
+                .setParameter("status", status.name())
+                .setParameter("finishedAt", finishedAt)
+                .executeUpdate();
+    }
+
     private UUID insertJob(ComplianceJobStatus status) {
         UUID id = UUID.randomUUID();
         entityManager.createNativeQuery(

--- a/src/test/java/org/tornotron/echno_backend/compliance/domain/ComplianceRuleTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/domain/ComplianceRuleTest.java
@@ -1,0 +1,70 @@
+package org.tornotron.echno_backend.compliance.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What {@code effectiveFrom} means, asserted where it is decided.
+ *
+ * <p>{@code createdAt} and {@code updatedAt} are Hibernate's to write and are not tested here.
+ * {@code effectiveFrom} is the application's, and it is the one the sweep reads, so the two
+ * things that have to hold are that a rule always has one and that nothing quietly moves it.
+ */
+class ComplianceRuleTest {
+
+    /**
+     * A rule the curator says nothing about is in force from when we learned of it. Leaving it
+     * null is not an option, because the sweep would then have no way to tell a rule that is new
+     * to us from one that has always been there, and the column is what this whole mechanism
+     * rests on.
+     */
+    @Test
+    void aNewRuleBecomesEffectiveWhenItIsCreated() {
+        ComplianceRule rule = new ComplianceRule();
+        LocalDateTime before = LocalDateTime.now();
+
+        rule.defaultEffectiveFrom();
+
+        assertThat(rule.getEffectiveFrom())
+                .isNotNull()
+                .isAfterOrEqualTo(before);
+    }
+
+    /**
+     * A curator who dates a rule explicitly means it. Back-dating is how a rule that has been in
+     * force for years is recorded without re-assessing every project against it, and overwriting
+     * that with the load time would do exactly the thing the sweep is supposed to avoid.
+     */
+    @Test
+    void anExplicitEffectiveFromIsNotOverwritten() {
+        LocalDateTime stated = LocalDateTime.of(2024, 3, 1, 0, 0);
+        ComplianceRule rule = new ComplianceRule();
+        rule.setEffectiveFrom(stated);
+
+        rule.defaultEffectiveFrom();
+
+        assertThat(rule.getEffectiveFrom()).isEqualTo(stated);
+    }
+
+    /**
+     * The distinction the sweep depends on. Correcting a rule's wording is not the rule coming
+     * into force again, so nothing about editing a rule touches {@code effectiveFrom}: only a
+     * deliberate re-dating does. A sweep keyed on {@code updatedAt} instead would treat a typo
+     * fix across the catalogue as the whole catalogue changing and re-assess every approved
+     * project in every tenant.
+     */
+    @Test
+    void correctingTheWordingDoesNotChangeWhenTheRuleCameIntoForce() {
+        LocalDateTime inForceSince = LocalDateTime.of(2026, 8, 21, 9, 30);
+        ComplianceRule rule = new ComplianceRule();
+        rule.setEffectiveFrom(inForceSince);
+        rule.setDescription("Approval from the local planning authority");
+
+        rule.setDescription("Approval from the local planning authority, before excavation");
+
+        assertThat(rule.getEffectiveFrom()).isEqualTo(inForceSince);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweepTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweepTest.java
@@ -1,0 +1,328 @@
+package org.tornotron.echno_backend.compliance.sweep;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobDto;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
+import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the sweep decides, and what it refuses to decide.
+ *
+ * <p>The comparison is the whole of this class's behaviour, so most of these tests are one
+ * project and two timestamps. The rest are the bounds: the per-run cap, and the two ways a
+ * single project can go wrong without taking the pass down with it.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceRuleSweepTest {
+
+    private static final Long ORG_ID = 7L;
+    private static final LocalDateTime RULE_CHANGED = LocalDateTime.of(2026, 8, 21, 9, 30);
+
+    @Mock
+    private ComplianceRuleRepository ruleRepository;
+    @Mock
+    private ComplianceGenerationJobRepository jobRepository;
+    @Mock
+    private ComplianceGenerationJobService jobService;
+    @Mock
+    private TransactionRetryTemplate retryTemplate;
+
+    private ComplianceSweepProperties properties;
+    private ComplianceRuleSweep sweep;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        properties = new ComplianceSweepProperties();
+        sweep = new ComplianceRuleSweep(ruleRepository, jobRepository, jobService,
+                new TenantScopedJobRunner(), retryTemplate, properties);
+
+        lenient().when(retryTemplate.execute(anyString(), any(Supplier.class)))
+                .thenAnswer(call -> ((Supplier<Object>) call.getArgument(1)).get());
+    }
+
+    // -------------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------------
+
+    /** One jurisdiction whose newest rule came into force at {@link #RULE_CHANGED}. */
+    private void catalogueChangedAt(LocalDateTime effectiveFrom) {
+        when(ruleRepository.findNewestEffectiveFromByJurisdiction())
+                .thenReturn(List.of(jurisdiction("Tamil Nadu", ProjectType.RESIDENTIAL, effectiveFrom)));
+    }
+
+    private ComplianceRuleRepository.JurisdictionChange jurisdiction(String state,
+                                                                    ProjectType type,
+                                                                    LocalDateTime effectiveFrom) {
+        return new ComplianceRuleRepository.JurisdictionChange() {
+            @Override
+            public String getState() {
+                return state;
+            }
+
+            @Override
+            public ProjectType getProjectType() {
+                return type;
+            }
+
+            @Override
+            public LocalDateTime getNewestEffectiveFrom() {
+                return effectiveFrom;
+            }
+        };
+    }
+
+    private ComplianceGenerationJobRepository.SweepCandidate project(long id,
+                                                                    String state,
+                                                                    LocalDateTime lastAssessedAt) {
+        return new ComplianceGenerationJobRepository.SweepCandidate() {
+            @Override
+            public Long getProjectId() {
+                return id;
+            }
+
+            @Override
+            public Long getOrganizationId() {
+                return ORG_ID;
+            }
+
+            @Override
+            public String getProjectState() {
+                return state;
+            }
+
+            @Override
+            public String getProjectAddress() {
+                return "Some Street";
+            }
+
+            @Override
+            public String getProjectType() {
+                return ProjectType.RESIDENTIAL.name();
+            }
+
+            @Override
+            public LocalDateTime getLastAssessedAt() {
+                return lastAssessedAt;
+            }
+        };
+    }
+
+    private void candidates(ComplianceGenerationJobRepository.SweepCandidate... rows) {
+        when(jobRepository.findSweepCandidates(anyInt())).thenReturn(List.of(rows));
+    }
+
+    private void submitCreates(boolean created) {
+        when(jobService.submit(anyLong(), anyLong()))
+                .thenReturn(new ComplianceGenerationJobService.Accepted(
+                        (ComplianceGenerationJobDto) null, created));
+    }
+
+    // -------------------------------------------------------------------------------
+    // The comparison
+    // -------------------------------------------------------------------------------
+
+    /**
+     * The backlog case, and the reason the issue was filed: a project approved before any rules
+     * covered it has never been assessed, so it is stale whatever the timestamps say.
+     */
+    @Test
+    void queuesAProjectThatWasNeverAssessed() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", null));
+        submitCreates(true);
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+    }
+
+    @Test
+    void queuesAProjectAssessedBeforeTheNewestRuleChange() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED.minusDays(1)));
+        submitCreates(true);
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+    }
+
+    /**
+     * The case that keeps the sweep cheap. A project already assessed against everything in
+     * force costs nothing, every night, for ever.
+     */
+    @Test
+    void leavesAProjectAssessedAfterTheNewestRuleChangeAlone() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED.plusDays(1)));
+
+        sweep.runPass();
+
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+
+    /**
+     * An assessment at exactly the moment the rule came into force counts as having seen it.
+     * The boundary has to fall one way or the other, and falling this way means a rule and an
+     * assessment written in the same instant do not put the project back in the queue every
+     * night with nothing to add.
+     */
+    @Test
+    void treatsAnAssessmentAtTheSameInstantAsUpToDate() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED));
+
+        sweep.runPass();
+
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+
+    /** State is matched the way generation matches it, so casing cannot hide a rule change. */
+    @Test
+    void matchesTheJurisdictionCaseInsensitively() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "TAMIL NADU", null));
+        submitCreates(true);
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+    }
+
+    // -------------------------------------------------------------------------------
+    // The bounds
+    // -------------------------------------------------------------------------------
+
+    /**
+     * The spend bound. Without it one pass over a large estate queues every stale project at
+     * once, which is a bill rather than a bug, and is the reason the cap is configuration.
+     */
+    @Test
+    void stopsAtThePerRunCap() {
+        properties.setMaxProjectsPerRun(2);
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", null),
+                project(2L, "Tamil Nadu", null),
+                project(3L, "Tamil Nadu", null),
+                project(4L, "Tamil Nadu", null));
+        submitCreates(true);
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+        verify(jobService).submit(2L, ORG_ID);
+        verify(jobService, never()).submit(3L, ORG_ID);
+        verify(jobService, never()).submit(4L, ORG_ID);
+    }
+
+    /**
+     * A run already in flight is not a second run, and it does not spend one of the pass's
+     * slots either: the project is already being dealt with.
+     */
+    @Test
+    void doesNotCountAProjectAlreadyRunningAgainstTheCap() {
+        properties.setMaxProjectsPerRun(1);
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", null), project(2L, "Tamil Nadu", null));
+        when(jobService.submit(1L, ORG_ID)).thenReturn(
+                new ComplianceGenerationJobService.Accepted((ComplianceGenerationJobDto) null, false));
+        when(jobService.submit(2L, ORG_ID)).thenReturn(
+                new ComplianceGenerationJobService.Accepted((ComplianceGenerationJobDto) null, true));
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+        verify(jobService).submit(2L, ORG_ID);
+    }
+
+    // -------------------------------------------------------------------------------
+    // One bad project must not cost the others their night
+    // -------------------------------------------------------------------------------
+
+    /**
+     * A project whose state cannot be resolved is skipped before anything is submitted. There
+     * is nothing to retry: generation refuses it at the precondition, so queueing it would
+     * produce a failed job every night and no compliances ever.
+     */
+    @Test
+    void skipsAProjectWhoseStateCannotBeResolved() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, null, null));
+
+        sweep.runPass();
+
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+
+    /**
+     * A precondition failure on one project is expected, not exceptional, and the pass has to
+     * carry on to the next one. Without the catch the first such project ends the pass, and
+     * because candidates come back oldest-assessed first it would be the same project every
+     * night, blocking everything behind it for ever.
+     */
+    @Test
+    void carriesOnAfterOneProjectIsRefused() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", null), project(2L, "Tamil Nadu", null));
+        when(jobService.submit(1L, ORG_ID))
+                .thenThrow(new InvalidRequestException("No compliance rules are registered yet."));
+        when(jobService.submit(2L, ORG_ID)).thenReturn(
+                new ComplianceGenerationJobService.Accepted((ComplianceGenerationJobDto) null, true));
+
+        sweep.runPass();
+
+        verify(jobService).submit(2L, ORG_ID);
+    }
+
+    /**
+     * The sweep ships switched off, and that is a decision rather than an oversight: turning it
+     * on spends inference money, and which catalogue changes justify that is a product call.
+     * A default that flipped to true in a later edit would start spending on every environment
+     * that upgraded, so it is worth a test rather than a comment.
+     */
+    @Test
+    void isOffByDefault() {
+        ComplianceSweepProperties defaults = new ComplianceSweepProperties();
+
+        assertThat(defaults.isEnabled()).isFalse();
+        assertThat(defaults.getCron()).isEqualTo("0 0 2 * * *");
+        assertThat(defaults.getZone()).isEqualTo("UTC");
+        assertThat(defaults.getMaxProjectsPerRun()).isEqualTo(25);
+        assertThat(defaults.getScanLimit()).isEqualTo(500);
+    }
+
+    /** An empty catalogue is not an occasion to queue anything; there is nothing to compare to. */
+    @Test
+    void doesNothingWhenNoRulesAreActive() {
+        when(ruleRepository.findNewestEffectiveFromByJurisdiction()).thenReturn(List.of());
+
+        sweep.runPass();
+
+        verify(jobRepository, never()).findSweepCandidates(anyInt());
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+}


### PR DESCRIPTION
Closes #553.

Compliance is generated when a project is approved and only then. A project approved before the rules that cover it existed never gets them, and nothing goes back for it. The moment Anand's curated catalogue lands, every project approved before it is permanently missing compliances that nobody knows are missing, and someone finds out by noticing an empty list.

Two things here: the timestamp, which had to come first, and the sweep that reads it.

## The timestamp, and why it is three columns rather than two

The issue asked for `created_at` and `updated_at`. Building it that way would have produced a sweep that regenerates the world, so this adds a third.

`created_at` and `updated_at` are ordinary audit columns written by Hibernate. Nothing schedules off them. `effective_from` is the curated one and the only input to the sweep.

They are not the same fact, and the difference is the whole design. `updated_at` moves on **any** write: a corrected typo in `description`, a widened `authority` string, and every row of a bulk re-seed whose content did not change at all. A sweep keyed on it would read a comma fix across the catalogue as the whole catalogue changing, and spend a model call per approved project per tenant to re-derive answers that are identical. That is expensive and it is also simply wrong, because nothing about the answer changed.

So `effective_from` is deliberately inert. It is set once, to the insert time, by a `@PrePersist` that fires only when the caller has not supplied one, and the application never touches it again. Editing a rule does not move it. Re-dating it forward is a curator's deliberate statement that the rule is materially different and projects should be assessed against it again, and that act is the only thing that makes an already-assessed project stale.

Two cases that are easy to get wrong, stated in the entity javadoc so the next person does not have to rediscover them. Flipping `active` back to true does not by itself re-date a rule, so a rule switched off and on again reaches only projects that were never assessed; move `effective_from` too if the intent is that everyone re-assesses. And a rule loaded with a back-dated `effective_from` reaches nobody already assessed, which is right for recording history and wrong for a rule that is new to us.

### The backfill is load bearing

Changelog `069` dates the existing seeded rules to when the seed **actually ran**, read out of Liquibase's own `databasechangelog` (2026-08-21 on IITM staging), rather than to `now()`.

This is the difference between the first pass doing nothing and the first pass queueing a job for every approved project in every tenant. The 21 seeded rules have been in force since `037` applied. Dating them to `now()` would make every one newer than every assessment ever done, so every approved project would read as stale, spend a model call and create nothing, because those projects were already assessed against exactly those rules. The coalesce chain degrades to the changeset id, then the filename, then `current_timestamp`; a row that lands on the fallback costs one wasted call, not a wrong answer.

## The sweep

`ComplianceRuleSweep` compares, per approved project, the newest `effective_from` among the active rules for its jurisdiction against the last time a run for that project actually finished. Never assessed is stale by definition, which is the backlog the issue is about.

**It queues, it does not generate.** Every stale project goes through `ComplianceGenerationJobService.submit`, the same entry point approval and the manual endpoint use. Calling generation inline from a scheduler thread would put a model call per project outside any lease, with no record it was attempted, no progress for anyone watching, and nothing to recover it when the replica restarts halfway through, which is the whole of what #542 built the queue to fix. Going through the queue also means the one-active-job-per-project partial index does the obvious right thing: a project with a run already in flight is handed back that run instead of getting a second one, and that outcome does not consume one of the pass's slots.

### What happens to a project already carrying compliances from an older catalogue

Nothing is duplicated and nothing is contradicted. Generation is already idempotent per `(projectId, complianceRuleRef)`: `ComplianceGenerationService.persist` skips a rule that already has an inspection on the project, and the partial unique index on `(organization_id, project_id, compliance_rule_ref)` from #510 / changelog `060` is what makes that an invariant rather than an unlocked read. A swept project therefore gains only the compliances it was missing, and existing rows are untouched, including any a user has since scheduled, added check items to, or raised an NCR against.

One consequence worth being explicit about, because it is a real limit rather than an oversight: generation only ever **creates**. A rule whose text was corrected produces no change on a project that already has that rule's inspection, even if the sweep re-runs it. That is another reason `effective_from` is the right trigger and `updated_at` is not, since re-sweeping for a text correction would cost a model call and change nothing at all.

### Pacing

The thundering herd is prevented by the queue rather than by anything in the sweep. Enqueueing is an insert. `compliance.job.max-in-flight` (default 2 per replica) decides how many runs ever reach the inference endpoint at once, so a pass that queues 25 jobs produces a queue that drains two at a time, not 25 simultaneous calls against a rate-limited endpoint. This is exactly why the sweep must not bypass the queue.

On top of that the pass bounds both what it reads and what it spends:

- `scan-limit` (500) bounds the cross-tenant scan. An unbounded scan of every approved project is fine at today's 29 and is not fine later.
- `max-projects-per-run` (25) bounds the spend. At the measured ~1.7 s and ~57 completion tokens per rule, 25 projects over a 21-rule catalogue is roughly nine minutes of wall clock at two in flight.

Candidates come back oldest-assessed first with nulls first, so a capped pass puts the real backlog at the front, makes deterministic progress, and the next pass continues behind it.

## What is left configurable, and off by default

`compliance.sweep.enabled` is **false**, and the bean does not exist unless it is turned on. Saying that plainly: the mechanism is settled, the policy is not, and three of the open questions are product decisions this code cannot make.

- Which catalogue changes justify re-assessment. This PR's answer is "whatever a curator re-dates", which is a mechanism, not a policy.
- How often a pass should run. `cron` defaults to 02:00 `UTC`.
- Whether a tenant should be able to decline it, since the spend is real and lands on whoever owns the inference key. Not built; there is no per-tenant switch here.

The issue's own open question I did answer, and it is worth flagging for disagreement. A project whose state still cannot be resolved is skipped quietly every pass rather than retried against the model, because there is nothing to retry: the precondition fails before any call is made. Retrying it nightly for ever costs nothing but achieves nothing. Skipping it silently for ever would be its own version of this bug, so the pass counts them and logs the count. Surfacing that on the project itself, where somebody would actually see it, is a UI change and is left open.

## Tests

Every test below was proven to fail by mutating the single behaviour it guards, on `lab-node-116-f`, then restoring.

| Test | Mutation applied | Result without it |
|---|---|---|
| `leavesAProjectAssessedAfterTheNewestRuleChangeAlone` | up-to-date check removed | FAILED (`NeverWantedButInvoked`) |
| `treatsAnAssessmentAtTheSameInstantAsUpToDate` | up-to-date check removed | FAILED |
| `queuesAProjectThatWasNeverAssessed` | null last-assessed treated as up to date | FAILED |
| `stopsAtThePerRunCap` | per-run cap removed | FAILED |
| `doesNotCountAProjectAlreadyRunningAgainstTheCap` | already-running counted against the cap | FAILED |
| `skipsAProjectWhoseStateCannotBeResolved` | unresolvable-state guard removed | FAILED |
| `carriesOnAfterOneProjectIsRefused` | expected-exception catch removed | FAILED |
| `matchesTheJurisdictionCaseInsensitively` | case-sensitive jurisdiction key | FAILED |
| `doesNothingWhenNoRulesAreActive` | empty-catalogue short circuit removed | FAILED |
| `isOffByDefault` | `enabled` defaulted to true | FAILED |
| `aNewRuleBecomesEffectiveWhenItIsCreated` | `@PrePersist` body removed | FAILED |
| `anExplicitEffectiveFromIsNotOverwritten` | `@PrePersist` overwrites unconditionally | FAILED |
| `reportsWhenEachJurisdictionLastChanged` (IT) | `069` backfill leaves `effective_from` null | FAILED |
| `findsAnApprovedProjectThatWasNeverAssessed` (IT) | new query, no prior behaviour | n/a |
| `doesNotCountAFailedRunAsAnAssessment` (IT) | `FAILED` added to the assessed statuses | FAILED |
| `countsARunThatFoundNothingApplicableAsAnAssessment` (IT) | `NOTHING_TO_REPORT` dropped from the assessed statuses | FAILED |
| `countsASucceededRunAsAnAssessment` (IT) | new query, no prior behaviour | n/a |

The integration tests went into the existing `ComplianceGenerationServiceIT` rather than a new class, deliberately: they need the real CockroachDB and the migration-seeded catalogue, and reusing that class's context means no additional Spring context is cached in a JVM that already runs at `maxHeapSize=1024m` with no `forkEvery`.

Both new queries are exercised against a real database, which is the only place they can be. `findSweepCandidates` is native SQL over a table its repository does not own, with a left join whose null is load bearing, and `findNewestEffectiveFromByJurisdiction` is the only assertion that the backfill actually dated the seeded rows. Full `./gradlew build` green on `.116`.

## Changelog

`069`, checked against `origin/development` (max `068`) and against every open PR immediately before pushing; no other PR touches a v4.0 changelog.

## Not done here

No `effective_from` editing surface. Re-dating a rule is a database operation today, which is fine while the catalogue is curated by hand, and is the obvious next thing if the sweep is turned on and used in anger.
