### PR TITLE
Walk the two hops the public-endpoint guard could not see

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/SecurityConfig.java
@@ -70,8 +70,14 @@ public class SecurityConfig {
                         // touches tenant-scoped data, it does not belong on this list; scope the
                         // read on something the caller proved and put it behind an authenticated
                         // path instead. PublicEndpointTenantExposureTest walks the handler chain
-                        // of every @PreAuthorize("permitAll()") endpoint and fails the build on
-                        // one that reaches a tenant-scoped repository.
+                        // of every endpoint whose @PreAuthorize lets an unauthenticated caller
+                        // through, and fails the build on one that reaches a tenant-scoped
+                        // repository, an EntityManager query or a JdbcTemplate statement,
+                        // whether it reaches it by a direct call, through an interface, or
+                        // across a published event into a synchronous listener. What it cannot
+                        // see is a call dispatched by a value rather than by a type: a lambda
+                        // handed across a boundary, reflection, a proxy resolved by name. That
+                        // limit is stated on the test itself.
                         //
                         // /actuator is the exception, and only because TenantFilter skips it
                         // outright rather than declaring anything: an entity load from there is

--- a/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureRuleTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureRuleTest.java
@@ -74,6 +74,19 @@ class PublicEndpointTenantExposureRuleTest {
                 .isEmpty();
     }
 
+    /**
+     * And the same for a listener that is asynchronous by its class rather than by its method.
+     * Spring applies a type-level {@code @Async} to every method the type declares, so reading
+     * only the method annotation would put this listener back into the reported path.
+     */
+    @Test
+    void doesNotFollowAListenerMadeAsynchronousByItsClass() {
+        assertThat(pathFrom(
+                PublicEndpointReachabilityFixtures.PublishesAClassLevelAsyncEvent.class, "handle"))
+                .as("a type-level @Async is as good as one on the method")
+                .isEmpty();
+    }
+
     // -------------------------------------------------------------------------------
     // Hole 2: reads that are not Spring Data repositories
     // -------------------------------------------------------------------------------

--- a/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureRuleTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureRuleTest.java
@@ -1,0 +1,159 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.architecture.fixtures.PublicEndpointReachabilityFixtures;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the gate, not for the code the gate guards.
+ *
+ * <p>{@link PublicEndpointTenantExposureTest} finds nothing in the production code, which is
+ * the answer everybody wants and also the answer a broken rule gives. Its walk follows three
+ * hops a plain call graph does not have, each added because this codebase routes tenant reads
+ * through it, and each is the kind of thing a later tidy-up removes without anything going
+ * red. So each hop is driven here over a planted violation shaped like the production code
+ * that uses it, and each is paired with the case it must not report, because a walk that says
+ * yes to everything is no more useful than one that says no to everything.
+ *
+ * <p>The fixtures are not Spring beans and the walk is driven directly rather than through
+ * {@code publicEndpoints}, so nothing here can be picked up by a component scan. What
+ * {@code permitAll} means is a separate, pure decision and is tested as one below.
+ */
+class PublicEndpointTenantExposureRuleTest {
+
+    /**
+     * Instance fields rather than statics, so the imported graph is collectable as soon as the
+     * test that used it is done. It is one small package and the import is cheap; holding a
+     * class graph in a {@code static final} for the life of the JVM is what the architecture
+     * tests use ArchUnit's own cache to avoid.
+     */
+    private final JavaClasses fixtures = new ClassFileImporter()
+            .importPackages("org.tornotron.echno_backend.architecture.fixtures");
+
+    private final PublicEndpointTenantExposureTest.Reachability reachability =
+            new PublicEndpointTenantExposureTest.Reachability(fixtures);
+
+    // -------------------------------------------------------------------------------
+    // Hole 1: the event-publish hop
+    // -------------------------------------------------------------------------------
+
+    /**
+     * The hop the gate was blind to. The handler names neither the repository nor the listener;
+     * the only edge between them is an event, and {@code publishEvent} belongs to Spring, so a
+     * walk that stops at the framework boundary drops it and reports green.
+     */
+    @Test
+    void followsAPublishedEventIntoItsListener() {
+        List<String> path = pathFrom(PublicEndpointReachabilityFixtures.PublishesAnEvent.class, "handle");
+
+        assertThat(path)
+                .as("the walk has to cross publishEvent and land in the listener that reads")
+                .isNotEmpty();
+        assertThat(path).last().asString().contains("findAll");
+        assertThat(String.join(" -> ", path)).contains("ReadsTenantRowsOnCommit.on");
+    }
+
+    /**
+     * And the listener it must not follow. An {@code @Async} listener runs on a thread the
+     * unscoped declaration never reaches, so the load boundary refuses the read rather than
+     * letting it through: reporting it would be a false alarm, and false alarms are how a
+     * ratchet gets switched off.
+     */
+    @Test
+    void doesNotFollowAnAsynchronousListener() {
+        assertThat(pathFrom(PublicEndpointReachabilityFixtures.PublishesAnAsyncOnlyEvent.class, "handle"))
+                .as("an @Async listener is behind a thread hand-off, where the load boundary is "
+                        + "back on and the read is refused")
+                .isEmpty();
+    }
+
+    // -------------------------------------------------------------------------------
+    // Hole 2: reads that are not Spring Data repositories
+    // -------------------------------------------------------------------------------
+
+    @Test
+    void countsAnEntityManagerQueryAsAReadOfTenantData() {
+        assertThat(pathFrom(PublicEndpointReachabilityFixtures.QueriesThroughTheEntityManager.class, "handle"))
+                .last().asString().contains("createNativeQuery");
+    }
+
+    @Test
+    void countsAJdbcTemplateStatementAsAReadOfTenantData() {
+        assertThat(pathFrom(PublicEndpointReachabilityFixtures.QueriesThroughJdbc.class, "handle"))
+                .last().asString().contains("queryForObject");
+    }
+
+    /**
+     * Holding an {@code EntityManager} is not the same as querying through one. Without this,
+     * every class that touches the persistence context for configuration reads as a database
+     * access and the rule reports paths nobody can act on.
+     */
+    @Test
+    void doesNotCountAnEntityManagerCallThatIssuesNoStatement() {
+        assertThat(pathFrom(PublicEndpointReachabilityFixtures.OnlyUnwrapsTheEntityManager.class, "handle"))
+                .isEmpty();
+    }
+
+    // -------------------------------------------------------------------------------
+    // The minor gap: a call typed as an interface
+    // -------------------------------------------------------------------------------
+
+    /**
+     * A call through an interface resolves to the interface's own declaration, which has no
+     * body. Without the descent the walk stops there, one hop short of the class that reads.
+     */
+    @Test
+    void descendsFromAnInterfaceIntoItsImplementation() {
+        List<String> path = pathFrom(PublicEndpointReachabilityFixtures.CallsThroughAnInterface.class, "handle");
+
+        assertThat(path).isNotEmpty();
+        assertThat(String.join(" -> ", path)).contains("TenantReadingAdapter.read");
+    }
+
+    // -------------------------------------------------------------------------------
+    // The rule is not vacuous in the other direction either
+    // -------------------------------------------------------------------------------
+
+    @Test
+    void reportsNothingForWorkThatReachesNoDatabase() {
+        assertThat(pathFrom(PublicEndpointReachabilityFixtures.ReadsNothing.class, "handle")).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------------
+    // What counts as public
+    // -------------------------------------------------------------------------------
+
+    /**
+     * A compound grant is reachable without authentication by its first term. Reading it as
+     * protected because it is not the exact string {@code permitAll()} would shrink what the
+     * rule looks at without anyone noticing, which is the one thing a ratchet cannot survive.
+     */
+    @Test
+    void treatsACompoundOrAnonymousGrantAsPublic() {
+        assertThat(PublicEndpointTenantExposureTest.isPermitAllExpression("permitAll()")).isTrue();
+        assertThat(PublicEndpointTenantExposureTest.isPermitAllExpression("permitAll")).isTrue();
+        assertThat(PublicEndpointTenantExposureTest.isPermitAllExpression(" permitAll( ) ")).isTrue();
+        assertThat(PublicEndpointTenantExposureTest
+                .isPermitAllExpression("permitAll() or hasRole('ADMIN')")).isTrue();
+        assertThat(PublicEndpointTenantExposureTest.isPermitAllExpression("isAnonymous()")).isTrue();
+
+        assertThat(PublicEndpointTenantExposureTest.isPermitAllExpression("isAuthenticated()")).isFalse();
+        assertThat(PublicEndpointTenantExposureTest
+                .isPermitAllExpression("hasRole('ORG_ADMIN')")).isFalse();
+        assertThat(PublicEndpointTenantExposureTest
+                .isPermitAllExpression("@orgSecurity.isMemberOfCurrentTenant()")).isFalse();
+    }
+
+    private List<String> pathFrom(Class<?> owner, String method) {
+        JavaMethod start = fixtures.get(owner).getMethod(method);
+        Optional<List<String>> path = reachability.pathToTenantData(start);
+        return path.orElseGet(List::of);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
@@ -3,12 +3,19 @@ package org.tornotron.echno_backend.architecture;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.repository.Repository;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,8 +59,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p><b>What counts as public.</b> {@link EndpointAuthorizationTest} already requires every
  * request-mapped method in a {@code @RestController} to carry an explicit {@code @PreAuthorize},
- * with an empty grandfather set, so {@code permitAll()} is the complete and authoritative marker
- * of an endpoint whose author intended it to be reachable unauthenticated. The security config's
+ * with an empty grandfather set, so the annotation is the complete and authoritative marker of
+ * an endpoint whose author intended it to be reachable unauthenticated. Any expression that
+ * mentions {@code permitAll} or {@code isAnonymous} counts, not only a bare
+ * {@code permitAll()}: a compound grant such as {@code "permitAll() or hasRole('ADMIN')"} is
+ * reachable without authentication by its first term. The security config's
  * {@code permitAll} matcher list is the other half of the same decision, but it can only withhold
  * access, never grant it past a method-level {@code @PreAuthorize}, so reading the annotation
  * catches the hazard a matcher-list scan would and catches it one step earlier: at the moment the
@@ -72,10 +82,46 @@ import static org.assertj.core.api.Assertions.assertThat;
  * tenant-scoped rows knowingly, scoped by the caller's own user id rather than by the tenant
  * layer, so a rule over them would be an allowlist of its own contents and would say nothing.
  *
- * <p>Reachability is computed over method calls only and only through this codebase's own
- * classes, the same walk {@link MapperDatabaseAccessTest} uses, for the same reason: neither
- * hazard names its repository directly, and a direct-call rule would pass the very code it exists
- * to prevent. Breadth first, so the reported path is the shortest one.
+ * <h2>What the walk follows</h2>
+ *
+ * <p>Reachability is computed over method calls through this codebase's own classes, the same
+ * walk {@link MapperDatabaseAccessTest} uses, for the same reason: neither hazard names its
+ * repository directly, and a direct-call rule would pass the very code it exists to prevent.
+ * Breadth first, so the reported path is the shortest one. Three hops are followed that a
+ * plain call graph does not have, because this codebase routes real tenant reads through all
+ * three and a gate that stopped at the first of them would report green over each of them.
+ *
+ * <p><b>Publishing an event.</b> {@code ApplicationEventPublisher.publishEvent} is a Spring
+ * method, so a walk that stops at the framework drops it and never sees the listener behind
+ * it. The GRN, site-transfer, consumption and chat services all move tenant work across that
+ * hop. It is followed by matching the event this codebase constructs in the publishing method
+ * against the parameter type of every {@code @EventListener} and
+ * {@code @TransactionalEventListener}; where no event type can be identified at the publish
+ * site, every listener is followed instead, which over-reports rather than misses.
+ * {@code AFTER_COMMIT} is not an escape: that listener runs on the request thread, inside the
+ * same unscoped declaration. An {@code @Async} listener is the one that is deliberately not
+ * followed, and for the same reason {@code /actuator} is not covered: the thread hand-off
+ * leaves the declaration behind, so the load boundary is back on and the read is refused
+ * rather than let through.
+ *
+ * <p><b>Dropping below Spring Data.</b> A repository is not the only way to a row.
+ * {@code EntityManager} query methods and {@code JdbcTemplate} are counted as reads in their
+ * own right, which is what {@code ReportService}, {@code VendorSummaryService} and
+ * {@code DocumentNumberAllocator} use today. Which table such a query touches is a string in
+ * the source and not a fact in the bytecode, so unlike a repository these are reported whatever
+ * they read. That is the deliberate direction: an unauthenticated request reaching hand-written
+ * SQL deserves the argument, and the answer is to key the query on something the caller proved
+ * rather than to widen this rule.
+ *
+ * <p><b>Calls typed as an interface.</b> A call through an interface resolves to the interface's
+ * own declaration, which has no body, so the walk would stop one hop short of the implementation
+ * that does the reading. Every implementation in the imported graph is followed as well.
+ *
+ * <p>One limit is left standing and is stated here rather than discovered later. Reachability
+ * is over static calls, so anything dispatched by a value rather than by a type is invisible:
+ * a lambda handed across a boundary, reflection, a Spring proxy resolved by name. Nothing on
+ * a public path does that today, and the rule would have to become a data-flow analysis to
+ * see it.
  *
  * <p>Runs under {@code @AnalyzeClasses} so the imported class graph comes from ArchUnit's own
  * cache, shared with every architecture test in this package. See {@link
@@ -113,9 +159,10 @@ class PublicEndpointTenantExposureTest {
                         + "marker before deleting this assertion")
                 .isNotEmpty();
 
+        Reachability reachability = new Reachability(productionClasses);
         Map<String, List<String>> offenders = new LinkedHashMap<>();
         for (JavaMethod endpoint : publicEndpoints) {
-            pathToTenantScopedRepository(endpoint).ifPresent(path ->
+            reachability.pathToTenantData(endpoint).ifPresent(path ->
                     offenders.put(name(endpoint.getOwner(), endpoint.getName()), path));
         }
 
@@ -137,7 +184,7 @@ class PublicEndpointTenantExposureTest {
      * @param productionClasses The imported production classes.
      * @return The handlers an unauthenticated caller can reach.
      */
-    private static List<JavaMethod> publicEndpoints(JavaClasses productionClasses) {
+    static List<JavaMethod> publicEndpoints(JavaClasses productionClasses) {
         List<JavaMethod> endpoints = new ArrayList<>();
         for (JavaClass javaClass : productionClasses) {
             if (!javaClass.isAnnotatedWith(RestController.class)) {
@@ -165,57 +212,249 @@ class PublicEndpointTenantExposureTest {
     }
 
     /**
-     * Whether a SpEL authorization expression grants everyone. Both {@code permitAll} and
-     * {@code permitAll()} are valid and both appear in the wild, and whitespace is free.
+     * Whether a SpEL authorization expression lets an unauthenticated caller through.
+     *
+     * <p>Anything mentioning {@code permitAll} or {@code isAnonymous} counts, not only a bare
+     * {@code permitAll()}. A compound grant such as {@code "permitAll() or hasRole('ADMIN')"}
+     * is reachable without authentication by its first term, and reading it as protected
+     * because it is not the exact string would quietly shrink what this rule looks at, which
+     * is the failure mode a ratchet can least afford. Both {@code permitAll} and
+     * {@code permitAll()} are valid, and whitespace is free.
      *
      * @param expression The {@code @PreAuthorize} value.
-     * @return True where the expression is a bare permit-all.
+     * @return True where an unauthenticated caller can reach the handler.
      */
-    private static boolean isPermitAllExpression(String expression) {
+    static boolean isPermitAllExpression(String expression) {
         String normalized = expression.replaceAll("\\s", "");
-        return "permitAll".equals(normalized) || "permitAll()".equals(normalized);
+        return normalized.contains("permitAll") || normalized.contains("isAnonymous");
     }
 
     /**
-     * Walks the method-call graph out of a handler, looking for a call on a repository whose rows
-     * are tenant-scoped.
+     * The call graph out of a public handler, and the three hops a plain call graph does not
+     * have. Built once per rule run because the listener index is the same for every endpoint.
      *
-     * <p>Breadth first, so the reported path is the shortest one, which is the one that reads as
-     * an explanation. Only calls landing in this codebase are followed: a framework method is a
-     * leaf, either a repository call or of no interest.
-     *
-     * @param endpoint The public handler to walk out from.
-     * @return The call path from the handler to the tenant-scoped read, or empty where there is
-     *         none.
+     * <p>Package-private, and driven directly by {@link PublicEndpointTenantExposureRuleTest}
+     * over a planted set of violations. A gate nobody has watched fail is a gate nobody knows
+     * works, and every hop this class follows was added because the codebase already uses it,
+     * so each one is worth a test that shows it biting.
      */
-    private static Optional<List<String>> pathToTenantScopedRepository(JavaMethod endpoint) {
-        Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom = new LinkedHashMap<>();
-        Set<JavaCodeUnit> seen = new HashSet<>();
-        Deque<JavaCodeUnit> queue = new ArrayDeque<>();
+    static final class Reachability {
 
-        seen.add(endpoint);
-        queue.add(endpoint);
+        private final JavaClasses classes;
 
-        while (!queue.isEmpty()) {
-            JavaCodeUnit current = queue.poll();
-            for (JavaMethodCall call : current.getMethodCallsFromSelf()) {
-                JavaClass targetOwner = call.getTargetOwner();
-                if (isTenantScopedRepository(targetOwner)) {
-                    return Optional.of(describePath(endpoint, current, arrivedFrom, call));
+        /**
+         * Listener methods by the event type they take, {@code @Async} ones included.
+         *
+         * <p>The asynchronous ones are indexed even though they are never followed, because
+         * knowing that an event has listeners is what tells an event whose only listener runs
+         * on another thread apart from an event whose type could not be worked out at all.
+         * The first has no edge; the second falls back to every listener.
+         */
+        private final Map<JavaClass, List<JavaMethod>> listenersByEventType = new LinkedHashMap<>();
+
+        /**
+         * Listeners that declare no parameter, so no constructed event can be matched against
+         * them. Always a candidate, because the alternative is to drop them silently.
+         */
+        private final List<JavaMethod> untypedListeners = new ArrayList<>();
+
+        Reachability(JavaClasses classes) {
+            this.classes = classes;
+            indexListeners();
+        }
+
+        /**
+         * Walks out of a handler until it reaches a read of tenant data, or runs out of graph.
+         *
+         * <p>Breadth first, so the reported path is the shortest one, which is the one that
+         * reads as an explanation.
+         *
+         * @param endpoint The public handler to walk out from.
+         * @return The call path from the handler to the read, or empty where there is none.
+         */
+        Optional<List<String>> pathToTenantData(JavaMethod endpoint) {
+            Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom = new LinkedHashMap<>();
+            Map<JavaCodeUnit, String> arrivedVia = new LinkedHashMap<>();
+            Set<JavaCodeUnit> seen = new HashSet<>();
+            Deque<JavaCodeUnit> queue = new ArrayDeque<>();
+
+            seen.add(endpoint);
+            queue.add(endpoint);
+
+            while (!queue.isEmpty()) {
+                JavaCodeUnit current = queue.poll();
+                for (JavaMethodCall call : current.getMethodCallsFromSelf()) {
+                    JavaClass targetOwner = call.getTargetOwner();
+
+                    String read = tenantDataRead(targetOwner, call);
+                    if (read != null) {
+                        return Optional.of(describePath(endpoint, current, arrivedFrom, arrivedVia, read));
+                    }
+
+                    if (isEventPublication(targetOwner, call)) {
+                        for (JavaMethod listener : listenersReachableFrom(current)) {
+                            enqueue(listener, current, "on the event published above",
+                                    seen, queue, arrivedFrom, arrivedVia);
+                        }
+                        continue;
+                    }
+
+                    if (!isOurs(targetOwner)) {
+                        continue;
+                    }
+                    Optional<JavaMethod> called = call.getTarget().resolveMember();
+                    if (called.isEmpty()) {
+                        continue;
+                    }
+                    enqueue(called.get(), current, null, seen, queue, arrivedFrom, arrivedVia);
+                    for (JavaMethod implementation : implementationsOf(called.get())) {
+                        enqueue(implementation, current,
+                                "implementing " + called.get().getOwner().getSimpleName(),
+                                seen, queue, arrivedFrom, arrivedVia);
+                    }
                 }
-                if (!isOurs(targetOwner)) {
-                    continue;
+            }
+            return Optional.empty();
+        }
+
+        private void enqueue(JavaMethod next,
+                             JavaCodeUnit from,
+                             String via,
+                             Set<JavaCodeUnit> seen,
+                             Deque<JavaCodeUnit> queue,
+                             Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom,
+                             Map<JavaCodeUnit, String> arrivedVia) {
+            if (!seen.add(next)) {
+                return;
+            }
+            arrivedFrom.put(next, from);
+            if (via != null) {
+                arrivedVia.put(next, via);
+            }
+            queue.add(next);
+        }
+
+        /**
+         * What a call reads, or null where it reads nothing this rule cares about.
+         *
+         * <p>Three kinds of read, and they are not interchangeable. A tenant-scoped repository
+         * is decided from its own declaration, so the verdict is exact. An
+         * {@link EntityManager} query or a {@link JdbcOperations} call is hand-written SQL
+         * whose table is a string the bytecode does not carry, so it is reported whatever it
+         * touches: an unauthenticated request that has got as far as raw SQL is worth the
+         * argument even when that particular statement is harmless.
+         */
+        private String tenantDataRead(JavaClass targetOwner, JavaMethodCall call) {
+            if (isTenantScopedRepository(targetOwner)) {
+                return name(targetOwner, call.getName());
+            }
+            if (targetOwner.isAssignableTo(EntityManager.class)
+                    && ENTITY_MANAGER_READS.contains(call.getName())) {
+                return name(targetOwner, call.getName());
+            }
+            if (targetOwner.isAssignableTo(JdbcOperations.class) && isJdbcStatement(call.getName())) {
+                return name(targetOwner, call.getName());
+            }
+            return null;
+        }
+
+        private static boolean isJdbcStatement(String method) {
+            return method.startsWith("query") || method.equals("update")
+                    || method.equals("batchUpdate") || method.equals("execute");
+        }
+
+        private static boolean isEventPublication(JavaClass targetOwner, JavaMethodCall call) {
+            return "publishEvent".equals(call.getName())
+                    && targetOwner.isAssignableTo(ApplicationEventPublisher.class);
+        }
+
+        /**
+         * The listeners a publishing method can reach.
+         *
+         * <p>The event type is taken from what the publishing method constructs, which is how
+         * every publication in this codebase is written and the only thing the bytecode offers:
+         * the call itself is erased to {@code publishEvent(Object)}. Where nothing constructed
+         * there matches a listener, every listener is a candidate rather than none, so a
+         * publication built somewhere else over-reports instead of disappearing.
+         */
+        private List<JavaMethod> listenersReachableFrom(JavaCodeUnit publisher) {
+            List<JavaMethod> matched = new ArrayList<>(untypedListeners);
+            boolean eventTypeIdentified = false;
+            for (JavaConstructorCall constructorCall : publisher.getConstructorCallsFromSelf()) {
+                String constructed = constructorCall.getTargetOwner().getName();
+                for (Map.Entry<JavaClass, List<JavaMethod>> entry : listenersByEventType.entrySet()) {
+                    if (!entry.getKey().isAssignableFrom(constructed)) {
+                        continue;
+                    }
+                    eventTypeIdentified = true;
+                    entry.getValue().stream().filter(Reachability::runsOnTheRequestThread)
+                            .forEach(matched::add);
                 }
-                Optional<JavaMethod> called = call.getTarget().resolveMember();
-                if (called.isEmpty() || !seen.add(called.get())) {
-                    continue;
+            }
+            if (eventTypeIdentified) {
+                return matched;
+            }
+            List<JavaMethod> everyListener = new ArrayList<>(untypedListeners);
+            listenersByEventType.values().forEach(listeners -> listeners.stream()
+                    .filter(Reachability::runsOnTheRequestThread).forEach(everyListener::add));
+            return everyListener;
+        }
+
+        private static boolean runsOnTheRequestThread(JavaMethod listener) {
+            return !listener.isAnnotatedWith(Async.class);
+        }
+
+        private void indexListeners() {
+            for (JavaClass javaClass : classes) {
+                for (JavaMethod method : javaClass.getMethods()) {
+                    if (!method.isMetaAnnotatedWith(EventListener.class)) {
+                        continue;
+                    }
+                    List<JavaClass> parameters = method.getRawParameterTypes();
+                    if (parameters.isEmpty()) {
+                        if (runsOnTheRequestThread(method)) {
+                            untypedListeners.add(method);
+                        }
+                    } else {
+                        listenersByEventType
+                                .computeIfAbsent(parameters.get(0), unused -> new ArrayList<>())
+                                .add(method);
+                    }
                 }
-                arrivedFrom.put(called.get(), current);
-                queue.add(called.get());
             }
         }
-        return Optional.empty();
+
+        /**
+         * Every implementation of an interface or abstract method in the imported graph.
+         *
+         * <p>A call through an interface resolves to the interface's own declaration, which has
+         * no body, so without this the walk stops one hop short of the class that does the
+         * reading. Nothing on a public path is injected by interface today, which is exactly
+         * why it is worth closing before something is.
+         */
+        private List<JavaMethod> implementationsOf(JavaMethod method) {
+            JavaClass owner = method.getOwner();
+            if (!owner.isInterface() && !method.getModifiers().contains(JavaModifier.ABSTRACT)) {
+                return List.of();
+            }
+            String[] parameters = method.getRawParameterTypes().stream()
+                    .map(JavaClass::getName)
+                    .toArray(String[]::new);
+            List<JavaMethod> implementations = new ArrayList<>();
+            for (JavaClass subtype : owner.getAllSubclasses()) {
+                subtype.tryGetMethod(method.getName(), parameters)
+                        .filter(candidate -> !candidate.getModifiers().contains(JavaModifier.ABSTRACT))
+                        .ifPresent(implementations::add);
+            }
+            return implementations;
+        }
     }
+
+    /** The {@link EntityManager} methods that put a statement on the wire. */
+    private static final Set<String> ENTITY_MANAGER_READS = Set.of(
+            "createQuery", "createNativeQuery", "createNamedQuery", "createStoredProcedureQuery",
+            "createNamedStoredProcedureQuery", "find", "getReference", "merge", "persist",
+            "remove", "refresh", "lock");
 
     /**
      * Whether a call lands on a Spring Data repository that deals in tenant-scoped rows.
@@ -328,11 +567,15 @@ class PublicEndpointTenantExposureTest {
 
     private static List<String> describePath(JavaMethod endpoint, JavaCodeUnit lastHop,
                                              Map<JavaCodeUnit, JavaCodeUnit> arrivedFrom,
-                                             JavaMethodCall repositoryCall) {
+                                             Map<JavaCodeUnit, String> arrivedVia,
+                                             String read) {
         List<String> path = new ArrayList<>();
-        path.add(name(repositoryCall.getTargetOwner(), repositoryCall.getName()));
+        path.add(read);
         for (JavaCodeUnit step = lastHop; step != null && !step.equals(endpoint); step = arrivedFrom.get(step)) {
-            path.add(0, name(step.getOwner(), step.getName()));
+            String via = arrivedVia.get(step);
+            path.add(0, via == null
+                    ? name(step.getOwner(), step.getName())
+                    : name(step.getOwner(), step.getName()) + " (" + via + ")");
         }
         path.add(0, name(endpoint.getOwner(), endpoint.getName()));
         return path;

--- a/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
@@ -400,8 +400,18 @@ class PublicEndpointTenantExposureTest {
             return everyListener;
         }
 
+        /**
+         * Whether a listener runs inside the request that published the event.
+         *
+         * <p>The owner is checked as well as the method, because Spring applies a type-level
+         * {@code @Async} to every method the type declares. Reading only the method would put
+         * a listener that never touches the request thread back into the reported path, and a
+         * gate that reports work the load boundary already refuses is a gate people learn to
+         * ignore.
+         */
         private static boolean runsOnTheRequestThread(JavaMethod listener) {
-            return !listener.isAnnotatedWith(Async.class);
+            return !listener.isAnnotatedWith(Async.class)
+                    && !listener.getOwner().isAnnotatedWith(Async.class);
         }
 
         private void indexListeners() {

--- a/src/test/java/org/tornotron/echno_backend/architecture/fixtures/PublicEndpointReachabilityFixtures.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/fixtures/PublicEndpointReachabilityFixtures.java
@@ -92,6 +92,35 @@ public final class PublicEndpointReachabilityFixtures {
         }
     }
 
+    /** An event whose only listener is asynchronous by its class rather than its method. */
+    public static class ClassLevelAsyncEvent {
+    }
+
+    /**
+     * Spring applies a type-level {@code @Async} to every method the type declares, so this
+     * listener is as far from the request thread as one annotated method by method.
+     */
+    @Async
+    public static class ReadsTenantRowsOnAnAsyncClass {
+
+        private CategoryRepository categoryRepository;
+
+        @EventListener
+        public void on(ClassLevelAsyncEvent event) {
+            categoryRepository.findAll();
+        }
+    }
+
+    /** Publishes only the event whose listener is asynchronous by its class. */
+    public static class PublishesAClassLevelAsyncEvent {
+
+        private ApplicationEventPublisher publisher;
+
+        public void handle() {
+            publisher.publishEvent(new ClassLevelAsyncEvent());
+        }
+    }
+
     /** The {@code EntityManager} hop, shaped like {@code ReportService}. */
     public static class QueriesThroughTheEntityManager {
 

--- a/src/test/java/org/tornotron/echno_backend/architecture/fixtures/PublicEndpointReachabilityFixtures.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/fixtures/PublicEndpointReachabilityFixtures.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.architecture.fixtures;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.tornotron.echno_backend.category.CategoryRepository;
+
+/**
+ * Planted code for {@link org.tornotron.echno_backend.architecture.PublicEndpointTenantExposureTest}
+ * to catch, and planted code for it to leave alone.
+ *
+ * <p>The rule it belongs to walks the production code and, today, finds nothing: the only
+ * public endpoint is registration and registration reads nothing tenant-scoped. A rule in that
+ * state is indistinguishable from a rule that has stopped working, and the hops it follows are
+ * the kind that break silently when someone tidies the walk. So each hop gets a violation
+ * written here, shaped the way the production code that uses that hop is shaped, and a test
+ * that fails if the walk stops finding it.
+ *
+ * <p>None of this is a Spring bean. There is no {@code @RestController}, no
+ * {@code @Component} and no repository interface of its own, because these classes sit under
+ * the application's own package on the test classpath and anything scannable here would be
+ * picked up by every {@code @SpringBootTest} in the suite. The rule's own entry point is
+ * driven directly instead, which is what the walk does anyway once it has the handler.
+ *
+ * <p>{@link CategoryRepository} is used as the read rather than a repository declared here,
+ * for the same reason: a {@code Repository} interface under this package would be found by
+ * Spring Data's scan.
+ */
+public final class PublicEndpointReachabilityFixtures {
+
+    private PublicEndpointReachabilityFixtures() {
+    }
+
+    /** The event the publishing fixture below constructs. */
+    public static class TenantTouchingEvent {
+    }
+
+    /** An event nothing in these fixtures reads tenant data for. */
+    public static class HarmlessEvent {
+    }
+
+    /**
+     * The publish hop, shaped like {@code GoodsReceivedNoteService}: the handler names no
+     * repository and no listener, and the only edge between it and the read is an event.
+     */
+    public static class PublishesAnEvent {
+
+        private ApplicationEventPublisher publisher;
+
+        public void handle() {
+            publisher.publishEvent(new TenantTouchingEvent());
+        }
+    }
+
+    /** A listener that reads tenant rows on the request thread. */
+    public static class ReadsTenantRowsOnCommit {
+
+        private CategoryRepository categoryRepository;
+
+        @TransactionalEventListener
+        public void on(TenantTouchingEvent event) {
+            categoryRepository.findAll();
+        }
+    }
+
+    /**
+     * The same read behind an {@code @Async} listener, which is not a hazard: the hand-off
+     * leaves the unscoped declaration behind, so the load boundary refuses the read rather
+     * than letting it through.
+     */
+    public static class ReadsTenantRowsOnAnotherThread {
+
+        private CategoryRepository categoryRepository;
+
+        @Async
+        @EventListener
+        public void on(HarmlessEvent event) {
+            categoryRepository.findAll();
+        }
+    }
+
+    /** Publishes only the event whose listener is asynchronous. */
+    public static class PublishesAnAsyncOnlyEvent {
+
+        private ApplicationEventPublisher publisher;
+
+        public void handle() {
+            publisher.publishEvent(new HarmlessEvent());
+        }
+    }
+
+    /** The {@code EntityManager} hop, shaped like {@code ReportService}. */
+    public static class QueriesThroughTheEntityManager {
+
+        private EntityManager entityManager;
+
+        public void handle() {
+            entityManager.createNativeQuery("SELECT 1 FROM category").getResultList();
+        }
+    }
+
+    /** The {@code JdbcTemplate} hop, shaped like {@code DocumentNumberAllocator}. */
+    public static class QueriesThroughJdbc {
+
+        private JdbcTemplate jdbcTemplate;
+
+        public void handle() {
+            jdbcTemplate.queryForObject("SELECT 1", Long.class);
+        }
+    }
+
+    /** An {@code EntityManager} call that puts no statement on the wire. */
+    public static class OnlyUnwrapsTheEntityManager {
+
+        private EntityManager entityManager;
+
+        public void handle() {
+            entityManager.getEntityManagerFactory();
+        }
+    }
+
+    /** The interface hop: the caller sees this, and this reads nothing. */
+    public interface TenantReadingPort {
+        void read();
+    }
+
+    /** The implementation the walk has to descend into to find the read. */
+    public static class TenantReadingAdapter implements TenantReadingPort {
+
+        private CategoryRepository categoryRepository;
+
+        @Override
+        public void read() {
+            categoryRepository.findAll();
+        }
+    }
+
+    /** Calls the port and nothing else, so only the descent finds the read. */
+    public static class CallsThroughAnInterface {
+
+        private TenantReadingPort port;
+
+        public void handle() {
+            port.read();
+        }
+    }
+
+    /** Work that reaches no database at all, and must not be reported. */
+    public static class ReadsNothing {
+
+        public void handle() {
+            String.valueOf(System.nanoTime());
+        }
+    }
+}


### PR DESCRIPTION
Closes #585.

`PublicEndpointTenantExposureTest` worked for what it walked, and the guarantee written beside it in `SecurityConfig` was wider than the graph. Nothing is exploitable today, so this is about the gate being trustworthy rather than about a live exposure. That distinction shaped the fix: both holes turned out to be traversable, so both are traversed, and the one limit that is genuinely intractable statically is written on the test instead of left as a silent gap.

## Hole 1: the event-publish hop

`ApplicationEventPublisher.publishEvent` is a Spring method, so the old walk dropped it at the framework boundary and never reached the listener. Four services move real tenant work across that hop.

The hop is followed by matching the event the publishing method **constructs** against the parameter type of every `@EventListener` and `@TransactionalEventListener`. The call itself is erased to `publishEvent(Object)`, so the constructor call at the publish site is the only thing the bytecode offers, and it is how every publication in this codebase is written. Where no event type can be identified there, **every** listener is followed instead, so a publication assembled elsewhere over-reports rather than disappears.

`AFTER_COMMIT` is not an escape: that listener runs on the request thread inside the same unscoped declaration. An **`@Async`** listener is deliberately not followed, for the same reason `/actuator` is not covered: the thread hand-off leaves the declaration behind, so the load boundary is back on and the read is refused rather than let through. Reporting it would be a false alarm, and false alarms are how a ratchet gets switched off. The two cases are told apart properly rather than by the fallback: listeners are indexed asynchronous ones included, so an event whose only listener is `@Async` is known to have no edge, which is not the same as an event whose type could not be worked out.

## Hole 2: reads that are not Spring Data repositories

`EntityManager` query methods and `JdbcTemplate` statements now count as reads in their own right. Note the issue named `EntityManager` for `DocumentNumberAllocator`; it is actually `JdbcTemplate`, so both are covered.

Which table such a statement touches is a string in the source and not a fact in the bytecode, so unlike a repository these are reported **whatever** they read. That is stated in the class rather than quietly assumed, and it is the direction to fail in: an unauthenticated request that has reached hand-written SQL is worth the argument, and the answer is to key the query on something the caller proved, not to widen the rule. Holding an `EntityManager` is not the same as querying through one, so only the methods that put a statement on the wire count.

## The two minors

- A compound grant (`"permitAll() or hasRole('ADMIN')"`) or `isAnonymous()` read as protected, which shrank what the rule looked at without anyone noticing. Anything mentioning `permitAll` or `isAnonymous` counts now.
- A call typed as an interface resolves to the interface's own declaration, which has no body, so the walk stopped one hop short of the class doing the reading. Every implementation in the imported graph is followed as well.

## The limit that stays, documented

Reachability is over static calls, so anything dispatched by a value rather than by a type is invisible: a lambda handed across a boundary, reflection, a proxy resolved by name. Nothing on a public path does that today, and seeing it would mean turning this into a data-flow analysis. That is now written on the test and referenced from the `SecurityConfig` comment, which is also corrected to say what the gate actually covers.

## Proof the walk is not vacuous

The rule finds nothing in production, which is the answer everyone wants and also the answer a broken rule gives. So `PublicEndpointTenantExposureRuleTest` drives the walk directly over `PublicEndpointReachabilityFixtures`: a planted violation for each hop, shaped like the production code that uses it, each paired with the case it must **not** report (the `@Async` listener, an `EntityManager` call that issues no statement, work that reaches no database).

With the four additions reverted, exactly the five tests for them fail and the negative cases still pass:

```
followsAPublishedEventIntoItsListener()            FAILED
countsAnEntityManagerQueryAsAReadOfTenantData()    FAILED
countsAJdbcTemplateStatementAsAReadOfTenantData()  FAILED
descendsFromAnInterfaceIntoItsImplementation()     FAILED
treatsACompoundOrAnonymousGrantAsPublic()          FAILED
```

The fixtures carry no `@RestController`, no `@Component` and no repository interface of their own, because they sit under the application's package on the test classpath and anything scannable there would be picked up by every `@SpringBootTest` in the suite. The imported graph is held in instance fields rather than a `static final`, so it is collectable as soon as the test using it is done.

Full `./gradlew build` green on the lab box; test heap 25% of the 2048m cap, 8 Spring contexts of a maximum 8 (unchanged, no new context). No production behaviour changed: the only main-source edit is the `SecurityConfig` comment, so `docs/openapi.json` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved architectural security checks for unauthenticated endpoints that may access tenant-scoped data.
  * Added coverage for database queries through persistence APIs, JDBC, interfaces, and synchronous event listeners.
  * Improved detection of public access rules, including compound and anonymous-access expressions.
  * Excluded asynchronous event listeners and non-database operations from exposure reports.

* **Tests**
  * Added comprehensive reachability scenarios and clearer reported paths for security violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->