### PR TITLE
Read an organization's managers from the org role, not a flag nobody set

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4714,9 +4714,6 @@
             "format": "date-time",
             "type": "string"
           },
-          "manager": {
-            "type": "boolean"
-          },
           "managerId": {
             "description": "Id of this employee's reporting manager.",
             "example": 5,
@@ -4848,11 +4845,6 @@
             "example": 7,
             "format": "int64",
             "type": "integer"
-          },
-          "isManager": {
-            "description": "Whether the employee is a manager.",
-            "example": false,
-            "type": "boolean"
           },
           "joiningDate": {
             "description": "Date the employee joined.",
@@ -32547,7 +32539,7 @@
     },
     "/api/v1/employee/web/managers": {
       "get": {
-        "description": "Returns every employee flagged as a manager in the current tenant.",
+        "description": "Returns every employee holding a manager organization role in the current tenant.",
         "operationId": "getAllTheManagers",
         "responses": {
           "200": {
@@ -32652,7 +32644,7 @@
     },
     "/api/v1/employee/web/managers/organizationId/{organizationId}": {
       "get": {
-        "description": "Returns every employee flagged as a manager within the given organization.",
+        "description": "Returns every employee holding a manager organization role within the given organization.",
         "operationId": "getAllManagersForAnOrganization",
         "parameters": [
           {

--- a/src/main/java/org/tornotron/echno_backend/employee/Employee.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/Employee.java
@@ -119,9 +119,11 @@ public class Employee implements TenantScopedEntity {
     @Column(name = "date_of_birth",nullable = false)
     private LocalDateTime dateOfBirth;
 
-    @Column(name = "is_manager", nullable = false)
-    private boolean isManager = false;
-
+    /**
+     * The organization roles this employee holds, mirrored from the Keycloak groups on their
+     * token. This is the only record of whether someone manages: there is no separate boolean,
+     * because a second copy of the same fact only ever drifted from this one.
+     */
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "employee_org_roles", joinColumns = @JoinColumn(name = "employee_id"))
     @Column(name = "role")

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeControllerWeb.java
@@ -316,7 +316,7 @@ public class EmployeeControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List all managers",
-            description = "Returns every employee flagged as a manager in the current tenant."
+            description = "Returns every employee holding a manager organization role in the current tenant."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Managers returned"),
@@ -330,7 +330,7 @@ public class EmployeeControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin','project-manager')")
     @Operation(
             summary = "List managers for an organization",
-            description = "Returns every employee flagged as a manager within the given organization."
+            description = "Returns every employee holding a manager organization role within the given organization."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Managers returned"),

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeHierarchyService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeHierarchyService.java
@@ -112,6 +112,15 @@ public class EmployeeHierarchyService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Lists the employees who manage: the holders of an organization role in
+     * {@link OrgRole#getManagerRoles()}.
+     *
+     * <p>The role is what decides this, because the role is what the authorization layer
+     * already reads. It comes from the Keycloak group on the caller's token, so a manager
+     * list built from roles is the same set of people the {@code @PreAuthorize} checks let
+     * through.
+     */
     @Transactional(readOnly = true)
     public List<EmployeeDto> readAllTheManagers() {
         return employeeRepository.findEmployeesByOrgRoles(OrgRole.getManagerRoles())
@@ -120,9 +129,18 @@ public class EmployeeHierarchyService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * The same list, narrowed to one organization.
+     *
+     * <p>This used to read an {@code is_manager} boolean on the employee row, which nothing
+     * ever set: it was false on every row on staging, so the endpoint returned an empty list
+     * for every organization while the unscoped read above returned the right people. Both
+     * now answer from the org roles.
+     */
     @Transactional(readOnly = true)
     public List<EmployeeDto> readAllTheManagersByOrganizationId(Long organizationId) {
-        return employeeRepository.findEmployeesByOrganization_IdAndIsManager(organizationId,true)
+        return employeeRepository
+                .findEmployeesByOrganizationIdAndOrgRoles(organizationId, OrgRole.getManagerRoles())
                 .stream()
                 .map(employee -> employeeMapper.toDto(employee))
                 .collect(Collectors.toList());

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -28,8 +28,27 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
      */
     Optional<Employee> findEmployeeByEmployeeName(String employeeName);
 
+    /**
+     * Finds every employee holding at least one of the given organization roles.
+     *
+     * <p>Membership of a role is what makes someone a manager here. The roles are mirrored
+     * from the Keycloak group the token carries, which is the same source the
+     * {@code @PreAuthorize} checks read, so a query written this way agrees with the
+     * authorization layer by construction.
+     */
     @Query("SELECT DISTINCT e FROM Employee e JOIN e.orgRoles r WHERE r IN :roles")
     List<Employee> findEmployeesByOrgRoles(@Param("roles") Set<OrgRole> roles);
+
+    /**
+     * The same read, narrowed to one organization.
+     *
+     * @param organizationId The organization to look within.
+     * @param roles          The roles that count as managing.
+     */
+    @Query("SELECT DISTINCT e FROM Employee e JOIN e.orgRoles r "
+            + "WHERE e.organization.id = :orgId AND r IN :roles")
+    List<Employee> findEmployeesByOrganizationIdAndOrgRoles(@Param("orgId") Long organizationId,
+                                                            @Param("roles") Set<OrgRole> roles);
 
     /**
      * Checks if an employee record exists for a given user and organization.
@@ -69,14 +88,6 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     List<Employee> findByManager_Id(Long managerId);
 
     boolean existsByManager_Id(Long managerId);
-
-
-    List<Employee> findEmployeesByIsManager(boolean isManager);
-
-    List<Employee> findEmployeesByOrganization_IdAndIsManager(Long organizationId, boolean isManager);
-
-    @Query("select e.id from Employee e where e.isManager = true")
-    List<Long> findAllManagerIds();
 
     @Query("SELECT e FROM Employee e JOIN e.orgRoles r WHERE e.organization.id = :orgId AND r = :role")
     List<Employee> findByOrganizationIdAndOrgRole(Long orgId, OrgRole role);

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeCreationDto.java
@@ -79,7 +79,4 @@ public class EmployeeCreationDto {
     @Schema(description = "Name of the organization the employee belongs to.", example = "Asset Homes")
     @Size(max = 255, message = "organizationName must be at most 255 characters")
     private String organizationName;
-
-    @Schema(description = "Whether the employee is a manager.", example = "false")
-    private boolean isManager;
 }

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -101,9 +101,6 @@ public class EmployeeDto {
             example = "https://cdn.echno.xyz/avatars/emp-0042.png")
     private String profilePictureUrl;
 
-    @Schema(description = "Whether the employee is a manager.", example = "false")
-    private Boolean isManager;
-
     @Schema(description = "Organization roles granted to the employee.", example = "[\"project-manager\"]")
     private Set<OrgRole> orgRoles;
 

--- a/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/mapper/EmployeeMapper.java
@@ -10,10 +10,9 @@ import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 /**
  * Maps {@link Employee} to its DTO. Most profile fields live on the associated
  * {@code User}, and the organization/manager associations are flattened to id + name.
- * The attachment list is signed through {@link AttachmentMapper}.
- *
- * {@code isManager} is deliberately left unset to match the previous converter, which
- * never populated it (the DTO field stays null rather than the entity's boolean false).
+ * The attachment list is signed through {@link AttachmentMapper}. Whether an employee
+ * manages is read from {@code orgRoles}, which this copies straight across; there is no
+ * separate flag to populate.
  */
 @Mapper(componentModel = "spring", uses = {AttachmentMapper.class, ShiftTimingMapper.class})
 public interface EmployeeMapper {
@@ -37,6 +36,5 @@ public interface EmployeeMapper {
     @Mapping(source = "user.createdAt", target = "createdAt")
     @Mapping(source = "user.updatedAt", target = "updatedAt")
     @Mapping(source = "user.attachments", target = "attachments")
-    @Mapping(target = "isManager", ignore = true)
     EmployeeDto toDto(Employee employee);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -343,4 +343,7 @@
     <!-- v4.0 - Compliance rules: when a rule was written, and when it came into force -->
     <include file="db/changelog/v4.0/069-add-compliance-rule-timestamps.xml"/>
 
+    <!-- v4.0 - Employees: drop the unwritten is_manager flag; the org role is the answer -->
+    <include file="db/changelog/v4.0/070-drop-employee-is-manager.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/070-drop-employee-is-manager.xml
+++ b/src/main/resources/db/changelog/v4.0/070-drop-employee-is-manager.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="070-01-drop-employee-is-manager" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="employee" columnName="is_manager"/>
+        </preConditions>
+
+        <comment>
+            Removes the employee.is_manager boolean.
+
+            Whether someone manages is decided by their organization role, mirrored from the
+            Keycloak group their token carries: OrgRole.getManagerRoles() is what the
+            @PreAuthorize checks read, and what the client library's isManager() computes. The
+            column was a second, stored answer to the same question, and nothing ever wrote it.
+            On staging it was false on all thirty rows while five people held a manager role, so
+            the one query that read it returned an empty manager list for every organization.
+            That query now reads the roles, and the two queries left against the column had no
+            callers at all.
+
+            Nothing is backfilled and nothing is lost: the column carried no information that
+            employee_org_roles does not already hold, and every row in it was false.
+        </comment>
+
+        <dropColumn tableName="employee" columnName="is_manager"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeManagerListingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeManagerListingIT.java
@@ -1,0 +1,130 @@
+package org.tornotron.echno_backend.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the manager listings, against a real CockroachDB.
+ *
+ * <p>Regression guard for the org-scoped listing. It used to read an {@code is_manager}
+ * boolean on the employee row, which nothing ever wrote: on staging it was false on all
+ * thirty rows while five people held a manager role, so the endpoint returned an empty
+ * list for every organization while the unscoped listing beside it returned the right
+ * people. These tests seed exactly that shape, role holders and no flag, so they fail
+ * against the old query and pass against the role-based one.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({EmployeeHierarchyService.class, EmployeeMapperImpl.class,
+        AttachmentMapperImpl.class, ShiftTimingMapper.class})
+class EmployeeManagerListingIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private EmployeeHierarchyService hierarchyService;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
+    @Test
+    void managersForAnOrganization_areTheRoleHolders() {
+        Organization org = persistOrganization("Role Org");
+        persistEmployee(org, "Priya Manager", Set.of(OrgRole.PROJECT_MANAGER));
+        persistEmployee(org, "Sam Admin", Set.of(OrgRole.SYSTEM_ADMIN));
+        persistEmployee(org, "Ravi Worker", Set.of());
+        em.flush();
+        em.clear();
+
+        List<EmployeeDto> managers = hierarchyService.readAllTheManagersByOrganizationId(org.getId());
+
+        assertThat(managers).extracting(EmployeeDto::getEmployeeName)
+                .containsExactlyInAnyOrder("Priya Manager", "Sam Admin");
+    }
+
+    @Test
+    void managersForAnOrganization_excludeAnotherOrganizationsManagers() {
+        Organization mine = persistOrganization("Mine");
+        Organization theirs = persistOrganization("Theirs");
+        persistEmployee(mine, "My Manager", Set.of(OrgRole.HR_ADMIN));
+        persistEmployee(theirs, "Their Manager", Set.of(OrgRole.HR_ADMIN));
+        em.flush();
+        em.clear();
+
+        List<EmployeeDto> managers = hierarchyService.readAllTheManagersByOrganizationId(mine.getId());
+
+        assertThat(managers).extracting(EmployeeDto::getEmployeeName)
+                .containsExactly("My Manager");
+    }
+
+    @Test
+    void managersForAnOrganization_agreeWithTheUnscopedListing() {
+        Organization org = persistOrganization("Only Org");
+        persistEmployee(org, "Sole Manager", Set.of(OrgRole.ORG_MANAGER));
+        persistEmployee(org, "Sole Worker", Set.of());
+        em.flush();
+        em.clear();
+
+        List<EmployeeDto> scoped = hierarchyService.readAllTheManagersByOrganizationId(org.getId());
+        List<EmployeeDto> unscoped = hierarchyService.readAllTheManagers();
+
+        // The two listings answer the same question and disagreed for as long as one of
+        // them read the flag instead of the role.
+        assertThat(scoped).extracting(EmployeeDto::getEmployeeName)
+                .containsExactlyInAnyOrderElementsOf(
+                        unscoped.stream()
+                                .filter(e -> org.getId().equals(e.getOrganizationId()))
+                                .map(EmployeeDto::getEmployeeName)
+                                .toList());
+        assertThat(scoped).isNotEmpty();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private void persistEmployee(Organization org, String name, Set<OrgRole> roles) {
+        User user = new User();
+        user.setKeycloakId("kc-" + name.toLowerCase().replace(" ", "-"));
+        user.setName(name);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(name.toLowerCase().replace(" ", ".") + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        employee.setOrgRoles(new java.util.HashSet<>(roles));
+        em.persist(employee);
+    }
+}


### PR DESCRIPTION
Closes #520.

## The bug

`GET /api/v1/employee/web/managers/organizationId/{id}` returns an empty list for every
organization, and always has. Two sibling methods in `EmployeeHierarchyService` answered the
same question from different places:

```java
readAllTheManagers()                   -> findEmployeesByOrgRoles(OrgRole.getManagerRoles())
readAllTheManagersByOrganizationId(id) -> findEmployeesByOrganization_IdAndIsManager(id, true)
```

Nothing has ever written `employee.is_manager`. On IITM staging it is `false` on all 30 rows,
across all four organizations, while five people hold a role in `OrgRole.getManagerRoles()`.
So the second query cannot return a row, for any organization, ever, while the first one a
method above it returns the right people.

## Which side is authoritative

The organization role, and the codebase had already decided that three times over:

- `@PreAuthorize` checks `OrgRole.getManagerRoles()`, derived from the token's group claim.
- `echno-core`'s `isManager(roles)` is a function of the roles array, and `use-authorization.ts`
  consumes it. No client reads the column.
- `EmployeeMapper` deliberately left `isManager` unset, so the response field was null on every
  response the API has ever served.

The scoped read now uses the same source as its sibling, narrowed to one organization.

## What else goes

With that query gone the column has no readers at all. The two remaining queries against it,
`findEmployeesByIsManager` and `findAllManagerIds`, had no callers anywhere in main or test, so
`is_manager` had become a schema field that names a real concept and holds nothing. That is
exactly how the next person writes another query that silently returns nothing, so the column,
those two queries, and the entity field go, in changeset `070-drop-employee-is-manager`.

The two DTO fields go with them. `EmployeeDto.isManager` was mapped to null on every response,
and `EmployeeCreationDto.isManager` bound as `manager` rather than `isManager` and was never read; neither name appears anywhere in
`echno-core` or `echno-web`, and unknown request properties are ignored, so an older client
still sending the field is unaffected. Snapshot regenerated.

Keeping the column and backfilling it from Keycloak was the alternative. It is only worth doing
if something needs to filter managers in SQL without joining the roles, and
`findEmployeesByOrgRoles` shows nothing does.

## Proof

`EmployeeManagerListingIT` seeds the staging shape, role holders and no flag, against a real
CockroachDB. Against `development` all three tests fail with the listing returning `[]`:

```
Expecting actual:
  []
to contain exactly in any order:
  ["Priya Manager", "Sam Admin"]
```

Against this branch all three pass. One of them asserts the scoped and unscoped listings agree,
which is the property that was broken.

## Related

`employee.reporting_manager` came up in the same table and is filed separately as #587: it is an
unmapped `varchar` that no Java code touches and that is null on all 30 staging rows, with
`manager_id` carrying the real relationship. Not changed here.

## One deployment note

The drop ships in the same release as the code that stops reading the column, rather than a
release later. On the compose staging that is safe, because the backend is replaced rather than
rolled. On the k8s deployment a rolling update starts the new pod, which runs Liquibase, while
old pods are still serving, and those old pods still name `is_manager` in every employee select,
so they would fail for the length of the rollout. It is seconds on a staging cluster and there
is no production instance yet, which is why it is one release and not two, but it is a
contract-phase migration and worth knowing before the same pattern reaches a client.
