### PR TITLE
Settle leave authorization on the record, not on the id the caller sent

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -65489,7 +65489,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -66565,7 +66565,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -66688,7 +66688,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -66801,7 +66801,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -66914,7 +66914,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -67037,7 +67037,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -67401,7 +67401,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -67914,7 +67914,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -68036,7 +68036,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -68619,7 +68619,7 @@
                 }
               }
             },
-            "description": "Caller is not the employee identified by the id"
+            "description": "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -45,8 +45,7 @@ public class LeaveRequestController {
     }
 
     @PostMapping
-//    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Create a leave request",
             description = "Creates a leave request for the given employee from the dates, policy and reason "
@@ -56,7 +55,7 @@ public class LeaveRequestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Request created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The request payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The requested dates overlap an existing leave request, or the balance is insufficient")
     })
     public ResponseEntity<LeaveRequestDto> createRequest(
@@ -171,8 +170,9 @@ public class LeaveRequestController {
     }
 
     @PatchMapping("requestId/{requestId}")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    // Ownership is settled in LeaveRequestService against the request's own employee: this
+    // handler takes no employee id, so there is nothing here for a self-check to read.
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Partially update a leave request",
             description = "Applies the given field updates to a draft leave request and returns the "
@@ -181,7 +181,7 @@ public class LeaveRequestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The updated dates overlap an existing leave request, or the request is no longer editable")
     })
@@ -194,8 +194,9 @@ public class LeaveRequestController {
     }
 
     @PostMapping("/requestId/{requestId}/submit")
-//    @PreAuthorize("hasAuthority('leave:create') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    // Ownership is settled in LeaveRequestService against the request's own employee: this
+    // handler takes no employee id, so there is nothing here for a self-check to read.
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Submit a leave request for approval",
             description = "Moves a draft leave request into the approval workflow, assigning the first "
@@ -203,7 +204,7 @@ public class LeaveRequestController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request submitted"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a submittable state, or the balance is insufficient")
     })
@@ -212,8 +213,9 @@ public class LeaveRequestController {
     }
 
     @PostMapping("/requestId/{requestId}/cancel")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    // Ownership is settled in LeaveRequestService against the request's own employee: this
+    // handler takes no employee id, so there is nothing here for a self-check to read.
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Cancel a leave request",
             description = "Cancels an already-approved leave request and records the given reason, "
@@ -221,7 +223,7 @@ public class LeaveRequestController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request cancelled"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a cancellable state")
     })
@@ -232,8 +234,9 @@ public class LeaveRequestController {
     }
 
     @PostMapping("/requestId/{requestId}/withdraw")
-//    @PreAuthorize("hasAuthority('leave:update') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    // Ownership is settled in LeaveRequestService against the request's own employee: this
+    // handler takes no employee id, so there is nothing here for a self-check to read.
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Withdraw a leave request",
             description = "Withdraws a leave request that is still pending approval, before any approver "
@@ -241,7 +244,7 @@ public class LeaveRequestController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request withdrawn"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "The request is not in a withdrawable state")
     })

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -47,7 +47,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping
-    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Create a leave request",
             description = "Creates a leave request for the given employee from the dates, policy and reason "
@@ -57,7 +57,7 @@ public class LeaveRequestControllerWeb {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Request created"),
             @ApiResponse(responseCode = "400", description = "The request payload failed validation"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"),
             @ApiResponse(responseCode = "409", description = "The requested dates overlap an existing leave request, or the balance is insufficient")
     })
     public ResponseEntity<LeaveRequestDto> createRequest(
@@ -184,7 +184,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PatchMapping("/update")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Partially update a leave request",
             description = "Applies the given field updates to a draft leave request and returns the "
@@ -193,7 +193,7 @@ public class LeaveRequestControllerWeb {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Request updated"),
             @ApiResponse(responseCode = "400", description = "One of the update fields failed validation"),
-            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @ApiResponse(responseCode = "409", description = "The updated dates overlap an existing leave request, or the request is no longer editable")
     })
@@ -207,7 +207,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("employeeId/{employeeId}/submit")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Submit a leave request for approval",
             description = "Moves a draft leave request into the approval workflow, assigning the first "
@@ -215,7 +215,7 @@ public class LeaveRequestControllerWeb {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Request submitted"),
-            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @ApiResponse(responseCode = "409", description = "The request is not in a submittable state, or the balance is insufficient")
     })
@@ -224,7 +224,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("/cancel")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Cancel a leave request",
             description = "Cancels an already-approved leave request and records the given reason, "
@@ -232,7 +232,7 @@ public class LeaveRequestControllerWeb {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Request cancelled"),
-            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @ApiResponse(responseCode = "409", description = "The request is not in a cancellable state")
     })
@@ -244,7 +244,7 @@ public class LeaveRequestControllerWeb {
     }
 
     @PostMapping("employeeId/{employeeId}/withdraw")
-    @PreAuthorize("@orgSecurity.isSelfInCurrentTenant(#employeeId)")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Withdraw a leave request",
             description = "Withdraws a leave request that is still pending approval, before any approver "
@@ -252,7 +252,7 @@ public class LeaveRequestControllerWeb {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Request withdrawn"),
-            @ApiResponse(responseCode = "403", description = "Caller is not the employee identified by the id"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the request belongs to nor a holder of the system-admin or hr-admin role"),
             @ApiResponse(responseCode = "404", description = "No leave request with the given id"),
             @ApiResponse(responseCode = "409", description = "The request is not in a withdrawable state")
     })

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.leave;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -9,6 +10,7 @@ import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
@@ -43,6 +45,10 @@ public class LeaveRequestService {
     private final LeaveApprovalService approvalService;
     private final LeaveRequestValidator leaveRequestValidator;
     private final LeaveRequestMapper leaveRequestMapper;
+    private final OrganizationSecurityService orgSecurity;
+
+    /** The roles that may raise or act on a leave request belonging to somebody else. */
+    private static final String[] LEAVE_ADMIN_ROLES = {"system-admin", "hr-admin"};
 
     public LeaveRequestService(
             LeaveRequestRepository requestRepository,
@@ -52,7 +58,8 @@ public class LeaveRequestService {
             EmployeeRepository employeeRepository,
             LeaveApprovalService approvalService,
             LeaveRequestValidator leaveRequestValidator,
-            LeaveRequestMapper leaveRequestMapper) {
+            LeaveRequestMapper leaveRequestMapper,
+            OrganizationSecurityService orgSecurity) {
         this.requestRepository = requestRepository;
         this.sequenceRepository = sequenceRepository;
         this.policyRepository = policyRepository;
@@ -61,6 +68,33 @@ public class LeaveRequestService {
         this.approvalService = approvalService;
         this.leaveRequestValidator = leaveRequestValidator;
         this.leaveRequestMapper = leaveRequestMapper;
+        this.orgSecurity = orgSecurity;
+    }
+
+    /**
+     * Refuses the call unless the caller is the employee the leave belongs to, or holds a role
+     * that may act for other people.
+     *
+     * <p>This has to live here rather than in the {@code @PreAuthorize} guard because the guard
+     * can only see what the caller sent. Every one of these endpoints names the employee in a
+     * query parameter or a path segment, so a guard reading that parameter checks the caller
+     * against a number the caller chose. On create that let any member of the tenant raise leave
+     * in a colleague's name; on the request-scoped calls it let any member pass their own
+     * employee id alongside somebody else's request id and edit, cancel or withdraw it. The
+     * employee id is an argument, not evidence.
+     *
+     * @param employeeId The employee the leave belongs to, resolved from the record where there
+     *     is one rather than taken from the request.
+     * @throws AccessDeniedException if the caller is neither that employee nor a leave admin.
+     */
+    private void requireActorMayActFor(Long employeeId) {
+        if (orgSecurity.isSelfInCurrentTenant(employeeId)
+                || orgSecurity.hasAnyOrgRoleForCurrentTenant(LEAVE_ADMIN_ROLES)) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Leave can only be raised or acted on for yourself, unless you hold the "
+                        + "system-admin or hr-admin role");
     }
 
     /**
@@ -74,9 +108,13 @@ public class LeaveRequestService {
      * @param employeeId The ID of the employee the request is for.
      * @return The created request.
      * @throws ResourceNotFoundException if the employee or policy is not found in this organization.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to
+     *     nor a holder of the system-admin or hr-admin role.
      */
     @Transactional
     public LeaveRequestDto createRequest(LeaveRequestCreationDto dto,Long employeeId) {
+        requireActorMayActFor(employeeId);
+
         Employee employee = employeeRepository.findByIdAndOrganizationId(employeeId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Employee with ID " + employeeId + " was not found in this organization"));
@@ -241,12 +279,16 @@ public class LeaveRequestService {
      * @return The updated request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is not in draft status.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to
+     *     nor a holder of the system-admin or hr-admin role.
      */
     @Transactional
     public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates) {
         LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
+
+        requireActorMayActFor(request.getEmployee().getId());
 
         if (request.getStatus() != LeaveStatus.DRAFT) {
             throw new InvalidRequestException(
@@ -290,12 +332,16 @@ public class LeaveRequestService {
      * @return The submitted request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is not in draft status.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to
+     *     nor a holder of the system-admin or hr-admin role.
      */
     @Transactional
     public LeaveRequestDto submitRequest(Long requestId) {
         LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
+
+        requireActorMayActFor(request.getEmployee().getId());
 
         if (request.getStatus() != LeaveStatus.DRAFT) {
             throw new InvalidRequestException(
@@ -330,12 +376,16 @@ public class LeaveRequestService {
      * @return The cancelled request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is already cancelled or rejected.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to
+     *     nor a holder of the system-admin or hr-admin role.
      */
     @Transactional
     public LeaveRequestDto cancelRequest(Long requestId, String reason) {
         LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
+
+        requireActorMayActFor(request.getEmployee().getId());
 
         if (request.getStatus() == LeaveStatus.CANCELLED ||
             request.getStatus() == LeaveStatus.REJECTED) {
@@ -370,12 +420,16 @@ public class LeaveRequestService {
      * @return The withdrawn request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is neither draft nor pending approval.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to
+     *     nor a holder of the system-admin or hr-admin role.
      */
     @Transactional
     public LeaveRequestDto withdrawRequest(Long requestId) {
         LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
+
+        requireActorMayActFor(request.getEmployee().getId());
 
         if (request.getStatus() != LeaveStatus.DRAFT &&
             request.getStatus() != LeaveStatus.PENDING_APPROVAL) {

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestActorAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestActorAuthorizationTest.java
@@ -1,0 +1,243 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestCreationDto;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who may raise leave, and who may act on a leave request once it exists.
+ *
+ * <p>Both questions used to be answered by an id the caller sent. Creation was guarded by tenant
+ * membership alone while taking the employee as a query parameter, so any colleague could file
+ * leave in somebody else's name: the request carried their employee record, held days against
+ * their balance and entered their approval chain. The request-scoped calls were guarded by a
+ * self-check on that same parameter, which is not tied to the request being acted on, so passing
+ * your own employee id alongside a colleague's request id got you through the guard and then let
+ * the service edit, submit, cancel or withdraw their request.
+ *
+ * <p>What settles it now is the record: the employee is read off the stored request rather than
+ * off the call, and only that employee or a leave admin gets through. These tests fail on the
+ * old code, the create case with a saved request rather than a refusal and the others by the
+ * cancellation going through.
+ */
+@ExtendWith(MockitoExtension.class)
+class LeaveRequestActorAuthorizationTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 8L;
+    private static final Long REQUEST_ID = 42L;
+
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveRequestSequenceRepository sequenceRepository;
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveApprovalService approvalService;
+    @Mock private LeaveRequestValidator leaveRequestValidator;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private LeaveRequestService service() {
+        return new LeaveRequestService(
+                requestRepository,
+                sequenceRepository,
+                policyRepository,
+                balanceRepository,
+                employeeRepository,
+                approvalService,
+                leaveRequestValidator,
+                leaveRequestMapper,
+                orgSecurity);
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        return organization;
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        employee.setOrganization(organization());
+        return employee;
+    }
+
+    /** A colleague's request, approved, so cancelling it would release days from their balance. */
+    private LeaveRequest colleaguesApprovedRequest() {
+        LeaveRequest request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setEmployee(employee(COLLEAGUE_EMPLOYEE_ID));
+        request.setOrganization(organization());
+        request.setStatus(LeaveStatus.APPROVED);
+        request.setStartDate(LocalDate.of(2026, 9, 1));
+        request.setEndDate(LocalDate.of(2026, 9, 3));
+        return request;
+    }
+
+    private LeaveRequestCreationDto creationDto() {
+        LeaveRequestCreationDto dto = new LeaveRequestCreationDto();
+        dto.setLeavePolicyId(3L);
+        dto.setStartDate(LocalDate.of(2026, 9, 1));
+        dto.setEndDate(LocalDate.of(2026, 9, 3));
+        dto.setReason("Family function");
+        return dto;
+    }
+
+    /** Nobody in particular: a plain member of the tenant, holding no leave-admin role. */
+    private void callerIsAPlainMember() {
+        lenient().when(orgSecurity.isSelfInCurrentTenant(anyLong())).thenReturn(false);
+        lenient().when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(false);
+    }
+
+    @Test
+    void createRequest_isRefused_whenRaisedForSomebodyElse() {
+        // The hole as it stood: a member of the tenant, naming a colleague's employee id.
+        callerIsAPlainMember();
+
+        assertThatThrownBy(() -> service().createRequest(creationDto(), COLLEAGUE_EMPLOYEE_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        // Refused before the record is even looked up, so nothing is written and nothing is held
+        // against the colleague's balance.
+        verifyNoInteractions(employeeRepository, policyRepository, requestRepository);
+    }
+
+    @Test
+    void createRequest_isAllowed_forYourself() {
+        // The ordinary case has to keep working: this is how everyone files their own leave.
+        when(orgSecurity.isSelfInCurrentTenant(CALLER_EMPLOYEE_ID)).thenReturn(true);
+        when(employeeRepository.findByIdAndOrganizationId(CALLER_EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee(CALLER_EMPLOYEE_ID)));
+
+        // Stops at the policy lookup, which is far enough past the guard to prove it let go.
+        when(policyRepository.findByIdAndOrganization_Id(3L, ORG_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().createRequest(creationDto(), CALLER_EMPLOYEE_ID))
+                .isNotInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void createRequest_isAllowed_forSomebodyElse_byALeaveAdmin() {
+        // HR filing on an employee's behalf is a real workflow and must not be caught by the fix.
+        when(orgSecurity.isSelfInCurrentTenant(COLLEAGUE_EMPLOYEE_ID)).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(any(String[].class))).thenReturn(true);
+        when(employeeRepository.findByIdAndOrganizationId(COLLEAGUE_EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee(COLLEAGUE_EMPLOYEE_ID)));
+        when(policyRepository.findByIdAndOrganization_Id(3L, ORG_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().createRequest(creationDto(), COLLEAGUE_EMPLOYEE_ID))
+                .isNotInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void cancelRequest_isRefused_onSomebodyElsesRequest() {
+        // The sharper half: the old guard read an employee id from the query string, so a caller
+        // passing their own id could cancel any request in the tenant. Cancelling an approved one
+        // restores the days to the owner's balance and wipes their leave.
+        callerIsAPlainMember();
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesApprovedRequest()));
+
+        assertThatThrownBy(() -> service().cancelRequest(REQUEST_ID, "no longer needed"))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(requestRepository, never()).save(any());
+    }
+
+    @Test
+    void updateRequest_isRefused_onSomebodyElsesRequest() {
+        callerIsAPlainMember();
+        LeaveRequest draft = colleaguesApprovedRequest();
+        draft.setStatus(LeaveStatus.DRAFT);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> service().updateRequest(REQUEST_ID, Map.of("reason", "changed")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(requestRepository, never()).save(any());
+    }
+
+    @Test
+    void withdrawRequest_isRefused_onSomebodyElsesRequest() {
+        callerIsAPlainMember();
+        LeaveRequest pending = colleaguesApprovedRequest();
+        pending.setStatus(LeaveStatus.PENDING_APPROVAL);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> service().withdrawRequest(REQUEST_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(requestRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRequest_isRefused_onSomebodyElsesRequest() {
+        callerIsAPlainMember();
+        LeaveRequest draft = colleaguesApprovedRequest();
+        draft.setStatus(LeaveStatus.DRAFT);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> service().submitRequest(REQUEST_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(approvalService);
+    }
+
+    @Test
+    void cancelRequest_isAllowed_onYourOwnRequest() {
+        // The owner keeps the ability the fix is protecting.
+        LeaveRequest own = colleaguesApprovedRequest();
+        own.setEmployee(employee(CALLER_EMPLOYEE_ID));
+        own.setStatus(LeaveStatus.DRAFT);
+        when(orgSecurity.isSelfInCurrentTenant(CALLER_EMPLOYEE_ID)).thenReturn(true);
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(own));
+        when(requestRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThatCode(() -> service().cancelRequest(REQUEST_ID, "plans changed"))
+                .doesNotThrowAnyException();
+
+        verify(requestRepository).save(any());
+    }
+}


### PR DESCRIPTION
Found beside the OpenAPI contract check (#580 / echno-core#57), which flagged `POST /leave-requests/web` as guarded only by `isMemberOfCurrentTenant()` while taking an `employeeId`. Reading the family through settled what that allows, and it is worse than the one endpoint.

## What was reachable

**Create.** `POST /leave-requests/web` and `POST /leave-requests` were guarded by tenant membership alone and took the employee as a query parameter. Any member of a tenant could file leave in a colleague's name. The saved request carries the colleague's employee record, holds days against their balance, and enters their approval chain, so it is not a cosmetic attribution: `LeaveRequestService.createRequest` looks the employee up by the id it was handed and never asks who is calling.

**Update, submit, cancel, withdraw.** These were guarded by `isSelfInCurrentTenant(#employeeId)`, which checks the caller against an employee id the caller chose, and never against the request being acted on. `updateRequest(requestId, updates)` and its siblings load by `requestId` alone. So passing your own employee id alongside a colleague's request id passed the guard and then edited, submitted, cancelled or withdrew their request. Cancelling an approved one sets `CANCELLED`, clears the approver and restores the used days.

The UI pins every one of these to the signed-in employee, so nothing is exploitable through the product. The API is another matter, and this is the layer that has to hold.

## The fix

The employee id is an argument, not evidence. Ownership is resolved from the stored record and checked in `LeaveRequestService`, where the record is: the employee the request belongs to, or a `system-admin` / `hr-admin`, and nobody else. Create is the one call with no record to read yet, so it checks the employee it is given, which is exactly the check that was missing.

Putting it in the service rather than the annotation is deliberate. A `@PreAuthorize` on these handlers can only read what the caller sent, which is the hole itself. HR filing or cancelling on somebody's behalf stays possible, and is covered.

## The non-web controller was refusing everything

`LeaveRequestController`'s update, submit, cancel and withdraw carried `isSelfInCurrentTenant(#employeeId)` while declaring no `employeeId` parameter. SpEL resolves an undefined variable to null, so the check ran as `isSelfInCurrentTenant(null)`, found no employee and refused every call. Those four are now the tenant gate the annotation can actually evaluate, with ownership answered in the service alongside the web family's, so they work and are guarded rather than being dead and guarded by accident.

## Tests

`LeaveRequestActorAuthorizationTest`, eight cases: create for a colleague refused before anything is written, create for yourself and create by a leave admin still allowed, and update/submit/cancel/withdraw on somebody else's request refused with nothing saved, plus the owner's own cancel still going through. All eight fail with the service check removed; the five refusals fail by the action succeeding.

Full suite green on `.116`, and `docs/openapi.json` regenerated for the four changed 403 descriptions.