### PR TITLE
Accept the purchase-order edits the web screens actually send

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13784,11 +13784,17 @@
         "type": "object"
       },
       "PurchaseOrderItemUpdateDto": {
-        "description": "Payload to update a purchase order line item's quantity, price or remarks.",
+        "description": "Payload to update a purchase order line item's material, quantity, price or remarks.",
         "properties": {
           "id": {
             "description": "Id of the item to update.",
             "example": 512,
+            "format": "int64",
+            "type": "integer"
+          },
+          "materialId": {
+            "description": "Change the material the line is for. Only while nothing has been received against it.",
+            "example": 88,
             "format": "int64",
             "type": "integer"
           },
@@ -13815,7 +13821,7 @@
         "type": "object"
       },
       "PurchaseOrderUpdateDto": {
-        "description": "Payload to update a purchase order's status, delivery date, remarks or total.",
+        "description": "Payload to update a purchase order's status, project, delivery date or remarks.",
         "properties": {
           "expectedDeliveryDate": {
             "description": "Updated expected delivery date.",
@@ -13826,6 +13832,12 @@
           "id": {
             "description": "Id of the purchase order to update.",
             "example": 204,
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "description": "Reallocate the order to a different project.",
+            "example": 17,
             "format": "int64",
             "type": "integer"
           },
@@ -13840,7 +13852,7 @@
             "type": "string"
           },
           "totalAmount": {
-            "description": "Updated total value in INR.",
+            "description": "Ignored. The total is derived from the line items and recomputed on every line change.",
             "example": 492500.0,
             "type": "number"
           }
@@ -84353,7 +84365,7 @@
         ]
       },
       "put": {
-        "description": "Replaces a line item's ordered quantity, unit price and remarks.",
+        "description": "Updates a line item's material, ordered quantity, unit price or remarks. The id is read from the request body. The material can only change while nothing has been received against the line.",
         "operationId": "updatePurchaseOrderItem",
         "requestBody": {
           "content": {
@@ -84384,7 +84396,7 @@
                 }
               }
             },
-            "description": "A field failed validation"
+            "description": "A field failed validation, or the material was changed on a line that has already received stock"
           },
           "402": {
             "content": {
@@ -84414,7 +84426,7 @@
                 }
               }
             },
-            "description": "No purchase order item with the given id"
+            "description": "No purchase order item with the given id, or the payload names a material that does not exist in this organization"
           },
           "409": {
             "content": {
@@ -84931,7 +84943,7 @@
         ]
       },
       "patch": {
-        "description": "Replaces a line item's ordered quantity, unit price and remarks.",
+        "description": "Updates a line item's material, ordered quantity, unit price or remarks. The id is read from the request body. The material can only change while nothing has been received against the line.",
         "operationId": "updatePurchaseOrderItem_1",
         "requestBody": {
           "content": {
@@ -84962,7 +84974,7 @@
                 }
               }
             },
-            "description": "A field failed validation"
+            "description": "A field failed validation, or the material was changed on a line that has already received stock"
           },
           "402": {
             "content": {
@@ -84992,7 +85004,7 @@
                 }
               }
             },
-            "description": "No purchase order item with the given id"
+            "description": "No purchase order item with the given id, or the payload names a material that does not exist in this organization"
           },
           "409": {
             "content": {
@@ -86067,7 +86079,7 @@
         ]
       },
       "patch": {
-        "description": "Applies a partial update to a purchase order's status, expected delivery date, remarks or total amount.",
+        "description": "Applies a partial update to a purchase order's status, project, expected delivery date or remarks. The total is the sum of the line items and is recomputed whenever one of them changes, so it is not settable here.",
         "operationId": "updatePurchaseOrder",
         "requestBody": {
           "content": {
@@ -86128,7 +86140,7 @@
                 }
               }
             },
-            "description": "No purchase order with the given id"
+            "description": "No purchase order with the given id, or the payload names a project that does not exist in this organization"
           },
           "409": {
             "content": {
@@ -86878,7 +86890,7 @@
         ]
       },
       "patch": {
-        "description": "Applies a partial update to a purchase order's status, expected delivery date, remarks or total amount.",
+        "description": "Applies a partial update to a purchase order's status, project, expected delivery date or remarks. The total is the sum of the line items and is recomputed whenever one of them changes, so it is not settable here.",
         "operationId": "updatePurchaseOrder_1",
         "requestBody": {
           "content": {
@@ -86939,7 +86951,7 @@
                 }
               }
             },
-            "description": "No purchase order with the given id"
+            "description": "No purchase order with the given id, or the payload names a project that does not exist in this organization"
           },
           "409": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderController.java
@@ -157,14 +157,15 @@ public class PurchaseOrderController {
     @PatchMapping
     @Operation(
             summary = "Update a purchase order",
-            description = "Applies a partial update to a purchase order's status, expected delivery date, "
-                    + "remarks or total amount."
+            description = "Applies a partial update to a purchase order's status, project, expected "
+                    + "delivery date or remarks. The total is the sum of the line items and is "
+                    + "recomputed whenever one of them changes, so it is not settable here."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id, or the payload names a project that does not exist in this organization")
     })
     public ResponseEntity<PurchaseOrderDto> updatePurchaseOrder(@Valid @RequestBody PurchaseOrderUpdateDto updateDto) {
         PurchaseOrderDto updated = purchaseOrderService.updatePurchaseOrder(updateDto);

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -156,14 +156,15 @@ public class PurchaseOrderControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a purchase order",
-            description = "Applies a partial update to a purchase order's status, expected delivery date, "
-                    + "remarks or total amount."
+            description = "Applies a partial update to a purchase order's status, project, expected "
+                    + "delivery date or remarks. The total is the sum of the line items and is "
+                    + "recomputed whenever one of them changes, so it is not settable here."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id, or the payload names a project that does not exist in this organization")
     })
     public ResponseEntity<PurchaseOrderDto> updatePurchaseOrder(@Valid @RequestBody PurchaseOrderUpdateDto updateDto) {
         PurchaseOrderDto updated = purchaseOrderService.updatePurchaseOrder(updateDto);

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
@@ -269,12 +269,15 @@ public class PurchaseOrderService {
     /**
      * Applies a partial update to a purchase order header.
      *
-     * <p>Only the non-null status, expected delivery date, and remarks are changed. Line
-     * items and the order total are not affected.
+     * <p>Only the non-null status, project, expected delivery date, and remarks are changed.
+     * Line items are not affected, and neither is the order total: it is the sum of the lines
+     * and is recomputed whenever one of them changes, so {@code totalAmount} on the payload is
+     * ignored rather than written.
      *
      * @param updateDto The purchase order id and the header fields to change.
      * @return The updated purchase order as a DTO.
-     * @throws ResourceNotFoundException if no purchase order with the given id exists in this organization.
+     * @throws ResourceNotFoundException if no purchase order with the given id exists in this
+     *     organization, or the payload names a project that does not.
      */
     @Transactional
     public PurchaseOrderDto updatePurchaseOrder(PurchaseOrderUpdateDto updateDto) {
@@ -283,6 +286,13 @@ public class PurchaseOrderService {
 
         if (updateDto.getStatus() != null) {
             purchaseOrder.setStatus(PurchaseOrderStatus.valueOf(updateDto.getStatus()));
+        }
+
+        if (updateDto.getProjectId() != null) {
+            Project project = projectRepository.findByIdAndOrganization_Id(updateDto.getProjectId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Project with ID " + updateDto.getProjectId() + " was not found in this organization"));
+            purchaseOrder.setProject(project);
         }
 
         if (updateDto.getExpectedDeliveryDate() != null) {

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/dto/PurchaseOrderUpdateDto.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Schema(description = "Payload to update a purchase order's status, delivery date, remarks or total.")
+@Schema(description = "Payload to update a purchase order's status, project, delivery date or remarks.")
 @Data
 public class PurchaseOrderUpdateDto {
 
@@ -18,12 +18,22 @@ public class PurchaseOrderUpdateDto {
     @Schema(description = "New lifecycle status.", example = "APPROVED")
     private String status;
 
+    @Schema(description = "Reallocate the order to a different project.", example = "17")
+    private Long projectId;
+
     @Schema(description = "Updated expected delivery date.", example = "2026-02-14T00:00:00")
     private LocalDateTime expectedDeliveryDate;
 
     @Schema(description = "Updated remarks.", example = "Vendor confirmed dispatch for 2026-02-12")
     private String remarks;
 
-    @Schema(description = "Updated total value in INR.", example = "492500.00")
+    /**
+     * Ignored. The order total is the sum of its line items and is recomputed whenever one of
+     * them is added, changed or removed, so a value sent here would be overwritten by the next
+     * line edit. Kept on the payload only until the web client stops sending it; see
+     * tornotron/echno-core#57.
+     */
+    @Schema(description = "Ignored. The total is derived from the line items and recomputed on every line change.",
+            example = "492500.00")
     private BigDecimal totalAmount;
 }

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -151,13 +151,13 @@ public class PurchaseOrderItemController {
     @PutMapping
     @Operation(
             summary = "Update a purchase order item",
-            description = "Replaces a line item's ordered quantity, unit price and remarks."
+            description = "Updates a line item's material, ordered quantity, unit price or remarks. The id is read from the request body. The material can only change while nothing has been received against the line."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item updated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, or the material was changed on a line that has already received stock"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id, or the payload names a material that does not exist in this organization")
     })
     public ResponseEntity<PurchaseOrderItemResponseDto> updatePurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemUpdateDto updateDto) {

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -147,13 +147,13 @@ public class PurchaseOrderItemControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Update a purchase order item",
-            description = "Replaces a line item's ordered quantity, unit price and remarks."
+            description = "Updates a line item's material, ordered quantity, unit price or remarks. The id is read from the request body. The material can only change while nothing has been received against the line."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Purchase order item updated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, or the material was changed on a line that has already received stock"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order item with the given id, or the payload names a material that does not exist in this organization")
     })
     public ResponseEntity<PurchaseOrderItemResponseDto> updatePurchaseOrderItem(
             @Valid @RequestBody PurchaseOrderItemUpdateDto updateDto) {

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.indentItem.IndentItem;
 import org.tornotron.echno_backend.indentItem.IndentItemRepository;
@@ -153,10 +154,38 @@ public class PurchaseOrderItemService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Applies a partial update to a line item, then recomputes its total and the parent order's.
+     *
+     * <p>The material may be changed only while nothing has been received against the line.
+     * Once a goods received note has posted against it the line is the record of what arrived,
+     * and swapping the material underneath it would move that receipt onto stock that was never
+     * delivered.
+     *
+     * @param updateDto The item id and the fields to change.
+     * @return The updated line item.
+     * @throws ResourceNotFoundException if no item with the given id exists in this organization,
+     *     or the payload names a material that does not.
+     * @throws InvalidRequestException if the material is changed on a line that has already
+     *     received stock.
+     */
     @Transactional
     public PurchaseOrderItemResponseDto updatePurchaseOrderItem(PurchaseOrderItemUpdateDto updateDto) {
         PurchaseOrderItem item = purchaseOrderItemRepository.findByIdAndOrganization_Id(updateDto.getId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Purchase order item with ID " + updateDto.getId() + " was not found in this organization"));
+
+        if (updateDto.getMaterialId() != null
+                && !updateDto.getMaterialId().equals(item.getMaterial().getId())) {
+            if (item.getReceivedQuantity() != null && item.getReceivedQuantity() > 0) {
+                throw new InvalidRequestException(
+                        "Purchase order item " + updateDto.getId() + " has already received stock, so its "
+                                + "material cannot be changed; cancel the line and add a new one instead");
+            }
+            Material material = materialRepository.findByIdAndOrganization_Id(updateDto.getMaterialId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Material with ID " + updateDto.getMaterialId() + " was not found in this organization"));
+            item.setMaterial(material);
+        }
 
         if (updateDto.getOrderedQuantity() != null) {
             item.setOrderedQuantity(updateDto.getOrderedQuantity());

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/dto/PurchaseOrderItemUpdateDto.java
@@ -6,13 +6,17 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 
-@Schema(description = "Payload to update a purchase order line item's quantity, price or remarks.")
+@Schema(description = "Payload to update a purchase order line item's material, quantity, price or remarks.")
 @Data
 public class PurchaseOrderItemUpdateDto {
 
     @Schema(description = "Id of the item to update.", example = "512")
     @NotNull(message = "Item ID is required")
     private Long id;
+
+    @Schema(description = "Change the material the line is for. Only while nothing has been "
+            + "received against it.", example = "88")
+    private Long materialId;
 
     @Schema(description = "Updated ordered quantity.", example = "450")
     private Integer orderedQuantity;

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderUpdateFieldsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderUpdateFieldsTest.java
@@ -1,0 +1,280 @@
+package org.tornotron.echno_backend.purchaseOrder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.indent.IndentRepository;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderUpdateDto;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemService;
+import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemUpdateDto;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The fields a purchase-order edit is allowed to move.
+ *
+ * <p>Both edit screens post through these two update calls, and until now neither of them could
+ * reach the backend at all: echno-core addressed the id in the path, where no route exists.
+ * Once the client is pointed at the right route the payload becomes visible for the first time,
+ * and two of the controls on those screens turned out to have nothing behind them. The purchase
+ * order's project select and the line's material select were both sent and both dropped, because
+ * no such field existed on either update DTO.
+ *
+ * <p>Both are real columns with real screens, so they are accepted here rather than removed from
+ * the client. The material carries the one restriction the data needs: once a goods received note
+ * has posted against a line, that line is the record of what arrived.
+ */
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderUpdateFieldsTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long PO_ID = 204L;
+    private static final Long ITEM_ID = 512L;
+
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private IndentRepository indentRepository;
+    @Mock private PurchaseOrderMapper purchaseOrderMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private PurchaseOrderItemRepository purchaseOrderItemRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private IndentItemRepository indentItemRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private PurchaseOrderService purchaseOrderService;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private PurchaseOrderService orderService() {
+        return new PurchaseOrderService(
+                purchaseOrderRepository,
+                vendorRepository,
+                indentRepository,
+                purchaseOrderMapper,
+                tenantEntityHelper,
+                employeeRepository,
+                projectRepository,
+                purchaseOrderItemRepository,
+                materialRepository,
+                indentItemRepository,
+                documentNumberAllocator,
+                retryTemplate);
+    }
+
+    private PurchaseOrderItemService itemService() {
+        return new PurchaseOrderItemService(
+                purchaseOrderItemRepository,
+                purchaseOrderRepository,
+                materialRepository,
+                indentItemRepository,
+                tenantEntityHelper,
+                purchaseOrderService);
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        return organization;
+    }
+
+    private Project project(Long id) {
+        Project project = new Project();
+        project.setId(id);
+        project.setOrganization(organization());
+        return project;
+    }
+
+    private Material material(Long id) {
+        Material material = new Material();
+        material.setId(id);
+        material.setOrganization(organization());
+        return material;
+    }
+
+    private PurchaseOrder purchaseOrder() {
+        PurchaseOrder purchaseOrder = new PurchaseOrder();
+        purchaseOrder.setId(PO_ID);
+        purchaseOrder.setOrganization(organization());
+        purchaseOrder.setStatus(PurchaseOrderStatus.DRAFT);
+        purchaseOrder.setProject(project(1L));
+        purchaseOrder.setTotalAmount(new BigDecimal("492500.00"));
+        return purchaseOrder;
+    }
+
+    private PurchaseOrderItem lineItem(int receivedQuantity) {
+        PurchaseOrderItem item = new PurchaseOrderItem();
+        item.setId(ITEM_ID);
+        item.setOrganization(organization());
+        item.setPurchaseOrder(purchaseOrder());
+        item.setMaterial(material(11L));
+        item.setOrderedQuantity(50);
+        item.setReceivedQuantity(receivedQuantity);
+        item.setUnitPrice(new BigDecimal("64.00"));
+        return item;
+    }
+
+    @Test
+    void updatingAPurchaseOrder_movesItToTheProjectTheEditSent() {
+        // The project select on the PO header card. The field had no home on the update DTO, so
+        // the value arrived and went nowhere.
+        PurchaseOrder stored = purchaseOrder();
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(PO_ID, ORG_ID)).thenReturn(Optional.of(stored));
+        when(projectRepository.findByIdAndOrganization_Id(17L, ORG_ID)).thenReturn(Optional.of(project(17L)));
+        when(purchaseOrderRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PurchaseOrderUpdateDto update = new PurchaseOrderUpdateDto();
+        update.setId(PO_ID);
+        update.setProjectId(17L);
+
+        orderService().updatePurchaseOrder(update);
+
+        assertThat(stored.getProject().getId()).isEqualTo(17L);
+    }
+
+    @Test
+    void updatingAPurchaseOrder_refusesAProjectFromAnotherOrganization() {
+        // The lookup is tenant-scoped, so a project id from elsewhere is simply not found rather
+        // than reallocating the order across a tenant boundary.
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(PO_ID, ORG_ID)).thenReturn(Optional.of(purchaseOrder()));
+        when(projectRepository.findByIdAndOrganization_Id(999L, ORG_ID)).thenReturn(Optional.empty());
+
+        PurchaseOrderUpdateDto update = new PurchaseOrderUpdateDto();
+        update.setId(PO_ID);
+        update.setProjectId(999L);
+
+        assertThatThrownBy(() -> orderService().updatePurchaseOrder(update))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(purchaseOrderRepository, never()).save(any());
+    }
+
+    @Test
+    void updatingAPurchaseOrder_leavesTheTotalToTheLineItems() {
+        // totalAmount is on the payload and always has been ignored: the total is the sum of the
+        // lines and is recomputed whenever one changes. Pinned so honouring it is a decision
+        // somebody makes rather than something that slides in with a rename.
+        PurchaseOrder stored = purchaseOrder();
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(PO_ID, ORG_ID)).thenReturn(Optional.of(stored));
+        when(purchaseOrderRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PurchaseOrderUpdateDto update = new PurchaseOrderUpdateDto();
+        update.setId(PO_ID);
+        update.setTotalAmount(new BigDecimal("1.00"));
+
+        orderService().updatePurchaseOrder(update);
+
+        assertThat(stored.getTotalAmount()).isEqualByComparingTo("492500.00");
+    }
+
+    @Test
+    void updatingALineItem_changesTheMaterialTheEditSent() {
+        // The material select on the Edit Item row, sent on every save and dropped until now.
+        PurchaseOrderItem stored = lineItem(0);
+        when(purchaseOrderItemRepository.findByIdAndOrganization_Id(ITEM_ID, ORG_ID)).thenReturn(Optional.of(stored));
+        when(materialRepository.findByIdAndOrganization_Id(88L, ORG_ID)).thenReturn(Optional.of(material(88L)));
+        when(purchaseOrderItemRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PurchaseOrderItemUpdateDto update = new PurchaseOrderItemUpdateDto();
+        update.setId(ITEM_ID);
+        update.setMaterialId(88L);
+
+        itemService().updatePurchaseOrderItem(update);
+
+        assertThat(stored.getMaterial().getId()).isEqualTo(88L);
+    }
+
+    @Test
+    void updatingALineItem_refusesToChangeTheMaterialOnceStockHasArrived() {
+        // A goods received note has posted against this line. Swapping the material underneath it
+        // would move a real receipt onto stock nobody delivered.
+        when(purchaseOrderItemRepository.findByIdAndOrganization_Id(ITEM_ID, ORG_ID))
+                .thenReturn(Optional.of(lineItem(20)));
+
+        PurchaseOrderItemUpdateDto update = new PurchaseOrderItemUpdateDto();
+        update.setId(ITEM_ID);
+        update.setMaterialId(88L);
+
+        assertThatThrownBy(() -> itemService().updatePurchaseOrderItem(update))
+                .isInstanceOf(InvalidRequestException.class);
+
+        verify(purchaseOrderItemRepository, never()).save(any());
+    }
+
+    @Test
+    void updatingALineItem_leavesAReceivedLineEditableInEveryOtherWay() {
+        // The restriction is on the material alone. Correcting the price of a part-delivered line
+        // is ordinary work and must not be caught by it.
+        PurchaseOrderItem stored = lineItem(20);
+        when(purchaseOrderItemRepository.findByIdAndOrganization_Id(ITEM_ID, ORG_ID)).thenReturn(Optional.of(stored));
+        when(purchaseOrderItemRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PurchaseOrderItemUpdateDto update = new PurchaseOrderItemUpdateDto();
+        update.setId(ITEM_ID);
+        update.setUnitPrice(new BigDecimal("70.00"));
+
+        itemService().updatePurchaseOrderItem(update);
+
+        assertThat(stored.getUnitPrice()).isEqualByComparingTo("70.00");
+        // Line total follows the price, and the order total is recomputed from the lines.
+        assertThat(stored.getTotalPrice()).isEqualByComparingTo("3500.00");
+        verify(purchaseOrderService).recalculateTotalAmount(PO_ID);
+    }
+
+    @Test
+    void updatingALineItem_acceptsTheMaterialItAlreadyHas_evenAfterAReceipt() {
+        // The web client sends the material on every save, including saves that only change the
+        // remarks. Rejecting an unchanged material would turn every edit of a part-delivered line
+        // into a 400.
+        PurchaseOrderItem stored = lineItem(20);
+        when(purchaseOrderItemRepository.findByIdAndOrganization_Id(ITEM_ID, ORG_ID)).thenReturn(Optional.of(stored));
+        when(purchaseOrderItemRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PurchaseOrderItemUpdateDto update = new PurchaseOrderItemUpdateDto();
+        update.setId(ITEM_ID);
+        update.setMaterialId(11L);
+        update.setRemarks("Vendor revised delivery window");
+
+        itemService().updatePurchaseOrderItem(update);
+
+        assertThat(stored.getRemarks()).isEqualTo("Vendor revised delivery window");
+    }
+}


### PR DESCRIPTION
The backend half of the two purchase-order PATCH outages on echno-core#57. The client half is a separate PR on echno-core, and it depends on this one being merged first, because `etc/backend-request-fields.json` is derived from `docs/openapi.json` at `development`.

## The outage this pairs with

echno-core sends `PATCH /purchase-orders/web/{id}` and `PATCH /purchase-order-items/{id}`. Verified against the running backend's own `/v3/api-docs` pulled off `.116`: `/purchase-orders/web/{id}` serves `GET` and nothing else, and `/purchase-order-items/{id}` serves `GET` and `DELETE`. Both real routes are on the collection, with the id in the body. Editing a purchase order's header, its remarks, or any line item has been a 404 behind a "Failed to update" toast for as long as those routes have existed, and nobody flagged it.

Nothing here is needed to end the 404 itself, which is a client-side path fix. What this PR is for is the second half: correcting the paths makes the payloads reach a DTO for the first time, and two of the controls on those screens turn out to be sending fields no DTO has.

## What changes

**`PurchaseOrderUpdateDto.projectId`.** The header card renders a project select in edit mode and posts it. `PurchaseOrder.project` is a real column, `nullable = false`, and `createPurchaseOrder` resolves it; the update DTO simply had no such field. The service now resolves it through `projectRepository.findByIdAndOrganization_Id`, the same tenant-scoped lookup create uses, so an id belonging to another organization is a 404 rather than a reallocation across a tenant boundary.

**`PurchaseOrderItemUpdateDto.materialId`.** The Edit Item row renders a material select and posts it. Same shape: real column on the line, set on create, absent from the update DTO. Accepted now, with one restriction. Once a goods received note has posted against a line, the line is the record of what arrived, so the material may only change while `receivedQuantity` is still zero; past that it is a 400 telling the caller to cancel the line and raise a new one. Sending the material the line already has is always fine, because the web client sends it on every save including saves that only touch the remarks, and rejecting an unchanged value would turn every edit of a part-delivered line into a 400.

**`totalAmount` stays, and stays ignored.** `updatePurchaseOrder` has never applied it, and that is right: the order total is the sum of its lines and `recalculateTotalAmount` runs on every line create, update and delete, so a value written here would survive until the next line edit. It is now documented as ignored on the schema and in the javadoc rather than reading as settable, and echno-core stops sending it. Removing it outright would break the published core that still does, so that is a later step once the web app is off it.

## Tests

`PurchaseOrderUpdateFieldsTest`, seven cases: the project moves, a project from another organization is refused with nothing saved, the total is left to the line items, the material changes on an untouched line, the material is refused on a line that has already received stock, an unchanged material is accepted after a receipt, and a received line stays editable in every other way with its line total and the order total recomputed. Disabling just the two new service branches fails four of them.

Full suite green on `.116`; `docs/openapi.json` regenerated.