### PR TITLE
Watermark the compliance sweep on when a run started, not when it finished

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/ComplianceGenerationService.java
@@ -133,6 +133,27 @@ public class ComplianceGenerationService {
     private record GenerationInputs(Project project, String state, List<ComplianceRule> candidateRules) {}
 
     /**
+     * What a run would be, decided without calling the model: which jurisdiction the project
+     * falls in, and how many rules that jurisdiction has for it.
+     *
+     * <p>The jurisdiction is returned as well as the count because the job row records it.
+     * A count alone says how much work a run is; the jurisdiction says what the work was
+     * about, and that is what lets the nightly sweep tell a project whose state was corrected
+     * after it was assessed from one that has not changed at all.
+     *
+     * @param state       the resolved Indian state, never null on a returned instance
+     * @param projectType the project's type, never null on a returned instance
+     * @param ruleCount   how many active rules that jurisdiction holds for this project type
+     */
+    public record CandidateRules(String state, ProjectType projectType, int ruleCount) {
+
+        /** The stored form of the jurisdiction this run covers. */
+        public String jurisdiction() {
+            return Jurisdiction.key(state, projectType);
+        }
+    }
+
+    /**
      * Generates the missing compliance inspections for a project. Returns the DTOs of
      * the rows created by this call; the list is empty in the genuine "generation ran
      * but nothing applied" cases (the AI found no applicable rule, or every applicable
@@ -166,9 +187,9 @@ public class ComplianceGenerationService {
      * job the user has to go and read. Only failures that genuinely need the model reach the
      * caller as a failed job.
      *
-     * @return how many candidate rules a run would assess
+     * @return the jurisdiction a run would assess under and how many candidate rules it holds
      */
-    public int validateAndCountCandidateRules(Long projectId, Long orgId) {
+    public CandidateRules validateAndCountCandidateRules(Long projectId, Long orgId) {
         GenerationInputs inputs = retryTemplate.execute(
                 "ComplianceGenerationService.loadInputs", () -> loadInputs(projectId, orgId));
         if (!complianceAiService.isConfigured()) {
@@ -176,7 +197,8 @@ public class ComplianceGenerationService {
                     "The compliance AI service is not configured, so suggestions cannot be "
                             + "generated. Set the compliance AI key and try again.");
         }
-        return inputs.candidateRules().size();
+        return new CandidateRules(inputs.state(), inputs.project().getProjectType(),
+                inputs.candidateRules().size());
     }
 
     /** How many model calls a run over {@code ruleCount} rules takes at the configured batch size. */

--- a/src/main/java/org/tornotron/echno_backend/compliance/Jurisdiction.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/Jurisdiction.java
@@ -1,0 +1,42 @@
+package org.tornotron.echno_backend.compliance;
+
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.util.Locale;
+
+/**
+ * The pair that decides which rules apply to a project: its state and its type.
+ *
+ * <p>There is one string form of that pair and it is built here, because two separate places
+ * need it and they must agree. The sweep groups the rule catalogue by it, and every generation
+ * job records the one it was accepted for, so that the sweep can tell a project reassessed
+ * under a different jurisdiction from one that has simply not changed. Two hand-rolled key
+ * builders that drifted apart would make every project look reassessed under a new
+ * jurisdiction, which is a silent bill rather than a visible bug.
+ *
+ * <p>The state is lower-cased because the rule query matches it case-insensitively, so
+ * {@code Tamil Nadu} and {@code TAMIL NADU} are the same jurisdiction and must produce the
+ * same key. The type is not, because it is an enum constant and its case is fixed.
+ */
+public final class Jurisdiction {
+
+    /** Column width for the stored form; well clear of the longest state name plus a type. */
+    public static final int MAX_LENGTH = 120;
+
+    private Jurisdiction() {
+    }
+
+    /**
+     * The key for one jurisdiction, or null if either half is missing.
+     *
+     * <p>Null rather than a partial key on purpose: a project whose state cannot be resolved
+     * has no jurisdiction at all, and giving it a key would let it compare equal to another
+     * project in the same predicament.
+     */
+    public static String key(String state, ProjectType projectType) {
+        if (state == null || state.isBlank() || projectType == null) {
+            return null;
+        }
+        return state.trim().toLowerCase(Locale.ROOT) + "|" + projectType.name();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJob.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJob.java
@@ -99,6 +99,31 @@ public class ComplianceGenerationJob implements TenantScopedEntity {
     @Column(name = "rules_total", nullable = false)
     private int rulesTotal;
 
+    /**
+     * Which jurisdiction the run was accepted for, in the form
+     * {@link org.tornotron.echno_backend.compliance.Jurisdiction#key}: the project's state and
+     * type at accept time.
+     *
+     * <p>Recorded because "when was this project last assessed" is not on its own enough to
+     * decide whether it still is. A project assessed under one state and then corrected to
+     * another has an assessment that covers nothing it is now subject to, and comparing its
+     * timestamp against the new jurisdiction's newest rule can perfectly well say it is up to
+     * date. The sweep therefore compares the jurisdiction as well as the timestamp, and this
+     * is the column that lets it.
+     *
+     * <p>Accept time rather than run time, for the same reason {@link #rulesTotal} is: the row
+     * describes what was accepted. If the project's state is changed in the gap between accept
+     * and run, this says the old jurisdiction while the run covers the new one, and the sweep
+     * then sees a mismatch and queues one more run than it needed to. That is the harmless
+     * direction, and generation is idempotent per rule, so the extra run creates nothing.
+     *
+     * <p>Null on every row written before the column existed, and null is read as "not known",
+     * which falls back to the timestamp comparison alone rather than declaring the whole
+     * backlog stale.
+     */
+    @Column(name = "jurisdiction", length = 120)
+    private String jurisdiction;
+
     /** Rules the model has come back on so far. Only ever moves forward within an attempt. */
     @Column(name = "rules_assessed", nullable = false)
     private int rulesAssessed;

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobRepository.java
@@ -180,48 +180,109 @@ public interface ComplianceGenerationJobRepository extends JpaRepository<Complia
     Optional<DispatchRow> findDispatchRow(@Param("id") UUID id);
 
     /**
-     * Approved projects across every tenant, each with the last time compliance was actually
-     * assessed for it. The nightly sweep's one scan.
+     * Approved projects across every tenant, each with what the sweep needs to decide whether
+     * it is still up to date. The nightly sweep's one scan.
      *
      * <p>Cross-tenant and scalars only, for the same reason the dispatcher queries above are:
      * the caller has no tenant, because its whole job is to work out which tenants have
      * something to do. It establishes one per project before anything is enqueued.
      *
-     * <p>"Assessed" means a run that reached the model and came back, which is {@code SUCCEEDED}
-     * or {@code NOTHING_TO_REPORT}. The second of those matters: a run that assessed every rule
-     * and found none applicable did the work, and treating it as never-assessed would put the
-     * project back in the queue every night for ever. {@code FAILED} deliberately does not
-     * count, because a failed run assessed nothing, and {@code QUEUED} and {@code RUNNING} do
-     * not count because they have not finished; a project with one in flight is filtered out
-     * later by the job table's own one-active-job-per-project index, not here.
+     * <h2>The watermark is the run's start, not its finish</h2>
+     *
+     * <p>{@code lastAssessedAt} is the {@code started_at} of the newest run that succeeded,
+     * and the difference from {@code finished_at} is a rule that would otherwise be skipped
+     * for ever. A run reads the rule catalogue once, at the top, and then spends minutes in
+     * the model. A rule written during those minutes is not in that snapshot and cannot be,
+     * but its {@code effective_from} is earlier than the moment the run finished, so a sweep
+     * watermarked on {@code finished_at} reads the project as covering a rule no run has ever
+     * looked at, on that pass and on every pass after it. Watermarking on the start says only
+     * what the run can actually vouch for: everything in force when it began. Anything dated
+     * after that is compared honestly, and the cost of the change is at most one extra run per
+     * project, which creates nothing because generation is idempotent per rule.
+     *
+     * <p>The same reasoning covers the retried job. {@code started_at} is written with
+     * {@code COALESCE(started_at, ...)} by the claim, so it keeps the first attempt's start
+     * across a requeue, and an earlier watermark can only over-trigger.
+     *
+     * <p>"Assessed" still means a run that reached the model and came back, which is
+     * {@code SUCCEEDED} or {@code NOTHING_TO_REPORT}. The second of those matters: a run that
+     * assessed every rule and found none applicable did the work, and treating it as
+     * never-assessed would put the project back in the queue every night for ever.
+     * {@code FAILED} deliberately does not count, so a run that started, spent minutes and
+     * then failed marks nothing as assessed; {@code QUEUED} and {@code RUNNING} do not count
+     * because they have not finished, and a project with one in flight is filtered out later
+     * by the job table's own one-active-job-per-project index, not here.
      *
      * <p>A null {@code lastAssessedAt} is a project that has never had a completed run at all,
      * which is exactly the backlog this exists for: everything approved before generation was
-     * wired up, and everything whose approval-time run failed silently. Ordering nulls first
-     * puts that backlog at the front of a capped pass.
+     * wired up, and everything whose approval-time run failed silently.
      *
-     * <p>The project's jurisdiction is returned raw rather than matched here. Resolving a state
-     * from a free-text address is Java, so the comparison against the rule catalogue happens in
-     * the caller; this query's job is only to bound what the caller looks at.
+     * <h2>The jurisdiction that run covered</h2>
+     *
+     * <p>{@code lastAssessedJurisdiction} comes off the same row as the watermark, so the two
+     * describe one run rather than two. Without it, a project assessed under one state and
+     * then corrected to another compares its old timestamp against the new state's newest
+     * rule, and if that state's rules predate the assessment the project reads as up to date
+     * with an empty compliance list, permanently. It is null for every run recorded before the
+     * column existed, and the caller reads that null as "not known" rather than as a change.
+     *
+     * <h2>Ordering is by last attempt, not last success</h2>
+     *
+     * <p>{@code ORDER BY} runs on the newest terminal run of any kind, failures included,
+     * which is not the same as the watermark and is deliberately so. A project that fails
+     * every night neither counts as assessed nor blocks its own resubmission, so ordering by
+     * success alone leaves it permanently at the front of the queue: twenty-five such projects
+     * consume the whole per-run cap every night and nothing behind them is ever reached. Being
+     * attempted is enough to move a project down the list, so a pass always reaches new work,
+     * and a project that keeps failing is retried once a pass instead of monopolising it.
      */
     @Query(value = "SELECT p.id AS \"projectId\", "
             + "p.organization_id AS \"organizationId\", "
             + "p.project_state AS \"projectState\", "
             + "p.project_address AS \"projectAddress\", "
             + "p.project_type AS \"projectType\", "
-            + "j.last_finished_at AS \"lastAssessedAt\" "
+            + "a.started_at AS \"lastAssessedAt\", "
+            + "a.jurisdiction AS \"lastAssessedJurisdiction\", "
+            + "t.last_attempt_at AS \"lastAttemptAt\" "
             + "FROM project p "
-            + "LEFT JOIN (SELECT project_id, organization_id, max(finished_at) AS last_finished_at "
+            + "LEFT JOIN (SELECT DISTINCT ON (organization_id, project_id) "
+            + "                  organization_id, project_id, started_at, jurisdiction "
             + "           FROM compliance_generation_jobs "
             + "           WHERE status IN ('SUCCEEDED', 'NOTHING_TO_REPORT') "
-            + "           GROUP BY project_id, organization_id) j "
-            + "  ON j.project_id = p.id AND j.organization_id = p.organization_id "
+            + "           ORDER BY organization_id, project_id, started_at DESC NULLS LAST) a "
+            + "  ON a.project_id = p.id AND a.organization_id = p.organization_id "
+            + "LEFT JOIN (SELECT project_id, organization_id, max(finished_at) AS last_attempt_at "
+            + "           FROM compliance_generation_jobs "
+            + "           WHERE status IN ('SUCCEEDED', 'NOTHING_TO_REPORT', 'FAILED') "
+            + "           GROUP BY project_id, organization_id) t "
+            + "  ON t.project_id = p.id AND t.organization_id = p.organization_id "
             + "WHERE p.status = 'approved' "
             + "  AND p.organization_id IS NOT NULL "
             + "  AND p.project_type IS NOT NULL "
-            + "ORDER BY j.last_finished_at ASC NULLS FIRST, p.id ASC "
+            + "ORDER BY t.last_attempt_at ASC NULLS FIRST, p.id ASC "
             + "LIMIT :limit", nativeQuery = true)
     List<SweepCandidate> findSweepCandidates(@Param("limit") int limit);
+
+    /**
+     * How many generation jobs have been created since a moment, across every tenant.
+     *
+     * <p>The sweep's per-run cap is a cap on spend, and {@code @Scheduled} has no leader
+     * election, so on N replicas the same pass runs N times and a cap counted in memory is
+     * really N times the configured number. Counting the rows instead makes the budget one
+     * that every replica reads: whichever replica enqueues first is visible to the others
+     * before they have got far, and the overshoot falls from a whole cap per replica to
+     * roughly one project per replica, since a replica can only overshoot by the submits it
+     * makes between two counts. It is not mutual exclusion and does not pretend to be; it is
+     * the bound that costs one small count query per submit rather than a coordination
+     * protocol.
+     *
+     * <p>It counts every job created in the window, not only the sweep's own. That is the
+     * right reading of a spend cap: a run queued by an approval during the sweep costs the
+     * same inference as one the sweep queued.
+     */
+    @Query(value = "SELECT count(*) FROM compliance_generation_jobs WHERE created_at >= :since",
+            nativeQuery = true)
+    long countCreatedSince(@Param("since") LocalDateTime since);
 
     /** One approved project the sweep has to decide about. */
     interface SweepCandidate {
@@ -235,7 +296,23 @@ public interface ComplianceGenerationJobRepository extends JpaRepository<Complia
 
         String getProjectType();
 
+        /**
+         * When the newest successful run for this project started, or null if there has never
+         * been one. The start rather than the finish; see the query.
+         */
         LocalDateTime getLastAssessedAt();
+
+        /**
+         * The jurisdiction that run was accepted for, or null if it is not recorded (every run
+         * from before the column existed).
+         */
+        String getLastAssessedJurisdiction();
+
+        /**
+         * When the newest terminal run of any kind finished, failures included. Ordering only;
+         * it is never compared against the rule catalogue.
+         */
+        LocalDateTime getLastAttemptAt();
     }
 
     /** What a worker needs off a claimed row before it can establish the tenant and start. */

--- a/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobService.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobService.java
@@ -61,7 +61,9 @@ public class ComplianceGenerationJobService {
      *         or the configuration cannot support a run, with the fix in the message
      */
     public Accepted submit(Long projectId, Long orgId) {
-        int ruleCount = complianceGenerationService.validateAndCountCandidateRules(projectId, orgId);
+        ComplianceGenerationService.CandidateRules candidates =
+                complianceGenerationService.validateAndCountCandidateRules(projectId, orgId);
+        int ruleCount = candidates.ruleCount();
         int batches = complianceGenerationService.batchCount(ruleCount);
 
         Optional<ComplianceGenerationJob> running = retryTemplate.execute(
@@ -74,7 +76,7 @@ public class ComplianceGenerationJobService {
         try {
             ComplianceGenerationJob job = retryTemplate.execute(
                     "ComplianceGenerationJobService.submit",
-                    () -> insert(projectId, ruleCount, batches));
+                    () -> insert(projectId, candidates, batches));
             log.info("Accepted compliance generation job {} for project {} in organization {} "
                             + "({} rule(s) over {} batch(es))",
                     job.getId(), projectId, orgId, ruleCount, batches);
@@ -113,12 +115,15 @@ public class ComplianceGenerationJobService {
         return latest.stream().findFirst().map(ComplianceGenerationJobDto::from);
     }
 
-    private ComplianceGenerationJob insert(Long projectId, int ruleCount, int batches) {
+    private ComplianceGenerationJob insert(Long projectId,
+                                           ComplianceGenerationService.CandidateRules candidates,
+                                           int batches) {
         ComplianceGenerationJob job = new ComplianceGenerationJob();
         job.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
         job.setProjectId(projectId);
         job.setStatus(ComplianceJobStatus.QUEUED);
-        job.setRulesTotal(ruleCount);
+        job.setRulesTotal(candidates.ruleCount());
+        job.setJurisdiction(candidates.jurisdiction());
         job.setBatchesTotal(batches);
         job.setMaxAttempts(Math.max(1, jobProperties.getMaxAttempts()));
         return jobRepository.save(job);

--- a/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweep.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweep.java
@@ -11,6 +11,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
 import org.tornotron.echno_backend.common.multitenancy.WithoutTenant;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.compliance.IndianStateResolver;
+import org.tornotron.echno_backend.compliance.Jurisdiction;
 import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
 import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
 import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
@@ -19,7 +20,6 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -38,9 +38,34 @@ import java.util.Map;
  *
  * <h2>What makes a project stale</h2>
  *
- * <p>One comparison: the newest {@code effectiveFrom} among the active rules for the project's
- * jurisdiction, against the last time a run for that project actually finished. Never assessed
- * is stale by definition.
+ * <p>Two comparisons, and both have to say the project is covered before it is left alone.
+ * The newest {@code effectiveFrom} among the active rules for the project's jurisdiction,
+ * against the moment the last successful run for that project <em>started</em>; and the
+ * jurisdiction that run was accepted for, against the one the project is in now. Never
+ * assessed is stale by definition.
+ *
+ * <p>The watermark is the run's start rather than its finish, and that is the difference
+ * between a sweep that catches up and one that can lose a rule for good. A run snapshots the
+ * catalogue once and then spends minutes in the model, so a rule written during those minutes
+ * is not in the snapshot and cannot be; but its {@code effectiveFrom} is still earlier than
+ * the moment that run finished. Watermarked on the finish, the project reads as covering a
+ * rule nothing ever assessed it against, on that pass and on every pass after it, which is
+ * precisely the miss this class exists to prevent. Watermarked on the start, the run vouches
+ * only for what was in force when it began. It over-triggers by at most one run per project
+ * and that run creates nothing, because generation is idempotent per rule.
+ *
+ * <p>The jurisdiction is compared for the same kind of reason. A project assessed under Tamil
+ * Nadu and later corrected to Kerala has an assessment that covers none of the rules it is now
+ * subject to, and if Kerala's rules predate that assessment the timestamps alone say it is up
+ * to date. Its compliance list would then be empty for ever.
+ *
+ * <p>One gap is left open knowingly. A rule <em>back-dated</em> below a project's watermark is
+ * invisible to this whenever it is written, in flight or not, because {@code effectiveFrom} is
+ * the only input and the sweep cannot distinguish a rule that was always there from one that
+ * appeared today claiming it was. That is a property of keying on the curated date rather than
+ * on {@code createdAt}, which is a deliberate choice made in the design (see below), and the
+ * remedy is a curatorial one: date a rule from when it starts applying to projects, not from
+ * whatever historical date it was published.
  *
  * <p>{@code effectiveFrom} rather than {@code updatedAt} is the entire design of this. The two
  * are easy to conflate and the difference is the difference between a sweep that costs almost
@@ -68,8 +93,23 @@ import java.util.Map;
  * in flight against the inference endpoint, so a pass that queues 25 jobs produces a queue that
  * drains two at a time, not 25 simultaneous calls to a rate-limited endpoint. On top of that
  * this pass bounds both what it reads ({@code scanLimit}) and what it spends
- * ({@code maxProjectsPerRun}), and takes candidates oldest-assessed first so a capped pass
- * still makes deterministic progress and the next one continues behind it.
+ * ({@code maxProjectsPerRun}), and takes candidates least-recently-attempted first so a capped
+ * pass still makes deterministic progress and the next one continues behind it.
+ *
+ * <p>Least-recently-<em>attempted</em>, not least-recently-assessed. A failed run counts as
+ * neither an assessment nor a reason to stop resubmitting, so ordering on success alone parks
+ * a project that fails every night permanently at the front of the list, where twenty-five
+ * such projects eat the whole cap and nothing behind them is ever reached. Having been tried
+ * is enough to move a project down.
+ *
+ * <p>The spend cap is read from the job table rather than counted in memory, because
+ * {@code @Scheduled} elects no leader: on N replicas this pass runs N times, and a cap held in
+ * a local variable is really N caps. Counting the rows created since the pass began makes the
+ * budget one that all N replicas share. It is not mutual exclusion, and the honest statement
+ * of what it buys is that the overshoot falls from a whole cap per replica to about one
+ * project per replica, being what a replica can submit between two counts. Anything tighter
+ * than that is a coordination protocol, and none is worth writing for a nightly job whose
+ * work is idempotent.
  *
  * <h2>Off by default</h2>
  *
@@ -125,6 +165,8 @@ public class ComplianceRuleSweep {
      * waiting on a cron.
      */
     void runPass() {
+        LocalDateTime passStartedAt = LocalDateTime.now();
+
         Map<String, LocalDateTime> newestByJurisdiction = loadJurisdictionChanges();
         if (newestByJurisdiction.isEmpty()) {
             log.debug("Compliance sweep found no active rules; nothing to compare projects against");
@@ -142,24 +184,30 @@ public class ComplianceRuleSweep {
         int upToDate = 0;
 
         for (ComplianceGenerationJobRepository.SweepCandidate candidate : candidates) {
-            if (enqueued >= cap) {
-                log.info("Compliance sweep stopped at its per-run cap of {} project(s); the rest "
-                        + "are picked up by the next pass", cap);
-                break;
-            }
-
-            LocalDateTime newest = newestFor(candidate, newestByJurisdiction);
-            if (newest == null) {
-                // No jurisdiction we could resolve, or no active rules for it. Generation would
-                // refuse this project anyway, so there is nothing to queue.
+            String jurisdiction = jurisdictionOf(candidate);
+            if (jurisdiction == null) {
+                // No jurisdiction we could resolve. Generation would refuse this project
+                // anyway, so there is nothing to queue.
                 notAssessable++;
                 continue;
             }
 
-            LocalDateTime lastAssessed = candidate.getLastAssessedAt();
-            if (lastAssessed != null && !newest.isAfter(lastAssessed)) {
+            LocalDateTime newest = newestByJurisdiction.get(jurisdiction);
+            if (newest == null) {
+                // No active rules registered for it, so again nothing a run could assess.
+                notAssessable++;
+                continue;
+            }
+
+            if (isCovered(candidate, jurisdiction, newest)) {
                 upToDate++;
                 continue;
+            }
+
+            if (!withinBudget(cap, enqueued, passStartedAt)) {
+                log.info("Compliance sweep stopped at its per-run cap of {} project(s); the rest "
+                        + "are picked up by the next pass", cap);
+                break;
             }
 
             switch (submit(candidate)) {
@@ -172,6 +220,57 @@ public class ComplianceRuleSweep {
         log.info("Compliance sweep looked at {} approved project(s): queued {}, {} already running, "
                         + "{} up to date, {} not assessable yet",
                 candidates.size(), enqueued, alreadyRunning, upToDate, notAssessable);
+    }
+
+    /**
+     * Whether the last successful run for this project already covers everything in force.
+     *
+     * <p>Both halves have to hold. The run has to have started after the newest rule in the
+     * jurisdiction came into force, and it has to have been a run in <em>this</em>
+     * jurisdiction. A run whose jurisdiction was not recorded, which is every run from before
+     * that column existed, is taken at its timestamp alone rather than treated as a change, so
+     * turning this on does not re-assess the entire estate on the first pass.
+     *
+     * <p>The equality boundary falls on the side of covered: a rule that came into force at
+     * the exact instant a run started was in that run's snapshot, since the snapshot is read
+     * after the run is claimed. It has to fall one way or the other, and falling this way
+     * means a rule and a run written in the same instant do not requeue the project nightly
+     * with nothing to add.
+     */
+    private boolean isCovered(ComplianceGenerationJobRepository.SweepCandidate candidate,
+                              String jurisdiction,
+                              LocalDateTime newest) {
+        LocalDateTime lastAssessed = candidate.getLastAssessedAt();
+        if (lastAssessed == null) {
+            return false;
+        }
+
+        String assessedJurisdiction = candidate.getLastAssessedJurisdiction();
+        if (assessedJurisdiction != null && !assessedJurisdiction.equals(jurisdiction)) {
+            log.debug("Compliance sweep sees project {} moved from jurisdiction {} to {}; its "
+                            + "last assessment covers rules it is no longer subject to",
+                    candidate.getProjectId(), assessedJurisdiction, jurisdiction);
+            return false;
+        }
+
+        return !newest.isAfter(lastAssessed);
+    }
+
+    /**
+     * Whether this pass may still enqueue, counting what every replica has enqueued rather
+     * than only what this one has.
+     *
+     * <p>The local count is kept in the comparison as well as the shared one so the cap still
+     * means something to a caller holding a repository that reports nothing, and because the
+     * shared count cannot be lower than what this replica has itself inserted in any case.
+     */
+    private boolean withinBudget(int cap, int enqueuedHere, LocalDateTime passStartedAt) {
+        if (enqueuedHere >= cap) {
+            return false;
+        }
+        long queuedAnywhere = retryTemplate.execute("ComplianceRuleSweep.countCreatedSince",
+                () -> jobRepository.countCreatedSince(passStartedAt));
+        return Math.max(enqueuedHere, queuedAnywhere) < cap;
     }
 
     /** What happened to one candidate. */
@@ -224,7 +323,7 @@ public class ComplianceRuleSweep {
                     || change.getNewestEffectiveFrom() == null) {
                 continue;
             }
-            byJurisdiction.merge(key(change.getState(), change.getProjectType()),
+            byJurisdiction.merge(Jurisdiction.key(change.getState(), change.getProjectType()),
                     change.getNewestEffectiveFrom(),
                     (a, b) -> a.isAfter(b) ? a : b);
         }
@@ -232,27 +331,16 @@ public class ComplianceRuleSweep {
     }
 
     /**
-     * The newest applicable rule change for one project, or null if it has no jurisdiction we
-     * can resolve or no active rules in it.
+     * The jurisdiction one project is in now, or null if it has none we can resolve.
      *
      * <p>The state is resolved exactly as generation resolves it, including the free-text
      * address fallback, so the sweep cannot decide a project is stale on a jurisdiction that
      * generation would then refuse to use.
      */
-    private LocalDateTime newestFor(ComplianceGenerationJobRepository.SweepCandidate candidate,
-                                    Map<String, LocalDateTime> newestByJurisdiction) {
+    private String jurisdictionOf(ComplianceGenerationJobRepository.SweepCandidate candidate) {
         String state = IndianStateResolver.forProject(
                 candidate.getProjectState(), candidate.getProjectAddress());
-        if (state == null) {
-            return null;
-        }
-
-        ProjectType projectType = parseProjectType(candidate.getProjectType());
-        if (projectType == null) {
-            return null;
-        }
-
-        return newestByJurisdiction.get(key(state, projectType));
+        return Jurisdiction.key(state, parseProjectType(candidate.getProjectType()));
     }
 
     /**
@@ -271,9 +359,5 @@ public class ComplianceRuleSweep {
                     value);
             return null;
         }
-    }
-
-    private String key(String state, ProjectType projectType) {
-        return state.toLowerCase(Locale.ROOT) + "|" + projectType.name();
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceSweepProperties.java
+++ b/src/main/java/org/tornotron/echno_backend/compliance/sweep/ComplianceSweepProperties.java
@@ -48,8 +48,10 @@ public class ComplianceSweepProperties {
      * <p>This bounds the scan, not the spend. It exists because the query runs across every
      * tenant with no organization filter, and an unbounded scan of every approved project in
      * the database is the kind of query that is fine at today's 29 projects and is not fine
-     * later. Candidates come back oldest-assessed first, so a pass that hits this ceiling
-     * still makes deterministic progress and the next one continues from where it left off.
+     * later. Candidates come back least-recently-attempted first, so a pass that hits this
+     * ceiling still makes deterministic progress and the next one continues from where it left
+     * off, and a project that fails every night sinks down the list instead of holding the
+     * front of it.
      */
     private int scanLimit = 500;
 
@@ -63,6 +65,11 @@ public class ComplianceSweepProperties {
      * the measured 1.7 seconds and 57 completion tokens per rule, 25 projects over a 21-rule
      * catalogue is about nine minutes of wall clock at the default two in flight, and it is
      * the number to raise once someone has looked at a real bill.
+     *
+     * <p>It is counted from the job table rather than in memory, so it is one budget shared by
+     * every replica rather than one each. That is a bound and not a lock: two replicas that
+     * start a pass in the same second can both submit before either sees the other, so the
+     * real ceiling is this number plus roughly one project per replica.
      */
     private int maxProjectsPerRun = 25;
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -346,4 +346,7 @@
     <!-- v4.0 - Employees: drop the unwritten is_manager flag; the org role is the answer -->
     <include file="db/changelog/v4.0/070-drop-employee-is-manager.xml"/>
 
+    <!-- v4.0 - Compliance jobs: which jurisdiction a run was accepted for -->
+    <include file="db/changelog/v4.0/071-add-compliance-job-jurisdiction.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/071-add-compliance-job-jurisdiction.xml
+++ b/src/main/resources/db/changelog/v4.0/071-add-compliance-job-jurisdiction.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="071-add-compliance-job-jurisdiction" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="compliance_generation_jobs" columnName="jurisdiction"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            A generation job recorded how much work it was (rules_total) but not what the work
+            was about. That is enough to answer "when was this project last assessed" and not
+            enough to answer "is that assessment still the right one".
+
+            The case it gets wrong: a project assessed under Tamil Nadu whose state is later
+            corrected to Kerala. Its timestamp is recent, so the nightly sweep compares it
+            against Kerala's newest rule, finds those rules older, and reads the project as up
+            to date. Nothing is ever generated for the state it is actually in, and the symptom
+            is an empty compliance list nobody can explain.
+
+            The value is the pair the rule query matches on, lower-cased state and project type,
+            joined by a pipe: "tamil nadu|RESIDENTIAL". One column rather than two because it is
+            compared whole and never filtered on either half, and lower-cased at the point of
+            writing because the rule lookup is case-insensitive and two spellings of one state
+            must not read as two jurisdictions.
+
+            Nullable, and deliberately not backfilled. There is no honest value for a run that
+            happened before this was recorded: the project's state today is not evidence of what
+            it was assessed under. The sweep reads null as "not known" and falls back to the
+            timestamp alone, which is what it did before this column existed. Backfilling from
+            the project instead would assert a fact we do not have, and defaulting it to
+            anything would make every historical run look like a jurisdiction change and queue
+            an inference call for every approved project in every tenant on the first pass.
+        </comment>
+
+        <addColumn tableName="compliance_generation_jobs">
+            <column name="jurisdiction" type="VARCHAR(120)"/>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="compliance_generation_jobs" columnName="jurisdiction"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/ComplianceGenerationServiceIT.java
@@ -16,6 +16,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -24,6 +26,12 @@ import org.tornotron.echno_backend.common.retry.SqlStateDetector;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.common.retry.TransactionalWorkRunner;
 import org.tornotron.echno_backend.compliance.ai.OpenAiCompatibleComplianceService;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedJobRunner;
+import org.tornotron.echno_backend.compliance.domain.ComplianceRule;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobDto;
+import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobService;
+import org.tornotron.echno_backend.compliance.sweep.ComplianceRuleSweep;
+import org.tornotron.echno_backend.compliance.sweep.ComplianceSweepProperties;
 import org.tornotron.echno_backend.compliance.job.ComplianceGenerationJobRepository;
 import org.tornotron.echno_backend.compliance.job.ComplianceJobStatus;
 import org.tornotron.echno_backend.compliance.repository.ComplianceRuleRepository;
@@ -41,6 +49,7 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.List;
 import java.util.UUID;
 
@@ -48,6 +57,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,6 +112,9 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     @Autowired
     private ComplianceRuleRepository ruleRepository;
 
+    @Autowired
+    private TransactionRetryTemplate retryTemplate;
+
     private Long orgAId;
     private Long projectId;
 
@@ -147,6 +163,9 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
         // Committed seed rows survive the rollback; remove them by hand. The global
         // compliance_rules seed is left intact (it is shared reference data).
         inCommittedTx(() -> {
+            entityManager.createNativeQuery(
+                            "DELETE FROM compliance_rules WHERE code LIKE 'IT-RACE-%'")
+                    .executeUpdate();
             entityManager.createNativeQuery(
                             "DELETE FROM compliance_generation_jobs WHERE organization_id = :org")
                     .setParameter("org", orgAId).executeUpdate();
@@ -431,6 +450,25 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     }
 
     /**
+     * And it counts it from when it started, which is the only moment it can honestly vouch
+     * for. A run reads the rule catalogue once and then spends minutes in the model, so
+     * everything it knows about was in force at the start; a rule written during those minutes
+     * is older than the finish and yet was never assessed.
+     */
+    @Test
+    void countsASucceededRunFromWhenItStartedNotWhenItFinished() {
+        LocalDateTime finishedAt = LocalDateTime.now().withNano(0);
+        LocalDateTime startedAt = finishedAt.minusMinutes(5);
+        inCommittedTx(() -> insertFinishedJob(projectId, ComplianceJobStatus.SUCCEEDED,
+                startedAt, finishedAt, "tamil nadu|RESIDENTIAL"));
+
+        ComplianceGenerationJobRepository.SweepCandidate candidate = sweepCandidateForSeededProject();
+
+        assertThat(candidate.getLastAssessedAt()).isEqualTo(startedAt);
+        assertThat(candidate.getLastAssessedJurisdiction()).isEqualTo("tamil nadu|RESIDENTIAL");
+    }
+
+    /**
      * A failed run assessed nothing, so it must not make the project look done. A project whose
      * only run failed belongs in the backlog, which is where the sweep will find it.
      */
@@ -454,6 +492,132 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
         assertThat(sweepCandidateForSeededProject().getLastAssessedAt()).isNotNull();
     }
 
+    /**
+     * The race the watermark exists to survive, run rather than described.
+     *
+     * <p>The project has a run in flight: claimed, so its start is on the row, and not yet
+     * finished. The run reads the catalogue and hands it to the model, and it is while the
+     * model is answering that a rule is written for the project's jurisdiction. Nothing about
+     * that rule can reach this run, because the snapshot was taken before it existed, and the
+     * run then finishes and writes a {@code finished_at} later than the rule's
+     * {@code effective_from}. Watermarked on the finish, the sweep reads the project as
+     * covering a rule nothing has ever assessed it against, and does so on every pass after
+     * this one as well: the rule is lost, not delayed.
+     *
+     * <p>The three timestamps are asserted before the sweep runs, so a change that stopped
+     * producing the race would fail here rather than quietly turn this into a test of nothing.
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void queuesAProjectForARuleWrittenWhileItsLastRunWasStillGoing() {
+        UUID jobId = UUID.randomUUID();
+        inCommittedTx(() -> {
+            entityManager.createNativeQuery(
+                            "INSERT INTO compliance_generation_jobs (id, organization_id, project_id, "
+                                    + "status, rules_total, rules_assessed, batches_total, batches_done, "
+                                    + "created_count, attempt, max_attempts, jurisdiction, created_at, "
+                                    + "updated_at) VALUES (:id, :org, :project, 'QUEUED', 6, 0, 1, 0, 0, "
+                                    + "0, 3, 'tamil nadu|RESIDENTIAL', now()::timestamp, now()::timestamp)")
+                    .setParameter("id", jobId)
+                    .setParameter("org", orgAId)
+                    .setParameter("project", projectId)
+                    .executeUpdate();
+            LocalDateTime claimedAt = LocalDateTime.now();
+            jobRepository.claim(jobId, "replica-a", claimedAt.plusMinutes(5), claimedAt);
+        });
+
+        // The curator writes the rule while the model is answering. loadInputs has already
+        // run by the time this stub is called, so the rule cannot be in the run's snapshot.
+        AtomicReference<ComplianceRule> writtenMidRun = new AtomicReference<>();
+        when(complianceAiService.suggestCompliances(
+                any(Project.class), anyString(), any(), any(ComplianceGenerationProgress.class)))
+                .thenAnswer(call -> {
+                    inCommittedTx(() -> writtenMidRun.set(insertRuleInForceNow("IT-RACE-1")));
+                    return List.of(new ComplianceSuggestion(RULE_PRE, true, "critical",
+                            List.of("Obtain the building plan approval"), "Required before work starts",
+                            "pre-construction"));
+                });
+
+        TenantContext.setCurrentOrgId(orgAId);
+        service.generateForProject(projectId, orgAId);
+        LocalDateTime finishedAt = LocalDateTime.now();
+        inCommittedTx(() -> entityManager.createNativeQuery(
+                        "UPDATE compliance_generation_jobs SET status = 'SUCCEEDED', "
+                                + "finished_at = :finishedAt, updated_at = :finishedAt WHERE id = :id")
+                .setParameter("id", jobId)
+                .setParameter("finishedAt", finishedAt)
+                .executeUpdate());
+
+        ComplianceGenerationJobRepository.SweepCandidate candidate = sweepCandidateForSeededProject();
+        LocalDateTime effectiveFrom = writtenMidRun.get().getEffectiveFrom();
+        assertThat(candidate.getLastAssessedAt())
+                .as("the run has to have started before the rule was written, or there is no race "
+                        + "here to survive")
+                .isBefore(effectiveFrom);
+        assertThat(effectiveFrom)
+                .as("and the rule has to have been written before the run finished, which is what "
+                        + "makes a finished_at watermark hide it")
+                .isBefore(finishedAt);
+
+        ComplianceGenerationJobService jobService = sweepWith(unboundedSweep());
+
+        verify(jobService).submit(projectId, orgAId);
+    }
+
+    /**
+     * The jurisdiction half of the same guarantee. A project assessed under one state and then
+     * corrected to another has a recent, successful assessment covering rules it is no longer
+     * subject to, and every rule in the state it is actually in predates that assessment. On
+     * timestamps alone it reads as up to date and its compliance list stays empty for ever.
+     */
+    @Test
+    void queuesAProjectWhoseStateWasCorrectedAfterItWasAssessed() {
+        LocalDateTime finishedAt = LocalDateTime.now().withNano(0);
+        inCommittedTx(() -> insertFinishedJob(projectId, ComplianceJobStatus.SUCCEEDED,
+                finishedAt.minusMinutes(5), finishedAt, "kerala|RESIDENTIAL"));
+
+        ComplianceGenerationJobService jobService = sweepWith(unboundedSweep());
+
+        verify(jobService).submit(projectId, orgAId);
+    }
+
+    /**
+     * Ordering, which is what decides whether a capped pass ever reaches new work. A project
+     * that fails every night is not assessed and does not block its own resubmission, so
+     * ordering on successful runs alone leaves it tied with the never-attempted backlog and,
+     * having the lower id, ahead of it. Twenty-five of those and nothing else is ever queued.
+     * Being attempted has to be enough to move it down.
+     */
+    @Test
+    void putsAProjectThatKeepsFailingBehindOneThatWasNeverTried() {
+        LocalDateTime finishedAt = LocalDateTime.now().withNano(0);
+        Long[] ids = new Long[2];
+        inCommittedTx(() -> {
+            ids[0] = persistApprovedProject("Keeps Failing");
+            ids[1] = persistApprovedProject("Never Tried");
+            insertFinishedJob(ids[0], ComplianceJobStatus.FAILED,
+                    finishedAt.minusMinutes(5), finishedAt, null);
+        });
+
+        List<Long> order = jobRepository.findSweepCandidates(500).stream()
+                .map(ComplianceGenerationJobRepository.SweepCandidate::getProjectId)
+                .filter(id -> id.equals(ids[0]) || id.equals(ids[1]))
+                .toList();
+
+        assertThat(order)
+                .as("the never-tried project comes first even though the failing one has the "
+                        + "lower id, which is the tiebreak that used to starve the pass")
+                .containsExactly(ids[1], ids[0]);
+    }
+
+    /** A pass wide enough that nothing another test left behind can crowd this one out. */
+    private ComplianceSweepProperties unboundedSweep() {
+        ComplianceSweepProperties properties = new ComplianceSweepProperties();
+        properties.setScanLimit(2000);
+        properties.setMaxProjectsPerRun(2000);
+        return properties;
+    }
+
     private ComplianceGenerationJobRepository.SweepCandidate sweepCandidateForSeededProject() {
         return jobRepository.findSweepCandidates(200).stream()
                 .filter(candidate -> projectId.equals(candidate.getProjectId()))
@@ -463,19 +627,68 @@ class ComplianceGenerationServiceIT extends AbstractIntegrationTest {
     }
 
     private void insertFinishedJob(ComplianceJobStatus status, LocalDateTime finishedAt) {
+        insertFinishedJob(projectId, status, finishedAt.minusMinutes(5), finishedAt, null);
+    }
+
+    private void insertFinishedJob(Long project,
+                                   ComplianceJobStatus status,
+                                   LocalDateTime startedAt,
+                                   LocalDateTime finishedAt,
+                                   String jurisdiction) {
         entityManager.createNativeQuery(
                         "INSERT INTO compliance_generation_jobs (id, organization_id, project_id, "
                                 + "status, rules_total, rules_assessed, batches_total, batches_done, "
-                                + "created_count, attempt, max_attempts, finished_at, created_at, "
-                                + "updated_at) VALUES "
-                                + "(:id, :org, :project, :status, 6, 6, 1, 1, 0, 1, 3, :finishedAt, "
-                                + "now()::timestamp, now()::timestamp)")
+                                + "created_count, attempt, max_attempts, started_at, finished_at, "
+                                + "jurisdiction, created_at, updated_at) VALUES "
+                                + "(:id, :org, :project, :status, 6, 6, 1, 1, 0, 1, 3, :startedAt, "
+                                + ":finishedAt, :jurisdiction, now()::timestamp, now()::timestamp)")
                 .setParameter("id", UUID.randomUUID())
                 .setParameter("org", orgAId)
-                .setParameter("project", projectId)
+                .setParameter("project", project)
                 .setParameter("status", status.name())
+                .setParameter("startedAt", startedAt)
                 .setParameter("finishedAt", finishedAt)
+                .setParameter("jurisdiction", jurisdiction)
                 .executeUpdate();
+    }
+
+    /** A second approved project in the same organization and jurisdiction. */
+    private Long persistApprovedProject(String name) {
+        Project project = new Project();
+        project.setProjectName(name);
+        project.setProjectAddress("9 Anna Salai, Chennai, Tamil Nadu, India");
+        project.setProjectType(ProjectType.RESIDENTIAL);
+        project.setStatus(ProjectCreationStatus.approved);
+        project.setOrganization(entityManager.find(Organization.class, orgAId));
+        entityManager.persist(project);
+        entityManager.flush();
+        return project.getId();
+    }
+
+    /** A rule written into the shared catalogue now, as a curator adding one would. */
+    private ComplianceRule insertRuleInForceNow(String code) {
+        ComplianceRule rule = new ComplianceRule();
+        rule.setState("Tamil Nadu");
+        rule.setProjectType(ProjectType.RESIDENTIAL);
+        rule.setPhase(CompliancePhase.PRE_CONSTRUCTION);
+        rule.setCode(code);
+        rule.setName("Rule added mid-run");
+        rule.setDescription("Written while a generation run was in flight");
+        rule.setDefaultRiskLevel(ComplianceRiskLevel.CRITICAL);
+        rule.setAuthority("Test authority");
+        rule.setActive(true);
+        rule.setEffectiveFrom(LocalDateTime.now());
+        return ruleRepository.saveAndFlush(rule);
+    }
+
+    /** The sweep, built by hand so this class needs no second application context. */
+    private ComplianceGenerationJobService sweepWith(ComplianceSweepProperties properties) {
+        ComplianceGenerationJobService jobService = mock(ComplianceGenerationJobService.class);
+        lenient().when(jobService.submit(anyLong(), anyLong())).thenReturn(
+                new ComplianceGenerationJobService.Accepted((ComplianceGenerationJobDto) null, true));
+        new ComplianceRuleSweep(ruleRepository, jobRepository, jobService,
+                new TenantScopedJobRunner(), retryTemplate, properties).sweep();
+        return jobService;
     }
 
     private UUID insertJob(ComplianceJobStatus status) {

--- a/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/job/ComplianceGenerationJobServiceTest.java
@@ -12,6 +12,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.compliance.ComplianceGenerationService;
+import org.tornotron.echno_backend.project.enums.ProjectType;
 import org.tornotron.echno_backend.organization.Organization;
 
 import java.sql.SQLException;
@@ -39,6 +40,10 @@ class ComplianceGenerationJobServiceTest {
     private static final Long ORG_ID = 7L;
     private static final Long PROJECT_ID = 42L;
 
+    /** Twenty-five active rules for one project's jurisdiction, as accept time works it out. */
+    private static final ComplianceGenerationService.CandidateRules CANDIDATES =
+            new ComplianceGenerationService.CandidateRules("Tamil Nadu", ProjectType.RESIDENTIAL, 25);
+
     @Mock
     private ComplianceGenerationJobRepository jobRepository;
     @Mock
@@ -61,7 +66,8 @@ class ComplianceGenerationJobServiceTest {
 
     @Test
     void acceptsAJobRecordingHowMuchWorkItIs() {
-        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenReturn(CANDIDATES);
         when(complianceGenerationService.batchCount(25)).thenReturn(3);
         when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
         when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
@@ -75,6 +81,10 @@ class ComplianceGenerationJobServiceTest {
         verify(jobRepository).save(saved.capture());
         assertThat(saved.getValue().getStatus()).isEqualTo(ComplianceJobStatus.QUEUED);
         assertThat(saved.getValue().getRulesTotal()).isEqualTo(25);
+        assertThat(saved.getValue().getJurisdiction())
+                .as("the row has to say what the run covers, or a later state correction cannot "
+                        + "be told from no change at all")
+                .isEqualTo("tamil nadu|RESIDENTIAL");
         assertThat(saved.getValue().getBatchesTotal())
                 .as("the caller can show a progress bar before the first batch has run")
                 .isEqualTo(3);
@@ -105,7 +115,8 @@ class ComplianceGenerationJobServiceTest {
     @Test
     void aSecondRequestJoinsTheRunAlreadyInFlight() {
         ComplianceGenerationJob running = queuedJob();
-        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenReturn(CANDIDATES);
         when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.of(running));
 
         ComplianceGenerationJobService.Accepted accepted = service.submit(PROJECT_ID, ORG_ID);
@@ -126,7 +137,8 @@ class ComplianceGenerationJobServiceTest {
     @Test
     void aRequestThatLosesTheInsertRaceReturnsTheWinnersJob() {
         ComplianceGenerationJob winner = queuedJob();
-        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenReturn(CANDIDATES);
         when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID))
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.of(winner));
@@ -148,7 +160,8 @@ class ComplianceGenerationJobServiceTest {
     void aRequestThatLosesToAJobThatHasSinceFinishedReturnsThatFinishedJob() {
         ComplianceGenerationJob finished = queuedJob();
         finished.setStatus(ComplianceJobStatus.NOTHING_TO_REPORT);
-        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenReturn(CANDIDATES);
         when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
         when(jobRepository.findLatestForProject(anyLong(), anyLong(), any(Pageable.class)))
                 .thenReturn(List.of(finished));
@@ -164,7 +177,8 @@ class ComplianceGenerationJobServiceTest {
     /** A failure that is not the duplicate is not swallowed as one. */
     @Test
     void anUnrelatedWriteFailureIsNotMistakenForALostRace() {
-        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID)).thenReturn(25);
+        when(complianceGenerationService.validateAndCountCandidateRules(PROJECT_ID, ORG_ID))
+                .thenReturn(CANDIDATES);
         when(jobRepository.findActiveForProject(ORG_ID, PROJECT_ID)).thenReturn(Optional.empty());
         when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(new Organization());
         when(jobRepository.save(any())).thenThrow(new IllegalStateException("the disk is full"));

--- a/src/test/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweepTest.java
+++ b/src/test/java/org/tornotron/echno_backend/compliance/sweep/ComplianceRuleSweepTest.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.project.enums.ProjectType;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,6 +100,13 @@ class ComplianceRuleSweepTest {
     private ComplianceGenerationJobRepository.SweepCandidate project(long id,
                                                                     String state,
                                                                     LocalDateTime lastAssessedAt) {
+        return project(id, state, lastAssessedAt, null);
+    }
+
+    private ComplianceGenerationJobRepository.SweepCandidate project(long id,
+                                                                    String state,
+                                                                    LocalDateTime lastAssessedAt,
+                                                                    String assessedJurisdiction) {
         return new ComplianceGenerationJobRepository.SweepCandidate() {
             @Override
             public Long getProjectId() {
@@ -126,6 +135,16 @@ class ComplianceRuleSweepTest {
 
             @Override
             public LocalDateTime getLastAssessedAt() {
+                return lastAssessedAt;
+            }
+
+            @Override
+            public String getLastAssessedJurisdiction() {
+                return assessedJurisdiction;
+            }
+
+            @Override
+            public LocalDateTime getLastAttemptAt() {
                 return lastAssessedAt;
             }
         };
@@ -201,6 +220,54 @@ class ComplianceRuleSweepTest {
         verify(jobService, never()).submit(anyLong(), anyLong());
     }
 
+    // -------------------------------------------------------------------------------
+    // The jurisdiction half of the comparison
+    // -------------------------------------------------------------------------------
+
+    /**
+     * A recent assessment is only evidence about the jurisdiction it was made in. Correct a
+     * project's state after it has been assessed and its timestamp still looks fresh, so on
+     * the timestamp alone the sweep leaves it alone and the project keeps an empty compliance
+     * list for the state it is actually in, permanently.
+     */
+    @Test
+    void queuesAProjectWhoseJurisdictionChangedSinceItWasAssessed() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED.plusDays(1), "kerala|RESIDENTIAL"));
+        submitCreates(true);
+
+        sweep.runPass();
+
+        verify(jobService).submit(1L, ORG_ID);
+    }
+
+    /** The same jurisdiction is not a change, and must not cost a run every night. */
+    @Test
+    void leavesAProjectAssessedInTheSameJurisdictionAlone() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED.plusDays(1), "tamil nadu|RESIDENTIAL"));
+
+        sweep.runPass();
+
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+
+    /**
+     * Runs from before the jurisdiction was recorded say nothing about it, and "nothing" has
+     * to read as no change rather than as a change. Reading it the other way would put every
+     * approved project in every tenant through a model call on the first pass after the
+     * upgrade, which is a bill arriving overnight for no new answers.
+     */
+    @Test
+    void treatsAnUnrecordedJurisdictionAsNoChange() {
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", RULE_CHANGED.plusDays(1), null));
+
+        sweep.runPass();
+
+        verify(jobService, never()).submit(anyLong(), anyLong());
+    }
+
     /** State is matched the way generation matches it, so casing cannot hide a rule change. */
     @Test
     void matchesTheJurisdictionCaseInsensitively() {
@@ -237,6 +304,38 @@ class ComplianceRuleSweepTest {
         verify(jobService).submit(2L, ORG_ID);
         verify(jobService, never()).submit(3L, ORG_ID);
         verify(jobService, never()).submit(4L, ORG_ID);
+    }
+
+    /**
+     * The cap is a budget every replica shares, not one each.
+     *
+     * <p>{@code @Scheduled} elects no leader, so on three replicas this pass runs three times
+     * on the same night and a cap counted in a local variable authorises three times the spend
+     * it says. Reading what has already been queued is what turns it back into one number.
+     * Here twenty of the twenty-five are already spoken for by other replicas, so this one may
+     * queue five and no more, however many stale projects it can see.
+     */
+    @Test
+    void sharesThePerRunCapWithTheOtherReplicas() {
+        properties.setMaxProjectsPerRun(25);
+        catalogueChangedAt(RULE_CHANGED);
+        candidates(project(1L, "Tamil Nadu", null), project(2L, "Tamil Nadu", null),
+                project(3L, "Tamil Nadu", null), project(4L, "Tamil Nadu", null),
+                project(5L, "Tamil Nadu", null), project(6L, "Tamil Nadu", null),
+                project(7L, "Tamil Nadu", null), project(8L, "Tamil Nadu", null));
+        // Twenty jobs are already on the table from the other replicas, and every job this
+        // pass queues joins them, exactly as the count would see it against a real database.
+        AtomicLong queuedAnywhere = new AtomicLong(20);
+        when(jobRepository.countCreatedSince(any(LocalDateTime.class)))
+                .thenAnswer(call -> queuedAnywhere.get());
+        when(jobService.submit(anyLong(), anyLong())).thenAnswer(call -> {
+            queuedAnywhere.incrementAndGet();
+            return new ComplianceGenerationJobService.Accepted((ComplianceGenerationJobDto) null, true);
+        });
+
+        sweep.runPass();
+
+        verify(jobService, times(5)).submit(anyLong(), anyLong());
     }
 
     /**


### PR DESCRIPTION
Closes #586.

## The miss

The sweep asked one question of each approved project: has it been assessed since the newest rule in its jurisdiction came into force? "Assessed" was the last successful run's `finished_at`.

`ComplianceGenerationService.loadInputs` snapshots the rule catalogue at the top of a run, and the model calls then take minutes. A rule written during those minutes is not in the snapshot and cannot be, but its `effective_from` is still earlier than the moment the run finished. The project therefore read as up to date on a rule nothing had ever assessed it against, and on every later pass too, because the comparison never changes. That is the exact class of miss #553 exists to close.

## Does `started_at` close the window or move it?

It closes it for every rule dated at or after the moment it is written, which is what a curator adding a rule does. A run's rule snapshot is read after its claim, so `started_at` is at or before the snapshot; a rule written after the snapshot is written after `started_at`, so `effective_from > started_at` and the sweep sees it. The margin also stops being zero: it is the whole run duration rather than the instant between the last write and the finish, so clock skew of seconds no longer flips the comparison.

Two properties are worth stating rather than leaving implied:

- A **failed** run marks nothing. `started_at` is only read off runs whose status is `SUCCEEDED` or `NOTHING_TO_REPORT`, so a run that starts, spends ten minutes and fails leaves the project exactly as stale as it was.
- A **requeued** run keeps its first attempt's start, because the claim writes `started_at = COALESCE(started_at, :now)`. That is the conservative direction; an earlier watermark can only over-trigger, and generation is idempotent per `(project, ruleRef)` so the extra run creates nothing.

What is **not** closed, and is now documented in the class rather than left to be rediscovered: a rule **back-dated** below a project's watermark is invisible whenever it is written, in flight or not. That is a property of keying on the curated `effective_from` rather than on `created_at`, which is the deliberate design of #553, and the remedy is curatorial (date a rule from when it starts applying, not from whatever historical date it was published).

## The two lows, handled here

**Per project rather than per jurisdiction.** Jobs now record the jurisdiction they were accepted for (`tamil nadu|RESIDENTIAL`, built in one place by `Jurisdiction.key` so the sweep and the job cannot drift apart), and the sweep compares that as well as the timestamp. A project assessed under Tamil Nadu and corrected to Kerala no longer reads as up to date against Kerala's older rules. Runs from before the column say nothing about it, and null reads as no change rather than as a change, so turning the sweep on does not put every approved project in every tenant through a model call on the first pass. Changelog 071, nullable, deliberately not backfilled.

**Cap starvation.** Candidates are ordered by their last terminal run of any kind, failures included, instead of by their last success. A project that fails every night now sinks below the never-attempted backlog instead of sitting at the front of it with twenty-five siblings eating the whole cap.

**Per-replica caps.** The cap is counted from the job table rather than from a local variable, so N replicas share one budget instead of authorising N times the spend. This is a bound and not a lock, and the code says so: two replicas that start in the same second can both submit before either sees the other, so the real ceiling is the cap plus roughly one project per replica. Anything tighter is a coordination protocol, and none is worth writing for a nightly job whose work is idempotent.

## Proof

The race is exercised rather than asserted. In `ComplianceGenerationServiceIT`, a job is claimed through the real `claim` SQL so its `started_at` is real, a real generation run then goes through `ComplianceGenerationService`, and the stubbed model **writes a new rule while it is answering** - by which point `loadInputs` has already snapshotted the catalogue, so the run demonstrably cannot see it. The run is then finished and the sweep is run. The test asserts the three timestamps are in the racing order before it asserts the outcome, so a change that stopped producing the race fails here rather than quietly becoming a test of nothing.

Against the pre-fix comparison (watermark restored to `finished_at`, ordering restored to last success, jurisdiction check removed), all four new integration tests fail and every pre-existing test still passes:

```
queuesAProjectForARuleWrittenWhileItsLastRunWasStillGoing()  FAILED
queuesAProjectWhoseStateWasCorrectedAfterItWasAssessed()     FAILED
putsAProjectThatKeepsFailingBehindOneThatWasNeverTried()     FAILED
countsASucceededRunFromWhenItStartedNotWhenItFinished()      FAILED
```

and the two unit tests for the jurisdiction comparison and the shared budget fail against their own pre-fix logic.

Full `./gradlew build` green on the lab box, 8 contexts cached of a maximum 8 (no new Spring context: the sweep is built by hand in the existing slice), test heap 24% of the 2048m cap.

No controller or DTO changed, so `docs/openapi.json` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compliance jobs now record the project’s jurisdiction when submitted.
  * Compliance sweeps detect changes to applicable rules or jurisdiction and re-queue projects for assessment.
  * Sweep prioritization now favors projects least recently attempted.
  * Shared job limits help control processing across concurrent sweep runs.

* **Bug Fixes**
  * Improved watermarking ensures rule updates made during a sweep are not missed.
  * Failed projects no longer block projects awaiting their first assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->