### PR TITLE
Drop the employee reporting_manager column nothing has ever written

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -352,4 +352,7 @@
     <!-- v4.0 - Regularizations: the raiser's user id, so the self-approval rule always has one -->
     <include file="db/changelog/v4.0/072-add-regularization-requested-by-user-id.xml"/>
 
+    <!-- v4.0 - Employees: drop the free-text reporting_manager; manager_id is the reporting line -->
+    <include file="db/changelog/v4.0/074-drop-employee-reporting-manager.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/074-drop-employee-reporting-manager.xml
+++ b/src/main/resources/db/changelog/v4.0/074-drop-employee-reporting-manager.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="074-01-drop-employee-reporting-manager" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="employee" columnName="reporting_manager"/>
+        </preConditions>
+
+        <comment>
+            Removes the employee.reporting_manager string.
+
+            The reporting line is manager_id, the self-referencing foreign key behind
+            Employee.manager: it is validated by EmployeeHierarchyService.validateManager
+            (same organization, not self, no cycle) and read by findByManager_Id for the
+            subordinates listing. reporting_manager is the older free-text column that
+            052-refactor-reporting-manager replaced in v1.2 without dropping. No entity
+            field, DTO field or query has referenced it since, so Hibernate has never read
+            or written it, and on staging it was null on all thirty rows while manager_id
+            carried four real reporting lines.
+
+            Nothing is backfilled and nothing is lost: no application code could have put a
+            value there, and the column is empty everywhere it has been measured.
+        </comment>
+
+        <dropColumn tableName="employee" columnName="reporting_manager"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeSchemaIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeSchemaIT.java
@@ -1,0 +1,48 @@
+package org.tornotron.echno_backend.employee;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the shape of the employee table as Liquibase builds it, against a real
+ * CockroachDB (see {@link AbstractIntegrationTest}).
+ *
+ * <p>An employee's reporting line is {@code manager_id}, the self-referencing foreign
+ * key behind {@link Employee#getManager()}. The free-text {@code reporting_manager}
+ * column it replaced in v1.2 stayed in the schema afterwards with no entity field, DTO
+ * field or query behind it, so it read as a second answer to the same question while
+ * holding nothing. Dropping it is what this asserts, together with the column that does
+ * carry the relationship still being there.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class EmployeeSchemaIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void employeeTable_hasManagerId_andNoReportingManagerColumn() {
+        List<String> columns = employeeColumns();
+
+        assertThat(columns).contains("manager_id");
+        assertThat(columns).doesNotContain("reporting_manager");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> employeeColumns() {
+        return em.createNativeQuery(
+                        "SELECT lower(column_name) FROM information_schema.columns "
+                                + "WHERE lower(table_name) = 'employee' "
+                                + "AND table_schema = current_schema()")
+                .getResultList();
+    }
+}


### PR DESCRIPTION
Closes #587.

## What this removes

`employee.reporting_manager`, a `VARCHAR(255)` that has been in the schema since `v1.0/009-create-employee.xml` and was carried through the `v2.0`, `v3.0` and `v4.0` baseline squashes.

## The claim, re-checked rather than inherited

The issue says no Java code maps it. That holds, and it holds a little more widely than the issue states:

- `Employee` has no `reportingManager` field. The reporting line is `manager` / `@JoinColumn(name = "manager_id")`.
- Case-insensitive grep for `reporting_manager` / `reportingManager` over the whole backend repo hits **only** changelog XML: `v1.0/009`, `v1.2/052`, and the three baselines. Nothing in `src/`.
- The same grep over `echno-core` and `echno-web` returns nothing either, so the column has never reached a DTO or the client.

`v1.2/052-refactor-reporting-manager.xml` is the reason it looks like a duplicate: it added `manager_id`, the FK, and the index, and left the string column it replaced sitting beside them. `EmployeeHierarchyService.validateManager` (same organization, not self, no cycle) and `findByManager_Id` are what carry the relationship now; the measurement on the issue was 0 of 30 rows with `reporting_manager` set against 4 with `manager_id`.

## What is here

- `v4.0/072-drop-employee-reporting-manager.xml`, guarded on `columnExists` so re-running against a database that already dropped it marks-ran instead of failing, plus the master include.
- `EmployeeSchemaIT`, a Liquibase-built-schema assertion against the real CockroachDB container: `employee` has `manager_id` and does not have `reporting_manager`.

Nothing else changes: no entity field, DTO field or query to remove with it, no data to migrate, no API surface, so `docs/openapi.json` is untouched.

## Verified

On the lab box, against the real container:

- With the changeset: `EmployeeSchemaIT` passes.
- With the master include removed: it fails on `not to contain ["reporting_manager"] but found ["reporting_manager"]`.

The negative run also confirms `is_manager` is already gone from the built schema, so this sits cleanly on top of #520.