### PR TITLE
Give the test run room, and a voice when it runs out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,37 @@ ext {
     // measured), then to 25% after the leave-accrual, employee-hierarchy,
     // attendance-regularization and project-invite-code service tests (25.50% measured).
     jacocoLineFloor = 0.25
+
+    // Heap cap for the test JVM, the size of the Spring context cache, and the two thresholds
+    // the testHeapHeadroom gate applies to the first. All four are overridable per run with
+    // -P, which is how the numbers below were measured rather than guessed. Every figure here
+    // is from a full run of the suite (1310 tests) on the lab build box.
+    //
+    // The suite is 31 distinct Spring test configurations, so 31 contexts and 31 Hibernate
+    // SessionFactory instances over the 98 entities, all in one JVM because there is no
+    // forkEvery. Holding all of them costs 1150 MB live. That is more than the 1024m this cap
+    // used to be, which is why a run with the context cache left at Spring's default fails:
+    // 1297 tests pass, then the architecture tests need the whole class graph resident, the
+    // heap has nothing left, and the run ends with an OutOfMemoryError inside ArchUnit and
+    // zero assertion failures anywhere. Capping the cache at 8 is what has been holding that
+    // off, at a peak live set of 485 MB and a cost of exactly one extra context build over
+    // the run (37 loads against 36) and no measurable wall clock.
+    //
+    // The cap is now sized so that the cache cap is a choice rather than the only thing
+    // standing between the suite and that failure: 2048m holds the whole 1150 MB working set
+    // with 40% to spare even if the cache limit were removed, and leaves the run as actually
+    // configured at a quarter of the cap. The CI runner has room for it. ubuntu-latest on a
+    // public repository is 4 vCPU and 16 GB, not the 2 vCPU and 7 GB this was first sized
+    // against, and the test JVM shares it only with the CockroachDB container that
+    // AbstractIntegrationTest already limits to 2 GB, plus the Gradle daemon.
+    testMaxHeap = findProperty('testMaxHeap') ?: '2048m'
+    testContextCacheSize = findProperty('testContextCacheSize') ?: '8'
+    // Above this fraction of the cap the build stops and explains itself; above the lower one
+    // it warns. The gap between them is deliberately wide, because what it is watching moves
+    // in steps: each new test configuration is another whole context, worth roughly a
+    // thirtieth of the full working set, and each new entity grows every context at once.
+    testHeapFailRatio = (findProperty('testHeapFailRatio') ?: '0.80') as double
+    testHeapWarnRatio = (findProperty('testHeapWarnRatio') ?: '0.65') as double
 }
 
 repositories {
@@ -71,7 +102,9 @@ dependencies {
     testImplementation 'com.github.dasniko:testcontainers-keycloak:3.7.0'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     runtimeOnly 'org.postgresql:postgresql'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Compile scope rather than runtime only: TestHeapHeadroomListener implements the
+    // launcher's TestExecutionListener, so the interface has to be on the test compile path.
+    testImplementation 'org.junit.platform:junit-platform-launcher'
 }
 
 
@@ -101,12 +134,27 @@ tasks.named('test') {
     // pinned version from the 'api.version' system property (not DOCKER_API_VERSION,
     // which is a docker-CLI variable). 1.44 is accepted by both CI and the lab host.
     systemProperty 'api.version', '1.44'
-    // Bound the forked test JVM so the whole run fits the 2 vCPU / 7 GB CI runner
-    // alongside the shared CockroachDB container: an unbounded heap plus the
-    // container's default cache (a quarter of host memory) can exhaust the runner
-    // and the OOM killer then takes the database, failing the rest of the suite.
-    maxHeapSize = '1024m'
+    maxHeapSize = testMaxHeap
     jvmArgs '-XX:MaxMetaspaceSize=512m'
+    // Make running out of heap say so. Without these the first OutOfMemoryError is thrown
+    // inside whatever context happened to be loading, is caught and reported as a failure
+    // of that unrelated test, and the run limps on producing more of the same. Exiting on
+    // the first one collapses that into a single unambiguous failure, and the dump beside
+    // it says what was resident. Together with the testHeapHeadroom gate below, which is
+    // meant to stop the run before it ever gets here.
+    def heapDumpDir = layout.buildDirectory.dir('reports/test-heap').get().asFile
+    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError',
+            "-XX:HeapDumpPath=${heapDumpDir}",
+            '-XX:+ExitOnOutOfMemoryError'
+    // HotSpot will not create the dump directory itself, and silently writes nothing if it
+    // is missing, which would lose the one artefact worth having at that moment.
+    doFirst {
+        heapDumpDir.mkdirs()
+        // The listener merges its readings into this file so that a forked run reports the
+        // worst any of its JVMs reached. Clear it first, or the merge reaches back into the
+        // previous run and the build reports a peak that nothing in this one produced.
+        new File(heapDumpDir, 'heap-headroom.properties').delete()
+    }
     // Bound how many Spring test contexts the run keeps alive at once. There is no
     // forkEvery, so one JVM serves the whole suite and the default cache of 32 means
     // every distinct test configuration's context, each with its own Hibernate
@@ -116,14 +164,77 @@ tasks.named('test') {
     // Capping the cache makes Spring close the least recently used context instead of
     // holding all of them; a context is rebuilt if a later class needs it again,
     // which costs seconds where the alternative costs the build.
-    systemProperty 'spring.test.context.cache.maxSize', '8'
+    systemProperty 'spring.test.context.cache.maxSize', testContextCacheSize
     // Print each test as it starts and finishes so a CI log always shows which test
     // is running; without this, a hung test leaves no trace of which one stalled.
     testLogging {
         events 'started', 'passed', 'skipped', 'failed'
         exceptionFormat 'short'
     }
-    finalizedBy jacocoTestReport
+    finalizedBy jacocoTestReport, 'testHeapHeadroom'
+}
+
+// Reports how close the run came to the heap cap, and fails if it came too close.
+//
+// The suite runs in one JVM and Spring holds a cached context per distinct test
+// configuration, so the live set only grows over a run. When it reaches the cap the
+// error surfaces in whichever test loads a context next, which is nearly never the
+// test that caused it, and the natural reading of "Failed to load ApplicationContext"
+// in six untouched classes is that the problem is pre-existing. This gate exists so
+// that the run says it is near the ceiling while there is still room, in the build's
+// own voice, rather than leaving it to be diagnosed from the wrong symptom later.
+//
+// TestHeapHeadroomListener writes the measurement; this reads it. Finalizes the test
+// task, so it reports on a failed run too.
+tasks.register('testHeapHeadroom') {
+    group = 'verification'
+    description = 'Reports the test JVM heap live set against its cap and fails when headroom runs out.'
+    def report = layout.buildDirectory.file('reports/test-heap/heap-headroom.properties')
+    def failRatio = testHeapFailRatio
+    def warnRatio = testHeapWarnRatio
+    outputs.upToDateWhen { false }
+    doLast {
+        def file = report.get().asFile
+        if (!file.exists()) {
+            logger.lifecycle('Test heap: no measurement was written. If the run failed, the test JVM ' +
+                    'probably died before it could finish; look for a heap dump in ' +
+                    "${file.parentFile} and read the failures as a memory problem, not a test one.")
+            return
+        }
+        def measured = new Properties()
+        file.withInputStream { measured.load(it) }
+        def mb = { long bytes -> String.format('%.0f MB', bytes / 1048576d) }
+        long peak = Math.max(measured.peakLiveSetBytes as long, measured.endLiveSetBytes as long)
+        long cap = measured.maxHeapBytes as long
+        double used = cap > 0 ? peak / (double) cap : 0d
+        long machine = measured.machineMemoryBytes as long
+        def contexts = measured.contextsCached as int
+        def summary = "Test heap: ${mb(peak)} live of a ${mb(cap)} cap " +
+                "(${String.format('%.0f%%', used * 100)} used, ${mb(cap - peak)} spare, " +
+                "${mb(measured.peakOccupancyBytes as long)} occupied at the fullest)" +
+                (contexts >= 0 ? ", ${contexts} Spring contexts cached of a maximum " +
+                        "${measured.contextCacheMaxSize} (${measured.contextLoads} loaded, " +
+                        "${measured.contextHits} reused)" : '') +
+                (machine > 0 ? ", on a machine with ${String.format('%.1f GB', machine / 1073741824d)}" : '')
+        def advice = '\nWhat to do, cheapest first:\n' +
+                '  - reuse an existing test configuration rather than introducing another context\n' +
+                '  - lower testContextCacheSize so fewer contexts are held at once (costs rebuilds)\n' +
+                '  - raise testMaxHeap, having checked against the machine memory reported above\n' +
+                'All three are properties in build.gradle and can be overridden per run with -P.'
+        if (used >= failRatio) {
+            throw new GradleException(summary +
+                    "\n\nThat is past the ${String.format('%.0f%%', failRatio * 100)} mark, which means the next " +
+                    'test added here is likely to fail in a class it never touched, as a context-loading ' +
+                    'error rather than an assertion. Failing now, while the cause is still legible.' + advice)
+        }
+        if (used >= warnRatio) {
+            logger.warn(summary +
+                    "\n\nHeadroom is getting short: past ${String.format('%.0f%%', failRatio * 100)} the build " +
+                    'stops. Worth acting before a new test finds the ceiling for you.' + advice)
+            return
+        }
+        logger.lifecycle(summary)
+    }
 }
 
 jacoco {

--- a/src/test/java/org/tornotron/echno_backend/support/TestHeapHeadroomListener.java
+++ b/src/test/java/org/tornotron/echno_backend/support/TestHeapHeadroomListener.java
@@ -1,0 +1,245 @@
+package org.tornotron.echno_backend.support;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * Measures how close the test JVM came to its heap cap, and records it where the build
+ * can act on it.
+ *
+ * <p>The suite runs in one JVM, and Spring keeps a cached application context per distinct
+ * test configuration, each with its own Hibernate {@code SessionFactory} over every entity.
+ * That memory is held until the cache evicts it, so a run accumulates. When the total
+ * reaches the cap the failure lands wherever the next allocation happened to be, as a
+ * context-loading error in a class the author never touched, with no assertion failing
+ * anywhere. This listener exists so the run reports its own headroom while it still has
+ * some, rather than leaving the shortage to be inferred later from the wrong symptom.
+ *
+ * <p>Two different numbers are recorded, and the difference between them matters.
+ *
+ * <p>The <em>live set</em> is what cannot be reclaimed, and it is the number that predicts
+ * failure: the JVM throws {@code OutOfMemoryError} when a full collection cannot free enough
+ * for the next allocation. It is sampled by asking for a collection and reading what is left,
+ * every {@value #SAMPLE_INTERVAL_MILLIS} milliseconds through the run and once more after the
+ * last test. Sampling has to be active rather than passive because the run's worst moment is
+ * not its last: the architecture tests hold the whole application's class graph in memory
+ * partway through, on top of whatever contexts are cached at the time, and that is gone again
+ * by the end.
+ *
+ * <p>The <em>occupancy</em> high-water mark is how full the heap got, garbage included, taken
+ * from collections that swept the old generation. It runs far higher than the live set,
+ * because a collector under no pressure has no reason to collect early, and it is reported for
+ * context rather than gated on. Reading occupancy as though it were the live set would have
+ * this build permanently declaring an emergency.
+ *
+ * <p>Registered through {@code META-INF/services}, so it applies to every test JVM the
+ * build starts without any test needing to know about it.
+ */
+public class TestHeapHeadroomListener implements TestExecutionListener {
+
+    /** Where the run leaves its measurement for the build to read. */
+    static final String REPORT_PATH = "build/reports/test-heap/heap-headroom.properties";
+
+    /** How often the live set is sampled. Each sample costs one collection of a second or less. */
+    private static final long SAMPLE_INTERVAL_MILLIS = 15_000;
+
+    private final AtomicLong peakLiveSetBytes = new AtomicLong();
+    private final AtomicLong peakOccupancyBytes = new AtomicLong();
+    private final Set<GarbageCollectorMXBean> subscribed = new HashSet<>();
+    private NotificationListener notificationListener;
+    private Thread sampler;
+
+    @Override
+    public void testPlanExecutionStarted(TestPlan testPlan) {
+        startLiveSetSampler();
+        Set<String> heapPools = new HashSet<>();
+        for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+            if (pool.getType() == MemoryType.HEAP) {
+                heapPools.add(pool.getName());
+            }
+        }
+        notificationListener = (notification, handback) -> {
+            if (!GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION.equals(notification.getType())) {
+                return;
+            }
+            GarbageCollectionNotificationInfo info =
+                    GarbageCollectionNotificationInfo.from((CompositeData) notification.getUserData());
+            // A young-only collection leaves the old generation untouched, so its post-collection
+            // reading says nothing at all about the whole heap. Only collections that swept the
+            // old generation are worth recording, and even those are occupancy, not live set.
+            if (!sweptOldGeneration(info)) {
+                return;
+            }
+            long used = 0;
+            for (Map.Entry<String, MemoryUsage> entry : info.getGcInfo().getMemoryUsageAfterGc().entrySet()) {
+                if (heapPools.contains(entry.getKey())) {
+                    used += entry.getValue().getUsed();
+                }
+            }
+            peakOccupancyBytes.accumulateAndGet(used, Math::max);
+        };
+        for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (gc instanceof NotificationEmitter emitter) {
+                emitter.addNotificationListener(notificationListener, null, null);
+                subscribed.add(gc);
+            }
+        }
+    }
+
+    /**
+     * Samples the live set through the run rather than only at the end. A collection is asked
+     * for and what survives it is recorded, which is the memory the run genuinely cannot give
+     * back. Fifteen seconds apart, so a suite of a few minutes pays well under a second in
+     * total and gets some thirty readings, which is enough to catch the architecture tests.
+     */
+    private void startLiveSetSampler() {
+        sampler = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(SAMPLE_INTERVAL_MILLIS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                System.gc();
+                peakLiveSetBytes.accumulateAndGet(
+                        ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed(), Math::max);
+            }
+        }, "test-heap-headroom-sampler");
+        sampler.setDaemon(true);
+        sampler.start();
+    }
+
+    private static boolean sweptOldGeneration(GarbageCollectionNotificationInfo info) {
+        String name = info.getGcName();
+        String action = info.getGcAction().toLowerCase(Locale.ROOT);
+        return name.contains("Old")
+                || name.contains("Concurrent")
+                || name.contains("MarkSweep")
+                || action.contains("major");
+    }
+
+    @Override
+    public void testPlanExecutionFinished(TestPlan testPlan) {
+        if (sampler != null) {
+            sampler.interrupt();
+        }
+        for (GarbageCollectorMXBean gc : subscribed) {
+            try {
+                ((NotificationEmitter) gc).removeNotificationListener(notificationListener);
+            } catch (Exception ignored) {
+                // Nothing useful to do at the end of the run if a bean has already gone.
+            }
+        }
+        // Two passes: the first clears the bulk, the second collects anything the first made
+        // unreachable (references cleared during collection, notably ArchUnit's soft-referenced
+        // class cache). What is left is what the run was genuinely holding.
+        System.gc();
+        System.gc();
+        long endLiveSetBytes = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        peakLiveSetBytes.accumulateAndGet(endLiveSetBytes, Math::max);
+        write(endLiveSetBytes);
+    }
+
+    private void write(long endLiveSetBytes) {
+        Properties properties = new Properties();
+        Path report = Paths.get(REPORT_PATH);
+        // A forked run writes this file once per fork. Keep the worst reading rather than the
+        // last one, so a build that forks still reports the peak the whole run reached.
+        if (Files.isReadable(report)) {
+            try (InputStream in = Files.newInputStream(report)) {
+                properties.load(in);
+            } catch (IOException ignored) {
+                properties.clear();
+            }
+        }
+        properties.setProperty("peakLiveSetBytes",
+                Long.toString(Math.max(readLong(properties, "peakLiveSetBytes"), peakLiveSetBytes.get())));
+        properties.setProperty("endLiveSetBytes",
+                Long.toString(Math.max(readLong(properties, "endLiveSetBytes"), endLiveSetBytes)));
+        properties.setProperty("peakOccupancyBytes",
+                Long.toString(Math.max(readLong(properties, "peakOccupancyBytes"), peakOccupancyBytes.get())));
+        properties.setProperty("maxHeapBytes", Long.toString(Runtime.getRuntime().maxMemory()));
+        properties.setProperty("machineMemoryBytes", Long.toString(machineMemoryBytes()));
+        describeContextCache(properties);
+        try {
+            Files.createDirectories(report.getParent());
+            try (OutputStream out = Files.newOutputStream(report)) {
+                properties.store(out, "Written by TestHeapHeadroomListener; read by the testHeapHeadroom task");
+            }
+        } catch (IOException e) {
+            // The measurement is diagnostic. Losing it must never be what fails a test run.
+            System.err.println("Could not write the test heap report: " + e.getMessage());
+        }
+    }
+
+    private static long readLong(Properties properties, String key) {
+        try {
+            return Long.parseLong(properties.getProperty(key, "0"));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Reads how many contexts Spring is holding. There is no public accessor for the shared
+     * cache, so this reaches the field directly and simply reports nothing if a future Spring
+     * version moves it. The count is the other half of the story: a heap reading on its own
+     * says the run is heavy, the context count says why.
+     */
+    private static void describeContextCache(Properties properties) {
+        try {
+            Class<?> delegate =
+                    Class.forName("org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate");
+            Field field = delegate.getDeclaredField("defaultContextCache");
+            field.setAccessible(true);
+            Object cache = field.get(null);
+            properties.setProperty("contextsCached", String.valueOf(invokeInt(cache, "size")));
+            properties.setProperty("contextCacheMaxSize", String.valueOf(invokeInt(cache, "getMaxSize")));
+            properties.setProperty("contextLoads", String.valueOf(invokeInt(cache, "getMissCount")));
+            properties.setProperty("contextHits", String.valueOf(invokeInt(cache, "getHitCount")));
+        } catch (Exception e) {
+            properties.setProperty("contextsCached", "-1");
+        }
+    }
+
+    private static int invokeInt(Object target, String method) throws Exception {
+        return (int) target.getClass().getMethod(method).invoke(target);
+    }
+
+    /** Total memory of the machine the run is on, so a CI log says what the cap is sized against. */
+    private static long machineMemoryBytes() {
+        try {
+            for (String line : Files.readAllLines(Paths.get("/proc/meminfo"))) {
+                if (line.startsWith("MemTotal:")) {
+                    return Long.parseLong(line.replaceAll("\\D+", "")) * 1024L;
+                }
+            }
+        } catch (Exception ignored) {
+            // Not Linux, or no procfs. The reading is optional.
+        }
+        return -1;
+    }
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,2 @@
+# Auto-registers the heap headroom measurement with every test JVM the build starts.
+org.tornotron.echno_backend.support.TestHeapHeadroomListener


### PR DESCRIPTION
Closes #481.

## What the suite actually costs

Measured on the lab build box, full suite, 1310 tests. The instrumentation added here is what produced these numbers, so they can be re-taken at any time.

| run | heap cap | context cache | peak live set | occupancy high water | result | wall clock |
|---|---|---|---|---|---|---|
| as merged today | 1024m | 8 | 506 MB (49%) | 618 MB | pass | 7m51s |
| all contexts held | 4096m | 64 | **1150 MB** | 1316 MB | pass | 8m14s |
| all contexts held | 1024m | 32 (Spring default) | over the cap | | **OOM** | 8m41s |
| all contexts held | 2048m | 32 | 1150 MB (56%) | 1164 MB | pass | 8m00s |
| **this branch** | **2048m** | **8** | **485 MB (24%)** | 645 MB | pass | 8m02s |

The suite is **31 distinct Spring test configurations**, so 31 contexts and 31 Hibernate `SessionFactory` instances over the 98 entities, all in one JVM because there is no `forkEvery`. Holding all of them costs 1150 MB, which is more than the 1024m cap. The run fits today only because #497 pinned the context cache at 8.

That is the real finding. The cap was not close to binding in the configuration we ship, but it was below the suite's own working set, so the cache limit was the only thing between the run and the failure, and nothing said so.

## Reproduced, then absorbed

Same branch, same tests, cache at Spring's default of 32, only the heap cap differs:

- **1024m**: 1297 tests pass, **zero assertion failures**, then `java.lang.OutOfMemoryError: Java heap space` inside `com.tngtech.archunit.core.domain.DomainObjectCreationContext.createJavaMethod`, surfacing as a failure of `EndpointAuthorizationTest`, a test the change never touched. Gradle reports only "There were failing tests. See the report at ...".
- **2048m**: passes, 1150 MB live of the 2048 MB cap.

## Why 2048m and what it costs CI

It is the smallest round number that holds the measured 1150 MB working set with real spare, so the cache cap becomes a performance choice rather than the only thing preventing a misleading failure.

`ubuntu-latest` on a public repository is 4 vCPU and 16 GB, not the 2 vCPU and 7 GB the old comment was sized against. The test JVM shares the runner with the CockroachDB container `AbstractIntegrationTest` already limits to 2 GB, and the Gradle daemon. 2 GB + 2 GB + daemon leaves roughly 11 GB unused. The CI run on this PR reports the runner's memory in its own log, from `/proc/meminfo`, so the assumption is checked rather than asserted.

## The other two levers, measured rather than argued

- **`forkEvery`** bounds accumulation but restarts everything per fork, and `AbstractIntegrationTest` starts its CockroachDB container in a static block, so a new fork means a new container as well as a fresh set of contexts. Measured on this configuration: `forkEvery = 50` takes **28m51s against the 8m02s baseline**, 3.6x, for 20 extra minutes on every push. It does work, holding the peak live set to 387 MB, but it is paying twenty minutes a run for headroom that 1 GB of unused runner memory buys for nothing. Not adopted.
- **Fewer contexts** attacks the cause, and 31 configurations for 1310 tests is not obviously wrong, but it is a large change across 54 `@DataJpaTest` classes and does not belong in this one.

Keeping the cache at 8 costs **one** extra context build over the whole run (37 loads against 36 with the cache at 64) and no measurable wall clock, so it stays.

## Making the ceiling visible

A number in a log nobody reads is not a warning, so there are three layers, in the order they would fire.

1. **Every build prints one line.** `testHeapHeadroom` finalizes `test`, so it reports on failed runs too:

   `Test heap: 485 MB live of a 2048 MB cap (24% used, 1563 MB spare, 645 MB occupied at the fullest), 8 Spring contexts cached of a maximum 8 (37 loaded, 4346 reused), on a machine with 15.6 GB`

2. **It warns at 65% of the cap and fails the build at 80%**, before the heap actually runs out, naming the three levers. Verified firing:

   ```
   > Task :testHeapHeadroom FAILED
   > Test heap: 138 MB live of a 512 MB cap (27% used, ...)
     That is past the 10% mark, which means the next test added here is likely to
     fail in a class it never touched, as a context-loading error rather than an
     assertion. Failing now, while the cause is still legible.
   ```

3. **If it runs out anyway, it says so plainly.** `-XX:+ExitOnOutOfMemoryError` collapses the cascade of unrelated context failures into one exit, `-XX:+HeapDumpOnOutOfMemoryError` leaves the evidence, and the task explains what happened. Same OOM as the reproduction above, on this branch:

   ```
   Test heap: no measurement was written. If the run failed, the test JVM probably
   died before it could finish; look for a heap dump in .../build/reports/test-heap
   and read the failures as a memory problem, not a test one.

   > Process 'Gradle Test Executor 1' finished with non-zero exit value 3
   ```

## How it measures

`TestHeapHeadroomListener` registers through `META-INF/services`, so it applies to every test JVM without any test knowing about it. It samples the **live set**, what survives a collection, every 15 seconds and once after the last test, rather than heap occupancy: occupancy on this suite peaks at 645 MB against a 506 MB live set, because a collector under no pressure has no reason to collect early, and gating on it would have the build permanently declaring an emergency. Occupancy is still reported, next to the number that matters.

`testMaxHeap`, `testContextCacheSize`, `testHeapFailRatio` and `testHeapWarnRatio` are all `-P` overridable, which is how every row in the table above was taken.
