### PR TITLE
Make the self-approval rule work when the raiser has no employee record

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularization.java
@@ -45,6 +45,17 @@ public class AttendanceRegularization implements TenantScopedEntity {
     @Column(name = "requested_by_id")
     private Long requestedById;
 
+    /**
+     * The platform user id of whoever raised the request.
+     *
+     * <p>Stamped alongside {@code requestedById} because that one is an employee id, and a caller
+     * can hold a role in the tenant without having an employee record in it yet, which left the
+     * request with no id at all and the self-approval rule with nothing to compare. Every
+     * authenticated caller has a user id, so this is the identity the rule can always fall back to.
+     */
+    @Column(name = "requested_by_user_id")
+    private Long requestedByUserId;
+
     @Column(name = "requested_at")
     private LocalDateTime requestedAt;
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -8,6 +8,7 @@ import org.tornotron.echno_backend.attendance.dto.*;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -76,9 +77,14 @@ public class AttendanceRegularizationService {
         this.selfApprovalPolicy = selfApprovalPolicy;
     }
 
-    /** Who the authenticated caller is, as recorded on a request: a display name and, when the
-     *  caller has an employee record in this tenant, that employee's id. */
-    private record Actor(String name, Long employeeId) {
+    /** Who the authenticated caller is, as recorded on a request: a display name, their platform
+     *  user id, and, when the caller has an employee record in this tenant, that employee's id. */
+    private record Actor(String name, Long userId, Long employeeId) {
+
+        /** The same identity as the self-approval rule compares parties by. */
+        ApprovalParty party() {
+            return new ApprovalParty(userId, employeeId);
+        }
     }
 
     /**
@@ -142,6 +148,7 @@ public class AttendanceRegularizationService {
                 .reason(dto.getReason())
                 .requestedBy(requestedBy)
                 .requestedById(requester.employeeId())
+                .requestedByUserId(requester.userId())
                 .status(settings.getRegularizationApprovalRequired()
                         ? RegularizationStatus.PENDING : RegularizationStatus.APPROVED)
                 .missingEvents(regularizationMapper.serializeMissingEvents(dto.getMissingEvents()))
@@ -179,8 +186,12 @@ public class AttendanceRegularizationService {
      * record, and refusing a self-rejection would leave an employee unable to withdraw a request
      * they raised by mistake.
      *
-     * <p>Requests stored before the requester was stamped from the session name nobody, so there is
-     * nothing to compare them against and they are let through.
+     * <p>The rule is applied to whichever identity the two sides share. A request records both the
+     * raiser's employee id and their platform user id, because a caller can hold a decision role in
+     * the tenant while having no employee record in it yet, and comparing employee ids alone left
+     * that caller free to raise a request and approve it themselves. Only a request that shares no
+     * identity with the approver at all, which now means one stored before the user id was kept,
+     * goes through without the comparison, and the policy logs that it could not be made.
      *
      * @param regularizationId The request to decide.
      * @param dto The decision and, on a rejection, the reason.
@@ -207,8 +218,9 @@ public class AttendanceRegularizationService {
         Actor approver = resolveCurrentActor();
         boolean selfApproved = dto.getStatus() == RegularizationStatus.APPROVED
                 && selfApprovalPolicy.checkSelfApproval(
-                        regularization.getRequestedById(),
-                        approver.employeeId(),
+                        new ApprovalParty(regularization.getRequestedByUserId(),
+                                regularization.getRequestedById()),
+                        approver.party(),
                         "Regularization request with ID " + regularizationId);
 
         regularization.setStatus(dto.getStatus());
@@ -309,11 +321,13 @@ public class AttendanceRegularizationService {
      * Resolves the authenticated caller into what gets recorded on a request.
      *
      * <p>The caller's employee record in the current organization is preferred, because the
-     * employee id is what the self-approval rule compares and what the web client links a
-     * requester by. A caller with no employee record in this tenant, for instance a bootstrap
-     * administrator, still gets a stable identity: their authenticated username, which is not
-     * something they can choose per request. Only a caller with no identity at all falls back to
-     * {@value #SYSTEM_ACTOR}, which the endpoint's authorization rules already rule out.
+     * employee id is what the attendance record carries and what the web client links a requester
+     * by. A caller with no employee record in this tenant, for instance a bootstrap administrator,
+     * still gets a stable identity: their authenticated username to display, and their platform
+     * user id to be compared by, which is the identity the self-approval rule falls back to when
+     * there is no employee on one side. Only a caller with no identity at all falls back to
+     * {@value #SYSTEM_ACTOR}, which the endpoint's authorization rules already rule out and which
+     * the self-approval rule now refuses to approve on rather than assuming it cannot happen.
      */
     private Actor resolveCurrentActor() {
         Long userId = userContextService.getCurrentUserId();
@@ -321,9 +335,9 @@ public class AttendanceRegularizationService {
                 : employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
                         .orElse(null);
         if (employee != null) {
-            return new Actor(employee.getEmployeeName(), employee.getId());
+            return new Actor(employee.getEmployeeName(), userId, employee.getId());
         }
         String username = userContextService.getCurrentUsername();
-        return new Actor(username == null || username.isBlank() ? SYSTEM_ACTOR : username, null);
+        return new Actor(username == null || username.isBlank() ? SYSTEM_ACTOR : username, userId, null);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/approval/ApprovalParty.java
+++ b/src/main/java/org/tornotron/echno_backend/common/approval/ApprovalParty.java
@@ -1,0 +1,51 @@
+package org.tornotron.echno_backend.common.approval;
+
+/**
+ * One side of a self-approval comparison: whoever raised a document, or whoever is approving it.
+ *
+ * <p>The modules that raise approvable documents do not all record their people the same way.
+ * Stock adjustments and construction invoices stamp the platform user id, because that is the
+ * only identity every authenticated caller has. Attendance regularizations stamp the employee id,
+ * because that is what the attendance record and the web client link a person by, and it is null
+ * for a caller who holds a role in the tenant but has no employee record in it yet.
+ *
+ * <p>Comparing across those two spaces is what this type exists for. It carries both ids, and a
+ * comparison succeeds on whichever the two sides have in common. Both ids are unique per person
+ * within their own space, so a match on either is conclusive and a mismatch on either is too.
+ * The alternative that was considered, comparing the display names the documents already carry,
+ * was rejected: {@code requestedBy} holds an employee name where there is an employee and a
+ * username where there is not, two people can share a name, and a person can change theirs.
+ *
+ * @param userId     the platform user id, null when the caller resolves to no user row.
+ * @param employeeId the employee id in the current tenant, null when the caller has no employee
+ *                   record there.
+ */
+public record ApprovalParty(Long userId, Long employeeId) {
+
+    /** A party known only by their platform user id, which is how the finance modules record one. */
+    public static ApprovalParty ofUser(Long userId) {
+        return new ApprovalParty(userId, null);
+    }
+
+    /** True when nothing at all names this party, so no comparison can involve them. */
+    public boolean isUnidentified() {
+        return userId == null && employeeId == null;
+    }
+
+    /**
+     * True when the two parties share at least one identity space, so a comparison between them
+     * means something. Two parties can both be identified and still not be comparable, for
+     * instance a regularization raised before the user id was stamped, whose raiser is known only
+     * as an employee, being decided by an approver who has no employee record in the tenant.
+     */
+    public boolean isComparableWith(ApprovalParty other) {
+        return (userId != null && other.userId != null)
+                || (employeeId != null && other.employeeId != null);
+    }
+
+    /** True when a shared identity space says these two are the same person. */
+    public boolean isSamePersonAs(ApprovalParty other) {
+        return (userId != null && userId.equals(other.userId))
+                || (employeeId != null && employeeId.equals(other.employeeId));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicy.java
+++ b/src/main/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicy.java
@@ -22,9 +22,30 @@ import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
  * logged and stays visible on the document, where the raiser and the approver are both recorded
  * and can be compared.
  *
- * <p>A document that names nobody as its raiser cannot be compared against anything, so it is
- * allowed through. That is the case only for rows written before the raiser was stamped from the
- * session, since every path that creates one now records who did it.
+ * <h2>What happens when the parties cannot be compared</h2>
+ *
+ * <p>A control that quietly permits whatever it cannot identify is not a control. Both callers
+ * have produced documents this rule was blind to: a regularization raised by a tenant member with
+ * no employee record carried no employee id, and a stock adjustment raised by a service account
+ * carries no user id. In each case the comparison was skipped and the approval went through as
+ * though a check had been made. The rule now splits that single silent outcome into three.
+ *
+ * <ul>
+ *   <li><b>An approval that names no approver is refused.</b> This is the one place the rule
+ *       fails closed. It is not a comparison that cannot be made, it is an entry about to be
+ *       posted by nobody: the approver id the document stores would be null as well, so there
+ *       would be no accountability on the posting at all. Every path that reaches here is a
+ *       role-gated approve endpoint on an authenticated session, so an approver who resolves to
+ *       no identity is a misconfigured account, not a legitimate caller.</li>
+ *   <li><b>A raiser who cannot be compared against the approver is allowed through, and logged
+ *       saying so.</b> Refusing instead would strand every document raised before its raiser was
+ *       stamped, and there is no second route to approving those, which is the same dead end the
+ *       break-glass exception exists to avoid. The approval proceeds, but at WARN, so an approval
+ *       whose segregation-of-duties check could not be made is visible rather than
+ *       indistinguishable from one that passed.</li>
+ *   <li><b>Anything comparable is compared,</b> on whichever identity the two parties share.
+ *       See {@link ApprovalParty}.</li>
+ * </ul>
  */
 @Slf4j
 @Component
@@ -42,17 +63,31 @@ public class SelfApprovalPolicy {
     /**
      * Applies the rule to one approval, and reports whether it went through as a self-approval.
      *
-     * @param raisedBy The user who raised the document, or null when the document does not say.
-     * @param approver The user approving it now.
+     * @param raisedBy The person who raised the document. Null, or a party carrying no id at all,
+     *                 where the document does not say who raised it.
+     * @param approver The person approving it now, taken from the session.
      * @param document How to name the document in the refusal, for example "Stock adjustment with ID 5".
      * @return true when the approver is approving their own document under the break-glass role,
      *         so the caller can record the approval as one; false when the two are different
-     *         people, which is the ordinary case.
+     *         people, which is the ordinary case, and also when they could not be compared.
      * @throws InvalidRequestException if the approver raised the document and does not hold the
-     *         break-glass role.
+     *         break-glass role, or if the approver resolves to no identity at all.
      */
-    public boolean checkSelfApproval(Long raisedBy, Long approver, String document) {
-        if (raisedBy == null || approver == null || !raisedBy.equals(approver)) {
+    public boolean checkSelfApproval(ApprovalParty raisedBy, ApprovalParty approver, String document) {
+        if (approver == null || approver.isUnidentified()) {
+            throw new InvalidRequestException(document + " cannot be approved by this session, "
+                    + "because it resolves to no user of this organization. An approval has to say "
+                    + "who gave it, and this one would record nobody. Sign in with an account that "
+                    + "belongs to the organization, or ask an administrator to check that this "
+                    + "account has been set up in it.");
+        }
+        if (raisedBy == null || raisedBy.isUnidentified() || !raisedBy.isComparableWith(approver)) {
+            log.warn("Self-approval check not made on {}: raiser {} and approver {} share no "
+                            + "identity to compare, so the approval was allowed without the check",
+                    document, raisedBy, approver);
+            return false;
+        }
+        if (!raisedBy.isSamePersonAs(approver)) {
             return false;
         }
         if (!orgSecurity.hasAnyOrgRoleForCurrentTenant(BREAK_GLASS_ROLE)) {
@@ -62,7 +97,7 @@ public class SelfApprovalPolicy {
                     + "approver to review it, or have a system administrator approve it, which is "
                     + "recorded as a self-approval.");
         }
-        log.warn("Self-approval: {} was raised and approved by user {}, allowed under the {} role",
+        log.warn("Self-approval: {} was raised and approved by {}, allowed under the {} role",
                 document, approver, BREAK_GLASS_ROLE);
         return true;
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
@@ -260,8 +261,9 @@ public class ConstructionInvoiceService {
                     "Only PENDING construction invoices can be approved; invoice "
                             + inv.getInvoiceNumber() + " is currently " + inv.getStatus());
         }
-        selfApprovalPolicy.checkSelfApproval(inv.getSubmittedBy(),
-                userContextService.getCurrentUserId(),
+        selfApprovalPolicy.checkSelfApproval(
+                ApprovalParty.ofUser(inv.getSubmittedBy()),
+                ApprovalParty.ofUser(userContextService.getCurrentUserId()),
                 "Construction invoice " + inv.getInvoiceNumber());
         postAndApprove(inv);
         return mapper.toDto(inv);

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -271,7 +272,9 @@ public class StockAdjustmentService {
 
         Long approver = userContextService.getCurrentUserId();
         boolean selfApproved = selfApprovalPolicy.checkSelfApproval(
-                stockAdjustment.getSubmittedBy(), approver, "Stock adjustment with ID " + id);
+                ApprovalParty.ofUser(stockAdjustment.getSubmittedBy()),
+                ApprovalParty.ofUser(approver),
+                "Stock adjustment with ID " + id);
 
         Project project = stockAdjustment.getProject();
         if (project == null) {

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -349,4 +349,7 @@
     <!-- v4.0 - Compliance jobs: which jurisdiction a run was accepted for -->
     <include file="db/changelog/v4.0/071-add-compliance-job-jurisdiction.xml"/>
 
+    <!-- v4.0 - Regularizations: the raiser's user id, so the self-approval rule always has one -->
+    <include file="db/changelog/v4.0/072-add-regularization-requested-by-user-id.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/072-add-regularization-requested-by-user-id.xml
+++ b/src/main/resources/db/changelog/v4.0/072-add-regularization-requested-by-user-id.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="072-add-regularization-requested-by-user-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="attendance_regularization" columnName="requested_by_user_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Record the platform user id of whoever raised a regularization request, next to the
+            employee id already stored in requested_by_id. The employee id is null for a caller who
+            holds a role in the tenant but has no employee record in it yet, and the self-approval
+            rule compared only that, so such a caller could raise a request and then approve it
+            themselves with the rule never firing. Every authenticated caller has a user id, so this
+            column gives the rule something to compare in that case. Rows written before this exists
+            keep a null here and are still compared on the employee id.
+        </comment>
+
+        <addColumn tableName="attendance_regularization">
+            <column name="requested_by_user_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
@@ -1,0 +1,338 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRegularization;
+import org.tornotron.echno_backend.attendance.AttendanceRegularizationRepository;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The segregation-of-duties rule on regularizations, run through the real
+ * {@link SelfApprovalPolicy} rather than a mock of it, for the caller shape that used to slip past
+ * it entirely.
+ *
+ * <p>A member who holds a decision role in the tenant but has no employee record in it yet, which
+ * is what a Keycloak group assigned before HR creates the record produces, was recorded on the
+ * request with no employee id. The rule compared employee ids alone and both sides were null, so
+ * it returned without comparing anything: the same account could raise a request and approve it,
+ * and even a break-glass approval left the corrected clock events looking like an ordinary one.
+ * The request now carries the raiser's platform user id as well, which is the identity every
+ * authenticated caller has, and the rule compares whichever identity the two sides share.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceRegularizationSelfApprovalTest {
+
+    private static final Long ORG = 100L;
+    private static final Long ATT_ID = 42L;
+    private static final Long REG_ID = 7L;
+    private static final String DOCUMENT = "Regularization request with ID " + REG_ID;
+
+    /** The member with a decision role and no employee record in this tenant. */
+    private static final Long ROLE_HOLDER_USER_ID = 900L;
+    private static final String ROLE_HOLDER = "hr.admin@echno.in";
+
+    /** An ordinary employee of the tenant, who is somebody else. */
+    private static final Long MANAGER_USER_ID = 901L;
+    private static final Long MANAGER_EMP_ID = 12L;
+    private static final String MANAGER = "manager-xyz";
+
+    @Mock private AttendanceRegularizationRepository regularizationRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private AttendanceRegularizationMapper regularizationMapper;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private AttendanceRegularizationService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
+                organizationRepository, employeeRepository, settingsService, calculationService,
+                regularizationMapper, userContextService, new SelfApprovalPolicy(orgSecurity));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    /**
+     * The defect this test exists for. The role holder raises the request and comes straight back
+     * to approve it. Before the raiser's user id was stored there was nothing on either side to
+     * compare, the rule returned without firing, and the correction was written.
+     */
+    @Test
+    void anEmployeeLessMemberCannotRaiseAndThenApproveTheirOwnRequest() {
+        signedInWithNoEmployeeRecord(ROLE_HOLDER_USER_ID, ROLE_HOLDER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+        Attendance attendance = attendance();
+        AttendanceRegularization pending = pendingRaisedBy(null, ROLE_HOLDER_USER_ID);
+        pending.setAttendance(attendance);
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED)))
+                .withMessageContaining(DOCUMENT)
+                .withMessageContaining("someone other than whoever raised the document");
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.PENDING);
+        assertThat(attendance.getClockEvents()).isEmpty();
+        verify(calculationService, never()).recalculate(any(), any());
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    /**
+     * The same pair under the break-glass role goes through, and the clock events it writes say
+     * the correction was self-approved. That note was being skipped too, which left the row
+     * indistinguishable from one raised before any of this was recorded.
+     */
+    @Test
+    void anEmployeeLessSystemAdministratorSelfApprovesAndTheClockEventsSaySo() {
+        signedInWithNoEmployeeRecord(ROLE_HOLDER_USER_ID, ROLE_HOLDER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+        Attendance attendance = attendance();
+        AttendanceRegularization pending = pendingRaisedBy(null, ROLE_HOLDER_USER_ID);
+        pending.setAttendance(attendance);
+        pending.setOrganization(organization());
+        pending.setRequestedEvents("[stored]");
+        stubApprovalWrites();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationMapper.deserializeRequestedEvents("[stored]"))
+                .thenReturn(List.of(correctedEvent(ClockEventType.EVENING_CLOCK_OUT)));
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+        assertThat(attendance.getClockEvents())
+                .singleElement()
+                .extracting(ClockEvent::getRegularizationReason)
+                .isEqualTo("Self-regularized (self-approved: raised and approved by the same person)");
+    }
+
+    /** Negative control: an employee-less approver deciding somebody else's request is unaffected. */
+    @Test
+    void anEmployeeLessApproverDecidingSomeoneElsesRequestIsAnOrdinaryApproval() {
+        signedInWithNoEmployeeRecord(ROLE_HOLDER_USER_ID, ROLE_HOLDER);
+        Attendance attendance = attendance();
+        AttendanceRegularization pending = pendingRaisedBy(MANAGER_EMP_ID, MANAGER_USER_ID);
+        pending.setAttendance(attendance);
+        pending.setOrganization(organization());
+        pending.setRequestedEvents("[stored]");
+        stubApprovalWrites();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+        when(regularizationMapper.deserializeRequestedEvents("[stored]"))
+                .thenReturn(List.of(correctedEvent(ClockEventType.EVENING_CLOCK_OUT)));
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+        assertThat(attendance.getClockEvents())
+                .singleElement()
+                .extracting(ClockEvent::getRegularizationReason)
+                .isEqualTo("Self-regularized");
+    }
+
+    /**
+     * The employee side still settles it on its own. An employee raising a request and approving
+     * it is the case the rule always caught, and it is caught the same way now that the comparison
+     * can also run on user ids.
+     */
+    @Test
+    void anEmployeeStillCannotApproveTheirOwnRequest() {
+        signedInAs(MANAGER_USER_ID, MANAGER_EMP_ID, MANAGER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+        AttendanceRegularization pending = pendingRaisedBy(MANAGER_EMP_ID, MANAGER_USER_ID);
+        pending.setAttendance(attendance());
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED)));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.PENDING);
+    }
+
+    /**
+     * A request stored before the user id was kept, decided by an approver with no employee record,
+     * shares no identity with them. It is let through rather than becoming unapprovable, which is
+     * the one case the rule still cannot check and now logs as such.
+     */
+    @Test
+    void aLegacyRequestIsStillApprovableByAnApproverItCannotBeComparedWith() {
+        signedInWithNoEmployeeRecord(ROLE_HOLDER_USER_ID, ROLE_HOLDER);
+        AttendanceRegularization pending = pendingRaisedBy(MANAGER_EMP_ID, null);
+        pending.setAttendance(attendance());
+        pending.setOrganization(organization());
+        stubApprovalWrites();
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+
+        service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+    }
+
+    /**
+     * The one place the rule fails closed. A session that resolves to no user and no employee
+     * would post a correction with a null approver on it, so it is refused instead of being
+     * compared against nothing and let past.
+     */
+    @Test
+    void anApproverThatResolvesToNoIdentityAtAllIsRefused() {
+        when(userContextService.getCurrentUserId()).thenReturn(null);
+        when(userContextService.getCurrentUsername()).thenReturn(null);
+        AttendanceRegularization pending = pendingRaisedBy(MANAGER_EMP_ID, MANAGER_USER_ID);
+        pending.setAttendance(attendance());
+        when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
+                .thenReturn(Optional.of(pending));
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED)))
+                .withMessageContaining("resolves to no user of this organization");
+
+        assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.PENDING);
+        verify(regularizationRepository, never()).save(any());
+    }
+
+    /** The stamping the rest of this depends on: the raiser's user id reaches the stored request. */
+    @Test
+    void submitRequestStampsTheRaisersUserIdEvenWithNoEmployeeRecord() {
+        signedInWithNoEmployeeRecord(ROLE_HOLDER_USER_ID, ROLE_HOLDER);
+        when(organizationRepository.findById(ORG)).thenReturn(Optional.of(organization()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG))
+                .thenReturn(Optional.of(attendance()));
+        when(settingsService.resolveEffectiveSettings(eq(ORG), any())).thenReturn(AttendanceSettings.builder()
+                .allowSelfRegularization(true)
+                .regularizationApprovalRequired(true)
+                .maxRegularizationDaysPerMonth(3)
+                .build());
+        when(regularizationRepository.countApprovedRegularizationsInMonth(eq(ROLE_HOLDER), any(), any()))
+                .thenReturn(0L);
+        when(regularizationRepository.findByAttendanceId(ATT_ID)).thenReturn(Optional.empty());
+        when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(regularizationMapper.toDto(any())).thenReturn(AttendanceRegularizationDto.builder().build());
+
+        RegularizationRequestDto dto = new RegularizationRequestDto();
+        dto.setAttendanceId(ATT_ID);
+        dto.setReason("Forgot to clock out");
+        service.submitRequest(dto);
+
+        ArgumentCaptor<AttendanceRegularization> captor =
+                ArgumentCaptor.forClass(AttendanceRegularization.class);
+        verify(regularizationRepository).save(captor.capture());
+        assertThat(captor.getValue().getRequestedById()).isNull();
+        assertThat(captor.getValue().getRequestedByUserId()).isEqualTo(ROLE_HOLDER_USER_ID);
+    }
+
+    private void signedInAs(Long userId, Long employeeId, String employeeName) {
+        Employee employee = new Employee();
+        employee.setId(employeeId);
+        employee.setEmployeeName(employeeName);
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(userId);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(userId, ORG))
+                .thenReturn(Optional.of(employee));
+    }
+
+    private void signedInWithNoEmployeeRecord(Long userId, String username) {
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(userId);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(userId, ORG))
+                .thenReturn(Optional.empty());
+        lenient().when(userContextService.getCurrentUsername()).thenReturn(username);
+    }
+
+    private void stubApprovalWrites() {
+        lenient().when(regularizationRepository.save(any(AttendanceRegularization.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(regularizationMapper.toDto(any()))
+                .thenReturn(AttendanceRegularizationDto.builder().build());
+    }
+
+    private AttendanceRegularization pendingRaisedBy(Long employeeId, Long userId) {
+        return AttendanceRegularization.builder()
+                .status(RegularizationStatus.PENDING)
+                .requestedBy(employeeId == null ? ROLE_HOLDER : MANAGER)
+                .requestedById(employeeId)
+                .requestedByUserId(userId)
+                .build();
+    }
+
+    private Organization organization() {
+        Organization org = new Organization();
+        org.setId(ORG);
+        return org;
+    }
+
+    private Attendance attendance() {
+        Attendance attendance = Attendance.builder()
+                .id(ATT_ID)
+                .attendanceDate(LocalDate.of(2024, 5, 10))
+                .projectId(9L)
+                .build();
+        attendance.setClockEvents(new ArrayList<>());
+        return attendance;
+    }
+
+    private ClockEventCreationDto correctedEvent(ClockEventType type) {
+        ClockEventCreationDto event = new ClockEventCreationDto();
+        event.setEventType(type);
+        event.setEventTimestamp(LocalDateTime.of(2024, 5, 10, 18, 0));
+        return event;
+    }
+
+    private RegularizationActionDto action(RegularizationStatus status) {
+        RegularizationActionDto action = new RegularizationActionDto();
+        action.setStatus(status);
+        return action;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -22,6 +22,7 @@ import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -67,7 +68,8 @@ class AttendanceRegularizationServiceTest {
     private static final Long REQUESTER_EMP_ID = 11L;
     private static final String APPROVER = "manager-xyz";
     private static final Long APPROVER_EMP_ID = 12L;
-    private static final Long USER_ID = 500L;
+    private static final Long REQUESTER_USER_ID = 500L;
+    private static final Long APPROVER_USER_ID = 501L;
 
     @Mock private AttendanceRegularizationRepository regularizationRepository;
     @Mock private AttendanceRepository attendanceRepository;
@@ -88,25 +90,30 @@ class AttendanceRegularizationServiceTest {
                 organizationRepository, employeeRepository, settingsService, calculationService,
                 regularizationMapper, userContextService, selfApprovalPolicy);
         // The session is the requesting employee unless a test says otherwise.
-        signedInAs(REQUESTER_EMP_ID, REQUESTER);
+        signedInAs(REQUESTER_USER_ID, REQUESTER_EMP_ID, REQUESTER);
     }
 
     /** Puts an employee of this tenant in the security context, as the service resolves it. */
-    private void signedInAs(Long employeeId, String employeeName) {
+    private void signedInAs(Long userId, Long employeeId, String employeeName) {
         Employee employee = new Employee();
         employee.setId(employeeId);
         employee.setEmployeeName(employeeName);
-        lenient().when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
-        lenient().when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG))
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(userId);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(userId, ORG))
                 .thenReturn(Optional.of(employee));
     }
 
     /** Puts an authenticated caller with no employee record of this tenant in the context. */
-    private void signedInWithNoEmployeeRecord(String username) {
-        lenient().when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
-        lenient().when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG))
+    private void signedInWithNoEmployeeRecord(Long userId, String username) {
+        lenient().when(userContextService.getCurrentUserId()).thenReturn(userId);
+        lenient().when(employeeRepository.findByUserIdAndOrganizationId(userId, ORG))
                 .thenReturn(Optional.empty());
         lenient().when(userContextService.getCurrentUsername()).thenReturn(username);
+    }
+
+    /** The raiser of {@link #pendingRaisedBy}, as the policy is handed it. */
+    private ApprovalParty raiser(Long employeeId) {
+        return new ApprovalParty(REQUESTER_USER_ID, employeeId);
     }
 
     @AfterEach
@@ -276,7 +283,7 @@ class AttendanceRegularizationServiceTest {
 
     @Test
     void processRegularization_approveWithShift_recalculatesAttendance() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         AttendanceRegularization pending = AttendanceRegularization.builder()
@@ -344,7 +351,7 @@ class AttendanceRegularizationServiceTest {
      */
     @Test
     void processRegularization_approve_appliesTheStoredCorrections() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         attendance.setClockEvents(new ArrayList<>());
@@ -387,7 +394,7 @@ class AttendanceRegularizationServiceTest {
      */
     @Test
     void processRegularization_approve_leavesAnExistingEventAlone() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         ClockEvent real = ClockEvent.builder()
@@ -424,7 +431,7 @@ class AttendanceRegularizationServiceTest {
 
     @Test
     void processRegularization_reject_doesNotRecalculate() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         AttendanceRegularization pending = AttendanceRegularization.builder()
@@ -471,15 +478,18 @@ class AttendanceRegularizationServiceTest {
         verify(regularizationRepository).save(captor.capture());
         assertThat(captor.getValue().getRequestedBy()).isEqualTo(REQUESTER);
         assertThat(captor.getValue().getRequestedById()).isEqualTo(REQUESTER_EMP_ID);
+        assertThat(captor.getValue().getRequestedByUserId()).isEqualTo(REQUESTER_USER_ID);
     }
 
     /**
      * A caller with no employee record in this tenant, for instance a bootstrap administrator, is
-     * still recorded by a name they cannot choose per request, and carries no employee id.
+     * still recorded by a name they cannot choose per request, and carries no employee id. Their
+     * user id is stamped instead, which is what leaves the self-approval rule something to compare
+     * when the same account comes back to approve the request it raised.
      */
     @Test
     void submitRequest_recordsTheAuthenticatedUsernameWhenTheCallerIsNotAnEmployeeHere() {
-        signedInWithNoEmployeeRecord("admin@echno.com");
+        signedInWithNoEmployeeRecord(REQUESTER_USER_ID, "admin@echno.com");
         stubOrgAndAttendance(attendance());
         when(settingsService.resolveEffectiveSettings(eq(ORG), any()))
                 .thenReturn(settings(true, true, 3));
@@ -497,6 +507,7 @@ class AttendanceRegularizationServiceTest {
         verify(regularizationRepository).save(captor.capture());
         assertThat(captor.getValue().getRequestedBy()).isEqualTo("admin@echno.com");
         assertThat(captor.getValue().getRequestedById()).isNull();
+        assertThat(captor.getValue().getRequestedByUserId()).isEqualTo(REQUESTER_USER_ID);
     }
 
     /**
@@ -505,7 +516,7 @@ class AttendanceRegularizationServiceTest {
      */
     @Test
     void processRegularization_recordsTheSignedInEmployeeAsTheApprover() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         AttendanceRegularization pending = pendingRaisedBy(REQUESTER_EMP_ID);
         pending.setAttendance(attendance());
         when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
@@ -530,7 +541,8 @@ class AttendanceRegularizationServiceTest {
         pending.setAttendance(attendance);
         when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
                 .thenReturn(Optional.of(pending));
-        when(selfApprovalPolicy.checkSelfApproval(REQUESTER_EMP_ID, REQUESTER_EMP_ID,
+        when(selfApprovalPolicy.checkSelfApproval(raiser(REQUESTER_EMP_ID),
+                new ApprovalParty(REQUESTER_USER_ID, REQUESTER_EMP_ID),
                 "Regularization request with ID " + REG_ID))
                 .thenThrow(new InvalidRequestException("raised by the same person"));
 
@@ -558,7 +570,8 @@ class AttendanceRegularizationServiceTest {
         pending.setRequestedEvents("[stored]");
         when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
                 .thenReturn(Optional.of(pending));
-        when(selfApprovalPolicy.checkSelfApproval(REQUESTER_EMP_ID, REQUESTER_EMP_ID,
+        when(selfApprovalPolicy.checkSelfApproval(raiser(REQUESTER_EMP_ID),
+                new ApprovalParty(REQUESTER_USER_ID, REQUESTER_EMP_ID),
                 "Regularization request with ID " + REG_ID)).thenReturn(true);
         when(regularizationMapper.deserializeRequestedEvents("[stored]"))
                 .thenReturn(List.of(correctedEvent(ClockEventType.EVENING_CLOCK_OUT, 18)));
@@ -578,7 +591,7 @@ class AttendanceRegularizationServiceTest {
     /** Negative control: an approval by someone else is an ordinary approval and says nothing extra. */
     @Test
     void processRegularization_anApprovalBySomeoneElseIsNotMarkedAsSelfApproved() {
-        signedInAs(APPROVER_EMP_ID, APPROVER);
+        signedInAs(APPROVER_USER_ID, APPROVER_EMP_ID, APPROVER);
         Attendance attendance = attendance();
         attendance.setShiftTiming(new ShiftTiming());
         attendance.setClockEvents(new ArrayList<>());
@@ -596,7 +609,8 @@ class AttendanceRegularizationServiceTest {
 
         service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
 
-        verify(selfApprovalPolicy).checkSelfApproval(REQUESTER_EMP_ID, APPROVER_EMP_ID,
+        verify(selfApprovalPolicy).checkSelfApproval(raiser(REQUESTER_EMP_ID),
+                new ApprovalParty(APPROVER_USER_ID, APPROVER_EMP_ID),
                 "Regularization request with ID " + REG_ID);
         assertThat(attendance.getClockEvents())
                 .singleElement()
@@ -633,6 +647,7 @@ class AttendanceRegularizationServiceTest {
     @Test
     void processRegularization_aRequestWithNoRecordedRequesterIdIsStillApprovable() {
         AttendanceRegularization pending = pendingRaisedBy(null);
+        pending.setRequestedByUserId(null);
         pending.setAttendance(attendance());
         when(regularizationRepository.findByIdAndOrganization_Id(REG_ID, ORG))
                 .thenReturn(Optional.of(pending));
@@ -642,7 +657,8 @@ class AttendanceRegularizationServiceTest {
 
         service.processRegularization(REG_ID, action(RegularizationStatus.APPROVED));
 
-        verify(selfApprovalPolicy).checkSelfApproval(null, REQUESTER_EMP_ID,
+        verify(selfApprovalPolicy).checkSelfApproval(new ApprovalParty(null, null),
+                new ApprovalParty(REQUESTER_USER_ID, REQUESTER_EMP_ID),
                 "Regularization request with ID " + REG_ID);
         assertThat(pending.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
     }
@@ -652,6 +668,7 @@ class AttendanceRegularizationServiceTest {
                 .status(RegularizationStatus.PENDING)
                 .requestedBy(REQUESTER)
                 .requestedById(requestedById)
+                .requestedByUserId(REQUESTER_USER_ID)
                 .build();
     }
 

--- a/src/test/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicyTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/approval/SelfApprovalPolicyTest.java
@@ -15,14 +15,20 @@ import static org.mockito.Mockito.when;
 /**
  * The rule itself, away from any document: two different people is the ordinary case and passes
  * silently, one person doing both halves is refused, a system administrator doing both halves is
- * allowed and reported back as a self-approval so the caller can record it, and a document that
- * names nobody as its raiser has nothing to compare and is let through.
+ * allowed and reported back as a self-approval so the caller can record it.
+ *
+ * <p>The rest of these cover what the rule does when it cannot simply compare two employee ids,
+ * which is where it used to fail open. A person recorded on one side by their user id and on the
+ * other by their employee id is still recognised as one person. A document whose raiser shares no
+ * identity with the approver is allowed through, because refusing would strand every document
+ * raised before its raiser was stamped. An approval that names no approver at all is refused,
+ * which is the one place the rule fails closed.
  */
 @ExtendWith(MockitoExtension.class)
 class SelfApprovalPolicyTest {
 
-    private static final Long DRAFTER = 11L;
-    private static final Long APPROVER = 12L;
+    private static final ApprovalParty DRAFTER = ApprovalParty.ofUser(11L);
+    private static final ApprovalParty APPROVER = ApprovalParty.ofUser(12L);
     private static final String DOCUMENT = "Stock adjustment with ID 5";
 
     @Mock private OrganizationSecurityService orgSecurity;
@@ -56,15 +62,86 @@ class SelfApprovalPolicyTest {
         assertThat(policy().checkSelfApproval(DRAFTER, DRAFTER, DOCUMENT)).isTrue();
     }
 
+    /**
+     * The case the attendance module was blind to: the raiser held no employee record when they
+     * filed, so only their user id names them, while by the time they approve the same session
+     * resolves to both ids. One shared identity is enough to recognise them.
+     */
     @Test
-    void aDocumentThatNamesNoRaiserHasNothingToCompareAndIsLetThrough() {
-        assertThat(policy().checkSelfApproval(null, APPROVER, DOCUMENT)).isFalse();
+    void oneSharedIdentityIsEnoughToRecogniseTheSamePersonAcrossTheTwoSpaces() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> policy().checkSelfApproval(
+                        new ApprovalParty(70L, null), new ApprovalParty(70L, 8L), DOCUMENT))
+                .withMessageContaining("someone other than whoever raised the document");
+    }
+
+    /** And the other way round: matching employee ids settle it even with no user id on the raiser. */
+    @Test
+    void matchingEmployeeIdsAreStillAMatchWhenTheRaiserHasNoUserId() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> policy().checkSelfApproval(
+                        new ApprovalParty(null, 8L), new ApprovalParty(70L, 8L), DOCUMENT));
+    }
+
+    /** Two people are two people whichever space they are compared in. */
+    @Test
+    void twoDifferentPeopleWithBothIdsIsStillTheOrdinaryCase() {
+        assertThat(policy().checkSelfApproval(
+                new ApprovalParty(70L, 8L), new ApprovalParty(71L, 9L), DOCUMENT)).isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+
+    /**
+     * A raiser recorded before the user id was kept, decided by an approver who has no employee
+     * record, shares no identity with them. That cannot be compared, and refusing would leave the
+     * document with no route to approval at all, so it goes through. The policy logs that the
+     * check was not made; what is asserted here is that it is not silently treated as a match.
+     */
+    @Test
+    void aRaiserThatSharesNoIdentityWithTheApproverIsLetThroughRatherThanStranded() {
+        assertThat(policy().checkSelfApproval(
+                new ApprovalParty(null, 8L), ApprovalParty.ofUser(70L), DOCUMENT)).isFalse();
         verifyNoInteractions(orgSecurity);
     }
 
     @Test
-    void anUnresolvedApproverIsNotTreatedAsAMatchAgainstAnUnresolvedRaiser() {
-        assertThat(policy().checkSelfApproval(null, null, DOCUMENT)).isFalse();
+    void aDocumentThatNamesNoRaiserHasNothingToCompareAndIsLetThrough() {
+        assertThat(policy().checkSelfApproval(new ApprovalParty(null, null), APPROVER, DOCUMENT))
+                .isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+
+    @Test
+    void aNullRaiserIsTreatedTheSameAsOneThatNamesNobody() {
+        assertThat(policy().checkSelfApproval(null, APPROVER, DOCUMENT)).isFalse();
+        verifyNoInteractions(orgSecurity);
+    }
+
+    /**
+     * The one refusal that is about the approver rather than the comparison. An approval that
+     * resolves to nobody would post an entry with a null approver on it, so it is not an approval,
+     * and it is certainly not evidence that a second person agreed.
+     */
+    @Test
+    void anApproverWhoResolvesToNobodyIsRefusedRatherThanWavedThrough() {
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> policy().checkSelfApproval(
+                        DRAFTER, new ApprovalParty(null, null), DOCUMENT))
+                .withMessageContaining(DOCUMENT)
+                .withMessageContaining("resolves to no user of this organization");
+        verifyNoInteractions(orgSecurity);
+    }
+
+    @Test
+    void anUnidentifiedApproverIsRefusedEvenWhenTheRaiserIsUnknownToo() {
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> policy().checkSelfApproval(null, null, DOCUMENT));
         verifyNoInteractions(orgSecurity);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
 import org.tornotron.echno_backend.common.exception.AccountNotFoundException;
 import org.tornotron.echno_backend.common.exception.InvalidJournalException;
@@ -47,12 +48,14 @@ import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
+import java.util.concurrent.atomic.AtomicLong;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
 
 /**
  * Pins the money path of the construction invoice approval workflow against a real
@@ -73,13 +76,27 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
         org.tornotron.echno_backend.finance.invoice.mapper.InvoiceMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
-        InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
+        InvoicePostingProperties.class, ChartOfAccountsSeeder.class,
         org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
         org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class,
         SelfApprovalPolicy.class, OrganizationSecurityService.class})
 class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
 
     private static final long PROJECT_ID = 4001L;
+
+    /**
+     * Two people, because approving an invoice is subject to the segregation-of-duties rule in
+     * {@link SelfApprovalPolicy} and this suite submits and approves in the same test. The session
+     * used to resolve to nobody here, which meant the rule had no approver to compare and these
+     * tests were posting entries without it ever running.
+     */
+    private static final long SUBMITTER_USER_ID = 7001L;
+    private static final long APPROVER_USER_ID = 7002L;
+
+    private final AtomicLong currentUserId = new AtomicLong(SUBMITTER_USER_ID);
+
+    @MockitoBean
+    private UserContextService userContextService;
 
     @Autowired
     private ConstructionInvoiceService service;
@@ -108,6 +125,8 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
     // The invoice and its journal entry stay in the rolled-back test transaction.
     @BeforeEach
     void seed() {
+        currentUserId.set(SUBMITTER_USER_ID);
+        when(userContextService.getCurrentUserId()).thenAnswer(inv -> currentUserId.get());
         TenantContext.clear();
         inCommittedTx(() -> {
             Organization org = persistOrganization("Posting Org");
@@ -144,13 +163,23 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
         });
     }
 
+    /** Approves as somebody other than whoever submitted, which is what the rule requires. */
+    private ConstructionInvoiceDto approveAsSomeoneElse(UUID invoiceId) {
+        handOverToTheApprover();
+        return service.approve(invoiceId);
+    }
+
+    private void handOverToTheApprover() {
+        currentUserId.set(APPROVER_USER_ID);
+    }
+
     @Test
     void approve_purchaseInvoice_postsExpenseGstInputAgainstPayable() {
         ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
         ConstructionInvoiceDto pending = service.submit(created.id());
         assertThat(pending.status()).isEqualTo(ConstructionInvoiceStatus.PENDING);
 
-        ConstructionInvoiceDto approved = service.approve(created.id());
+        ConstructionInvoiceDto approved = approveAsSomeoneElse(created.id());
         assertThat(approved.status()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
         assertThat(approved.journalEntryId()).isNotNull();
 
@@ -168,7 +197,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
         ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.SALES));
         service.submit(created.id());
 
-        ConstructionInvoiceDto approved = service.approve(created.id());
+        ConstructionInvoiceDto approved = approveAsSomeoneElse(created.id());
         assertThat(approved.status()).isEqualTo(ConstructionInvoiceStatus.APPROVED);
         assertThat(approved.journalEntryId()).isNotNull();
 
@@ -191,7 +220,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
     void cancel_approvedInvoice_reversesTheJournalEntry() {
         ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
         service.submit(created.id());
-        ConstructionInvoiceDto approved = service.approve(created.id());
+        ConstructionInvoiceDto approved = approveAsSomeoneElse(created.id());
         UUID originalJeId = approved.journalEntryId();
 
         ConstructionInvoiceDto cancelled = service.cancel(created.id(), "Ordered in error");
@@ -220,6 +249,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
         ConstructionInvoiceDto created = service.create(request(ConstructionInvoiceType.PURCHASE));
         service.submit(created.id());
 
+        handOverToTheApprover();
         assertThatExceptionOfType(AccountNotFoundException.class)
                 .isThrownBy(() -> service.approve(created.id()));
     }
@@ -236,7 +266,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
         ConstructionInvoiceDto created = service.create(clientRequest(seedClientProject()));
         service.submit(created.id());
 
-        ConstructionInvoiceDto approved = service.approve(created.id());
+        ConstructionInvoiceDto approved = approveAsSomeoneElse(created.id());
         assertThat(approved.arInvoiceId()).isNotNull();
 
         InvoiceDto ar = invoiceService.findById(approved.arInvoiceId());
@@ -262,7 +292,7 @@ class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
     void cancel_theArInvoiceOnItsOwn_isRefused_whileCancellingTheConstructionInvoiceUnwindsBoth() {
         ConstructionInvoiceDto created = service.create(clientRequest(seedClientProject()));
         service.submit(created.id());
-        ConstructionInvoiceDto approved = service.approve(created.id());
+        ConstructionInvoiceDto approved = approveAsSomeoneElse(created.id());
         UUID arInvoiceId = approved.arInvoiceId();
 
         // The AR door is shut: the construction invoice owns the entry they share.


### PR DESCRIPTION
Closes #584.

## The gap

`SelfApprovalPolicy.checkSelfApproval` short-circuited on either identity being null, and `AttendanceRegularizationService.resolveCurrentActor()` returns `employeeId = null` for a caller with no Employee row in the current organization. A member holding the org-member group plus `hr-admin` or `project-manager`, whose Employee row does not exist yet because the Keycloak groups were assigned before HR created it, could raise a regularization and approve it themselves with the rule never firing. Even for a system-admin the break-glass warn log and the "(self-approved)" note on the corrected clock events were skipped, so the row looked like a legacy one.

## What changed

**One identity convention across the three callers.** `ApprovalParty(userId, employeeId)` replaces the two bare `Long`s. The finance modules were passing user ids and attendance was passing employee ids into the same two parameters, which is how a comparison could silently be between two different things. A comparison now succeeds on whichever identity the two sides share; both are unique per person, so a match on either is conclusive.

Comparing the stored display names instead (option 2 on the issue) was rejected. `requestedBy` holds an employee name where there is an employee and a username where there is not, two people can share a name, and a person can change theirs. A segregation-of-duties control should not resolve identity by string match.

**Regularizations stamp the raiser's user id** (`requested_by_user_id`, changelog 071), because that is the identity every authenticated caller has. Rows written before this keep a null and are still compared on the employee id.

**The null short-circuit was itself failing open, so it is now three outcomes rather than one silent pass:**

| Case | Before | Now |
|---|---|---|
| Comparable, different people | allowed | allowed, unchanged |
| Comparable, same person | refused, or break-glass | unchanged |
| Approver names nobody at all | allowed silently | **refused** |
| Raiser shares no identity with the approver | allowed silently | allowed, logged at WARN |

The approver refusal is the one place this fails closed, and it is deliberately narrow. It is not a comparison that cannot be made, it is an entry about to be posted by nobody: the approver id stored on the document would be null too, so there would be no accountability on the posting at all. Every path that reaches the policy is a role-gated approve endpoint on an authenticated session.

The raiser side stays open on purpose. Refusing there would strand every document raised before its raiser was stamped, with no second route to approval, which is the same dead end the break-glass exception exists to avoid. It is logged instead, so an approval whose check could not be made is visible rather than indistinguishable from one that passed.

**Fallout worth naming:** the refusal caught `ConstructionInvoicePostingIT` approving invoices with no session identity at all, which means the self-approval rule had never actually run in that suite. It now submits and approves as two people, the way production does.

## No API change

No controller or DTO touched; `docs/openapi.json` verifies unchanged (`./gradlew openApiSnapshot` passes). Nothing needed in `echno-core`.

## Proof

`AttendanceRegularizationSelfApprovalTest` runs the real policy end to end. Against the pre-fix comparison these fail:

| Test | Pre-fix |
|---|---|
| `anEmployeeLessMemberCannotRaiseAndThenApproveTheirOwnRequest` | FAILED, the approval went through |
| `anEmployeeLessSystemAdministratorSelfApprovesAndTheClockEventsSaySo` | FAILED, no "(self-approved)" note |
| `anApproverThatResolvesToNoIdentityAtAllIsRefused` | FAILED, waved through |
| `SelfApprovalPolicyTest.oneSharedIdentityIsEnoughToRecogniseTheSamePersonAcrossTheTwoSpaces` | FAILED |
| `SelfApprovalPolicyTest.anApproverWhoResolvesToNobodyIsRefusedRatherThanWavedThrough` | FAILED |
| `SelfApprovalPolicyTest.anUnidentifiedApproverIsRefusedEvenWhenTheRaiserIsUnknownToo` | FAILED |

Negative controls pass either way: an employee-less approver deciding somebody else's request, an employee approving their own, and a legacy request staying approvable.

Full suite green on `.116`.

## The pending stock adjustment on staging

SA-563 (document id 2) is **not affected**. It carries `submitted_by = 34` (`qa-stock-adjustment-raiser@echno.in`, a real user id), and the approver resolves to a real user id as well, so the comparison runs, finds two different people, and the approval proceeds exactly as it does today. The account has no employee row, which is the shape this PR is about, but on the stock path the user id was always being compared, so nothing there changes.