### PR TITLE
Give AR invoices a way to be listed, scoped to the tenant asking

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/repositories/InvoiceRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/repositories/InvoiceRepository.java
@@ -1,21 +1,34 @@
 package org.tornotron.echno_backend.finance.invoice.repositories;
 
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.invoice.domain.Invoice;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
+/**
+ * Reads and writes for customer (accounts-receivable) invoices.
+ *
+ * <p>The list read goes through {@link JpaSpecificationExecutor}, whose
+ * {@code findAll(Specification, Pageable)} is a criteria query on the entity and therefore carries
+ * the Hibernate {@code orgFilter} declared on {@link Invoice}. That is what keeps one tenant's
+ * listing from enumerating another's, and it is why the filters are built as predicates rather
+ * than as derived query methods: a derived method per filter combination multiplies the surface
+ * that has to be proven scoped, and it cannot express two filters at once without a method for
+ * every pair.
+ */
+public interface InvoiceRepository extends JpaRepository<Invoice, UUID>, JpaSpecificationExecutor<Invoice> {
+
+    /**
+     * Org-scoped lookup by id with the lines, their revenue accounts and the customer fetched.
+     * Uses JPQL rather than a primary-key {@code find()} so the {@code orgFilter} is applied.
+     */
     @EntityGraph(attributePaths = {"lines", "lines.revenueAccount", "customer"})
     @Query("SELECT i FROM Invoice i WHERE i.id = :id")
     Optional<Invoice> findByIdWithLines(@Param("id") UUID id);
@@ -23,11 +36,4 @@ public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT i FROM Invoice i WHERE i.id = :id")
     Optional<Invoice> findByIdForUpdate(@Param("id") UUID id);
-
-    Page<Invoice> findByCustomerId(UUID customerId, Pageable pageable);
-    Page<Invoice> findByStatus(InvoiceStatus status, Pageable pageable);
-
-    @Query("SELECT i FROM Invoice i WHERE i.customer.id = :customerId " +
-            "AND i.status IN ('ISSUED','PARTIALLY_PAID') ORDER BY i.invoiceDate ASC")
-    List<Invoice> findOpenInvoicesByCustomer(@Param("customerId") UUID customerId);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/repositories/InvoiceSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/repositories/InvoiceSpecifications.java
@@ -1,0 +1,65 @@
+package org.tornotron.echno_backend.finance.invoice.repositories;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
+import org.tornotron.echno_backend.finance.invoice.domain.Invoice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Builds the optional list filters for customer invoices as a JPA {@link Specification}.
+ *
+ * <p>Only a non-null argument becomes a predicate, so an omitted parameter leaves that dimension
+ * unfiltered rather than binding a null-typed parameter on the Postgres wire protocol. Organization
+ * scoping is deliberately absent here: it comes from the Hibernate {@code orgFilter} enabled on the
+ * session for the request, which applies to this criteria query and to its count query alike.
+ * Restating it as a predicate would give a reader two places to check and one of them could drift.
+ */
+public final class InvoiceSpecifications {
+
+    /**
+     * The statuses that make an invoice a live receivable: issued to the customer and not yet
+     * settled in full. A draft is not owed yet, a paid invoice is no longer owed, and a cancelled
+     * one never will be.
+     */
+    public static final Set<InvoiceStatus> OPEN_STATUSES =
+            Set.of(InvoiceStatus.ISSUED, InvoiceStatus.PARTIALLY_PAID);
+
+    private InvoiceSpecifications() {
+    }
+
+    /**
+     * The list filters, combined with AND.
+     *
+     * <p>{@code openOnly} and {@code status} are independent and both are applied when both are
+     * given, so asking for open invoices with a status of PAID is a legal request that matches
+     * nothing. That is the honest answer to a contradictory filter, and it keeps the two parameters
+     * from having to know about each other.
+     *
+     * @param customerId Restrict to one customer, or null for every customer.
+     * @param status     Restrict to one lifecycle status, or null for every status.
+     * @param openOnly   Restrict to the {@link #OPEN_STATUSES} when true; no restriction when false.
+     * @return A specification matching invoices that satisfy every filter given.
+     */
+    public static Specification<Invoice> withFilters(UUID customerId,
+                                                     InvoiceStatus status,
+                                                     boolean openOnly) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (customerId != null) {
+                predicates.add(cb.equal(root.get("customer").get("id"), customerId));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (openOnly) {
+                predicates.add(root.get("status").in(OPEN_STATUSES));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceService.java
@@ -2,6 +2,9 @@ package org.tornotron.echno_backend.finance.invoice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
@@ -17,6 +20,7 @@ import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
 import org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapper;
 import org.tornotron.echno_backend.finance.invoice.repositories.InvoiceRepository;
+import org.tornotron.echno_backend.finance.invoice.repositories.InvoiceSpecifications;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
@@ -62,6 +66,43 @@ public class InvoiceService {
     private final PostingAccountResolver postingAccountResolver;
     private final TenantEntityHelper tenantEntityHelper;
     private final ConstructionInvoiceRepository constructionInvoiceRepo;
+
+    /**
+     * The order every page of the listing is read in.
+     *
+     * <p>A page with no order is a page in whatever order the storage engine happened to produce,
+     * which on a distributed engine is not stable between two requests: the same row can appear on
+     * page one and again on page two while another never appears at all. Newest invoice first is
+     * what a receivables screen wants; the invoice number breaks the tie between two invoices dated
+     * the same day, and because it is zero padded within a fiscal year it orders by issue sequence.
+     */
+    private static final Sort LIST_ORDER =
+            Sort.by(Sort.Order.desc("invoiceDate"), Sort.Order.desc("invoiceNumber"));
+
+    /**
+     * Lists invoices in the current tenant, newest first, one page at a time.
+     *
+     * <p>Every filter is optional and they combine with AND. Scoping to the caller's organization
+     * is not one of them: it comes from the Hibernate {@code orgFilter} on the transaction, which
+     * applies to the criteria query and to the count behind {@code getTotalElements} alike, so a
+     * member of one tenant cannot enumerate another's invoices and cannot learn how many there are
+     * either.
+     *
+     * @param customerId Restrict to one customer, or null for every customer.
+     * @param status     Restrict to one lifecycle status, or null for every status.
+     * @param openOnly   Restrict to invoices still owed (ISSUED or PARTIALLY_PAID) when true.
+     * @param pageNo     Zero-based page index.
+     * @param pageSize   Rows per page.
+     * @return The requested page of invoices, each with its line items.
+     */
+    @Transactional(readOnly = true)
+    public Page<InvoiceDto> findAll(UUID customerId, InvoiceStatus status, boolean openOnly,
+                                    int pageNo, int pageSize) {
+        return invoiceRepo.findAll(
+                        InvoiceSpecifications.withFilters(customerId, status, openOnly),
+                        PageRequest.of(pageNo, pageSize, LIST_ORDER))
+                .map(mapper::toDto);
+    }
 
     /**
      * Retrieves a single invoice with its line items.

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
@@ -2,15 +2,20 @@ package org.tornotron.echno_backend.finance.invoice.web;
 
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
 import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
@@ -45,6 +50,32 @@ public class InvoiceControllerWeb {
     })
     public ResponseEntity<InvoiceDto> createDraft(@Valid @RequestBody CreateInvoiceRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.createDraft(req));
+    }
+
+    @GetMapping
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "List invoices",
+            description = "Returns a page of customer invoices in the current tenant, newest invoice date "
+                    + "first. The optional customer, status and openOnly parameters narrow the result and "
+                    + "combine with AND; omitting a parameter leaves that dimension unfiltered. Use pageNo "
+                    + "and pageSize to page through the results."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching invoices"),
+            @ApiResponse(responseCode = "400", description = "pageNo or pageSize is outside its permitted range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public Page<InvoiceDto> list(
+            @Parameter(description = "Restrict to invoices billed to this customer.")
+            @RequestParam(required = false) UUID customerId,
+            @Parameter(description = "Restrict to invoices in this lifecycle status.")
+            @RequestParam(required = false) InvoiceStatus status,
+            @Parameter(description = "Restrict to invoices still owed, that is ISSUED or PARTIALLY_PAID.")
+            @RequestParam(required = false, defaultValue = "false") boolean openOnly,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return service.findAll(customerId, status, openOnly,
+                pageQuery.getPageNo(), pageQuery.getPageSize());
     }
 
     @GetMapping("/{id}")

--- a/src/test/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/invoice/service/InvoiceServiceIT.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -22,6 +23,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.invoice.InvoicePostingProperties;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
+import org.tornotron.echno_backend.finance.invoice.domain.Invoice;
 import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
 import org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapperImpl;
@@ -42,10 +44,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
- * Integration tests for {@link InvoiceService#createDraft} against a real CockroachDB.
- * These pin the money the customer is billed: per-line tax derived from the rate, the
- * invoice subtotal/tax/total rolled up from the lines, and the guards that keep a draft
- * well-formed (date order, active customer, postable income revenue accounts).
+ * Integration tests for {@link InvoiceService} against a real CockroachDB.
+ *
+ * <p>{@link InvoiceService#createDraft} pins the money the customer is billed: per-line tax
+ * derived from the rate, the invoice subtotal/tax/total rolled up from the lines, and the guards
+ * that keep a draft well-formed (date order, active customer, postable income revenue accounts).
+ *
+ * <p>{@link InvoiceService#findAll} pins the listing, which needs a real database for the two
+ * things that are not visible from a mock: that the Hibernate {@code orgFilter} scopes both the
+ * rows and the count, and that the fixed sort order actually pages.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -73,6 +80,10 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
     private UUID expenseId;    // active EXPENSE (wrong type)
     private UUID inactiveRevenueId; // inactive INCOME
 
+    // A second tenant, so the listing can be asked to leak and shown not to.
+    private Long otherOrgId;
+    private UUID otherCustomerId;
+
     // The tenant seed must be committed, not held in the rolled-back test transaction:
     // EntryNumberGenerator.next() runs in REQUIRES_NEW and only sees committed rows.
     @BeforeEach
@@ -87,6 +98,9 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
             Account expense = persistAccount(org, "5000", "Expense", AccountType.EXPENSE, true);
             Account inactiveRevenue = persistAccount(org, "4009", "Closed Revenue", AccountType.INCOME, false);
 
+            Organization otherOrg = persistOrganization("Rival Org");
+            Customer otherCustomer = persistCustomer(otherOrg, "CUST-9", true);
+
             entityManager.flush();
             orgId = org.getId();
             customerId = customer.getId();
@@ -95,6 +109,8 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
             revenueBId = revenueB.getId();
             expenseId = expense.getId();
             inactiveRevenueId = inactiveRevenue.getId();
+            otherOrgId = otherOrg.getId();
+            otherCustomerId = otherCustomer.getId();
         });
         TenantContext.setCurrentOrgId(orgId);
     }
@@ -103,18 +119,23 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
     void cleanup() {
         entityManager.unwrap(Session.class).disableFilter("orgFilter");
         TenantContext.clear();
-        if (orgId == null) {
+        inCommittedTx(() -> {
+            purgeOrganization(orgId);
+            purgeOrganization(otherOrgId);
+        });
+    }
+
+    private void purgeOrganization(Long org) {
+        if (org == null) {
             return;
         }
-        inCommittedTx(() -> {
-            exec("DELETE FROM invoice_lines WHERE invoice_id IN "
-                    + "(SELECT id FROM invoices WHERE organization_id = :org)");
-            exec("DELETE FROM invoices WHERE organization_id = :org");
-            exec("DELETE FROM document_sequence WHERE organization_id = :org");
-            exec("DELETE FROM accounts WHERE organization_id = :org");
-            exec("DELETE FROM customers WHERE organization_id = :org");
-            exec("DELETE FROM organization WHERE id = :org");
-        });
+        exec(org, "DELETE FROM invoice_lines WHERE invoice_id IN "
+                + "(SELECT id FROM invoices WHERE organization_id = :org)");
+        exec(org, "DELETE FROM invoices WHERE organization_id = :org");
+        exec(org, "DELETE FROM document_sequence WHERE organization_id = :org");
+        exec(org, "DELETE FROM accounts WHERE organization_id = :org");
+        exec(org, "DELETE FROM customers WHERE organization_id = :org");
+        exec(org, "DELETE FROM organization WHERE id = :org");
     }
 
     // --- Totals -----------------------------------------------------------
@@ -192,7 +213,180 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
                 service.createDraft(oneLine(customerId, UUID.randomUUID())));
     }
 
+    // --- Listing ----------------------------------------------------------
+
+    /**
+     * The listing is the surface tenant isolation matters most on: by id a caller has to already
+     * know the id, whereas a list hands over every row the query returns. This seeds two invoices
+     * in each of two organizations and asks from inside each in turn, so a query that ignored the
+     * scope would be caught whichever tenant it favoured, and asserts on the ids rather than the
+     * count alone so swapping one row for another cannot pass.
+     *
+     * <p>The count is checked too. {@code getTotalElements} comes from a separate count query, and
+     * a total that includes the other tenant's rows leaks how much business a rival is doing even
+     * when no row of theirs is returned.
+     */
+    @Test
+    void findAll_returnsOnlyTheInvoicesOfTheTenantAsking() {
+        UUID mine = persistInvoice(orgId, customerId, "INV-A-1",
+                LocalDate.of(2026, 8, 1), InvoiceStatus.ISSUED, "100", "0");
+        UUID alsoMine = persistInvoice(orgId, customerId, "INV-A-2",
+                LocalDate.of(2026, 8, 2), InvoiceStatus.DRAFT, "200", "0");
+        UUID theirs = persistInvoice(otherOrgId, otherCustomerId, "INV-B-1",
+                LocalDate.of(2026, 8, 3), InvoiceStatus.ISSUED, "300", "0");
+        UUID alsoTheirs = persistInvoice(otherOrgId, otherCustomerId, "INV-B-2",
+                LocalDate.of(2026, 8, 4), InvoiceStatus.DRAFT, "400", "0");
+
+        enableOrgFilter(orgId);
+        Page<InvoiceDto> asMine = service.findAll(null, null, false, 0, 10);
+        assertThat(asMine.getContent()).extracting(InvoiceDto::id)
+                .containsExactlyInAnyOrder(mine, alsoMine)
+                .doesNotContain(theirs, alsoTheirs);
+        assertThat(asMine.getTotalElements()).isEqualTo(2);
+        disableOrgFilter();
+
+        enableOrgFilter(otherOrgId);
+        Page<InvoiceDto> asTheirs = service.findAll(null, null, false, 0, 10);
+        assertThat(asTheirs.getContent()).extracting(InvoiceDto::id)
+                .containsExactlyInAnyOrder(theirs, alsoTheirs)
+                .doesNotContain(mine, alsoMine);
+        assertThat(asTheirs.getTotalElements()).isEqualTo(2);
+        disableOrgFilter();
+    }
+
+    /**
+     * A filter narrows within the tenant and never widens past it: asking for the other tenant's
+     * customer by id returns nothing rather than that customer's invoices. Without this a caller
+     * who learned a customer id would have a way through the listing that the unfiltered case
+     * does not show.
+     */
+    @Test
+    void findAll_filtersByCustomerAndCannotReachAnotherTenantsCustomer() {
+        UUID mine = persistInvoice(orgId, customerId, "INV-A-1",
+                LocalDate.of(2026, 8, 1), InvoiceStatus.ISSUED, "100", "0");
+        persistInvoice(orgId, inactiveCustomerId, "INV-A-2",
+                LocalDate.of(2026, 8, 2), InvoiceStatus.ISSUED, "200", "0");
+        persistInvoice(otherOrgId, otherCustomerId, "INV-B-1",
+                LocalDate.of(2026, 8, 3), InvoiceStatus.ISSUED, "300", "0");
+
+        enableOrgFilter(orgId);
+
+        assertThat(service.findAll(customerId, null, false, 0, 10).getContent())
+                .extracting(InvoiceDto::id)
+                .containsExactly(mine);
+        assertThat(service.findAll(otherCustomerId, null, false, 0, 10).getContent())
+                .isEmpty();
+
+        disableOrgFilter();
+    }
+
+    @Test
+    void findAll_filtersByStatus() {
+        UUID draft = persistInvoice(orgId, customerId, "INV-A-1",
+                LocalDate.of(2026, 8, 1), InvoiceStatus.DRAFT, "100", "0");
+        persistInvoice(orgId, customerId, "INV-A-2",
+                LocalDate.of(2026, 8, 2), InvoiceStatus.ISSUED, "200", "0");
+        persistInvoice(orgId, customerId, "INV-A-3",
+                LocalDate.of(2026, 8, 3), InvoiceStatus.CANCELLED, "300", "0");
+
+        enableOrgFilter(orgId);
+
+        assertThat(service.findAll(null, InvoiceStatus.DRAFT, false, 0, 10).getContent())
+                .extracting(InvoiceDto::id)
+                .containsExactly(draft);
+
+        disableOrgFilter();
+    }
+
+    /**
+     * {@code openOnly} is the one filter {@code status} cannot express, because what is still owed
+     * spans two statuses. A caller reduced to one status per request would have to make two and
+     * page each separately to build a receivables view.
+     */
+    @Test
+    void findAll_openOnlyReturnsWhatIsStillOwed() {
+        persistInvoice(orgId, customerId, "INV-A-1",
+                LocalDate.of(2026, 8, 1), InvoiceStatus.DRAFT, "100", "0");
+        UUID issued = persistInvoice(orgId, customerId, "INV-A-2",
+                LocalDate.of(2026, 8, 2), InvoiceStatus.ISSUED, "200", "0");
+        UUID partlyPaid = persistInvoice(orgId, customerId, "INV-A-3",
+                LocalDate.of(2026, 8, 3), InvoiceStatus.PARTIALLY_PAID, "300", "50");
+        persistInvoice(orgId, customerId, "INV-A-4",
+                LocalDate.of(2026, 8, 4), InvoiceStatus.PAID, "400", "400");
+        persistInvoice(orgId, customerId, "INV-A-5",
+                LocalDate.of(2026, 8, 5), InvoiceStatus.CANCELLED, "500", "0");
+
+        enableOrgFilter(orgId);
+
+        assertThat(service.findAll(null, null, true, 0, 10).getContent())
+                .extracting(InvoiceDto::id)
+                .containsExactlyInAnyOrder(issued, partlyPaid);
+        // The two narrowing filters simply AND, so a contradictory pair matches nothing.
+        assertThat(service.findAll(null, InvoiceStatus.PAID, true, 0, 10).getContent())
+                .isEmpty();
+
+        disableOrgFilter();
+    }
+
+    /**
+     * Paging is only paging if the order is fixed. Without a deterministic sort the engine is free
+     * to return the rows in a different order for each page, which lets one row appear on two
+     * pages while another appears on none, and no assertion on a single page would notice.
+     */
+    @Test
+    void findAll_pagesInAFixedNewestFirstOrder() {
+        UUID first = persistInvoice(orgId, customerId, "INV-A-1",
+                LocalDate.of(2026, 8, 1), InvoiceStatus.ISSUED, "100", "0");
+        UUID second = persistInvoice(orgId, customerId, "INV-A-2",
+                LocalDate.of(2026, 8, 2), InvoiceStatus.ISSUED, "200", "0");
+        UUID third = persistInvoice(orgId, customerId, "INV-A-3",
+                LocalDate.of(2026, 8, 3), InvoiceStatus.ISSUED, "300", "0");
+
+        enableOrgFilter(orgId);
+
+        Page<InvoiceDto> pageOne = service.findAll(null, null, false, 0, 2);
+        assertThat(pageOne.getContent()).extracting(InvoiceDto::id).containsExactly(third, second);
+        assertThat(pageOne.getTotalElements()).isEqualTo(3);
+        assertThat(service.findAll(null, null, false, 1, 2).getContent())
+                .extracting(InvoiceDto::id).containsExactly(first);
+
+        disableOrgFilter();
+    }
+
     // --- Helpers ----------------------------------------------------------
+
+    private void enableOrgFilter(Long org) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", org);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+
+    /**
+     * Writes an invoice row directly, bypassing {@link InvoiceService#createDraft}. The listing
+     * tests need invoices in a tenant the service cannot be asked to write into, and statuses the
+     * lifecycle would take several steps to reach, neither of which the creation path is for.
+     */
+    private UUID persistInvoice(Long org, UUID customer, String number, LocalDate invoiceDate,
+                                InvoiceStatus status, String total, String amountPaid) {
+        Invoice invoice = new Invoice();
+        invoice.setInvoiceNumber(number);
+        invoice.setCustomer(entityManager.getReference(Customer.class, customer));
+        invoice.setOrganization(entityManager.getReference(Organization.class, org));
+        invoice.setInvoiceDate(invoiceDate);
+        invoice.setDueDate(invoiceDate.plusDays(30));
+        invoice.setStatus(status);
+        invoice.setSubtotal(bd(total));
+        invoice.setTaxTotal(BigDecimal.ZERO);
+        invoice.setTotal(bd(total));
+        invoice.setAmountPaid(bd(amountPaid));
+        entityManager.persist(invoice);
+        entityManager.flush();
+        return invoice.getId();
+    }
 
     private CreateInvoiceRequest oneLine(UUID customer, UUID revenueAccount) {
         return new CreateInvoiceRequest(customer,
@@ -231,8 +425,8 @@ class InvoiceServiceIT extends AbstractIntegrationTest {
         return account;
     }
 
-    private void exec(String sql) {
-        entityManager.createNativeQuery(sql).setParameter("org", orgId).executeUpdate();
+    private void exec(Long org, String sql) {
+        entityManager.createNativeQuery(sql).setParameter("org", org).executeUpdate();
     }
 
     private void inCommittedTx(Runnable work) {

--- a/src/test/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceListingTest.java
@@ -1,0 +1,89 @@
+package org.tornotron.echno_backend.finance.invoice.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The AR invoice listing takes its page bounds from {@link PageQuery} and passes its filters
+ * straight through.
+ *
+ * <p>Both halves are worth pinning. The page bounds are the reason
+ * {@code PaginationParameterBoundTest} exists: a handler that reads the pair off its own request
+ * parameters is bounded by nothing, and one that takes a {@code PageQuery} and then ignores it is
+ * the same defect wearing the right type. The filters matter because dropping one on the floor
+ * fails silently: the caller asks for one customer's invoices, is handed every customer's, and
+ * nothing about the response says the filter was not applied.
+ */
+@ExtendWith(MockitoExtension.class)
+class InvoiceListingTest {
+
+    @Mock
+    private InvoiceService service;
+
+    @Test
+    void anUnfilteredListingAsksForTheFirstDefaultSizedPage() {
+        when(service.findAll(any(), any(), anyBoolean(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new InvoiceControllerWeb(service).list(null, null, false, new PageQuery());
+
+        verify(service).findAll(isNull(), isNull(), eq(false), eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    @Test
+    void theCallersPageBoundsReachTheService() {
+        PageQuery pageQuery = new PageQuery();
+        pageQuery.setPageNo(3);
+        pageQuery.setPageSize(50);
+        when(service.findAll(any(), any(), anyBoolean(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new InvoiceControllerWeb(service).list(null, null, false, pageQuery);
+
+        verify(service).findAll(isNull(), isNull(), eq(false), eq(3), eq(50));
+    }
+
+    @Test
+    void everyFilterIsPassedThrough() {
+        UUID customerId = UUID.randomUUID();
+        when(service.findAll(any(), any(), anyBoolean(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new InvoiceControllerWeb(service).list(
+                customerId, InvoiceStatus.ISSUED, true, new PageQuery());
+
+        verify(service).findAll(eq(customerId), eq(InvoiceStatus.ISSUED), eq(true),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    /**
+     * The page envelope reaches the caller intact. A listing that answered with the page content
+     * alone would drop the total, and a client with no total cannot tell a last page from a
+     * truncated one, which is the failure {@link UnpagedResultCap} exists to make visible on the
+     * endpoints that have no page parameters at all.
+     */
+    @Test
+    void theResponseCarriesThePageEnvelope() {
+        Page<?> page = Page.empty();
+        when(service.findAll(any(), any(), anyBoolean(), anyInt(), anyInt()))
+                .thenAnswer(invocation -> page);
+
+        assertThat(new InvoiceControllerWeb(service).list(null, null, false, new PageQuery()))
+                .isSameAs(page);
+    }
+}


### PR DESCRIPTION
Closes #576.

## What was wrong

`InvoiceControllerWeb` had four mappings and no way to enumerate anything: create a draft, `GET /{id}`, issue, cancel. Nothing in the repo returned a `List` or `Page<InvoiceDto>` on `development` or on any remote branch. A screen can only act on an invoice once it can put one in front of a user, so the issue and cancel endpoints were unreachable in practice, which is why the client for them (echno-web #334) was refused rather than built against a void.

`InvoiceRepository` already carried `findByCustomerId`, `findByStatus` and `findOpenInvoicesByCustomer`, all three uncalled. The listing was intended and never wired.

## The contract

```
GET /api/v1/finance/invoices/web
      ?pageNo=&pageSize=          bounded by PageQuery
      [&customerId=<uuid>]
      [&status=DRAFT|ISSUED|PARTIALLY_PAID|PAID|CANCELLED]
      [&openOnly=true]
  -> 200 Page<InvoiceDto>
     400 pageNo/pageSize outside its permitted range
     403 caller lacks the role in the current tenant
```

Bare `GET` on the collection rather than the `/all` the issue sketched: `/all` exists on `JournalEntryControllerWeb` only because a bare `GET` there is taken by its by-id lookup. Nothing takes it here, and the finance and inspection siblings that were written since (`ConstructionInvoiceControllerWeb`, `ConstructionPaymentControllerWeb`, `InspectionControllerWeb`, `NcrControllerWeb`, `ChecklistTemplateControllerWeb`) all list on the bare collection path and return `Page<Dto>`. `echno-core` already unwraps that envelope for construction invoices, so the client side has a parse helper to copy.

Rows are ordered newest invoice date first, with the invoice number breaking a same-day tie. A page with no order is a page in whatever order the storage engine produced, which on a distributed engine is not stable between two requests: a row can be served on two pages while another is served on none.

## Filters

Wired:

| Parameter | Why |
|---|---|
| `customerId` | The receivables view a person actually asks for. Was `findByCustomerId`. |
| `status` | Reaching a draft to issue it, or an issued invoice to cancel it, which is exactly what #334 needs. Was `findByStatus`. |
| `openOnly` | The one filter `status` cannot express: what is still owed spans `ISSUED` and `PARTIALLY_PAID`. Was `findOpenInvoicesByCustomer`. |

`openOnly` and `status` are independent and both apply when both are given, so `openOnly=true&status=PAID` is a legal request matching nothing. That is the honest answer to a contradictory filter and keeps the two parameters from having to know about each other.

Left out until a screen asks: invoice-date and due-date ranges, overdue-only (needs a clock in the query and a policy on what counts as overdue), text search on the invoice number or customer name, amount ranges, and a caller-chosen sort.

The three uncalled repository methods are gone, replaced by `InvoiceSpecifications`. One derived method per filter cannot answer two filters at once without a method for every pair, and `findOpenInvoicesByCustomer` also read an unbounded `List`.

## Tenant isolation

Scoping stays where it already is: the Hibernate `orgFilter` the `Invoice` entity declares and `HibernateFilterConfig` enables on the transaction. `JpaSpecificationExecutor.findAll(Specification, Pageable)` is a criteria query on the entity, so the filter covers the row query and the count query behind `getTotalElements` alike. A member of one tenant can neither enumerate another's invoices nor learn how many they have. Restating the scope as a predicate would give a reader two places to check and one of them could drift.

`InvoiceServiceIT` now seeds two organizations and asks from inside each in turn, asserting on ids rather than counts alone so swapping one row for another cannot pass, and asserting on the total so a leaked count is caught even when no foreign row is returned. A second test asks for the other tenant's customer by id and gets nothing, which closes the way through the filters that the unfiltered case would not show.

## Every new test was made to fail

Two mutation runs on `lab-node-116-f`, each reverted afterwards.

| Mutation | Test that failed | Tests that stayed green |
|---|---|---|
| `@Filter(name = "orgFilter")` removed from `Invoice` | `findAll_returnsOnlyTheInvoicesOfTheTenantAsking`, `findAll_filtersByCustomerAndCannotReachAnotherTenantsCustomer` | every other test in both classes, incl. `ConstructionInvoiceServiceIT`'s own tenant-scope test |
| `LIST_ORDER` dropped from the `PageRequest` | `findAll_pagesInAFixedNewestFirstOrder` | |
| `customerId` predicate dropped | `findAll_filtersByCustomerAndCannotReachAnotherTenantsCustomer` | |
| `status` predicate dropped | `findAll_filtersByStatus` | |
| `openOnly` predicate dropped | `findAll_openOnlyReturnsWhatIsStillOwed` | |
| controller ignores `PageQuery`, hardcodes page zero | `theCallersPageBoundsReachTheService` | the other three `InvoiceListingTest` cases |

## Conventions

- Page bounds come from `common/pagination/PageQuery`, so no `pageNo`/`pageSize` parameter is declared on the handler and `PaginationParameterBoundTest` passes. `pageSize` is bounded by the same `UnpagedResultCap.MAX_ROWS` ceiling as every other paginated endpoint.
- `UnboundedRepositoryReadTest` passes: the read takes a `Pageable`, and the one unbounded `List` query on this repository was deleted rather than allowlisted.
- `CappedWebListingTest` is untouched. It covers the bare listings that take no page parameters at all; this one takes them, so it belongs to the paginated family instead.
- `@PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")`, the same gate the four existing mappings carry. Everything on this controller posts to or reverses the ledger, and a listing that showed less than the actions can reach would only be confusing.
- No schema change, so no changelog.

## Not touched

Construction invoices keep their own controller and their own lifecycle. An AR invoice a construction invoice raised is already `ISSUED` and `InvoiceService.cancel` refuses it by name, so this listing makes those rows visible without making either action apply to them. Surfacing `arInvoiceId` through the `echno-core` `ConstructionInvoice` type, which #576 raised as an optional extra, is a core change and is not here.

## Verification

`InvoiceServiceIT` (13 tests, 5 new), `InvoiceListingTest` (4 new), the whole `architecture` package and the whole `common.pagination` package all pass on `lab-node-116-f` against a real CockroachDB 26.2.4.