### PR TITLE
Let an issue's type actually change when the web app asks

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7323,6 +7323,24 @@
             "example": "Spacing measured at 220 mm against a specified 200 mm across grid C.",
             "type": "string"
           },
+          "issueType": {
+            "deprecated": true,
+            "description": "Category of the issue, under the name the web client currently sends. Deprecated alias of type; send type instead.",
+            "enum": [
+              "technical",
+              "design",
+              "quality",
+              "safety",
+              "material",
+              "equipment",
+              "labour",
+              "weather",
+              "permit",
+              "coordination",
+              "other"
+            ],
+            "type": "string"
+          },
           "status": {
             "description": "Lifecycle status of the issue.",
             "enum": [

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.issue;
 
 import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,12 +32,32 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class IssueService {
 
+    private static final Logger log = LoggerFactory.getLogger(IssueService.class);
+
     private static final String ISSUES_FOLDER = "issues";
+
+    /**
+     * Keys the web client puts in an issue update that this endpoint has no field for, and drops
+     * on purpose rather than noisily.
+     *
+     * <p>{@code attachments} is the client telling the difference between "no upload" and
+     * "untouched": it sets {@code attachments: []} on every update, and the files themselves
+     * travel as their own multipart part, so the key in the JSON part carries nothing to apply.
+     * {@code priority} is a field the client's form offers and the {@code Issue} entity has no
+     * column for.
+     *
+     * <p>Everything else falls to the {@code default} branch and is logged, because a key nobody
+     * declared is how the {@code issueType} bug stayed invisible: the update answered 200 and
+     * changed nothing. Naming the two known ones here is what keeps that warning worth reading.
+     * Both are on the list in echno-core#57, and this set shrinks as that list is worked down.
+     */
+    private static final Set<String> SILENTLY_DROPPED_UPDATE_KEYS = Set.of("attachments", "priority");
 
     /**
      * The state an issue starts in, and the only one create accepts. It is what the web client's
@@ -264,6 +286,7 @@ public class IssueService {
                     issue.setDescription((String) value);
                     break;
                 case "type":
+                case "issueType":
                     issue.setType(parseIssueType((String) value));
                     break;
                 case "status":
@@ -274,6 +297,14 @@ public class IssueService {
                     Employee assignee = employeeRepository.findByIdAndOrganizationId(assigneeId, TenantContext.getCurrentOrgId())
                             .orElseThrow(() -> new ResourceNotFoundException("Assignee (employee) with ID " + assigneeId + " was not found in this organization"));
                     issue.setAssignedTo(assignee);
+                    break;
+                default:
+                    if (!SILENTLY_DROPPED_UPDATE_KEYS.contains(key)) {
+                        log.warn("Ignoring '{}' on the update of issue {}: this endpoint changes no such "
+                                + "field, so the caller was told the update succeeded and nothing about that "
+                                + "field changed. Either the client is sending the wrong name or the field "
+                                + "belongs here and does not exist yet.", key, issue.getId());
+                    }
                     break;
             }
         });

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -29,8 +29,15 @@ public class IssueCreationDto {
     @Size(min = 5, max = 2000, message = "Description must be between 5 and 2000 characters")
     private String description;
 
-    // The web client (echno-core) sends this field as "issueType"; accept both
-    // that and the canonical "type" so a create from the web populates it.
+    /**
+     * The canonical name is {@code type}, which is what the column and the entity call it.
+     *
+     * <p>The alias is transitional. Published versions of echno-core send {@code issueType} and
+     * reach the deployed web app only through a package release, so the name cannot change on
+     * both sides at once: the backend accepts either until every client has moved, and the
+     * update path in {@code IssueService} takes both for the same reason. Once echno-web is
+     * running a core that sends {@code type}, the alias and that second case both go.
+     */
     @NotNull
     @Enumerated(EnumType.STRING)
     @JsonAlias("issueType")

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
@@ -29,6 +29,21 @@ public class IssueUpdateFieldsDto {
     @Schema(description = "Category of the issue.")
     private IssueType type;
 
+    /**
+     * The same field under the name every published echno-core sends it as. It is here because the
+     * endpoint really does accept it, and a schema that left it out would be describing an
+     * endpoint that does not exist.
+     *
+     * <p>Transitional, and the reason it exists is the ordering: echno-core reaches the deployed
+     * web app only through a package release, so the name cannot change on both sides at once.
+     * It goes, along with the second case in {@code IssueService.partialUpdateAnIssue} and the
+     * {@code @JsonAlias} on {@link IssueCreationDto}, once echno-web is running a core that sends
+     * {@code type}.
+     */
+    @Schema(description = "Category of the issue, under the name the web client currently sends. "
+            + "Deprecated alias of type; send type instead.", deprecated = true)
+    private IssueType issueType;
+
     @Schema(description = "Lifecycle status of the issue.")
     private IssueStatus status;
 

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
@@ -1,0 +1,153 @@
+package org.tornotron.echno_backend.issue;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * The issue update endpoint reads its payload into a map and applies it with a {@code switch} over
+ * the keys, so an unrecognised key is not a 400: it is dropped, and the caller is told the update
+ * succeeded.
+ *
+ * <p>That is how changing an issue's type through the product came to do nothing. echno-core sends
+ * the field as {@code issueType}; the switch only named {@code type}. Create escaped it because
+ * create binds a real DTO and {@code @JsonAlias("issueType")} catches the name there, and a map
+ * has no property binding for an alias to attach to. So the two paths disagreed and only one of
+ * them was wrong.
+ *
+ * <p>These pin both halves: the update takes the name the client actually sends, and the keys the
+ * endpoint has no field for stay dropped rather than becoming a rejection that would fail every
+ * update the deployed web app makes.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class IssuePartialUpdateKeysTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private IssueRepository issueRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private IssueMapper issueMapper;
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    private IssueService service;
+    private Issue existing;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new IssueService(issueRepository, taskRepository, attachmentService,
+                issueMapper, employeeRepository, new PayloadValidator(validator));
+
+        TenantContext.setCurrentOrgId(1L);
+
+        Organization organization = new Organization();
+        organization.setId(1L);
+        existing = new Issue();
+        existing.setId(7L);
+        existing.setTitle("Honeycombing on the block A raft");
+        existing.setType(IssueType.quality);
+        existing.setStatus(IssueStatus.open);
+        existing.setOrganization(organization);
+
+        when(issueRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(existing));
+        when(issueRepository.save(any(Issue.class))).thenAnswer(call -> call.getArgument(0));
+        when(employeeRepository.findByIdAndOrganizationId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(new Employee()));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    @Test
+    void update_changesTheTypeWhenTheClientNamesItIssueType() {
+        // The name every published echno-core sends. Before this was handled the call returned 200
+        // and the type stayed exactly as it was.
+        service.partialUpdateAnIssue(Map.of("issueType", "safety"), 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getType()).isEqualTo(IssueType.safety);
+    }
+
+    @Test
+    void update_stillChangesTheTypeUnderItsCanonicalName() {
+        service.partialUpdateAnIssue(Map.of("type", "safety"), 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getType()).isEqualTo(IssueType.safety);
+    }
+
+    @Test
+    void update_appliesTheOtherFieldsAlongsideTheAliasedOne() {
+        // Ordering matters here: the aliased key must not shadow or short-circuit the rest.
+        Map<String, Object> updates = new LinkedHashMap<>();
+        updates.put("title", "Honeycombing along the north edge");
+        updates.put("issueType", "safety");
+        updates.put("status", "resolved");
+
+        service.partialUpdateAnIssue(updates, 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getTitle()).isEqualTo("Honeycombing along the north edge");
+        assertThat(existing.getType()).isEqualTo(IssueType.safety);
+        assertThat(existing.getStatus()).isEqualTo(IssueStatus.resolved);
+    }
+
+    @Test
+    void update_acceptsTheKeysItHasNoFieldForRatherThanRefusingTheRequest() {
+        // echno-core puts attachments: [] in the JSON part of every issue update, and the form
+        // offers a priority the entity has no column for. Refusing an unrecognised key would turn
+        // every update the deployed web app makes into a 400, so they are dropped and logged.
+        Map<String, Object> updates = new LinkedHashMap<>();
+        updates.put("attachments", java.util.List.of());
+        updates.put("priority", "high");
+        updates.put("somethingNobodyDeclared", "x");
+        updates.put("issueType", "safety");
+
+        service.partialUpdateAnIssue(updates, 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getType()).isEqualTo(IssueType.safety);
+    }
+}


### PR DESCRIPTION
Changing an issue's type through the product does nothing and reports success. This is the first item worked off the contract-check list in echno-core#57.

## What was wrong

`PATCH /issues/web/{id}` reads its payload into a `Map<String,Object>` and applies it with a `switch` over the keys. The switch named `type`; echno-core sends the field as `issueType`. No `default` branch, so the key fell through and the caller got a 200 with nothing changed.

Create escaped it because create binds a real DTO and `@JsonAlias("issueType")` catches the name there. A map never goes through property binding, so there is nothing for an alias to attach to. The two paths disagreed and only one of them was wrong. The doc comment in echno-core asserting that `issueType` matched the backend was wrong about both, since the backend field is `type`.

## Ordering

echno-core reaches the deployed echno-web only through a GitHub Packages release, so the client field name and the backend alias cannot change in the same breath. The sequence is expand, migrate, contract:

1. **This PR.** The backend accepts either name on update, as it already did on create. Deployed on its own it fixes the live bug for the currently-deployed web app with no client change at all.
2. **echno-core** renames what it sends to `type` and fixes the false doc comment (clears three findings off #57). Released.
3. **echno-web** bumps core and deploys. Not today.
4. **Follow-up, gated on 3.** Delete the `@JsonAlias`, the `issueType` case here, and the schema field. Tracked on #57.

Keeping the alias until the client has actually moved is the point: reversing steps 1 and 4 would break issue creation for every client still on a published core.

## The silent drop

The deeper defect is the missing `default`. A PATCH that ignores keys it does not recognise will hide the next one of these just as well.

It does **not** now reject unknown keys. That was checked rather than assumed: echno-core's `api-client.patchMultipart` stringifies the whole payload into the `data` part, and `issue-service.ts` sets `payload.attachments = []` on every update where no file is uploaded, plus a `priority` the `Issue` entity has no column for. Rejecting would turn every issue update the deployed web app makes into a 400.

So those two are named as deliberate drops with a comment saying why, and everything else falls to a `WARN` naming the key and the issue. That keeps the warning worth reading instead of firing on two keys that are already understood. The set shrinks as #57 is worked down.

The map itself stays, for the reason #522 gave: these endpoints have to tell a field left out from a field sent as an explicit null, and a bean cannot.

## Schema

`IssueUpdateFieldsDto` gains `issueType`, marked deprecated. `PartialUpdateSchemaContractTest` holds that schema to the keys the service actually applies, in both directions, so leaving it out would have failed the build and would also have published a schema that lied about what the endpoint accepts. `docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`; the diff is the one added property.

## Tests

`IssuePartialUpdateKeysTest`, four cases: the type changes under `issueType`, it still changes under `type`, an aliased key does not shadow the fields sent alongside it, and the undeclared keys are accepted rather than refused.

Verified they fail without the fix. With the `case "issueType"` line removed, 3 of the 4 fail; the fourth is the regression guard on the canonical name.

Run on `lab-node-116-f`: `IssuePartialUpdateKeysTest`, `PartialUpdateSchemaContractTest`, `IssueCreat*` and the OpenAPI tasks all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue updates now accept `issueType` as a transitional alias for `type`.
  - Existing fields can be updated alongside the aliased issue type without interruption.

- **Bug Fixes**
  - Unrecognized or intentionally unsupported update fields no longer cause update requests to fail.
  - Added clearer warnings for unsupported update fields.

- **Documentation**
  - Updated the API specification to document the deprecated `issueType` property and supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->