### PR TITLE
Name the keys a map-shaped request body actually accepts

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.employee;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -18,6 +20,7 @@ import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
 import java.util.List;
 import java.util.Map;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
 
 /**
  * REST controller for managing employees.
@@ -179,7 +182,11 @@ public class EmployeeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the employee update or admin authority"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
-    public ResponseEntity<ApiResponse> partialUpdateAnEmployee(@RequestBody Map<String,Object> updates,@PathVariable Long id) {
+    public ResponseEntity<ApiResponse> partialUpdateAnEmployee(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = EmployeeUpdateFieldsDto.class)))
+            @RequestBody Map<String, Object> updates,
+            @PathVariable Long id) {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
     }

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.employee;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,6 +21,7 @@ import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeLookupDto;
 import org.tornotron.echno_backend.employee.dto.EmployeeJoinOrgDto;
 import org.tornotron.echno_backend.employee.dto.EmployeePatchDto;
+import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
 import org.tornotron.echno_backend.employee.dto.OrgRoleAssignmentDto;
 
 import java.util.List;
@@ -202,7 +205,11 @@ public class EmployeeControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee nor a system or HR admin"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
-    public ResponseEntity<ApiResponse> partialUpdateAnEmployee(@RequestBody Map<String,Object> updates, @PathVariable Long id) {
+    public ResponseEntity<ApiResponse> partialUpdateAnEmployee(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = EmployeeUpdateFieldsDto.class)))
+            @RequestBody Map<String, Object> updates,
+            @PathVariable Long id) {
         employeeService.partialUpdateAnEmployee(updates,id);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse("Employee with id: "+id+" updated"));
     }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeePatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeePatchDto.java
@@ -12,7 +12,6 @@ public class EmployeePatchDto {
     @Schema(description = "Id of the employee to update.", example = "7")
     private Long id;
 
-    @Schema(description = "Fields to change, keyed by employee field name.",
-            example = "{\"designation\": \"Senior Site Engineer\", \"salary\": 72000.0}")
-    private Map<String,Object> updates;
+    @Schema(implementation = EmployeeUpdateFieldsDto.class)
+    private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
@@ -1,0 +1,62 @@
+package org.tornotron.echno_backend.employee.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.employee.enums.EmployeeStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * The fields a partial employee update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why these endpoints
+ * keep the map at runtime and publish this as their schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code EmployeeService.partialUpdateAnEmployee} actually accepts out of that method's source.
+ * The same keys reach the batch endpoint, which routes each element's updates through the same
+ * method.
+ */
+@Schema(description = "Fields a partial employee update may change. Every field is optional; only "
+        + "the fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class EmployeeUpdateFieldsDto {
+
+    @Schema(description = "Employee code within the organization.", example = "ECH-0412")
+    private String employeeId;
+
+    @Schema(description = "Employment status of the employee.")
+    private EmployeeStatus status;
+
+    @Schema(description = "Full name of the employee.", example = "Hrishikesh R")
+    private String employeeName;
+
+    @Schema(description = "Job title held.", example = "Site Engineer")
+    private String designation;
+
+    @Schema(description = "Date the employee joined.", example = "2024-06-01T00:00:00")
+    private LocalDateTime joiningDate;
+
+    @Schema(description = "Contact phone number.", example = "+91 99400 00000")
+    private String phoneNumber;
+
+    @Schema(description = "Monthly salary. Must be sent as a decimal number.", example = "62000.0")
+    private Double salary;
+
+    @Schema(description = "Id of the shift timing the employee works. Must belong to the employee's "
+            + "organization; null clears the assignment.", example = "3")
+    private Long shiftTimingId;
+
+    @Schema(description = "Department the employee belongs to.", example = "Execution")
+    private String department;
+
+    @Schema(description = "Work email address.", example = "hrishi@echno.xyz")
+    private String emailAddress;
+
+    @Schema(description = "Date of birth.", example = "1998-04-12T00:00:00")
+    private LocalDateTime dateOfBirth;
+
+    @Schema(description = "Id of the employee's manager. Must belong to the caller's organization, "
+            + "and may not introduce a cycle in the reporting line.", example = "7")
+    private Long managerId;
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,6 +17,7 @@ import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/leave-policies")
@@ -138,6 +141,8 @@ public class LeavePolicyController {
     })
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @PathVariable Long policyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = LeavePolicyUpdateFieldsDto.class)))
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(policyService.updatePolicy(policyId, updates));
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,6 +17,7 @@ import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto;
 
 @RestController
 @RequestMapping("/api/v1/leave-policies/web")
@@ -123,6 +126,8 @@ public class LeavePolicyControllerWeb {
     })
     public ResponseEntity<LeavePolicyDto> updatePolicy(
             @RequestParam Long policyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = LeavePolicyUpdateFieldsDto.class)))
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(policyService.updatePolicy(policyId, updates));
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,8 +14,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.leave.dto.LeaveCancellationDto;
+import org.tornotron.echno_backend.leave.dto.LeaveDaysCalculationDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto;
 import org.tornotron.echno_backend.leave.enums.LeaveStatus;
 
 import java.time.LocalDate;
@@ -182,6 +187,8 @@ public class LeaveRequestController {
     })
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @PathVariable Long requestId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = LeaveRequestUpdateFieldsDto.class)))
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(requestService.updateRequest(requestId, updates));
     }
@@ -220,9 +227,8 @@ public class LeaveRequestController {
     })
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @PathVariable Long requestId,
-            @RequestBody Map<String, String> body) {
-        String reason = body.get("reason");
-        return ResponseEntity.ok(requestService.cancelRequest(requestId, reason));
+            @Valid @RequestBody LeaveCancellationDto dto) {
+        return ResponseEntity.ok(requestService.cancelRequest(requestId, dto.getReason()));
     }
 
     @PostMapping("/requestId/{requestId}/withdraw")
@@ -277,17 +283,12 @@ public class LeaveRequestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<Map<String, Double>> calculateDays(
-            @RequestBody Map<String, String> body) {
-        LocalDate startDate = LocalDate.parse(body.get("startDate"));
-        LocalDate endDate = LocalDate.parse(body.get("endDate"));
-        String startType = body.get("startHalfDayType");
-        String endType = body.get("endHalfDayType");
-
+            @Valid @RequestBody LeaveDaysCalculationDto dto) {
         double totalDays = requestService.calculateTotalDays(
-                startDate,
-                startType != null ? org.tornotron.echno_backend.leave.enums.HalfDayType.valueOf(startType) : null,
-                endDate,
-                endType != null ? org.tornotron.echno_backend.leave.enums.HalfDayType.valueOf(endType) : null);
+                dto.getStartDate(),
+                dto.getStartHalfDayType(),
+                dto.getEndDate(),
+                dto.getEndHalfDayType());
 
         return ResponseEntity.ok(Map.of("totalDays", totalDays));
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.leave;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,8 +14,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.leave.dto.LeaveCancellationDto;
+import org.tornotron.echno_backend.leave.dto.LeaveDaysCalculationDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto;
 import org.tornotron.echno_backend.leave.enums.LeaveStatus;
 
 import java.time.LocalDate;
@@ -195,6 +200,8 @@ public class LeaveRequestControllerWeb {
     public ResponseEntity<LeaveRequestDto> updateRequest(
             @RequestParam Long requestId,
             @RequestParam Long employeeId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = LeaveRequestUpdateFieldsDto.class)))
             @RequestBody Map<String, Object> updates) {
         return ResponseEntity.ok(requestService.updateRequest(requestId, updates));
     }
@@ -232,9 +239,8 @@ public class LeaveRequestControllerWeb {
     public ResponseEntity<LeaveRequestDto> cancelRequest(
             @RequestParam Long requestId,
             @RequestParam Long employeeId,
-            @RequestBody Map<String, String> body) {
-        String reason = body.get("reason");
-        return ResponseEntity.ok(requestService.cancelRequest(requestId, reason));
+            @Valid @RequestBody LeaveCancellationDto dto) {
+        return ResponseEntity.ok(requestService.cancelRequest(requestId, dto.getReason()));
     }
 
     @PostMapping("employeeId/{employeeId}/withdraw")
@@ -286,17 +292,12 @@ public class LeaveRequestControllerWeb {
             @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
     })
     public ResponseEntity<Map<String, Double>> calculateDays(
-            @RequestBody Map<String, String> body) {
-        LocalDate startDate = LocalDate.parse(body.get("startDate"));
-        LocalDate endDate = LocalDate.parse(body.get("endDate"));
-        String startType = body.get("startHalfDayType");
-        String endType = body.get("endHalfDayType");
-
+            @Valid @RequestBody LeaveDaysCalculationDto dto) {
         double totalDays = requestService.calculateTotalDays(
-                startDate,
-                startType != null ? org.tornotron.echno_backend.leave.enums.HalfDayType.valueOf(startType) : null,
-                endDate,
-                endType != null ? org.tornotron.echno_backend.leave.enums.HalfDayType.valueOf(endType) : null);
+                dto.getStartDate(),
+                dto.getStartHalfDayType(),
+                dto.getEndDate(),
+                dto.getEndHalfDayType());
 
         return ResponseEntity.ok(Map.of("totalDays", totalDays));
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCancellationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveCancellationDto.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.leave.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Payload to cancel an approved leave request.
+ *
+ * <p>Replaces the {@code Map<String, String>} the endpoint read {@code reason} out of by hand. The
+ * map published as {@code additionalProperties}, so the document named neither the one key the
+ * endpoint reads nor the type it expects, and a caller who spelled it {@code cancellationReason}
+ * got a 200 and a cancellation with no reason recorded.
+ *
+ * <p>The reason stays optional, which is what the endpoint has always accepted.
+ */
+@Schema(description = "Payload to cancel an approved leave request.")
+@Data
+public class LeaveCancellationDto {
+
+    @Schema(description = "Why the leave is being cancelled, recorded against the request.",
+            example = "Travel plans changed")
+    @Size(max = 500, message = "Cancellation reason must not exceed 500 characters")
+    private String reason;
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveDaysCalculationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveDaysCalculationDto.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.leave.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.tornotron.echno_backend.leave.enums.HalfDayType;
+
+import java.time.LocalDate;
+
+/**
+ * Payload to calculate how many leave days a date range works out to.
+ *
+ * <p>Replaces the {@code Map<String, String>} the endpoint pulled four keys out of by hand. The map
+ * published as {@code additionalProperties}, so the document named none of them, and the hand
+ * parsing was doing the two jobs a bean does better: {@code LocalDate.parse} on a key the caller
+ * left out threw a NullPointerException, and a malformed date threw DateTimeParseException, both of
+ * which the global handler answers with 500. The endpoint has documented 400 for exactly those two
+ * cases since it was written. Reading the payload as a bean is what makes the documented answer the
+ * real one, so the two required dates carry {@code @NotNull} and the parse itself now happens in
+ * Jackson, which is a 400 either way.
+ */
+@Schema(description = "Date range to work out a leave day count for, with the optional half-day "
+        + "type at either end.")
+@Data
+public class LeaveDaysCalculationDto {
+
+    @Schema(description = "First day of the range.", example = "2026-09-14")
+    @NotNull(message = "startDate is required")
+    private LocalDate startDate;
+
+    @Schema(description = "Last day of the range.", example = "2026-09-18")
+    @NotNull(message = "endDate is required")
+    private LocalDate endDate;
+
+    @Schema(description = "Which half of the first day is taken, when the range starts at midday.")
+    private HalfDayType startHalfDayType;
+
+    @Schema(description = "Which half of the last day is taken, when the range ends at midday.")
+    private HalfDayType endHalfDayType;
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyUpdateFieldsDto.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.leave.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * The fields a partial leave-policy update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code LeavePolicyService.updatePolicy} actually accepts out of that method's source. Note that
+ * {@code leaveTypeCode} is deliberately absent: a policy's code is fixed at creation and the update
+ * path does not accept it.
+ */
+@Schema(description = "Fields a partial leave-policy update may change. Every field is optional; "
+        + "only the fields present in the request are applied. Keys not listed here are ignored.")
+@Data
+public class LeavePolicyUpdateFieldsDto {
+
+    @Schema(description = "Display name of the leave type.", example = "Casual Leave")
+    private String leaveTypeName;
+
+    @Schema(description = "Description of the leave type and when it applies.",
+            example = "Short-notice leave for personal matters.")
+    private String description;
+
+    @Schema(description = "Total days granted per year under this policy. Must be a number; null is "
+            + "rejected.", example = "12.0")
+    private Double annualQuota;
+
+    @Schema(description = "Days accrued per completed month.", example = "1.0")
+    private Double accrualRatePerMonth;
+
+    @Schema(description = "Maximum days that can be carried forward into the next year.", example = "5.0")
+    private Double carryForwardLimit;
+
+    @Schema(description = "Months into the next year before carried-forward days expire.", example = "3")
+    private Integer carryForwardExpiryMonths;
+
+    @Schema(description = "Smallest number of days that can be requested at once.", example = "0.5")
+    private Double minDaysPerRequest;
+
+    @Schema(description = "Largest number of days that can be requested at once.", example = "15.0")
+    private Double maxDaysPerRequest;
+
+    @Schema(description = "Minimum days of notice required before the leave starts.", example = "2")
+    private Integer advanceNoticeDays;
+
+    @Schema(description = "Whether a supporting attachment is required.", example = "false")
+    private Boolean requiresAttachment;
+
+    @Schema(description = "Consecutive days after which an attachment becomes required.", example = "3")
+    private Integer attachmentRequiredAfterDays;
+
+    @Schema(description = "Genders this policy applies to.", example = "ALL")
+    private String applicableGenders;
+
+    @Schema(description = "Months of service before an employee becomes eligible.", example = "6")
+    private Integer minServiceMonths;
+
+    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
+    private Boolean allowHalfDay;
+
+    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
+    private Boolean isPaid;
+
+    @Schema(description = "Whether the policy is available for new requests.", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "Whether requests go through the full multi-level approval chain.",
+            example = "true")
+    private Boolean multiLevelApprovalEnabled;
+
+    @Schema(description = "Order this policy is shown in, relative to the organization's others.",
+            example = "1")
+    private Integer displayOrder;
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestUpdateFieldsDto.java
@@ -1,0 +1,54 @@
+package org.tornotron.echno_backend.leave.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.leave.enums.HalfDayType;
+
+import java.time.LocalDate;
+
+/**
+ * The fields a partial leave-request update may carry, and the type each one is read as.
+ *
+ * <p>See {@code org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto} for why the endpoint
+ * keeps the map at runtime and publishes this as its schema. Nothing deserializes into this class.
+ *
+ * <p>The endpoint accepts these only while the request is still a draft, and recalculates
+ * {@code totalDays} from the dates afterwards, so the total is not among the fields a caller sets.
+ *
+ * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
+ * {@code LeaveRequestService.updateRequest} actually accepts out of that method's source.
+ */
+@Schema(description = "Fields a partial leave-request update may change, accepted only while the "
+        + "request is a draft. Every field is optional; only the fields present in the request are "
+        + "applied. Keys not listed here are ignored.")
+@Data
+public class LeaveRequestUpdateFieldsDto {
+
+    @Schema(description = "First day of leave. Must be a date; null is rejected.",
+            example = "2026-09-14")
+    private LocalDate startDate;
+
+    @Schema(description = "Which half of the first day is taken, when the leave starts at midday.")
+    private HalfDayType startHalfDayType;
+
+    @Schema(description = "Last day of leave. Must be a date; null is rejected.",
+            example = "2026-09-18")
+    private LocalDate endDate;
+
+    @Schema(description = "Which half of the last day is taken, when the leave ends at midday.")
+    private HalfDayType endHalfDayType;
+
+    @Schema(description = "Reason given for the leave.", example = "Family function")
+    private String reason;
+
+    @Schema(description = "How to reach the employee during the leave.",
+            example = "+91 99400 00000")
+    private String contactDuringLeave;
+
+    @Schema(description = "Id of the employee taking over the work.", example = "7")
+    private Long handoverToId;
+
+    @Schema(description = "Notes for the person taking over.",
+            example = "Block A pour is scheduled for the 16th; drawings are in the shared folder.")
+    private String handoverNotes;
+}

--- a/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationPatchDto.java
@@ -1,11 +1,18 @@
 package org.tornotron.echno_backend.organization.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
+@Schema(description = "A single organization's partial update within a batch: the organization id "
+        + "and the fields to change on it.")
 @Data
 public class OrganizationPatchDto {
+
+    @Schema(description = "Id of the organization to update.", example = "2")
     private Long id;
-    private Map<String ,Object> updates;
+
+    @Schema(implementation = OrganizationUpdateFieldsDto.class)
+    private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectPatchDto.java
@@ -12,7 +12,6 @@ public class ProjectPatchDto {
     @Schema(description = "Id of the project to update.", example = "42")
     private Long id;
 
-    @Schema(description = "Fields to change, keyed by project field name.",
-            example = "{\"status\": \"COMPLETED\", \"progress\": 1.0}")
-    private Map<String,Object> updates;
+    @Schema(implementation = ProjectUpdateFieldsDto.class)
+    private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskPatchDto.java
@@ -13,7 +13,6 @@ public class TaskPatchDto {
     @Schema(description = "Id of the task to update.", example = "108")
     private Long id;
 
-    @Schema(description = "Fields to change, keyed by task field name.",
-            example = "{\"status\": \"DONE\", \"progress\": 1.0}")
+    @Schema(implementation = TaskUpdateFieldsDto.class)
     private Map<String, Object> updates;
 }

--- a/src/main/java/org/tornotron/echno_backend/user/UserController.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserController.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.user;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,6 +23,7 @@ import org.tornotron.echno_backend.user.dto.UserPatchDto;
 
 import java.util.List;
 import java.util.Map;
+import org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto;
 
 /**
  * REST controller for managing users.
@@ -134,7 +137,11 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the user nor a system admin"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No user with the given id")
     })
-    public ResponseEntity<UserDto> partialUpdateAUser(@RequestBody Map<String, Object> updates, @PathVariable Long id) {
+    public ResponseEntity<UserDto> partialUpdateAUser(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = UserUpdateFieldsDto.class)))
+            @RequestBody Map<String, Object> updates,
+            @PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.partialUpdateAnUser(updates, id));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/user/dto/UserPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/user/dto/UserPatchDto.java
@@ -1,11 +1,18 @@
 package org.tornotron.echno_backend.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.Map;
 
+@Schema(description = "A single user's partial update within a batch: the user id and the fields to "
+        + "change on them.")
 @Data
 public class UserPatchDto {
+
+    @Schema(description = "Id of the user to update.", example = "31")
     private Long id;
-    private Map<String ,Object> updates;
+
+    @Schema(implementation = UserUpdateFieldsDto.class)
+    private Map<String, Object> updates;
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
@@ -3,7 +3,10 @@ package org.tornotron.echno_backend.architecture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
 import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto;
 import org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto;
 import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
 import org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto;
@@ -95,7 +98,19 @@ class PartialUpdateSchemaContractTest {
                 new UpdateSurface(
                         UserUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.user.UserService",
-                        "private void applyUpdates(Map<String, Object> updates, User user)"));
+                        "private void applyUpdates(Map<String, Object> updates, User user)"),
+                new UpdateSurface(
+                        EmployeeUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.employee.EmployeeService",
+                        "private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee)"),
+                new UpdateSurface(
+                        LeavePolicyUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.leave.LeavePolicyService",
+                        "public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates)"),
+                new UpdateSurface(
+                        LeaveRequestUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.leave.LeaveRequestService",
+                        "public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates)"));
     }
 
     @ParameterizedTest(name = "{0} describes exactly the keys its service accepts")

--- a/src/test/java/org/tornotron/echno_backend/architecture/RequestPayloadSchemaTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/RequestPayloadSchemaTest.java
@@ -11,18 +11,22 @@ import com.tngtech.archunit.junit.ArchTest;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Ratchet against an endpoint whose payload the published OpenAPI document cannot describe: a
- * {@code data} payload that travels as a {@code String} must say, in the document, what that string
- * actually holds.
+ * Ratchet against an endpoint whose payload the published OpenAPI document cannot describe. Two
+ * shapes qualify: a {@code data} payload that travels as a {@code String}, and a request body
+ * declared as a {@code Map}. Both must say, in the document, what they actually hold.
  *
  * <p>A multipart endpoint cannot take a {@code @RequestBody}, because the body is the multipart
  * envelope, so the JSON payload travels as a {@code data} part and the endpoint reads it with
@@ -45,6 +49,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link MultipartPayloadValidationTest} exists beside it: that one keeps the payload validated,
  * this one keeps it described.
  *
+ * <p>The map half is the other way the document ends up saying nothing. A {@code Map} body
+ * publishes as {@code additionalProperties}, so it names no key, holds no type and can never fail
+ * a check, and the services behind these bodies switch over a fixed set of keys with no
+ * {@code default}, which makes an unrecognised key a silent no-op. They keep the map at runtime on
+ * purpose, because a partial update has to tell an absent field from one explicitly set to null,
+ * so what they publish is a {@code *UpdateFieldsDto} naming the keys the switch accepts.
+ * {@link PartialUpdateSchemaContractTest} is what keeps those two in step.
+ *
  * <p>Scope is the {@code data} payload convention and not every string that reaches an endpoint. A
  * {@code @RequestParam} is in scope only when it is named {@code data} outright. A
  * {@code @RequestPart} is in scope when it is named {@code data} or names nothing at all, since an
@@ -61,6 +73,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RequestPayloadSchemaTest {
 
     private static final String PAYLOAD_PART = "data";
+
+    /**
+     * The map-shaped request bodies that stay undescribed, each with the reason.
+     *
+     * <p>A raw {@code Map} body is not automatically a defect. The entry here is a body whose keys
+     * are the caller's own data rather than a fixed field list, so no schema could name them
+     * without being wrong. Everything else that takes a map does so to keep an absent field
+     * distinguishable from one explicitly set to null, and those all publish a
+     * {@code *UpdateFieldsDto} that names their keys.
+     *
+     * <p>Keyed by the method's full name so an entry cannot quietly cover a method it was not
+     * written for, and checked for staleness below so a fixed entry does not sit here forever.
+     */
+    private static final Map<String, String> ALLOWED = Map.of(
+            "org.tornotron.echno_backend.keycloak.KeycloakManagementController"
+                    + ".addRealmRoles(java.util.Map)",
+            "the keys are the realm role names being created, which the caller chooses, so the "
+                    + "body is genuinely a map and not a fixed set of fields");
 
     @ArchTest
     static void everyStringPayloadPartDeclaresItsSchema(JavaClasses productionClasses) {
@@ -80,6 +110,90 @@ class RequestPayloadSchemaTest {
                         + "@Parameter(schema = @Schema(implementation = SomePayloadDto.class)) so "
                         + "the document says what the part carries")
                 .isEmpty();
+    }
+
+    @ArchTest
+    static void everyMapRequestBodyDeclaresItsSchema(JavaClasses productionClasses) {
+        List<String> offenders = mapRequestBodies(productionClasses)
+                .filter(entry -> declaredRequestBodyImplementation(entry.parameter()).isEmpty())
+                .filter(entry -> !ALLOWED.containsKey(entry.method().getFullName()))
+                .map(Entry::description)
+                .sorted()
+                .toList();
+
+        assertThat(offenders)
+                .as("a request body declared as a Map publishes as additionalProperties, so the "
+                        + "document names none of its keys and no key can ever fail against it; "
+                        + "declare the fields with @RequestBody(content = @Content(schema = "
+                        + "@Schema(implementation = SomeUpdateFieldsDto.class))), or add the "
+                        + "endpoint to ALLOWED with the reason its keys really are the caller's own")
+                .isEmpty();
+    }
+
+    /**
+     * Keeps {@link #ALLOWED} from outliving what it excuses. An entry naming a method that no
+     * longer takes an undescribed map is a stale exemption, and a stale exemption is how a rule
+     * stops being a rule.
+     */
+    @ArchTest
+    static void theAllowlistHasNoStaleEntries(JavaClasses productionClasses) {
+        Set<String> stillUndescribed = mapRequestBodies(productionClasses)
+                .filter(entry -> declaredRequestBodyImplementation(entry.parameter()).isEmpty())
+                .map(entry -> entry.method().getFullName())
+                .collect(Collectors.toSet());
+
+        assertThat(ALLOWED.keySet())
+                .as("every allowlist entry should name a method that still takes an undescribed "
+                        + "map body; remove the ones that no longer do")
+                .allMatch(stillUndescribed::contains);
+    }
+
+    /** One {@code @RequestBody Map} parameter, with the method it belongs to. */
+    private record Entry(JavaMethod method, JavaParameter parameter) {
+        String description() {
+            return method.getFullName() + " parameter " + parameter.getIndex();
+        }
+    }
+
+    private static java.util.stream.Stream<Entry> mapRequestBodies(JavaClasses productionClasses) {
+        return productionClasses.stream()
+                .filter(javaClass -> javaClass.isMetaAnnotatedWith(Controller.class))
+                .flatMap(javaClass -> javaClass.getMethods().stream())
+                .flatMap(method -> method.getParameters().stream()
+                        .filter(parameter -> parameter.getRawType().isAssignableTo(Map.class))
+                        .filter(parameter -> annotationOfType(parameter, RequestBody.class).isPresent())
+                        .map(parameter -> new Entry(method, parameter)));
+    }
+
+    /**
+     * The body type a parameter declares for the document, from the swagger
+     * {@code @RequestBody(content = @Content(schema = @Schema(implementation = ...)))}. The swagger
+     * annotation is a different type from Spring's {@code @RequestBody} and the two sit side by
+     * side: Spring's says where the value comes from, swagger's says what the document should show.
+     */
+    private static Optional<JavaClass> declaredRequestBodyImplementation(JavaParameter parameter) {
+        return annotationOfType(parameter, io.swagger.v3.oas.annotations.parameters.RequestBody.class)
+                .flatMap(annotation -> nestedAnnotationArrayFirst(annotation, "content"))
+                .flatMap(content -> nestedAnnotation(content, "schema"))
+                .flatMap(schema -> schema.get("implementation"))
+                .filter(JavaClass.class::isInstance)
+                .map(JavaClass.class::cast)
+                .filter(implementation -> !implementation.isEquivalentTo(Void.class));
+    }
+
+    /**
+     * The first element of a nested annotation array member. {@code @Content} is declared as an
+     * array on the swagger {@code @RequestBody}, and these endpoints declare exactly one.
+     */
+    private static Optional<JavaAnnotation<?>> nestedAnnotationArrayFirst(
+            JavaAnnotation<?> annotation, String member) {
+        return annotation.get(member)
+                .filter(Object[].class::isInstance)
+                .map(Object[].class::cast)
+                .filter(values -> values.length > 0)
+                .map(values -> values[0])
+                .filter(JavaAnnotation.class::isInstance)
+                .map(value -> (JavaAnnotation<?>) value);
     }
 
     /**


### PR DESCRIPTION
Item D of #522, second half. **Stacked on #575** (base is that branch); merge #575 first and this retargets to `development` with only its own commit.

## What was wrong

A request body declared as a `Map` publishes as `additionalProperties`. The document names no key, holds no type, and no key can ever fail against it. Nineteen bodies were in that state, counted from the document itself rather than from a grep.

It is not only a documentation problem. The services behind these bodies switch over a fixed key set with **no `default`**, so a key nobody recognises is a 200 and a silent no-op, and the published contract offered no way to notice. That is how #512 happened, and it is the half of tornotron/echno-core#49 a client-side test cannot work around.

## What is here

**Seven raw `@RequestBody Map` partial updates** and **seven batch bodies** whose `*PatchDto.updates` carries the same map now publish an `*UpdateFieldsDto` naming exactly the keys their switch applies. New: employee, leave policy, leave request. Reused from #575: task, issue, project, organization, user.

They keep the map at runtime, and that is deliberate rather than a shortcut. A partial update has to tell a field that was left out from one explicitly sent as null, a bean cannot (both arrive as a null property), and several of these fields are cleared by sending null. The batch endpoints route each element through the same private method as the single update, so they name the same class.

**Four leave endpoints get a real DTO, not a description of one.** `cancelRequest` reads one key out of a `Map<String, String>` and `calculateDays` reads four; neither is a partial update, so nothing was gained by the map. The hand parsing was also doing badly what a bean does well:

| request | before | after |
|---|---|---|
| `startDate` omitted | `LocalDate.parse(null)` → NPE → **500** | `@NotNull` → **400** |
| `startDate` malformed | `DateTimeParseException` → **500** | Jackson → **400** |
| `startHalfDayType` not a valid enum | `IllegalArgumentException` → 400 | Jackson → 400 |

Both endpoints have documented 400 for exactly the first two cases since they were written. This is what makes the documented answer the real one. Nothing that was accepted before is refused now: the reason on a cancellation stays optional, and unknown keys are still ignored (`FAIL_ON_UNKNOWN_PROPERTIES` is off).

**One stays a map.** `KeycloakManagementController.addRealmRoles` takes a map of role name to description, where the keys are the roles the caller is creating. No schema could name them without being wrong, so it is allowlisted with that reason rather than forced into a shape it does not have. It is the only one of the nineteen where the map is the payload rather than a stand-in for a type nobody wrote.

## Guards

`RequestPayloadSchemaTest` grows the matching rule: an undescribed map body fails the build the way an undescribed `data` part already does. The allowlist is checked for staleness beside it, in the shape `UnboundedRepositoryReadTest` already uses, so an exemption cannot outlive what it excuses.

`PartialUpdateSchemaContractTest` extends to the three new surfaces, reading the `case` labels out of `EmployeeService.partialUpdateAnEmployee`, `LeavePolicyService.updatePolicy` and `LeaveRequestService.updateRequest`.

Both rules were checked against their own absence: removing one `@RequestBody` schema fails the first at the exact parameter, and changing `addRealmRoles` to stop taking a map fails the staleness check.

## Verification

Booted the real application against a Testcontainers CockroachDB and read `/v3/api-docs`, before and after:

```
free-form map request bodies: 19   ->   1
batch updates now typed:       0   ->   7
```

The one remaining is `POST /api/v1/keycloak/roles`, the allowlisted entry.

`echno-core` calls the leave policy and leave request updates with fixed, named key sets (`updateLeavePolicyToJson`, `updateLeaveRequestToJson`), all of which the new schemas name. It does not call any of the seven batch endpoints, or the plain `/user/{id}`, `/employee/{id}` variants, at all.

Refs #522, tornotron/echno-core#49