### PR TITLE
Let an organization be edited without also replacing its logo

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6083,7 +6083,7 @@
       "IndentUpdateDto": {
         "description": "Payload to partially update an indent's number, project, status, expected date or remarks.",
         "properties": {
-          "createdByemployeeId": {
+          "createdByEmployeeId": {
             "description": "Id of the employee who raised the indent.",
             "example": 8,
             "format": "int64",

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
@@ -107,9 +107,9 @@ public class IndentService {
             indent.setIndentNumber(indentDto.getIndentNumber());
         }
 
-        if(indentDto.getCreatedByemployeeId() != null) {
-            Employee employee = employeeRepository.findByIdAndOrganizationId(indentDto.getCreatedByemployeeId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Employee with ID " + indentDto.getCreatedByemployeeId() + " was not found in this organization"));
+        if(indentDto.getCreatedByEmployeeId() != null) {
+            Employee employee = employeeRepository.findByIdAndOrganizationId(indentDto.getCreatedByEmployeeId(), TenantContext.getCurrentOrgId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Employee with ID " + indentDto.getCreatedByEmployeeId() + " was not found in this organization"));
             indent.setCreatedBy(employee);
         }
 

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentUpdateDto.java
@@ -12,7 +12,7 @@ public class IndentUpdateDto {
     private String indentNumber;
 
     @Schema(description = "Id of the employee who raised the indent.", example = "8")
-    private Long createdByemployeeId;
+    private Long createdByEmployeeId;
 
     @Schema(description = "Id of the project the indent is raised for.", example = "3")
     private Long projectId;

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -297,6 +297,8 @@ public class OrganizationService {
      * of an organization as provided in the updates map.
      * @param updates A {@link Map} where keys are the field names to update and values are the new values.
      * @param id The ID of the organization to update.
+     * @param attachments Files to attach, or null when the request carried no attachments part.
+     * @param entityType What the uploaded files are, for example ORGANIZATION_LOGO.
      * @return An {@link OrganizationSimpleDto} representing the updated organization.
      * @throws ResourceNotFoundException if no organization with the given ID is found.
      */
@@ -306,9 +308,14 @@ public class OrganizationService {
                .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + id + " was not found"));
        partialUpdateAnOrganization(updates,organization);
 
-       for (MultipartFile att:attachments) {
-           Attachment attachment = attachmentService.uploadAttachment(att,entityType,id,ORGANIZATION_FOLDER);
-           organization.addAttachment(attachment);
+       // The attachments part is optional, and Spring hands back null rather than an empty list
+       // when a multipart request omits it. Every organization edit that does not also replace
+       // the logo arrives that way, which is most of them.
+       if (attachments != null) {
+           for (MultipartFile att : attachments) {
+               Attachment attachment = attachmentService.uploadAttachment(att,entityType,id,ORGANIZATION_FOLDER);
+               organization.addAttachment(attachment);
+           }
        }
         return organizationMapper.toSimpleDto(repository.save(organization));
     }

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationPatchAttachmentsArgumentTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationPatchAttachmentsArgumentTest.java
@@ -1,0 +1,122 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.JsonPartBinder;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.mockito.ArgumentCaptor;
+
+/**
+ * What the organization PATCH handler receives when the request carries no attachments part.
+ *
+ * <p>This is the half of the null-logo crash that cannot be read off the service. The handler
+ * declares {@code @RequestParam(value = "attachments", required = false) List<MultipartFile>},
+ * and the question is whether an absent part reaches it as null or as an empty list. It reaches
+ * it as null, so the loop in the service ran over nothing at all.
+ *
+ * <p>The service is mocked here on purpose: this case is about the argument the framework builds,
+ * not about what the service does with it. {@link OrganizationPatchWithoutAttachmentsTest} takes
+ * the other half.
+ */
+@WebMvcTest(OrganizationWebController.class)
+@Import({OrganizationPatchAttachmentsArgumentTest.TestSecurityConfig.class, JsonPartBinder.class,
+        PayloadValidator.class})
+class OrganizationPatchAttachmentsArgumentTest {
+
+    private static final Long ORG_ID = 7L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OrganizationService organizationService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void allowTheCaller() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        when(orgSecurity.hasAnyOrgRole(anyLong(), anyString(), anyString())).thenReturn(true);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void anEditWithNoLogo_reachesTheServiceWithANullAttachmentsList() throws Exception {
+        when(organizationService.partialUpdateAnOrganization(any(), anyLong(), any(), anyString()))
+                .thenReturn(new OrganizationSimpleDto());
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data", "", MediaType.APPLICATION_JSON_VALUE,
+                "{\"organizationName\":\"Asset Homes Kerala\"}".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/v1/organization/web/{id}", ORG_ID)
+                        .file(data)
+                        .with(jwt()))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MultipartFile>> attachments =
+                ArgumentCaptor.forClass((Class<List<MultipartFile>>) (Class<?>) List.class);
+        verify(organizationService).partialUpdateAnOrganization(
+                any(), anyLong(), attachments.capture(), anyString());
+
+        // Null, not an empty list. Iterating this without a guard is the crash.
+        assertThat(attachments.getValue()).isNull();
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationPatchWithoutAttachmentsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationPatchWithoutAttachmentsTest.java
@@ -1,0 +1,102 @@
+package org.tornotron.echno_backend.organization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Editing an organization without replacing its logo.
+ *
+ * <p>The handler declares the attachments part as {@code required = false}, and Spring resolves an
+ * absent multipart parameter to null rather than to an empty list. The service then iterated it
+ * with no guard, so the loop dereferenced null. Every edit of an organization's name, address,
+ * email, phone or website that did not also upload a file went that way, which is nearly all of
+ * them. {@code IssueService} guards the same shape correctly; this one did not.
+ *
+ * <p>Two things are pinned, because either alone proves nothing. That Spring really hands the
+ * service a null is the companion web-slice case in
+ * {@link OrganizationPatchAttachmentsArgumentTest}; that a null crashes the service is here. The
+ * first test fails with a NullPointerException on the unguarded code.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrganizationPatchWithoutAttachmentsTest {
+
+    private static final Long ORG_ID = 7L;
+
+    @Mock private OrganizationRepository repository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private KeycloakGroupService keycloakGroupService;
+    @Mock private SubscriptionService subscriptionService;
+    @Mock private UserContextService userContextService;
+    @Mock private EmployeeService employeeService;
+    @Mock private OrganizationMapper organizationMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+    @Mock private PayloadValidator payloadValidator;
+
+    private OrganizationService service() {
+        return new OrganizationService(
+                repository,
+                attachmentService,
+                fileStorageService,
+                keycloakGroupService,
+                subscriptionService,
+                userContextService,
+                employeeService,
+                organizationMapper,
+                orgSecurity,
+                onboardingSeeder,
+                payloadValidator);
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        organization.setOrganizationName("Asset Homes");
+        return organization;
+    }
+
+    @Test
+    void updatingAnOrganization_withNoAttachmentsPart_doesNotCrash() {
+        Organization stored = organization();
+        when(repository.findById(ORG_ID)).thenReturn(Optional.of(stored));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(organizationMapper.toSimpleDto(any())).thenReturn(new OrganizationSimpleDto());
+
+        assertThatCode(() -> service().partialUpdateAnOrganization(
+                Map.of("organizationName", "Asset Homes Kerala"),
+                ORG_ID,
+                null,
+                "ORGANIZATION_LOGO"))
+                .doesNotThrowAnyException();
+
+        assertThatOrganizationWasRenamed(stored);
+        // No file arrived, so nothing should have been asked of the attachment store.
+        verifyNoInteractions(attachmentService);
+    }
+
+    private void assertThatOrganizationWasRenamed(Organization stored) {
+        org.assertj.core.api.Assertions.assertThat(stored.getOrganizationName())
+                .isEqualTo("Asset Homes Kerala");
+    }
+}


### PR DESCRIPTION
Two defects found beside the OpenAPI contract check (echno-core#57), neither of them on its list of 66.

## The crash

`OrganizationWebController.partialUpdateAnOrganization` declares

```java
@RequestParam(value = "attachments", required = false) List<MultipartFile> attachments
```

and `OrganizationService` iterated it straight away, with no null guard. Spring resolves an absent multipart parameter to null, not to an empty list, so every organization edit that did not also upload a file went through a loop over null. That is nearly all of them: the form has name, address, email, phone and website alongside the logo, and changing any of those without touching the logo took this path. `IssueService` guards exactly this shape correctly, which is what makes the omission look like a copy that lost a line rather than a decision.

This was reasoned rather than executed on echno-core#57, because the staging admin lacks the `system-admin` / `hr-admin` role the endpoint wants and granting one to make a test possible is not a thing to do. It is now settled by test instead, which is the better proof anyway.

**Two tests, because either alone proves nothing.** `OrganizationPatchAttachmentsArgumentTest` is a web slice with the service mocked: it PATCHes a multipart request carrying only the `data` part and captures what the handler was given, asserting it is null. That is the half you cannot read off the service. `OrganizationPatchWithoutAttachmentsTest` builds the service and calls it with null, which fails with a NullPointerException on the unguarded code and passes with the guard. Together they say the crash was live on every logo-less edit.

Worth noting for echno-core#57: this puts the organization `isActive` finding at #5 on that list out of reach entirely, not merely dropped. That PATCH could not complete at all unless a file went with it.

## The typo

`IndentUpdateDto.createdByemployeeId` has a lowercase `e`, against `createdByEmployeeId` on `IndentCreationDto`. `IndentService.updateIndent` reads the misspelled getter, so a caller sending the name the create endpoint uses would have it silently dropped: the indent's creator would not change and the response would say the update succeeded.

Nothing sends either name today. `UpdateIndentRequest` in echno-core has no such field, and echno-web sets `createdByEmployeeId` only on the create page. That is why this has gone unnoticed, and why renaming it costs nothing now: no deployed client is relying on the misspelling, so there is no migration to sequence. Left alone it becomes a live bug the first time somebody adds the field to the client by copying the name from the create DTO, which is exactly what they would do.

Full suite green on `.116`; `docs/openapi.json` regenerated for the renamed property.