### PR TITLE
Say what the data part of a write actually carries

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -58,8 +60,10 @@ public class AttendanceController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
-    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") String data,
-                                                         @RequestParam(value = "photoUrl", required = false) MultipartFile photoUrl) throws JsonProcessingException {
+    public ResponseEntity<AttendanceResponseDto> checkIn(
+            @Parameter(schema = @Schema(implementation = AttendanceCheckInDto.class))
+            @RequestParam("data") String data,
+            @RequestParam(value = "photoUrl", required = false) MultipartFile photoUrl) throws JsonProcessingException {
         AttendanceCheckInDto dto = jsonPartBinder.read(data, AttendanceCheckInDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.checkIn(dto,photoUrl));
     }
@@ -80,8 +84,10 @@ public class AttendanceController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
-    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") String data,
-                                                                  @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
+    public ResponseEntity<AttendanceResponseDto> recordClockEvent(
+            @Parameter(schema = @Schema(implementation = AttendanceClockEventDto.class))
+            @RequestParam("data") String data,
+            @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = jsonPartBinder.read(data, AttendanceClockEventDto.class);
         return ResponseEntity.ok(attendanceService.recordClockEvent(dto,photo));
     }

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.attendance;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -58,8 +60,10 @@ public class AttendanceControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
-    public ResponseEntity<AttendanceResponseDto> checkIn(@RequestParam("data") String data,
-                                                         @RequestParam(value = "photo", required = false)MultipartFile photo) throws JsonProcessingException {
+    public ResponseEntity<AttendanceResponseDto> checkIn(
+            @Parameter(schema = @Schema(implementation = AttendanceCheckInDto.class))
+            @RequestParam("data") String data,
+            @RequestParam(value = "photo", required = false)MultipartFile photo) throws JsonProcessingException {
         AttendanceCheckInDto dto = jsonPartBinder.read(data, AttendanceCheckInDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.checkIn(dto,photo));
     }
@@ -78,8 +82,10 @@ public class AttendanceControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
-    public ResponseEntity<AttendanceResponseDto> recordClockEvent(@RequestParam("data") String data,
-                                                                    @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
+    public ResponseEntity<AttendanceResponseDto> recordClockEvent(
+            @Parameter(schema = @Schema(implementation = AttendanceClockEventDto.class))
+            @RequestParam("data") String data,
+            @RequestParam(value = "photo", required = false) MultipartFile photo) throws JsonProcessingException {
         AttendanceClockEventDto dto = jsonPartBinder.read(data, AttendanceClockEventDto.class);
         return ResponseEntity.ok(attendanceService.recordClockEvent(dto,photo));
     }

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.chat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -172,6 +174,7 @@ public class ChatControllerWeb {
     })
     public ResponseEntity<ChatMessageDto> sendMessageWithAttachments(
             @PathVariable Long roomId,
+            @Parameter(schema = @Schema(implementation = SendMessageDto.class))
             @RequestPart("data") String data,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments)
             throws JsonProcessingException {

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -20,6 +22,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
 
 @RestController
 @Validated
@@ -81,8 +84,10 @@ public class IssueController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority")
     })
-    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") String data,
-                                                      @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<IssueSimpleDto> createIssue(
+            @Parameter(schema = @Schema(implementation = IssueCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         IssueCreationDto dto = jsonPartBinder.read(data, IssueCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueService.addIssue(dto,attachments));
@@ -103,6 +108,7 @@ public class IssueController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueSimpleDto> partialUpdateAnIssue(
+            @Parameter(schema = @Schema(implementation = IssueUpdateFieldsDto.class))
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.issue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
@@ -25,6 +27,7 @@ import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
 
 @RestController
 @Validated
@@ -149,8 +152,10 @@ public class IssueControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<IssueSimpleDto> createIssue(@RequestPart("data") String data,
-                                                      @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<IssueSimpleDto> createIssue(
+            @Parameter(schema = @Schema(implementation = IssueCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         IssueCreationDto dto = jsonPartBinder.read(data, IssueCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(issueService.addIssue(dto,attachments));
@@ -171,6 +176,7 @@ public class IssueControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueSimpleDto> partialUpdateAnIssue(
+            @Parameter(schema = @Schema(implementation = IssueUpdateFieldsDto.class))
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
@@ -1,0 +1,38 @@
+package org.tornotron.echno_backend.issue.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+
+/**
+ * The fields a partial issue update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code IssueService.partialUpdateAnIssue} actually accepts out of that method's source.
+ */
+@Schema(description = "Fields a partial issue update may change. Every field is optional; only the "
+        + "fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class IssueUpdateFieldsDto {
+
+    @Schema(description = "Short issue title.", example = "Rebar spacing off on grid C")
+    private String title;
+
+    @Schema(description = "Longer description of the issue.",
+            example = "Spacing measured at 220 mm against a specified 200 mm across grid C.")
+    private String description;
+
+    @Schema(description = "Category of the issue.")
+    private IssueType type;
+
+    @Schema(description = "Lifecycle status of the issue.")
+    private IssueStatus status;
+
+    @Schema(description = "Id of the employee the issue is assigned to. The employee must belong to "
+            + "the caller's organization.", example = "17")
+    private Long assignedToId;
+}

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.organization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -82,8 +84,10 @@ public class OrganizationController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
-    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") String data,
-                                                                    @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<OrganizationSimpleDto> createOrganization(
+            @Parameter(schema = @Schema(implementation = OrganizationCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         OrganizationCreationDto dto = jsonPartBinder.read(data, OrganizationCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addOrganization(dto,attachments));
     }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.organization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -19,6 +21,7 @@ import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/organization/web")
@@ -68,8 +71,10 @@ public class OrganizationWebController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "402", description = "Caller already has an organization and their plan does not cover another"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
-    public ResponseEntity<OrganizationSimpleDto> createOrganization(@RequestPart("data") String data,
-                                                                    @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<OrganizationSimpleDto> createOrganization(
+            @Parameter(schema = @Schema(implementation = OrganizationCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         OrganizationCreationDto dto = jsonPartBinder.read(data, OrganizationCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addOrganization(dto,attachments));
     }
@@ -149,6 +154,7 @@ public class OrganizationWebController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
     })
     public ResponseEntity<OrganizationSimpleDto> partialUpdateAnOrganization(
+            @Parameter(schema = @Schema(implementation = OrganizationUpdateFieldsDto.class))
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
             @RequestParam(value = "attachments",required = false) List<MultipartFile> attachments,

--- a/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationUpdateFieldsDto.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.organization.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * The fields a partial organization update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code OrganizationService.partialUpdateAnOrganization} actually accepts out of that method's
+ * source.
+ */
+@Schema(description = "Fields a partial organization update may change. Every field is optional; "
+        + "only the fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class OrganizationUpdateFieldsDto {
+
+    @Schema(description = "Registered name of the organization.", example = "Asset Homes")
+    private String organizationName;
+
+    @Schema(description = "Postal address of the organization.",
+            example = "IIT Madras Research Park, Chennai 600113")
+    private String organizationAddress;
+
+    @Schema(description = "Contact email for the organization.", example = "info@echno.xyz")
+    private String organizationEmail;
+
+    @Schema(description = "Contact phone number for the organization.", example = "+91 44 4000 0000")
+    private String organizationPhone;
+
+    @Schema(description = "Public website of the organization.", example = "https://echno.xyz")
+    private String organizationWebsite;
+
+    @Schema(description = "Stored key or URL of the organization logo.",
+            example = "organizations/2/logo.png")
+    private String organizationLogo;
+}

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -79,8 +81,10 @@ public class ProjectController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the project create or admin authority")
     })
-    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") String data,
-                                                          @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<ProjectSimpleDto> createProject(
+            @Parameter(schema = @Schema(implementation = ProjectCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         ProjectCreationDto dto = jsonPartBinder.read(data, ProjectCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addProject(dto, attachments));
     }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -27,6 +29,7 @@ import org.tornotron.echno_backend.project.dto.ProjectSimpleDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/project/web")
@@ -76,8 +79,10 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid project JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<ProjectSimpleDto> createProject(@RequestPart("data") String data,
-                                                          @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<ProjectSimpleDto> createProject(
+            @Parameter(schema = @Schema(implementation = ProjectCreationDto.class))
+            @RequestPart("data") String data,
+            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) throws JsonProcessingException {
         ProjectCreationDto dto = jsonPartBinder.read(data, ProjectCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addProject(dto, attachments));
     }
@@ -191,6 +196,7 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
     })
     public ResponseEntity<ProjectSimpleDto> partialUpdateAProject(
+            @Parameter(schema = @Schema(implementation = ProjectUpdateFieldsDto.class))
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
             @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
@@ -1,0 +1,64 @@
+package org.tornotron.echno_backend.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * The fields a partial project update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code ProjectService.partialUpdateAProject} actually accepts out of that method's source.
+ */
+@Schema(description = "Fields a partial project update may change. Every field is optional; only "
+        + "the fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class ProjectUpdateFieldsDto {
+
+    @Schema(description = "Name of the project.", example = "Marina Heights, phase 2")
+    private String projectName;
+
+    @Schema(description = "Street address of the site.", example = "12 Kamaraj Salai")
+    private String projectAddress;
+
+    @Schema(description = "City the site is in. Trimmed, and cleared when blank.", example = "Chennai")
+    private String projectCity;
+
+    @Schema(description = "State the site is in. Recorded in the canonical spelling for the state.",
+            example = "Tamil Nadu")
+    private String projectState;
+
+    @Schema(description = "Postal code of the site. Trimmed, and cleared when blank.",
+            example = "600113")
+    private String projectPostalCode;
+
+    @Schema(description = "Lifecycle status of the project.")
+    private ProjectCreationStatus status;
+
+    @Schema(description = "Planned start of the project.", example = "2026-09-01T09:00:00")
+    private LocalDateTime startDate;
+
+    @Schema(description = "Planned end of the project.", example = "2027-03-31T18:00:00")
+    private LocalDateTime endDate;
+
+    @Schema(description = "Kind of work the project covers.")
+    private ProjectType projectType;
+
+    @Schema(description = "Id of the finance customer the project bills to, as a UUID string. The "
+            + "customer must belong to the caller's organization; null or blank clears the link.",
+            example = "3f2a1c64-7b21-4d1e-9c8f-0a2b3c4d5e6f")
+    private UUID customerId;
+
+    @Schema(description = "Site longitude, between -180 and 180.", example = "80.2412")
+    private Float projectLongitude;
+
+    @Schema(description = "Site latitude, between -90 and 90.", example = "12.9915")
+    private Float projectLatitude;
+}

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -78,8 +80,10 @@ public class TaskController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task create or admin authority")
     })
-    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart String data,
-                                                    @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<TaskSimpleDto> createTask(
+            @Parameter(schema = @Schema(implementation = TaskCreationDto.class))
+            @RequestPart String data,
+            @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         TaskCreationDto dto = jsonPartBinder.read(data, TaskCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addTask(dto,attachments));
     }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -28,6 +30,7 @@ import org.tornotron.echno_backend.task.dto.TaskSimpleDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/tasks/web")
@@ -75,8 +78,10 @@ public class TaskControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
-    public ResponseEntity<TaskSimpleDto> createTask(@RequestPart String data,
-                                                    @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
+    public ResponseEntity<TaskSimpleDto> createTask(
+            @Parameter(schema = @Schema(implementation = TaskCreationDto.class))
+            @RequestPart String data,
+            @RequestParam(value = "attachments",required = false)List<MultipartFile> attachments) throws JsonProcessingException {
         TaskCreationDto dto = jsonPartBinder.read(data, TaskCreationDto.class);
         return ResponseEntity.status(HttpStatus.CREATED).body(service.addTask(dto,attachments));
     }
@@ -204,10 +209,12 @@ public class TaskControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No task with the given id")
     })
-    public ResponseEntity<TaskSimpleDto> partialUpdateATask(@RequestPart(value = "data", required = false) String data,
-                                                            @PathVariable Long id,
-                                                            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
-                                                            @RequestParam(value = "entityType", required = false, defaultValue = "TASK_ATTACHMENTS") String entityType) throws JsonProcessingException
+    public ResponseEntity<TaskSimpleDto> partialUpdateATask(
+            @Parameter(schema = @Schema(implementation = TaskUpdateFieldsDto.class))
+            @RequestPart(value = "data", required = false) String data,
+            @PathVariable Long id,
+            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
+            @RequestParam(value = "entityType", required = false, defaultValue = "TASK_ATTACHMENTS") String entityType) throws JsonProcessingException
     {
         Map<String, Object> updates = jsonPartBinder.readUpdates(data);
         return ResponseEntity.status(HttpStatus.OK).body(service.partialUpdateATask(updates, id,attachments, entityType));

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
@@ -1,0 +1,57 @@
+package org.tornotron.echno_backend.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.task.enums.TaskStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * The fields a partial task update may carry, and the type each one is read as.
+ *
+ * <p>The endpoint itself still takes the update as a map, because a partial update has to tell
+ * "field absent" from "field explicitly set to null", and a bean cannot: both arrive as a null
+ * property. Fields here are cleared by sending an explicit null, so replacing the map with a bean
+ * would silently drop that. What the map costs is the published contract: a map is
+ * {@code additionalProperties} in OpenAPI, so the document says nothing about which keys exist or
+ * what they hold, and a caller sending a key the service does not know gets a 200 and no change.
+ *
+ * <p>This class is the missing half. It is referenced from the endpoint as the request schema, so
+ * the published document names the fields and their types while the runtime keeps the map and its
+ * null semantics. Nothing deserializes into it and nothing constructs it.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code TaskService.partialUpdateATask} actually accepts out of that method's source and fails
+ * when they and these fields have drifted apart.
+ */
+@Schema(description = "Fields a partial task update may change. Every field is optional; only the "
+        + "fields present in the request are applied, and a field sent as null is cleared. Keys not "
+        + "listed here are ignored.")
+@Data
+public class TaskUpdateFieldsDto {
+
+    @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
+    private String title;
+
+    @Schema(description = "Longer description of the work to be done.",
+            example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
+    private String description;
+
+    @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
+    private LocalDateTime startDate;
+
+    @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
+    private LocalDateTime endDate;
+
+    @Schema(description = "Fraction of the task completed, between 0 and 1. A value that is neither "
+            + "null nor a number is ignored.", example = "0.4")
+    private Double progress;
+
+    @Schema(description = "Lifecycle status of the task.")
+    private TaskStatus status;
+
+    @Schema(description = "Free-form labels on the task. Replaces the existing labels rather than "
+            + "adding to them, and must be a list of strings.", example = "[\"concrete\", \"block-a\"]")
+    private List<String> tags;
+}

--- a/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
@@ -24,6 +26,7 @@ import org.tornotron.echno_backend.user.dto.UserPatchDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/user/web")
@@ -175,6 +178,7 @@ public class UserControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
     })
     public ResponseEntity<UserDto> partialUpdateAUser(
+            @Parameter(schema = @Schema(implementation = UserUpdateFieldsDto.class))
             @RequestPart(value = "data", required = false) String data,
             @PathVariable Long id,
             @RequestParam(value = "profilePicture", required = false) MultipartFile profilePicture,

--- a/src/main/java/org/tornotron/echno_backend/user/dto/UserUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/user/dto/UserUpdateFieldsDto.java
@@ -1,0 +1,76 @@
+package org.tornotron.echno_backend.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.user.enums.UserRole;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * The fields a partial user update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code UserService.applyUpdates} actually accepts out of that method's source.
+ */
+@Schema(description = "Fields a partial user update may change. Every field is optional; only the "
+        + "fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class UserUpdateFieldsDto {
+
+    @Schema(description = "Full name of the user.", example = "Hrishikesh R")
+    private String name;
+
+    @Schema(description = "Id of the organization the user lands in after signing in. Must be sent "
+            + "as a number.", example = "2")
+    private Long defaultOrganizationId;
+
+    @Schema(description = "Gender recorded for the user.", example = "MALE")
+    private String gender;
+
+    @Schema(description = "Blood group recorded for the user.", example = "O+")
+    private String bloodGroup;
+
+    @Schema(description = "Contact email of the user.", example = "hrishi@echno.xyz")
+    private String email;
+
+    @Schema(description = "Contact phone number of the user.", example = "+91 99400 00000")
+    private String phone;
+
+    @Schema(description = "Date of birth, sent as an ISO date-time string.",
+            example = "1998-04-12T00:00:00")
+    private LocalDateTime dateOfBirth;
+
+    @Schema(description = "Highest qualification held.", example = "B.Tech Civil Engineering")
+    private String qualification;
+
+    @Schema(description = "Postal address of the user.", example = "18 Anna Nagar, Chennai 600040")
+    private String address;
+
+    @Schema(description = "Years of experience. Must be sent as a whole number.", example = "6")
+    private Integer experience;
+
+    @Schema(description = "Stored key or URL of the uploaded CV.", example = "users/31/cv.pdf")
+    private String cvUrl;
+
+    @Schema(description = "Emergency contact for the user.", example = "Anand, +91 88485 42511")
+    private String emergencyContact;
+
+    @Schema(description = "Platform role held by the user.")
+    private UserRole role;
+
+    @Schema(description = "Stored key or URL of the profile picture.",
+            example = "users/31/profile.jpg")
+    private String profilePictureUrl;
+
+    @Schema(description = "Skills recorded for the user. Replaces the existing list rather than "
+            + "adding to it.", example = "[\"AutoCAD\", \"Site supervision\"]")
+    private List<String> skills;
+
+    @Schema(description = "Certifications recorded for the user. Replaces the existing list rather "
+            + "than adding to it.", example = "[\"NEBOSH IGC\"]")
+    private List<String> certifications;
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
@@ -1,0 +1,179 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto;
+import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
+import org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto;
+import org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Holds each partial-update schema to the keys its service actually accepts.
+ *
+ * <p>A partial update takes its body as a {@code Map<String, Object>}, because it has to tell a
+ * field that was left out from a field that was sent as null, and a bean cannot: both arrive as a
+ * null property, and several of these fields are cleared by sending an explicit null. The map is
+ * therefore the right runtime shape and is not what this test is trying to change.
+ *
+ * <p>What the map costs is the published contract. A map is {@code additionalProperties} in
+ * OpenAPI, so the document says nothing about which keys exist or what they hold, no key can ever
+ * fail against it, and a caller sending a key the service does not know gets a 200 and no change.
+ * The {@code *UpdateFieldsDto} classes supply that missing half: they are named as the request
+ * schema on the endpoint and never deserialized into.
+ *
+ * <p>Which leaves the obvious failure mode. A schema that describes nothing at runtime is a schema
+ * nothing keeps true, and a documentation class that drifts from the code is worse than no
+ * documentation, because it reads as authoritative. So this test reads the {@code case "..."}
+ * labels out of the service method's own source and fails when they and the schema's fields have
+ * moved apart in either direction. Adding a key to a service switch without adding it to the schema
+ * fails here, and so does the reverse.
+ *
+ * <p>Source rather than bytecode because a {@code switch} over strings compiles to a hash cascade
+ * that no longer carries the labels in a form worth reconstructing. Plain JUnit rather than a
+ * Spring context, because it reads two files and needs nothing else.
+ */
+class PartialUpdateSchemaContractTest {
+
+    private static final Path SOURCE_ROOT = Path.of("src", "main", "java");
+
+    /**
+     * A {@code case} label in a string switch. Matches both the arrow and colon forms, since the
+     * services use one each.
+     */
+    private static final Pattern CASE_LABEL = Pattern.compile("case\\s+\"([^\"]+)\"");
+
+    /**
+     * One partial-update surface: the schema class published for it, and the service method whose
+     * switch decides what it really accepts.
+     *
+     * @param schema The documentation-only class named as the endpoint's request schema.
+     * @param serviceClass Fully qualified name of the service holding the update method.
+     * @param methodSignature The opening text of the method declaration, used to find it in the
+     *                        source. Must be unique within the file.
+     */
+    private record UpdateSurface(Class<?> schema, String serviceClass, String methodSignature) {
+        @Override
+        public String toString() {
+            return schema.getSimpleName();
+        }
+    }
+
+    static List<UpdateSurface> surfaces() {
+        return List.of(
+                new UpdateSurface(
+                        TaskUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.task.TaskService",
+                        "private void partialUpdateATask(Map<String, Object> updates, Task task)"),
+                new UpdateSurface(
+                        IssueUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.issue.IssueService",
+                        "private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue)"),
+                new UpdateSurface(
+                        ProjectUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.project.ProjectService",
+                        "private void partialUpdateAProject(Map<String, Object> updates, Project project)"),
+                new UpdateSurface(
+                        OrganizationUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.organization.OrganizationService",
+                        "private void partialUpdateAnOrganization(Map<String, Object> updates, Organization organization)"),
+                new UpdateSurface(
+                        UserUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.user.UserService",
+                        "private void applyUpdates(Map<String, Object> updates, User user)"));
+    }
+
+    @ParameterizedTest(name = "{0} describes exactly the keys its service accepts")
+    @MethodSource("surfaces")
+    @DisplayName("A published partial-update schema names every accepted key and no others")
+    void schemaMatchesTheKeysTheServiceAccepts(UpdateSurface surface) throws IOException {
+        Set<String> accepted = acceptedKeys(surface);
+        Set<String> published = publishedFields(surface.schema());
+
+        assertThat(published)
+                .as("%s is the request schema published for this endpoint, so it has to name "
+                        + "exactly the keys %s applies. A key in the service and not the schema is "
+                        + "undocumented; a field in the schema and not the service is a documented "
+                        + "field the endpoint silently ignores.",
+                        surface.schema().getSimpleName(), surface.serviceClass())
+                .containsExactlyInAnyOrderElementsOf(accepted);
+    }
+
+    /** The keys the service's update switch names, read out of the method's own source. */
+    private static Set<String> acceptedKeys(UpdateSurface surface) throws IOException {
+        String body = methodBody(surface);
+        Set<String> keys = new LinkedHashSet<>();
+        Matcher matcher = CASE_LABEL.matcher(body);
+        while (matcher.find()) {
+            keys.add(matcher.group(1));
+        }
+        assertThat(keys)
+                .as("no case labels found in %s; the method signature this test looks for has "
+                        + "probably been reworded", surface.methodSignature())
+                .isNotEmpty();
+        return keys;
+    }
+
+    /** The properties the schema class declares, which is what springdoc publishes. */
+    private static Set<String> publishedFields(Class<?> schema) {
+        return java.util.Arrays.stream(schema.getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .map(Field::getName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * The text of the named method, from its declaration to its closing brace.
+     *
+     * <p>Brace counting is enough here and does not need a parser: these methods hold a switch over
+     * string literals and no brace ever appears inside one of them.
+     */
+    private static String methodBody(UpdateSurface surface) throws IOException {
+        Path source = SOURCE_ROOT.resolve(surface.serviceClass().replace('.', '/') + ".java");
+        assertThat(source)
+                .as("service source for %s, read relative to the project directory", surface.serviceClass())
+                .exists();
+        String text = Files.readString(source);
+
+        int start = text.indexOf(surface.methodSignature());
+        assertThat(start)
+                .as("method %s was not found in %s; if it has been renamed or its parameters "
+                        + "reformatted, update the signature this test looks for",
+                        surface.methodSignature(), source)
+                .isNotEqualTo(-1);
+        assertThat(text.indexOf(surface.methodSignature(), start + 1))
+                .as("method signature %s appears more than once in %s", surface.methodSignature(), source)
+                .isEqualTo(-1);
+
+        int cursor = text.indexOf('{', start);
+        int depth = 0;
+        for (int i = cursor; i < text.length(); i++) {
+            char character = text.charAt(i);
+            if (character == '{') {
+                depth++;
+            } else if (character == '}') {
+                depth--;
+                if (depth == 0) {
+                    return text.substring(cursor, i + 1);
+                }
+            }
+        }
+        throw new AssertionError("unbalanced braces after " + surface.methodSignature() + " in " + source);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/RequestPayloadSchemaTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/RequestPayloadSchemaTest.java
@@ -1,0 +1,159 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet against an endpoint whose payload the published OpenAPI document cannot describe: a
+ * {@code data} payload that travels as a {@code String} must say, in the document, what that string
+ * actually holds.
+ *
+ * <p>A multipart endpoint cannot take a {@code @RequestBody}, because the body is the multipart
+ * envelope, so the JSON payload travels as a {@code data} part and the endpoint reads it with
+ * {@code JsonPartBinder}. The declared Java type of that parameter is {@code String}, and springdoc
+ * documents what is declared, so every one of these endpoints published {@code type: string} for
+ * its payload. The document named no field, no type and no constraint for a third of the write
+ * surface, which meant a client could not be checked against it and a wrong field name was
+ * indistinguishable from a right one. That is the gap tornotron/echno-core#49 hit when it went to
+ * build a contract test and found nothing to check against.
+ *
+ * <p>The declared type cannot simply become the payload type. The clients append the part as a
+ * plain form field, so it arrives with no {@code application/json} content type, and Spring answers
+ * a typed {@code @RequestPart} parameter with 415 in that case. Verified against Spring Boot 3.4
+ * rather than assumed. So the runtime keeps the {@code String} and the schema is declared
+ * separately, with {@code @Parameter(schema = @Schema(implementation = ...))}, which springdoc
+ * merges into the multipart schema in place of the string.
+ *
+ * <p>This rule is what stops the next endpoint from reopening the hole. Fixing the ones that exist
+ * does nothing about the one written next week, which is the same reason
+ * {@link MultipartPayloadValidationTest} exists beside it: that one keeps the payload validated,
+ * this one keeps it described.
+ *
+ * <p>Scope is the {@code data} payload convention and not every string that reaches an endpoint. A
+ * {@code @RequestParam} is in scope only when it is named {@code data} outright. A
+ * {@code @RequestPart} is in scope when it is named {@code data} or names nothing at all, since an
+ * unnamed part takes the Java parameter name and a payload part written without a name is the exact
+ * shape this rule is here to catch.
+ *
+ * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's own
+ * cache, which every architecture test in this package shares. See {@link UnboundedRepositoryReadTest}
+ * for why that matters in a 1 GB test JVM.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class RequestPayloadSchemaTest {
+
+    private static final String PAYLOAD_PART = "data";
+
+    @ArchTest
+    static void everyStringPayloadPartDeclaresItsSchema(JavaClasses productionClasses) {
+        List<String> offenders = productionClasses.stream()
+                .filter(javaClass -> javaClass.isMetaAnnotatedWith(Controller.class))
+                .flatMap(javaClass -> javaClass.getMethods().stream())
+                .flatMap(method -> method.getParameters().stream()
+                        .filter(RequestPayloadSchemaTest::isStringPayloadParameter)
+                        .filter(parameter -> declaredSchemaImplementation(parameter).isEmpty())
+                        .map(parameter -> describe(method, parameter)))
+                .sorted()
+                .toList();
+
+        assertThat(offenders)
+                .as("a data payload declared as a String publishes as \"type: string\", which "
+                        + "describes none of its fields; declare the payload type with "
+                        + "@Parameter(schema = @Schema(implementation = SomePayloadDto.class)) so "
+                        + "the document says what the part carries")
+                .isEmpty();
+    }
+
+    /**
+     * A {@code String} parameter carrying the JSON payload of a multipart or query-encoded write.
+     *
+     * <p>{@code @RequestParam} counts as well as {@code @RequestPart}: the attendance check-in and
+     * clock-event endpoints take their payload as a query parameter, which springdoc publishes as a
+     * string query parameter, and is if anything less informative than an undescribed part.
+     */
+    private static boolean isStringPayloadParameter(JavaParameter parameter) {
+        if (!parameter.getRawType().isEquivalentTo(String.class)) {
+            return false;
+        }
+        Optional<String> partName = declaredName(parameter, RequestPart.class);
+        if (partName.isPresent()) {
+            return partName.get().isEmpty() || PAYLOAD_PART.equals(partName.get());
+        }
+        return declaredName(parameter, RequestParam.class)
+                .filter(PAYLOAD_PART::equals)
+                .isPresent();
+    }
+
+    /**
+     * The name a binding annotation declares, or an empty string when the annotation is present and
+     * names nothing. Both {@code value} and {@code name} are read, since the two are aliases and
+     * either may carry the name.
+     */
+    private static Optional<String> declaredName(JavaParameter parameter, Class<?> bindingAnnotation) {
+        return annotationOfType(parameter, bindingAnnotation)
+                .map(annotation -> stringMember(annotation, "value")
+                        .filter(value -> !value.isEmpty())
+                        .or(() -> stringMember(annotation, "name"))
+                        .orElse(""));
+    }
+
+    /**
+     * The payload type a parameter declares for the document, from either
+     * {@code @Parameter(schema = @Schema(implementation = ...))} or a bare {@code @Schema} on the
+     * parameter. Absent when neither names a type, which includes the case of a schema annotation
+     * that carries only a description.
+     */
+    private static Optional<JavaClass> declaredSchemaImplementation(JavaParameter parameter) {
+        Optional<JavaAnnotation<?>> schema = annotationOfType(parameter, Parameter.class)
+                .flatMap(annotation -> nestedAnnotation(annotation, "schema"))
+                .or(() -> annotationOfType(parameter, Schema.class));
+        return schema
+                .flatMap(annotation -> annotation.get("implementation"))
+                .filter(JavaClass.class::isInstance)
+                .map(JavaClass.class::cast)
+                .filter(implementation -> !implementation.isEquivalentTo(Void.class));
+    }
+
+    private static Optional<JavaAnnotation<?>> annotationOfType(JavaParameter parameter, Class<?> type) {
+        for (JavaAnnotation<?> annotation : parameter.getAnnotations()) {
+            if (annotation.getRawType().isEquivalentTo(type)) {
+                return Optional.of(annotation);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<JavaAnnotation<?>> nestedAnnotation(JavaAnnotation<?> annotation, String member) {
+        return annotation.get(member)
+                .filter(JavaAnnotation.class::isInstance)
+                .map(value -> (JavaAnnotation<?>) value);
+    }
+
+    private static Optional<String> stringMember(JavaAnnotation<?> annotation, String member) {
+        return annotation.get(member)
+                .filter(String.class::isInstance)
+                .map(String.class::cast);
+    }
+
+    private static String describe(JavaMethod method, JavaParameter parameter) {
+        return method.getFullName() + " parameter " + parameter.getIndex();
+    }
+}


### PR DESCRIPTION
Item D of #522, first half: the nineteen endpoints whose JSON payload travels as a `data` string.

## What was wrong

A multipart endpoint cannot take a `@RequestBody`, because the body is the multipart envelope, so its payload travels as a `data` part and the endpoint reads it with `JsonPartBinder`. The declared Java type of that parameter is `String`, springdoc documents what is declared, and so every one of these endpoints published `type: string` for its payload. The document named no field, no type and no constraint for any of them. Attendance check-in and clock-event are worse than undescribed: they take the payload as a `@RequestParam`, so the document advertised a string in the query string.

That is the gap tornotron/echno-core#49 ran into. It wants a contract test between the published spec and the hand-written TypeScript client, and for these endpoints there was nothing to check a field name against: `plannedStartDate` and `startDate` were equally valid, because the schema was "a string".

## Why the Java type could not simply change

The obvious fix is to declare the parameter as the payload type and let Spring bind it. It would break every client.

Both clients append the part with `formData.append('data', JSON.stringify(payload))`, which is a plain string form field carrying no `application/json` content type. Spring answers a typed `@RequestPart` with **415** in that case. Checked against Spring Boot 3.4 rather than assumed:

| part as sent | `@RequestPart String data` | `@RequestPart Payload data` |
|---|---|---|
| plain string field, no content type (what the clients send) | 200 | **415** |
| same JSON, part typed `application/json` | 200 | 200 |

So the runtime keeps the `String` and the schema is declared beside it with `@Parameter(schema = @Schema(implementation = ...))`, which springdoc merges into the multipart schema in place of the string. Nothing about how a request is parsed, validated or answered changes in this PR. Only what the document says about it.

## What is here

**Nine create endpoints and the chat send** name the payload DTO they already deserialize into: `TaskCreationDto`, `IssueCreationDto`, `OrganizationCreationDto`, `ProjectCreationDto`, `SendMessageDto`, and `AttendanceCheckInDto` / `AttendanceClockEventDto` for the four attendance endpoints, which stay documented as query parameters because that is genuinely where the client puts them.

**Six partial updates** name a new `*UpdateFieldsDto` listing the keys their service actually applies. Those endpoints keep the map at runtime on purpose: a partial update has to tell a field that was left out from one explicitly sent as null, a bean cannot (both arrive as a null property), and several of these fields are cleared by sending null. The fields class supplies the half the map cannot: it is the published schema and is never deserialized into.

**Two tests hold it.** A schema nothing enforces is a schema nothing keeps true, and a documentation class that has drifted from the code is worse than none, because it reads as authoritative.

- `PartialUpdateSchemaContractTest` reads the `case "..."` labels out of each service's update method and fails when they and the schema's fields have moved apart in either direction. Source rather than bytecode, because a string switch compiles to a hash cascade. Plain JUnit, no Spring context.
- `RequestPayloadSchemaTest` is the ratchet, in the shape of `MultipartPayloadValidationTest` beside it: a `data` payload declared as a `String` and left undescribed fails the build. Fixing the nineteen that exist does nothing about the twentieth, which is what this is for.

Both were checked against their own absence: removing one annotation fails the ratchet at the exact parameter, and deleting one field from `TaskUpdateFieldsDto` fails the contract test for that surface alone.

## Verification

Booted the real application against a Testcontainers CockroachDB and read `/v3/api-docs`. All nineteen `data` payloads resolve to a DTO schema; none is left as a bare string.

```
TYPED data payloads: 19
UNTYPED data payloads: 0
```

Nothing published consumed these as strings, so nothing downstream can break on the change: `echno-core` has no codegen, no committed spec, and no OpenAPI-derived types (`api:snapshot` diffs its own exported symbols, not any spec), and the only place it treats a body as a string beyond `JSON.stringify` is a `"salary"` float fix-up on the plain-JSON PATCH path, which none of these endpoints emits.

## What is left

The other half of item D, coming as a second PR: nineteen request bodies still publish as a free-form map, counted from this same document. Seven raw `@RequestBody Map` endpoints, six `*PatchDto.updates` batch bodies, and six on the leave and keycloak paths that this pass did not cover.

Refs #522, tornotron/echno-core#49