### PR TITLE
Give a stock adjustment a way to be rejected, and keep the refusal

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
@@ -24,10 +24,14 @@ import java.util.List;
  * values (e.g. {@code write_off}, {@code physical_count}) that are not valid Java enum
  * identifiers; the frontend validates them.
  *
- * <p>The document is a draft until it is approved. Approval posts each line to the stock
+ * <p>The document is a draft until it is decided. Approval posts each line to the stock
  * ledger and moves the balance, and stamps {@code processedAt}, which is what marks the
  * document as posted: a posted document cannot be posted again, edited, or deleted. See
  * {@link StockAdjustmentService#approve}.
+ *
+ * <p>Rejection is the other decision. It moves no stock and writes no ledger entry; it stamps
+ * {@code rejectedBy}, {@code rejectedAt} and {@code rejectionReason}, which is what marks the
+ * document as refused and freezes it the same way. See {@link StockAdjustmentService#reject}.
  */
 @Entity
 @Table(name = "stock_adjustment")
@@ -104,7 +108,9 @@ public class StockAdjustment implements TenantScopedEntity {
     @Column(name = "rejected_at")
     private LocalDateTime rejectedAt;
 
-    @Column(name = "rejection_reason")
+    // 500 is the width the column was created with; stated here so the mapping and the schema
+    // agree and a long reason is caught by validation rather than by the database.
+    @Column(name = "rejection_reason", length = 500)
     private String rejectionReason;
 
     @Column(name = "processed_by")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentRejectionRequest;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
@@ -29,8 +30,11 @@ import java.util.List;
                 + "per line item. This is the controlled way to set or correct a stock balance: approving "
                 + "a document posts its lines to the inventory ledger and moves the balance, so the "
                 + "resulting figure stays explainable. Endpoints cover creating, updating, browsing, "
-                + "approving and deleting stock adjustment documents for the caller's current tenant. "
-                + "Read endpoints require tenant membership; write and approval endpoints require the "
+                + "approving, rejecting and deleting stock adjustment documents for the caller's "
+                + "current tenant. A draft is either approved, which posts it, or rejected with a "
+                + "stated reason, which posts nothing and keeps the refused correction on the "
+                + "record; both decisions freeze the document. "
+                + "Read endpoints require tenant membership; write and decision endpoints require the "
                 + "system-admin or project-manager role, and approval additionally has to come from "
                 + "someone other than whoever raised the document."
 )
@@ -114,7 +118,9 @@ public class StockAdjustmentControllerWeb {
             summary = "Update a stock adjustment",
             description = "Replaces the header fields and line items of an existing stock adjustment with "
                     + "the given values. Refused once the adjustment has been approved and posted, since "
-                    + "the ledger entries would then describe a document that no longer exists."
+                    + "the ledger entries would then describe a document that no longer exists, and "
+                    + "refused once it has been rejected, since editing it would overwrite the record "
+                    + "of what was refused; raise a fresh adjustment in that case."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment updated"),
@@ -156,12 +162,44 @@ public class StockAdjustmentControllerWeb {
         return new ResponseEntity<>(stockAdjustmentService.approve(id), HttpStatus.OK);
     }
 
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Reject a stock adjustment, recording why it was refused",
+            description = "Records that an approver looked at the proposed correction and did not "
+                    + "accept it. Nothing is posted to the stock ledger and no balance moves: the "
+                    + "document is stamped with who rejected it, when, and the reason, and its status "
+                    + "becomes rejected. The reason is required, because keeping the refusal and its "
+                    + "grounds on the record is the whole difference between rejecting the document "
+                    + "and deleting it. Restricted to the system-admin and project-manager roles, the "
+                    + "same as approval, but unlike approval it may be done by whoever raised the "
+                    + "document: a rejection posts no entry for a second pair of eyes to check, and "
+                    + "the raiser could delete the draft outright in any case, so refusing them the "
+                    + "rejection would only push them to the outcome that keeps no record. An already "
+                    + "posted document cannot be rejected, since its movements are on the ledger; "
+                    + "correct those by raising a further adjustment. Rejection is terminal: the "
+                    + "document cannot then be edited, deleted, approved or rejected again, and a "
+                    + "raiser who wants to answer the objection raises a fresh draft."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment rejected"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "No reason was given, or the adjustment is already posted or already rejected"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No stock adjustment with the given id")
+    })
+    public ResponseEntity<StockAdjustmentDto> rejectStockAdjustment(
+            @PathVariable Long id,
+            @Valid @RequestBody StockAdjustmentRejectionRequest request) {
+        return new ResponseEntity<>(stockAdjustmentService.reject(id, request.reason()), HttpStatus.OK);
+    }
+
     @DeleteMapping("/{id}")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Delete a stock adjustment",
             description = "Deletes the stock adjustment with the given id. Refused once the adjustment "
-                    + "has been approved and posted; raise a further adjustment instead."
+                    + "has been approved and posted, and once it has been rejected, because both are "
+                    + "decisions worth keeping; raise a further adjustment instead."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustment deleted"),

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
@@ -1,12 +1,37 @@
 package org.tornotron.echno_backend.stockAdjustment;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface StockAdjustmentRepository extends JpaRepository<StockAdjustment, Long> {
 
     Optional<StockAdjustment> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Loads a document under a pessimistic write lock, so the transitions that read its state
+     * and then decide on it serialize against each other.
+     *
+     * <p>Every write path on this document is a read-decide-write: approve refuses a document
+     * already posted or rejected and then posts it, reject refuses one already posted or
+     * rejected and then stamps it, and update and delete both refuse a decided document before
+     * changing it. Two of those running at once on the same row would each read the state as it
+     * was before the other, both pass the guard, and both act. Concurrent approvals would post
+     * the movement to the stock ledger twice; an approval racing a rejection would post the
+     * movement and then record the document as refused; two rejections would overwrite the first
+     * reason with the second. With the lock the second caller waits, then reads the decision the
+     * first committed and is refused by the guard, which is the outcome the guards are there for.
+     *
+     * <p>The same lock the leave-approval and payable paths take for the same reason. Reads that
+     * only display the document keep the unlocked lookup above.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM StockAdjustment s WHERE s.id = :id AND s.organization.id = :orgId")
+    Optional<StockAdjustment> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
     boolean existsByAdjustmentNumberAndOrganization_Id(String adjustmentNumber, Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -51,10 +51,18 @@ import java.util.Optional;
  * refused, because changing the lines afterwards would leave the ledger describing a
  * document that no longer exists.
  *
+ * <p>A draft has one other way off the line: {@link #reject}, which records that an approver
+ * looked at the correction and refused it. It moves no stock, and it is the only outcome that
+ * keeps the refusal on the record. Deleting the document instead erases the fact that it was
+ * ever raised and why it was turned down, which on a document whose purpose is to make a
+ * balance explainable throws away half of what there was to explain. A rejected document is
+ * frozen the same way a posted one is, for the same reason: the decision has been taken and
+ * the record of it is the point.
+ *
  * <p>Because approval is what moves the balance, it is also where segregation of duties
  * applies: {@link #create} records who raised the document from the session, and
  * {@link #approve} refuses an approval by that same person unless they hold the break-glass
- * role. See {@link SelfApprovalPolicy}.
+ * role. See {@link SelfApprovalPolicy}. {@link #reject} is deliberately outside that rule.
  */
 @Service
 public class StockAdjustmentService {
@@ -94,6 +102,12 @@ public class StockAdjustmentService {
 
     /** Status a document carries once its movements are on the ledger. */
     static final String POSTED_STATUS = "processed";
+
+    /**
+     * Status a document carries once an approver has refused it. Part of the vocabulary the web
+     * client already reads, alongside {@link #DRAFT_STATUS} and {@link #POSTED_STATUS}.
+     */
+    static final String REJECTED_STATUS = "rejected";
 
     /**
      * Status a document carries until it is approved, and the only one a request body may ask
@@ -170,6 +184,7 @@ public class StockAdjustmentService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "edited");
+        requireNotRejected(stockAdjustment, "edited");
         Organization organization = stockAdjustment.getOrganization();
 
         applyHeaderFields(stockAdjustment, creationDto);
@@ -199,6 +214,7 @@ public class StockAdjustmentService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "deleted");
+        requireNotRejected(stockAdjustment, "deleted");
         stockAdjustmentRepository.delete(stockAdjustment);
     }
 
@@ -244,6 +260,7 @@ public class StockAdjustmentService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "posted again");
+        requireNotRejected(stockAdjustment, "approved");
 
         Long approver = userContextService.getCurrentUserId();
         boolean selfApproved = selfApprovalPolicy.checkSelfApproval(
@@ -341,6 +358,73 @@ public class StockAdjustmentService {
     }
 
     /**
+     * Rejects a stock adjustment, recording who refused it, when, and why.
+     *
+     * <p>This is the other way a draft leaves the pending state, and the only one that keeps the
+     * refusal. Nothing is written to the stock ledger and no balance moves: the document is
+     * stamped with the rejection and closed. Deleting it instead is what the module had before,
+     * and it removes the fact that a correction was proposed along with the reason it was not
+     * accepted, on a document that exists to make a balance explainable.
+     *
+     * <p>Three deliberate decisions sit behind this.
+     *
+     * <p><b>The reason is required.</b> Every posted line has to say why the stock moved, or
+     * {@link #resolveReason} refuses it. A rejection is held to the same standard: without the
+     * reason it records nothing that could not be read off the absence of an approval, and the
+     * next person looking at the balance is no better off than if the draft had been deleted.
+     *
+     * <p><b>Self-rejection is not subject to {@link SelfApprovalPolicy}.</b> That rule is the
+     * second pair of eyes on the entry an approval posts, and a rejection posts no entry. It also
+     * takes nothing away from anybody: whoever raised the document can already delete it outright,
+     * so refusing them the rejection would only push them towards the outcome that keeps no
+     * record. This follows the same reading the attendance path settled on for withdrawing your
+     * own request.
+     *
+     * <p><b>A posted document cannot be rejected.</b> Its lines are on the ledger and the balance
+     * has moved, so a rejection would claim a correction was refused while the stock figure says
+     * it happened. A posting is undone by raising a further adjustment, not by relabelling the
+     * one that posted it.
+     *
+     * <p>Rejection is terminal. The document cannot then be edited, deleted, approved or rejected
+     * again: there is one set of rejection columns, so an edit that reopened the document would
+     * have to overwrite the refusal to record the next decision, and the record of the refusal is
+     * the entire reason to reject rather than delete. A raiser who wants to answer the objection
+     * raises a fresh draft, which costs nothing because a draft posts nothing, and the rejected
+     * document stays alongside it saying what was asked for and why it was turned down.
+     *
+     * @param id The document to reject.
+     * @param reason Why it is being refused. Required.
+     * @return The rejected document as a DTO.
+     * @throws ResourceNotFoundException if no such document exists in this organization.
+     * @throws InvalidRequestException if the document is already posted, is already rejected, or no reason was given.
+     */
+    @Transactional
+    public StockAdjustmentDto reject(Long id, String reason) {
+        StockAdjustment stockAdjustment = stockAdjustmentRepository
+                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Stock adjustment with ID " + id + " was not found in this organization"));
+        requireNotPosted(stockAdjustment, "rejected");
+        requireNotRejected(stockAdjustment, "rejected again");
+
+        String statedReason = reason == null ? null : reason.trim();
+        if (!hasText(statedReason)) {
+            throw new InvalidRequestException("Rejecting stock adjustment with ID " + id
+                    + " needs a reason. The record of a refused correction is what the rejection is "
+                    + "for, and a rejection that does not say why says nothing the missing approval "
+                    + "did not already say.");
+        }
+
+        stockAdjustment.setStatus(REJECTED_STATUS);
+        stockAdjustment.setRejectedBy(userContextService.getCurrentUserId());
+        stockAdjustment.setRejectedAt(LocalDateTime.now());
+        stockAdjustment.setRejectionReason(statedReason);
+
+        StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
+        return stockAdjustmentMapper.toDto(saved);
+    }
+
+    /**
      * What a self-approved posting carries in the ledger. The document already records the raiser
      * and the approver side by side, but the ledger entry is what a stock figure is explained
      * from, so a movement nobody independent agreed to says so where the figure is read.
@@ -388,6 +472,24 @@ public class StockAdjustmentService {
             throw new InvalidRequestException("Stock adjustment with ID " + stockAdjustment.getId()
                     + " was posted to the stock ledger on " + stockAdjustment.getProcessedAt()
                     + " and cannot be " + action + ". Raise a further adjustment to correct it.");
+        }
+    }
+
+    /**
+     * Refuses to change or re-decide a document an approver has already refused.
+     *
+     * <p>The document carries one {@code rejectedBy}, one {@code rejectedAt} and one
+     * {@code rejectionReason}, so anything that reopened it would end up overwriting the refusal
+     * to record whatever came next, and the refusal is the whole reason {@link #reject} exists
+     * rather than a delete. A rejected document is therefore read-only, like a posted one, and
+     * the correction is pursued by raising a fresh draft alongside it.
+     */
+    private void requireNotRejected(StockAdjustment stockAdjustment, String action) {
+        if (stockAdjustment.getRejectedAt() != null) {
+            throw new InvalidRequestException("Stock adjustment with ID " + stockAdjustment.getId()
+                    + " was rejected on " + stockAdjustment.getRejectedAt()
+                    + " and cannot be " + action + ". Raise a new adjustment for the correction, so "
+                    + "the rejection and the reason given for it stay on the record.");
         }
     }
 

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -63,6 +63,13 @@ import java.util.Optional;
  * applies: {@link #create} records who raised the document from the session, and
  * {@link #approve} refuses an approval by that same person unless they hold the break-glass
  * role. See {@link SelfApprovalPolicy}. {@link #reject} is deliberately outside that rule.
+ *
+ * <p>Every write path here reads the document, decides on its state, and then writes, so all
+ * four load it through {@link StockAdjustmentRepository#lockByIdAndOrganizationId} rather than
+ * the plain lookup. Without that, two callers acting at once would each read the state as it
+ * stood before the other and both pass the guard: concurrent approvals would post the same
+ * movement to the ledger twice, and an approval racing a rejection would post the movement and
+ * then record the document as refused. Reads that only display the document are not locked.
  */
 @Service
 public class StockAdjustmentService {
@@ -180,7 +187,7 @@ public class StockAdjustmentService {
     @Transactional
     public StockAdjustmentDto update(Long id, StockAdjustmentCreationDto creationDto) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
-                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .lockByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "edited");
@@ -210,7 +217,7 @@ public class StockAdjustmentService {
     @Transactional
     public void delete(Long id) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
-                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .lockByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "deleted");
@@ -256,7 +263,7 @@ public class StockAdjustmentService {
     @Transactional
     public StockAdjustmentDto approve(Long id) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
-                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .lockByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "posted again");
@@ -401,7 +408,7 @@ public class StockAdjustmentService {
     @Transactional
     public StockAdjustmentDto reject(Long id, String reason) {
         StockAdjustment stockAdjustment = stockAdjustmentRepository
-                .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .lockByIdAndOrganizationId(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
         requireNotPosted(stockAdjustment, "rejected");

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentRejectionRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentRejectionRequest.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.stockAdjustment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Why an approver refused a stock adjustment.
+ *
+ * <p>The reason is required. A rejection exists so that a refused correction stays on the
+ * record instead of being deleted away, and a rejection carrying no reason records only that
+ * somebody said no, which is the part nobody needed written down. The same standard the
+ * posting path applies to a movement, that it must say why it happened, is applied to the
+ * decision not to make one.
+ *
+ * <p>The 500 character bound is the width of the {@code rejection_reason} column, so a longer
+ * reason is refused as a validation error rather than by the database.
+ */
+@Schema(description = "Payload to reject a stock adjustment, carrying the reason it was refused.")
+public record StockAdjustmentRejectionRequest(
+        @Schema(description = "Why the adjustment is being refused. Required.",
+                example = "Variance not supported by the count sheet")
+        @NotBlank @Size(max = 500) String reason
+) {}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -126,7 +126,7 @@ class StockAdjustmentApprovalTest {
         adjustment.setProject(project);
         adjustment.setLocation(headerLocation);
         adjustment.setPrimaryReason("physical_count");
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(ADJUSTMENT, ORG))
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(ADJUSTMENT, ORG))
                 .thenReturn(Optional.of(adjustment));
         return adjustment;
     }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -33,6 +34,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * who holds neither role is refused a write. If the write guard were ever loosened to
  * membership, the member-without-role delete test fails. Approving is held to the same
  * bar: it is the action that moves a stock balance, so a plain member must not reach it.
+ * So is rejecting, which closes the document and writes what the refusal is afterwards
+ * read from. The reason on a rejection is required, so a blank one is a 400 rather than
+ * an empty explanation on the record.
  * @orgSecurity is mocked so each branch is exercised independently.
  */
 @WebMvcTest(StockAdjustmentControllerWeb.class)
@@ -109,6 +113,44 @@ class StockAdjustmentControllerWebAuthzTest {
 
         mockMvc.perform(post("/api/v1/stock-adjustments/web/1/approve").with(jwt()).with(csrf()))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void reject_isOk_forAnElevatedRoleHolder() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/stock-adjustments/web/1/reject")
+                        .with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"Variance not supported by the count sheet\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void reject_isForbidden_forAPlainMemberWithoutAnElevatedRole() throws Exception {
+        // Rejecting closes the document and is the decision the record is then read from, so it
+        // is held to the same role bar as approving rather than to plain membership.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/stock-adjustments/web/1/reject")
+                        .with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"Variance not supported by the count sheet\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void reject_isBadRequest_whenNoReasonIsGiven() throws Exception {
+        // The reason is what separates a rejection from a delete, so a blank one is refused at
+        // the edge rather than stored as an empty explanation.
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/stock-adjustments/web/1/reject")
+                        .with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"  \"}"))
+                .andExpect(status().isBadRequest());
     }
 
     @TestConfiguration

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
@@ -134,7 +134,7 @@ class StockAdjustmentCreateStatusTest {
         StockAdjustment existing = new StockAdjustment();
         existing.setId(4L);
         existing.setStatus(StockAdjustmentService.DRAFT_STATUS);
-        lenient().when(stockAdjustmentRepository.findByIdAndOrganization_Id(4L, ORG))
+        lenient().when(stockAdjustmentRepository.lockByIdAndOrganizationId(4L, ORG))
                 .thenReturn(Optional.of(existing));
 
         assertThatExceptionOfType(InvalidRequestException.class)

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
@@ -1,0 +1,271 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Rejecting a stock adjustment is the other way a draft leaves the pending state, and the only
+ * one that keeps the refusal on the record: deleting the document takes the proposed correction
+ * and the grounds for turning it down away with it.
+ *
+ * <p>This pins what the transition has to guarantee. It stamps who refused the document, when and
+ * why, and moves it to the rejected status. It writes nothing to the stock ledger and moves no
+ * balance, which is what separates it from approval. It insists on a reason, on the same footing
+ * as the reason every posted movement has to carry. It refuses a document already posted, whose
+ * lines are on the ledger. It leaves the document read-only afterwards, because there is one set
+ * of rejection columns and reopening the document would overwrite the refusal.
+ *
+ * <p>It is also deliberately outside {@link SelfApprovalPolicy}: that rule is the second pair of
+ * eyes on the entry an approval posts, and a rejection posts none. The test below verifies the
+ * policy is not consulted at all rather than that it happens to pass.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentRejectionTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ADJUSTMENT = 5L;
+    private static final Long APPROVER = 42L;
+    private static final Long DRAFTER = 43L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private SelfApprovalPolicy selfApprovalPolicy;
+
+    private StockAdjustmentService service;
+    private Organization organization;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService,
+                selfApprovalPolicy);
+
+        organization = new Organization();
+        organization.setId(ORG);
+
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(APPROVER);
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    /** A draft raised by someone else, with one line, found in this organization. */
+    private StockAdjustment draftRaisedBy(Long raiser) {
+        StockAdjustment adjustment = new StockAdjustment();
+        adjustment.setId(ADJUSTMENT);
+        adjustment.setAdjustmentNumber("SA-2026-0005");
+        adjustment.setOrganization(organization);
+        adjustment.setStatus("draft");
+        adjustment.setSubmittedBy(raiser);
+        adjustment.setPrimaryReason("physical_count");
+
+        Project project = new Project();
+        project.setId(7L);
+        adjustment.setProject(project);
+
+        Material material = new Material();
+        material.setId(8L);
+        StockAdjustmentLineItem line = new StockAdjustmentLineItem();
+        line.setMaterial(material);
+        line.setPhysicalQuantity(46.0);
+        line.setOrganization(organization);
+        adjustment.addLineItem(line);
+
+        lenient().when(stockAdjustmentRepository.findByIdAndOrganization_Id(ADJUSTMENT, ORG))
+                .thenReturn(Optional.of(adjustment));
+        return adjustment;
+    }
+
+    @Test
+    void rejectingADraftRecordsWhoRefusedItWhenAndWhy() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+
+        service.reject(ADJUSTMENT, "Variance not supported by the count sheet");
+
+        assertThat(adjustment.getStatus()).isEqualTo("rejected");
+        assertThat(adjustment.getRejectedBy()).isEqualTo(APPROVER);
+        assertThat(adjustment.getRejectedAt()).isNotNull();
+        assertThat(adjustment.getRejectionReason()).isEqualTo("Variance not supported by the count sheet");
+        verify(stockAdjustmentRepository).saveAndFlush(adjustment);
+    }
+
+    @Test
+    void aRejectionPostsNothingToTheLedgerAndMovesNoBalance() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+
+        service.reject(ADJUSTMENT, "Count sheet unsigned");
+
+        verifyNoInteractions(inventoryTransactionRepository);
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+        assertThat(adjustment.getApprovedBy()).isNull();
+        assertThat(adjustment.getProcessedAt()).isNull();
+    }
+
+    /**
+     * The reason is what a rejection is for. Without it the document records only that somebody
+     * said no, which is already readable from the absent approval.
+     */
+    @Test
+    void aRejectionWithNoReasonIsRefused() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.reject(ADJUSTMENT, "   "))
+                .withMessageContaining("needs a reason");
+
+        assertThat(adjustment.getRejectedAt()).isNull();
+        assertThat(adjustment.getStatus()).isEqualTo("draft");
+    }
+
+    @Test
+    void aNullReasonIsRefusedTheSameWay() {
+        draftRaisedBy(DRAFTER);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.reject(ADJUSTMENT, null));
+    }
+
+    @Test
+    void theReasonIsStoredTrimmed() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+
+        service.reject(ADJUSTMENT, "  Variance not supported  ");
+
+        assertThat(adjustment.getRejectionReason()).isEqualTo("Variance not supported");
+    }
+
+    /**
+     * Rejecting your own document is left outside the self-approval rule. It posts no entry for a
+     * second pair of eyes to check, and whoever raised it could delete the draft outright anyway,
+     * so refusing the rejection would only push them to the outcome that keeps no record. Same
+     * reading the attendance path settled on for withdrawing your own request.
+     */
+    @Test
+    void rejectingYourOwnAdjustmentIsNotSubjectToTheSelfApprovalRule() {
+        StockAdjustment adjustment = draftRaisedBy(APPROVER);
+
+        service.reject(ADJUSTMENT, "Raised against the wrong location");
+
+        verify(selfApprovalPolicy, never()).checkSelfApproval(any(), any(), any());
+        assertThat(adjustment.getStatus()).isEqualTo("rejected");
+        assertThat(adjustment.getRejectedBy()).isEqualTo(APPROVER);
+    }
+
+    /**
+     * A posted document has moved stock. Rejecting it would claim the correction was refused
+     * while the ledger says it happened; a posting is undone by raising another adjustment.
+     */
+    @Test
+    void aPostedAdjustmentCannotBeRejected() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+        adjustment.setStatus("processed");
+        adjustment.setProcessedAt(LocalDateTime.now().minusDays(1));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.reject(ADJUSTMENT, "Variance not supported"))
+                .withMessageContaining("cannot be rejected");
+
+        assertThat(adjustment.getRejectedAt()).isNull();
+    }
+
+    /** One set of rejection columns, so a second rejection would overwrite the first. */
+    @Test
+    void aRejectedAdjustmentCannotBeRejectedAgain() {
+        StockAdjustment adjustment = rejectedAdjustment();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.reject(ADJUSTMENT, "A different reason"))
+                .withMessageContaining("cannot be rejected again");
+
+        assertThat(adjustment.getRejectionReason()).isEqualTo("Variance not supported by the count sheet");
+    }
+
+    /**
+     * Rejection is terminal. Editing the document would have to overwrite the refusal to record
+     * whatever came next, and that record is the entire reason to reject rather than delete.
+     */
+    @Test
+    void aRejectedAdjustmentCannotBeEdited() {
+        rejectedAdjustment();
+
+        StockAdjustmentCreationDto edit = new StockAdjustmentCreationDto();
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(ADJUSTMENT, edit))
+                .withMessageContaining("cannot be edited");
+    }
+
+    @Test
+    void aRejectedAdjustmentCannotBeDeleted() {
+        rejectedAdjustment();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.delete(ADJUSTMENT))
+                .withMessageContaining("cannot be deleted");
+        verify(stockAdjustmentRepository, never()).delete(any(StockAdjustment.class));
+    }
+
+    @Test
+    void aRejectedAdjustmentCannotThenBeApproved() {
+        rejectedAdjustment();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("cannot be approved");
+
+        verifyNoInteractions(inventoryTransactionRepository);
+    }
+
+    private StockAdjustment rejectedAdjustment() {
+        StockAdjustment adjustment = draftRaisedBy(DRAFTER);
+        adjustment.setStatus("rejected");
+        adjustment.setRejectedBy(APPROVER);
+        adjustment.setRejectedAt(LocalDateTime.now().minusHours(2));
+        adjustment.setRejectionReason("Variance not supported by the count sheet");
+        return adjustment;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
@@ -116,7 +116,7 @@ class StockAdjustmentRejectionTest {
         line.setOrganization(organization);
         adjustment.addLineItem(line);
 
-        lenient().when(stockAdjustmentRepository.findByIdAndOrganization_Id(ADJUSTMENT, ORG))
+        lenient().when(stockAdjustmentRepository.lockByIdAndOrganizationId(ADJUSTMENT, ORG))
                 .thenReturn(Optional.of(adjustment));
         return adjustment;
     }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepositoryIT.java
@@ -7,18 +7,32 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link StockAdjustmentRepository} against a real CockroachDB
  * (see {@link AbstractIntegrationTest}). Asserts the tenant-scoped lookup returns the
- * header together with its line item, and that a persisted document shows up in a
- * paginated {@code findAll}.
+ * header together with its line item, that a persisted document shows up in a
+ * paginated {@code findAll}, and that the locking lookup the decision paths take
+ * actually serializes them.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -29,6 +43,9 @@ class StockAdjustmentRepositoryIT extends AbstractIntegrationTest {
 
     @Autowired
     private TestEntityManager em;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
 
     @Test
     void findByIdAndOrganization_returnsTheDocumentWithItsLineItem() {
@@ -58,6 +75,73 @@ class StockAdjustmentRepositoryIT extends AbstractIntegrationTest {
 
         assertThat(result.getContent()).extracting(StockAdjustment::getAdjustmentNumber)
                 .contains("SA-0002");
+    }
+
+    /**
+     * A stock adjustment is decided by reading its state, checking it has not been decided
+     * already, and then writing. Approve, reject, update and delete all do that, so two of them
+     * running at once on the same document would each read the state as it stood before the
+     * other and both act: the ledger would carry the movement twice, or carry it under a
+     * document recorded as refused. This mirrors that race with the guard the service applies,
+     * through the same locking lookup. Without the lock every thread reads the undecided
+     * document and every thread decides it; with it they serialize and exactly one wins.
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void concurrentDecisions_onlyOneWins() throws Exception {
+        long[] ids = new TransactionTemplate(txManager).execute(status -> {
+            Organization org = new Organization();
+            org.setOrganizationName("Decision Org");
+            org.setOrganizationAddress("Decision address");
+            org.setOrganizationEmail("decision@example.test");
+            org.setOrganizationPhone("0000000000");
+            em.getEntityManager().persist(org);
+
+            StockAdjustment adjustment = new StockAdjustment();
+            adjustment.setOrganization(org);
+            adjustment.setAdjustmentNumber("SA-0003");
+            adjustment.setType("physical_count");
+            adjustment.setStatus("draft");
+            adjustment.setJustification("Contended count");
+            em.getEntityManager().persist(adjustment);
+
+            em.getEntityManager().flush();
+            return new long[] { adjustment.getId(), org.getId() };
+        });
+        long adjustmentId = ids[0];
+        long orgId = ids[1];
+
+        int threads = 4;
+        AtomicInteger decisions = new AtomicInteger(0);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                startGate.await();
+                new TransactionTemplate(txManager).executeWithoutResult(status -> {
+                    StockAdjustment adjustment = stockAdjustmentRepository
+                            .lockByIdAndOrganizationId(adjustmentId, orgId)
+                            .orElseThrow();
+                    // Mirror the service guards: decide only an undecided document.
+                    if (adjustment.getProcessedAt() == null && adjustment.getRejectedAt() == null) {
+                        adjustment.setStatus("rejected");
+                        adjustment.setRejectedAt(LocalDateTime.now());
+                        adjustment.setRejectionReason("Variance not supported by the count sheet");
+                        stockAdjustmentRepository.save(adjustment);
+                        decisions.incrementAndGet();
+                    }
+                });
+                return null;
+            }));
+        }
+        startGate.countDown();
+        for (Future<?> future : futures) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        assertThat(decisions.get()).isEqualTo(1);
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -168,7 +168,7 @@ class StockAdjustmentServiceTest {
 
     @Test
     void update_unknownDocument_throwsNotFound() {
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
                 .isThrownBy(() -> service.update(5L, baseDto()));
@@ -185,7 +185,7 @@ class StockAdjustmentServiceTest {
         existing.setOrganization(org);
         StockAdjustmentLineItem stale = new StockAdjustmentLineItem();
         existing.addLineItem(stale);
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(existing));
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(existing));
 
         StockAdjustmentCreationDto dto = baseDto();
         dto.setLineItems(List.of(line(MATERIAL, null)));
@@ -202,7 +202,7 @@ class StockAdjustmentServiceTest {
 
     @Test
     void delete_unknownDocument_throwsNotFound() {
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.empty());
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(ResourceNotFoundException.class)
                 .isThrownBy(() -> service.delete(5L));
@@ -213,7 +213,7 @@ class StockAdjustmentServiceTest {
     @Test
     void delete_existingDocument_deletes() {
         StockAdjustment existing = new StockAdjustment();
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(existing));
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(existing));
 
         service.delete(5L);
 
@@ -244,7 +244,7 @@ class StockAdjustmentServiceTest {
         StockAdjustment existing = new StockAdjustment();
         existing.setId(4L);
         existing.setSubmittedBy(SESSION_USER);
-        when(stockAdjustmentRepository.findByIdAndOrganization_Id(4L, ORG))
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(4L, ORG))
                 .thenReturn(Optional.of(existing));
         StockAdjustmentCreationDto dto = baseDto();
         dto.setSubmittedBy(999L);


### PR DESCRIPTION
Closes #573.

## What was missing

`stock_adjustment` has carried `rejected_by`, `rejected_at` and `rejection_reason` since `v4.0/029-create-stock-adjustments.xml` created it, `StockAdjustmentDto` exposes all three with schema descriptions, and the detail screen web #333 shipped displays them. Nothing wrote them. The only transition off a draft was `approve`, so an approver who looked at a variance and decided the count sheet did not support it had two options: approve it anyway, which posts the movement, or delete the document, which erases both the proposed correction and the reason it was turned down. On a document whose purpose is to make a balance explainable, that threw away half of what there was to explain.

`POST /api/v1/stock-adjustments/web/{id}/reject` now stamps who refused the document, when and why, moves it to the `rejected` status, and writes nothing to the stock ledger. Same role gate as approve (`system-admin` or `project-manager`); the rejecter comes from the session, never the request, which is the rule #559 and #562 enforced repo-wide.

Rebased on `development` after #572, which narrowed the location scope on `approve` to `StorageLocationScope.requireUsableForBalanceCorrection`. `reject` touches none of that: it never resolves a line's location, because it posts nothing.

## The four questions the issue asked to settle

**Does self-approval apply to rejection? No, following #562.** `AttendanceRegularizationService.processRegularization` consults `SelfApprovalPolicy` only on the approve branch, and its `rejectingYourOwnRequestIsNotSubjectToTheRule` test verifies the policy is not called at all on a rejection. The reasoning transfers exactly: the rule is the second pair of eyes on the entry an approval posts, and a rejection posts no entry, so there is nothing for a second pair of eyes to check.

Stock adjustments differ from regularizations in one way worth naming and then dismissing. The raiser of a regularization is an ordinary employee and the approver is a manager, whereas creating a stock adjustment is already gated to `system-admin` or `project-manager`, so raiser and rejecter hold the same roles. That makes self-rejection more reachable here, not more dangerous: the same person can already `DELETE` the draft outright, which is strictly more destructive because it keeps no record. Refusing them the rejection would only push them towards the delete. `rejectingYourOwnAdjustmentIsNotSubjectToTheSelfApprovalRule` pins it with `verify(selfApprovalPolicy, never())`, so a future change that routes rejection through the policy fails rather than passing quietly.

**Is a reason mandatory? Yes, and the API says so twice.** `StockAdjustmentRejectionRequest.reason` is `@NotBlank @Size(max = 500)`, so a missing or blank reason is a 400 at the edge before the service is entered, and the service repeats the check on its own argument so the rule holds for any caller. The 500 is the width of the `rejection_reason` column, so an over-long reason is a validation error rather than a database one.

The justification is the module's own standard. `resolveReason` refuses to post a line that gives no reason, on the grounds that a stock movement with no stated reason is what makes a balance unexplainable. A rejection without one records only that somebody said no, which was already readable from the absent approval, and leaves the next person looking at the balance no better off than if the draft had been deleted. Web #330 assumed the reason would be required; it is.

**What states can be rejected from?** #541 narrowed the reachable states to `draft` on create and on update, so in practice a document is a draft, posted, or now rejected.

- **Draft: rejectable.** This is the whole case.
- **Posted (`processedAt` set): refused.** Its lines are on the ledger and the balance has moved, so a rejection would claim the correction was refused while the stock figure says it happened. `requireNotPosted(adjustment, "rejected")`, the same guard `update` and `delete` use. A posting is corrected by raising a further adjustment, which is what the refusal message says.
- **Already rejected: refused.** See below.

**Is rejection terminal? Yes, and the edit path is refused too.** The document carries one `rejectedBy`, one `rejectedAt` and one `rejectionReason`. Anything that reopened it would have to overwrite the refusal in order to record whatever came next, and the record of the refusal is the entire reason to reject rather than delete. So a new `requireNotRejected` guard sits alongside `requireNotPosted` on `update`, `delete`, `approve` and `reject` itself: a rejected document is read-only exactly the way a posted one is.

The alternative, sending the document back to draft on edit, is what the issue speculated about. It was rejected because it makes the rejection self-erasing: the first thing anyone does with a rejected document destroys the record that motivated the endpoint. Resubmission is instead a fresh draft, which costs nothing (a draft posts nothing and moves no stock) and leaves the refused version standing alongside it saying what was asked for and why it was turned down.

`delete` is refused on a rejected document for the same reason, not only `update`. A rejection you can delete is not a record.

Checked what web #333 now sends before deciding: the edit screen was reworked onto the shared `stock-adjustment-form`, and its payload builder sends no `status` at all (`git grep status` in `features/stock-adjustments/components/stock-adjustment-form.tsx` is empty). So nothing on the client depended on a decided document staying writable, and the client-side `approval-gate.ts` already hides the approve action on `status === 'processed'`, which the new `rejected` status will need the same treatment for. Filed as echno-web #339.

`rejected` is not a new vocabulary word: `StockAdjustmentStatus` in `types/resource/stock-adjustment.ts` already has it, the list screen already filters on it and the detail screen already has a badge case for it.

## Serializing the decisions (from review)

The transitions all read the document, check its state and then write, and they loaded the row through the plain lookup, so two callers acting at once would each read the state as it stood before the other and both pass the guard. Concurrent approvals post the same movement to the ledger twice; an approval racing a rejection posts the movement and then records the document as refused; two rejections overwrite the first reason with the second. The approve half of that was there before this PR, and adding a second decision widens it.

`update`, `delete`, `approve` and `reject` now load through `StockAdjustmentRepository.lockByIdAndOrganizationId`, a `PESSIMISTIC_WRITE` lock, so the second caller waits, then reads what the first committed and is refused by the guard that exists for it. This is the pattern the repo already uses in `LeaveRequestRepository.lockByIdAndOrganizationId` (whose javadoc names the same approve/reject race) and `PayableRepository`. Reads that only display the document keep the unlocked lookup.

## Tests

`StockAdjustmentRejectionTest` (plain JUnit + Mockito, no Spring context) plus three cases added to the existing `StockAdjustmentControllerWebAuthzTest` web slice, which reuses that class's context rather than starting a new one.

Full suite on the lab box: `BUILD SUCCESSFUL`, no failures.

What each new test does against a build without its fix. Three mutants were run rather than one, so each guard is shown to be load-bearing on its own.

| Mutant | Test | Result without the fix |
|---|---|---|
| Production files reverted to `origin/development` | whole `StockAdjustmentRejectionTest` | does not compile, `cannot find symbol: reject` (8 sites) |
| ditto, rejection test removed so the slice compiles | `reject_isOk_forAnElevatedRoleHolder` | FAILED (no mapping, 404) |
| | `reject_isForbidden_forAPlainMemberWithoutAnElevatedRole` | FAILED |
| | `reject_isBadRequest_whenNoReasonIsGiven` | FAILED |
| `requireNotRejected` calls removed, `reject` kept | `aRejectedAdjustmentCannotBeRejectedAgain` | FAILED |
| | `aRejectedAdjustmentCannotBeEdited` | FAILED |
| | `aRejectedAdjustmentCannotBeDeleted` | FAILED |
| | `aRejectedAdjustmentCannotThenBeApproved` | FAILED |
| the mandatory-reason check removed from `reject` | `aRejectionWithNoReasonIsRefused` | FAILED |
| | `aNullReasonIsRefusedTheSameWay` | FAILED |
| the locking lookup swapped back for the plain one | `StockAdjustmentRepositoryIT.concurrentDecisions_onlyOneWins` | FAILED (more than one of four threads decides the same document) |

The concurrency case is an integration test against the real CockroachDB, added to the existing `StockAdjustmentRepositoryIT` rather than a class of its own so it reuses that Spring context instead of starting another.

The rest of the class (the stamping, the no-ledger-write, the trimming, the self-rejection exemption, the posted-document refusal) needs `reject` to exist at all, so it is covered by the first row.

## Follow-up

Web issue filed for the reject UI, echno-web #339: the service call, the detail-screen action behind a required-reason form, and `approval-gate.ts` treating `rejected` the way it already treats `processed`. Not built here.
