### PR TITLE
Record who moved a project's status, and when

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11968,6 +11968,52 @@
         },
         "type": "object"
       },
+      "PageStatusTransitionDto": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/StatusTransitionDto"
+            },
+            "type": "array"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "numberOfElements": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "size": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "totalElements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "PageStockAdjustmentDto": {
         "properties": {
           "content": {
@@ -13084,6 +13130,12 @@
             "format": "date-time",
             "type": "string"
           },
+          "createdBy": {
+            "description": "Id of the user who created the project. Null on projects created before this was recorded.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
+          },
           "customerId": {
             "description": "Finance customer the project is billed to. Null when no client is set.",
             "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
@@ -13193,6 +13245,18 @@
               "$ref": "#/components/schemas/TaskDto"
             },
             "type": "array"
+          },
+          "updatedAt": {
+            "description": "When the project was last written. Null on projects not written since this was recorded. It is a last-write stamp, so it is overwritten by the next edit to any field: to read who moved the project's status and when, use GET /api/v1/project/web/{id}/status-history.",
+            "example": "2026-08-28T16:41:12",
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedBy": {
+            "description": "Id of the user who last wrote the project.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -14970,6 +15034,55 @@
               "dimensional-check",
               "progress-check"
             ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StatusTransitionDto": {
+        "description": "One entry in a record's status trail: what it moved from, what it moved to, when, by whom, and whether the status was set at creation or changed afterwards. Entries are never edited or deleted.",
+        "properties": {
+          "changedBy": {
+            "description": "Id of the user who made the change. Null where no user context was available, which is the case for every BASELINE entry.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
+          },
+          "changedByName": {
+            "description": "That user's name as it read at the time, kept beside the id so a rename or a removal does not rewrite history.",
+            "example": "Anand Rajashekar",
+            "type": "string"
+          },
+          "fromStatus": {
+            "description": "Status held before this entry. Null when there was none: the record was created in the status below, or this is the baseline entry written when the trail began.",
+            "example": "upcoming",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database id of the entry.",
+            "example": 84,
+            "format": "int64",
+            "type": "integer"
+          },
+          "note": {
+            "description": "Anything recorded about the change beyond the two statuses. Optional.",
+            "example": "Approved after the site survey was signed off",
+            "type": "string"
+          },
+          "occurredAt": {
+            "description": "When the status came to be held. For a BASELINE entry this is when the trail began, not when the record was created.",
+            "example": "2026-08-30T11:14:02",
+            "format": "date-time",
+            "type": "string"
+          },
+          "source": {
+            "description": "How the status came about. CREATION means the record was created holding it, UPDATE means it was changed on an existing record, and BASELINE means it is the status the record was observed to hold when the trail began, before which nothing was recorded.",
+            "example": "UPDATE",
+            "type": "string"
+          },
+          "toStatus": {
+            "description": "Status held after this entry.",
+            "example": "approved",
             "type": "string"
           }
         },
@@ -80643,6 +80756,146 @@
           }
         },
         "summary": "Partially update a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/v1/project/web/{id}/status-history": {
+      "get": {
+        "description": "Returns a page of the project's status entries, newest first: what it moved from, what it moved to, when, by whom, and whether the status was set when the project was created or changed afterwards. Approval is the transition that carries behaviour, since it draws up the project's compliance inspections, so this is where to read who approved a project and when. Entries begin where recording began: a project created before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment, with no actor and no earlier status, because nothing else can truthfully be said about a history nobody recorded.",
+        "operationId": "readStatusHistory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageStatusTransitionDto"
+                }
+              }
+            },
+            "description": "Page of status entries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is neither a member of the current tenant nor holds an elevated role in it"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No project with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Read a project's status trail",
         "tags": [
           "Projects"
         ]

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransition.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransition.java
@@ -1,0 +1,117 @@
+package org.tornotron.echno_backend.common.history;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.Immutable;
+import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDateTime;
+
+/**
+ * One entry in a record's status trail: what it moved from, what it moved to, when, by whom,
+ * and whether the status was set at creation or changed afterwards.
+ *
+ * <p><strong>Shared storage, per-module exposure.</strong> The table is keyed by
+ * {@link #entityType} and {@link #entityId} rather than by a foreign key to one owner, the way
+ * {@code Attachment} already is, so every record with a gated status transition can use it
+ * without a table of its own. What is deliberately not shared is the API: each module reads its
+ * own trail through its own endpoint under its own authorization, because who may read a site
+ * transfer's history is not who may read a project's, and a single generic history endpoint
+ * would need a registry of per-type read rules to say so.
+ *
+ * <p><strong>Append-only.</strong> The entity is {@link Immutable} and
+ * {@link StatusTransitionRepository} offers no delete, so a written entry is never edited or
+ * removed. There is nothing to correct: an entry records what was observed at the time, and a
+ * later change is a further entry.
+ *
+ * <p><strong>No foreign key to the record it describes.</strong> This is the one departure from
+ * {@code AssetMovement}, which refuses to let an asset be deleted while its ledger holds
+ * entries. A movement is a fact about a live asset; a status trail has to outlive the record it
+ * describes, or deleting a project erases the evidence of who approved it. The polymorphic key
+ * gives that, at the cost of the database not constraining {@link #entityId}, which is why
+ * isolation rests on {@link #organization} and every read is organization-explicit.
+ *
+ * <p><strong>The actor's name is snapshotted beside the id.</strong> A user can be renamed or
+ * removed, and history that evaporates when that happens is not history.
+ */
+@Entity
+@Table(name = "status_transition", indexes = {
+        @Index(name = "idx_status_transition_entity", columnList = "entity_type, entity_id, occurred_at"),
+        @Index(name = "idx_status_transition_organization", columnList = "organization_id")
+})
+@Immutable
+@Filter(name = "orgFilter", condition = "organization_id = :organizationId")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StatusTransition implements TenantScopedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** The kind of record this entry belongs to, for example {@code PROJECT}. */
+    @Column(name = "entity_type", nullable = false, length = 50)
+    private String entityType;
+
+    /** The id of the record within its kind. Not a foreign key, deliberately. */
+    @Column(name = "entity_id", nullable = false)
+    private Long entityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    /**
+     * The status held before this entry, null when there was none: a creation, or the baseline
+     * written when the trail began.
+     */
+    @Column(name = "from_status", length = 50)
+    private String fromStatus;
+
+    /** The status held after this entry. */
+    @Column(name = "to_status", nullable = false, length = 50)
+    private String toStatus;
+
+    /** Whether the status was set at creation, changed later, or merely observed. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false, length = 20)
+    private StatusTransitionSource source;
+
+    /** When the status came to be held. */
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+
+    /** The user who made the change, null where no user context was available. */
+    @Column(name = "changed_by")
+    private Long changedBy;
+
+    /** That user's name as it read at the time. */
+    @Column(name = "changed_by_name", length = 200)
+    private String changedByName;
+
+    /**
+     * Anything worth saying about the change beyond the two statuses.
+     *
+     * <p>Optional, unlike {@code AssetMovement.reason}, which is required. A movement's reason
+     * is not derivable from the row, whereas an entry here already names what it moved from and
+     * what it moved to; requiring prose on every one buys a column full of "changed status".
+     */
+    @Column(name = "note", length = 500)
+    private String note;
+}

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorder.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorder.java
@@ -1,0 +1,87 @@
+package org.tornotron.echno_backend.common.history;
+
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * Writes entries to the shared status trail.
+ *
+ * <p>The single writer for every module that records a status transition. Callers hand it the
+ * record's kind and id, the organization the record belongs to, the two statuses and the acting
+ * user; it decides nothing about the domain and reads nothing back.
+ *
+ * <p>The organization comes from the record being changed and never from a request field, so a
+ * caller cannot file an entry into another tenant's trail.
+ */
+@Service
+public class StatusTransitionRecorder {
+
+    private final StatusTransitionRepository repository;
+
+    public StatusTransitionRecorder(StatusTransitionRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Records that a record was created holding a status.
+     *
+     * @param entityType   The kind of record, for example {@code PROJECT}.
+     * @param entityId     The record's id.
+     * @param organization The organization the record belongs to.
+     * @param status       The status it was created in.
+     * @param actor        The acting user, or null where there was no user context.
+     * @return The entry that was written.
+     */
+    public StatusTransition recordCreation(String entityType, Long entityId,
+                                           Organization organization, String status, User actor) {
+        return append(entityType, entityId, organization, null, status,
+                StatusTransitionSource.CREATION, actor, null);
+    }
+
+    /**
+     * Records a change of status on an existing record, if it is one.
+     *
+     * <p>Returns null and writes nothing when the two statuses are equal, so a caller can call
+     * this on every save without first working out whether the status moved. A save that leaves
+     * the status where it was is not a transition and must not appear in the trail as one.
+     *
+     * @param entityType   The kind of record, for example {@code PROJECT}.
+     * @param entityId     The record's id.
+     * @param organization The organization the record belongs to.
+     * @param fromStatus   The status held before the change, possibly null.
+     * @param toStatus     The status held after it.
+     * @param actor        The acting user, or null where there was no user context.
+     * @param note         Anything worth saying beyond the two statuses, or null.
+     * @return The entry that was written, or null when nothing changed.
+     */
+    public StatusTransition recordChange(String entityType, Long entityId,
+                                         Organization organization, String fromStatus,
+                                         String toStatus, User actor, String note) {
+        if (Objects.equals(fromStatus, toStatus)) {
+            return null;
+        }
+        return append(entityType, entityId, organization, fromStatus, toStatus,
+                StatusTransitionSource.UPDATE, actor, note);
+    }
+
+    private StatusTransition append(String entityType, Long entityId, Organization organization,
+                                    String fromStatus, String toStatus,
+                                    StatusTransitionSource source, User actor, String note) {
+        StatusTransition transition = new StatusTransition();
+        transition.setEntityType(entityType);
+        transition.setEntityId(entityId);
+        transition.setOrganization(organization);
+        transition.setFromStatus(fromStatus);
+        transition.setToStatus(toStatus);
+        transition.setSource(source);
+        transition.setOccurredAt(LocalDateTime.now());
+        transition.setChangedBy(actor != null ? actor.getId() : null);
+        transition.setChangedByName(actor != null ? actor.getName() : null);
+        transition.setNote(note);
+        return repository.save(transition);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRepository.java
@@ -1,0 +1,40 @@
+package org.tornotron.echno_backend.common.history;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Reads and appends to the shared status trail.
+ *
+ * <p>This extends {@link Repository} rather than {@code JpaRepository} on purpose. Spring Data
+ * implements only the methods a repository declares, so the trail has no {@code delete},
+ * {@code deleteAll} or bulk write surface for anything to reach by accident. Append-only is a
+ * property of the type here rather than a convention somebody has to remember, and
+ * {@link StatusTransition} is {@code @Immutable} on top of that, so an entry cannot be edited
+ * through a loaded instance either. It is the same shape as {@code AssetMovementRepository}.
+ *
+ * <p>Every read names the organization. The trail carries no foreign key to the record it
+ * describes, so the organization column is the whole of its tenant scope: a finder by
+ * {@code entityId} alone would cross tenants the moment two organizations held the same id.
+ */
+public interface StatusTransitionRepository extends Repository<StatusTransition, Long> {
+
+    /** Appends an entry. The only write this repository offers. */
+    StatusTransition save(StatusTransition transition);
+
+    /**
+     * One record's trail, newest first.
+     *
+     * <p>Newest first because the head of the trail is the entry that explains the status the
+     * record is in now, which is what a reader has asked about; a capped read from the oldest end
+     * would leave that entry off the page. The page carries the whole trail's size, so a
+     * shortened read can say it was shortened.
+     */
+    Page<StatusTransition> findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+            String entityType, Long entityId, Long organizationId, Pageable pageable);
+
+    /** How many entries a record carries, for callers that only need to know whether any exist. */
+    long countByEntityTypeAndEntityIdAndOrganization_Id(
+            String entityType, Long entityId, Long organizationId);
+}

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionSource.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionSource.java
@@ -1,0 +1,31 @@
+package org.tornotron.echno_backend.common.history;
+
+/**
+ * How a recorded status came about.
+ *
+ * <p>This is the column that answers the question the trail was built for. A record's status
+ * alone cannot say whether the record was born in that state or moved into it later, and that
+ * distinction is exactly what could not be established for the approved project with no
+ * compliance inspections: whether it was created approved or patched there. {@code CREATION}
+ * against {@code UPDATE} settles it.
+ */
+public enum StatusTransitionSource {
+
+    /** The record was created in this status. There is no earlier status to name. */
+    CREATION,
+
+    /** The status was changed on an existing record. */
+    UPDATE,
+
+    /**
+     * The status a record was observed to hold when its trail began, written once by the
+     * migration that introduced the trail.
+     *
+     * <p>It is not a transition and claims to be none. It exists so a reader can tell a record
+     * whose status has not moved since recording began from a record whose history was never
+     * recorded at all. Its timestamp is the migration's, never the record's creation time:
+     * dating the observed status at creation time would assert the record was created in that
+     * state, which is the one claim that cannot be made about anything that predates the trail.
+     */
+    BASELINE
+}

--- a/src/main/java/org/tornotron/echno_backend/common/history/dto/StatusTransitionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/dto/StatusTransitionDto.java
@@ -1,0 +1,51 @@
+package org.tornotron.echno_backend.common.history.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "One entry in a record's status trail: what it moved from, what it moved to, "
+        + "when, by whom, and whether the status was set at creation or changed afterwards. "
+        + "Entries are never edited or deleted.")
+@Data
+public class StatusTransitionDto {
+
+    @Schema(description = "Database id of the entry.", example = "84")
+    private Long id;
+
+    @Schema(description = "Status held before this entry. Null when there was none: the record was "
+            + "created in the status below, or this is the baseline entry written when the trail "
+            + "began.",
+            example = "upcoming")
+    private String fromStatus;
+
+    @Schema(description = "Status held after this entry.", example = "approved")
+    private String toStatus;
+
+    @Schema(description = "How the status came about. CREATION means the record was created holding "
+            + "it, UPDATE means it was changed on an existing record, and BASELINE means it is the "
+            + "status the record was observed to hold when the trail began, before which nothing "
+            + "was recorded.",
+            example = "UPDATE")
+    private String source;
+
+    @Schema(description = "When the status came to be held. For a BASELINE entry this is when the "
+            + "trail began, not when the record was created.",
+            example = "2026-08-30T11:14:02")
+    private LocalDateTime occurredAt;
+
+    @Schema(description = "Id of the user who made the change. Null where no user context was "
+            + "available, which is the case for every BASELINE entry.",
+            example = "17")
+    private Long changedBy;
+
+    @Schema(description = "That user's name as it read at the time, kept beside the id so a rename "
+            + "or a removal does not rewrite history.",
+            example = "Anand Rajashekar")
+    private String changedByName;
+
+    @Schema(description = "Anything recorded about the change beyond the two statuses. Optional.",
+            example = "Approved after the site survey was signed off")
+    private String note;
+}

--- a/src/main/java/org/tornotron/echno_backend/common/history/mapper/StatusTransitionMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/mapper/StatusTransitionMapper.java
@@ -1,0 +1,19 @@
+package org.tornotron.echno_backend.common.history.mapper;
+
+import org.mapstruct.Mapper;
+import org.tornotron.echno_backend.common.history.StatusTransition;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
+
+/**
+ * Maps {@link StatusTransition} to its DTO.
+ *
+ * <p>{@code entityType} and {@code entityId} are left off deliberately. A trail is always read
+ * through the endpoint of the record it belongs to, so both are already known to the caller, and
+ * echoing the polymorphic key in the response would invite a client to treat it as an address it
+ * can ask about directly.
+ */
+@Mapper(componentModel = "spring")
+public interface StatusTransitionMapper {
+
+    StatusTransitionDto toDto(StatusTransition transition);
+}

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -65,6 +65,26 @@ public class Project implements TenantScopedEntity {
     @Column(name = "created_at", nullable = true)
     private LocalDateTime createdAt;
 
+    /**
+     * The user who created the project. Null on every project that predates this column, because
+     * {@link #createdAt} recorded when a project appeared without ever recording who made it.
+     */
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    /**
+     * When the project was last written. Together with {@link #updatedBy} this answers "when did
+     * this last change, and by whom", which is all a last-write stamp can answer: the next edit
+     * to any field overwrites it, so it does not survive as a record of who approved the project.
+     * That is what the status trail is for.
+     */
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /** The user who last wrote the project. */
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
     /** The current status of the project. */
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = true)

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -20,6 +20,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.employee.dto.EmployeeDto;
@@ -173,6 +174,40 @@ public class ProjectControllerWeb {
     public ResponseEntity<?> readAProject(@PathVariable Long id) {
         ProjectDto project = service.getAProject(id);
         return new ResponseEntity<>(project,HttpStatus.OK);
+    }
+
+    /**
+     * Reads a project's status trail.
+     *
+     * @param id        The ID of the project whose trail to read.
+     * @param pageQuery The page bounds.
+     * @return A {@link ResponseEntity} containing a page of trail entries and HTTP status 200 (OK).
+     */
+    @GetMapping("{id}/status-history")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Read a project's status trail",
+            description = "Returns a page of the project's status entries, newest first: what it "
+                    + "moved from, what it moved to, when, by whom, and whether the status was set "
+                    + "when the project was created or changed afterwards. Approval is the "
+                    + "transition that carries behaviour, since it draws up the project's "
+                    + "compliance inspections, so this is where to read who approved a project and "
+                    + "when. Entries begin where recording began: a project created before the "
+                    + "trail existed carries a single BASELINE entry naming the status it was "
+                    + "observed to hold at that moment, with no actor and no earlier status, "
+                    + "because nothing else can truthfully be said about a history nobody recorded."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of status entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
+    public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
+            @PathVariable Long id,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(
+                service.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)),
+                HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -385,6 +385,11 @@ public class ProjectService {
      * "when did this last change, and by whom" and never "who approved it". That second question
      * belongs to the status trail, which is why both exist.
      *
+     * <p>Called from every path that saves a project, the team changes included. A stamp that
+     * covered only the field patch would report a project as untouched since last month while its
+     * team was rebuilt yesterday, which is worse than no stamp: it is a wrong answer to the one
+     * question it exists to answer.
+     *
      * @param project The project being written.
      * @param actor   The user making the change, or null where there was no user context.
      */
@@ -629,6 +634,8 @@ public class ProjectService {
         }
 
         project.getEmployees().add(employee);
+        // Adding somebody to the team is a change to the project, so it stamps like any other.
+        stampWrite(project, userContextService.getCurrentUser());
         repository.save(project);
 
         return project.getEmployees().stream()
@@ -653,6 +660,7 @@ public class ProjectService {
             throw new ResourceNotFoundException("Employee with ID " + employeeId + " is not assigned to project with ID " + projectId);
         }
 
+        stampWrite(project, userContextService.getCurrentUser());
         repository.save(project);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -16,6 +16,10 @@ import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -30,6 +34,8 @@ import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.project.dto.*;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.enums.ProjectType;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -53,6 +59,12 @@ public class ProjectService {
      */
     private static final ProjectCreationStatus DEFAULT_CREATION_STATUS = ProjectCreationStatus.upcoming;
 
+    /**
+     * The kind this module files its status trail under, in the shared {@code status_transition}
+     * table. It is the same discriminator the attachment table already uses for a project.
+     */
+    public static final String HISTORY_ENTITY_TYPE = "PROJECT";
+
     private final ProjectRepository repository;
     private final OrganizationRepository organizationRepository;
     private final EmployeeRepository employeeRepository;
@@ -62,6 +74,10 @@ public class ProjectService {
     private final ApplicationEventPublisher eventPublisher;
     private final CustomerRepository customerRepository;
     private final PayloadValidator payloadValidator;
+    private final UserContextService userContextService;
+    private final StatusTransitionRecorder statusTransitionRecorder;
+    private final StatusTransitionRepository statusTransitionRepository;
+    private final StatusTransitionMapper statusTransitionMapper;
 
     /**
      * Constructs a ProjectService with the necessary repositories.
@@ -72,6 +88,10 @@ public class ProjectService {
      * @param attachmentService      The service for attachment operations.
      * @param customerRepository     The repository used to validate the project's client.
      * @param payloadValidator       Runs the create payload's own constraints.
+     * @param userContextService     Names the user behind a write, for the stamps and the trail.
+     * @param statusTransitionRecorder Appends to the shared status trail.
+     * @param statusTransitionRepository Reads a project's status trail back.
+     * @param statusTransitionMapper Maps trail entries to their DTO.
      */
     public ProjectService(ProjectRepository repository,
                           OrganizationRepository organizationRepository,
@@ -80,7 +100,11 @@ public class ProjectService {
                           EmployeeMapper employeeMapper,
                           ApplicationEventPublisher eventPublisher,
                           CustomerRepository customerRepository,
-                          PayloadValidator payloadValidator) {
+                          PayloadValidator payloadValidator,
+                          UserContextService userContextService,
+                          StatusTransitionRecorder statusTransitionRecorder,
+                          StatusTransitionRepository statusTransitionRepository,
+                          StatusTransitionMapper statusTransitionMapper) {
         this.repository = repository;
         this.organizationRepository = organizationRepository;
         this.employeeRepository = employeeRepository;
@@ -90,6 +114,10 @@ public class ProjectService {
         this.eventPublisher = eventPublisher;
         this.customerRepository = customerRepository;
         this.payloadValidator = payloadValidator;
+        this.userContextService = userContextService;
+        this.statusTransitionRecorder = statusTransitionRecorder;
+        this.statusTransitionRepository = statusTransitionRepository;
+        this.statusTransitionMapper = statusTransitionMapper;
     }
 
     /**
@@ -114,13 +142,19 @@ public class ProjectService {
             if(repository.existsProjectByProjectName(projectDto.getProjectName())){
                 throw new DuplicateResourceException("Project with name '" + projectDto.getProjectName() + "' already exists");
             }
+            User actor = userContextService.getCurrentUser();
+            LocalDateTime now = LocalDateTime.now();
+
             Project project = new Project();
             project.setProjectName(projectDto.getProjectName());
             project.setProjectAddress(projectDto.getProjectAddress());
             project.setProjectCity(trimToNull(projectDto.getProjectCity()));
             project.setProjectState(canonicalState(projectDto.getProjectState()));
             project.setProjectPostalCode(trimToNull(projectDto.getProjectPostalCode()));
-            project.setCreatedAt(LocalDateTime.now());
+            project.setCreatedAt(now);
+            project.setCreatedBy(actor != null ? actor.getId() : null);
+            project.setUpdatedAt(now);
+            project.setUpdatedBy(actor != null ? actor.getId() : null);
             project.setProjectLatitude(projectDto.getProjectLatitude());
             project.setProjectLongitude(projectDto.getProjectLongitude());
             project.setStatus(projectDto.getStatus() != null
@@ -136,6 +170,12 @@ public class ProjectService {
             
             // Save the project first to get the ID
             Project savedProject = repository.save(project);
+
+            // The trail opens on the status the project was created in, so a project that was
+            // created already holding a status is distinguishable from one patched into it later.
+            statusTransitionRecorder.recordCreation(HISTORY_ENTITY_TYPE, savedProject.getId(),
+                    organization, savedProject.getStatus().name(), actor);
+
             // Upload attachments if provided
             if (attachments != null && !attachments.isEmpty()) {
                 List<Attachment> savedAttachments = attachmentService.uploadAttachments(attachments, "PROJECT", savedProject.getId(), PROJECTS_FOLDER);
@@ -304,7 +344,82 @@ public class ProjectService {
         });
 
         onApproval(project, previousStatus);
+
+        // Resolved once: both the trail entry and the stamp name the same user, and looking the
+        // user up costs a query.
+        User actor = userContextService.getCurrentUser();
+        recordStatusChange(project, previousStatus, actor);
+        stampWrite(project, actor);
     }
+
+    /**
+     * Appends a status change to the project's trail, if the patch was one.
+     *
+     * <p>Runs after {@link #onApproval}, so an approval the project's state does not allow is
+     * refused before anything is written. It is not conditional on the transition being an
+     * approval: approval is the transition that carries behaviour, but a project moved to
+     * {@code onHold} or {@code cancelled} raises the same question of who did it and when.
+     *
+     * <p>{@link StatusTransitionRecorder#recordChange} writes nothing when the two statuses are
+     * equal, so a patch that touched only the address leaves the trail alone.
+     *
+     * @param project        The project the patch has been applied to.
+     * @param previousStatus The status it held before the patch.
+     * @param actor          The user making the change, or null where there was no user context.
+     */
+    private void recordStatusChange(Project project, ProjectCreationStatus previousStatus, User actor) {
+        statusTransitionRecorder.recordChange(
+                HISTORY_ENTITY_TYPE,
+                project.getId(),
+                project.getOrganization(),
+                previousStatus != null ? previousStatus.name() : null,
+                project.getStatus() != null ? project.getStatus().name() : null,
+                actor,
+                null);
+    }
+
+    /**
+     * Stamps who wrote the project and when.
+     *
+     * <p>This is the last write and nothing more: the next patch overwrites it, so it answers
+     * "when did this last change, and by whom" and never "who approved it". That second question
+     * belongs to the status trail, which is why both exist.
+     *
+     * @param project The project being written.
+     * @param actor   The user making the change, or null where there was no user context.
+     */
+    private void stampWrite(Project project, User actor) {
+        project.setUpdatedAt(LocalDateTime.now());
+        project.setUpdatedBy(actor != null ? actor.getId() : null);
+    }
+
+    /**
+     * Reads a project's status trail, newest first.
+     *
+     * <p>Entries begin where recording began. A project created before the trail existed carries
+     * a single {@code BASELINE} entry naming the status it was observed to hold at that moment,
+     * with no actor and no earlier status, because there is nothing else that can truthfully be
+     * said about a history nobody recorded.
+     *
+     * @param id       The project whose trail to read.
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Entries per page.
+     * @return A page of trail entries, newest first.
+     * @throws ResourceNotFoundException if no project with the given ID is found in this organization.
+     */
+    @Transactional(readOnly = true)
+    public Page<StatusTransitionDto> getStatusHistory(Long id, int pageNo, int pageSize) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (!repository.existsByIdAndOrganization_Id(id, orgId)) {
+            throw new ResourceNotFoundException(
+                    "Project with ID " + id + " was not found in this organization");
+        }
+        return statusTransitionRepository
+                .findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+                        HISTORY_ENTITY_TYPE, id, orgId, PageRequest.of(pageNo, pageSize))
+                .map(statusTransitionMapper::toDto);
+    }
+
 
     /**
      * Runs the approval transition, once the whole patch has been applied.

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -38,6 +38,20 @@ public class ProjectDto {
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "Id of the user who created the project. Null on projects created before "
+            + "this was recorded.", example = "17")
+    private Long createdBy;
+
+    @Schema(description = "When the project was last written. Null on projects not written since "
+            + "this was recorded. It is a last-write stamp, so it is overwritten by the next edit "
+            + "to any field: to read who moved the project's status and when, use "
+            + "GET /api/v1/project/web/{id}/status-history.",
+            example = "2026-08-28T16:41:12")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "Id of the user who last wrote the project.", example = "17")
+    private Long updatedBy;
+
     @Schema(description = "Current project status.", example = "IN_PROGRESS")
     private ProjectCreationStatus status;
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -352,6 +352,9 @@
     <!-- v4.0 - Regularizations: the raiser's user id, so the self-approval rule always has one -->
     <include file="db/changelog/v4.0/072-add-regularization-requested-by-user-id.xml"/>
 
+    <!-- v4.0 - Projects: the last-write stamp, and the shared status trail behind who approved what -->
+    <include file="db/changelog/v4.0/073-project-change-history.xml"/>
+
     <!-- v4.0 - Employees: drop the free-text reporting_manager; manager_id is the reporting line -->
     <include file="db/changelog/v4.0/074-drop-employee-reporting-manager.xml"/>
 

--- a/src/main/resources/db/changelog/v4.0/073-project-change-history.xml
+++ b/src/main/resources/db/changelog/v4.0/073-project-change-history.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        The last-write stamp on a project.
+
+        created_at has been there all along and never recorded who made the project, and nothing
+        recorded a write after the create at all. These three answer "when did this last change,
+        and by whom", which is all a stamp can answer: the next patch overwrites it, so it does
+        not survive as a record of who approved the project. That question belongs to the status
+        trail below, which is why both exist.
+
+        Null on every project that predates this changeset. Nothing can be backfilled: the writes
+        that would have filled it have already happened and left no trace.
+    -->
+    <changeSet id="073-01-add-project-audit-columns" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="updated_at"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="project">
+            <column name="created_by" type="BIGINT"/>
+            <column name="updated_at" type="TIMESTAMP"/>
+            <column name="updated_by" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+    <!--
+        The shared status trail: what a record moved from, what it moved to, when, by whom, and
+        whether the status was set at creation or changed afterwards.
+
+        Append-only. Nothing updates or deletes a row, and the repository declares no delete at
+        all, so append-only is a property of the type rather than a convention. There is nothing
+        to correct either: an entry records what was observed at the time, and a later change is
+        a further entry.
+
+        Keyed by entity_type and entity_id rather than by a foreign key to one owner, the way the
+        attachment table already is. Two reasons. One, seven records here carry a status enum with
+        a gated transition, and a per-owner history table repeated seven times is seven tables of
+        identical shape that drift, which is what already happened to the bespoke approved_by and
+        submitted_by columns scattered across those entities. Two, and more important, a status
+        trail has to outlive the record it describes: a foreign key with ON DELETE CASCADE would
+        erase the evidence of who approved a project the moment the project was deleted, and one
+        with RESTRICT would make an approved project undeletable. Without a foreign key the
+        organization column is the whole of the row's tenant scope, which is why every read names
+        the organization and why an index leads with the entity key.
+
+        changed_by_name sits beside changed_by for the reason asset_movement snapshots its names:
+        history that evaporates when a user is renamed or removed is not history.
+    -->
+    <changeSet id="073-02-create-status-transition" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="status_transition"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="status_transition">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="entity_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT"/>
+
+            <column name="from_status" type="VARCHAR(50)"/>
+            <column name="to_status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="source" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="occurred_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="BIGINT"/>
+            <column name="changed_by_name" type="VARCHAR(200)"/>
+            <column name="note" type="VARCHAR(500)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="status_transition"
+                                 baseColumnNames="organization_id"
+                                 constraintName="fk_status_transition_organization"
+                                 referencedTableName="organization"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"/>
+
+        <createIndex tableName="status_transition" indexName="idx_status_transition_entity">
+            <column name="entity_type"/>
+            <column name="entity_id"/>
+            <column name="occurred_at"/>
+        </createIndex>
+        <createIndex tableName="status_transition" indexName="idx_status_transition_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <!--
+        Where the trail begins for projects that already exist.
+
+        One BASELINE row each, naming the status the project is observed to hold at the moment the
+        trail is introduced. It is not a transition and does not claim to be one; it exists so a
+        reader can tell a project whose status has not moved since recording began from a project
+        whose history was never recorded at all.
+
+        Dated CURRENT_TIMESTAMP, deliberately NOT the project's created_at. Dating the observed
+        status at creation time would assert the project was created in that state, and that is
+        exactly the claim that could not be checked for the approved project with no compliance
+        inspections. It is the one thing that must not be written here.
+
+        changed_by and changed_by_name are null for the same reason: nothing recorded who last
+        moved these projects, and inventing an actor would be worse than leaving the column empty.
+    -->
+    <changeSet id="073-03-seed-project-status-baseline" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM status_transition WHERE entity_type = 'PROJECT'
+            </sqlCheck>
+        </preConditions>
+
+        <sql>
+            INSERT INTO status_transition (
+                entity_type, entity_id, organization_id,
+                from_status, to_status, source, occurred_at, note
+            )
+            SELECT 'PROJECT',
+                   p.id,
+                   p.organization_id,
+                   NULL,
+                   p.status,
+                   'BASELINE',
+                   CURRENT_TIMESTAMP,
+                   'The status this project was observed to hold when its status trail began. What it was before that date, and who set it, was not recorded.'
+            FROM project p
+            WHERE p.status IS NOT NULL;
+        </sql>
+        <rollback>
+            <sql>DELETE FROM status_transition WHERE entity_type = 'PROJECT' AND source = 'BASELINE';</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorderIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorderIT.java
@@ -1,0 +1,182 @@
+package org.tornotron.echno_backend.common.history;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The shared status trail against a real CockroachDB, on the schema Liquibase builds (see
+ * {@link AbstractIntegrationTest}). Hibernate runs with {@code ddl-auto: validate}, so the
+ * context only starts if the entity and the migrated table agree.
+ *
+ * <p>What is pinned here is the trail's own behaviour rather than any one module's use of it:
+ * the opening entry, the no-op that must not become an entry, the snapshotted actor, and the
+ * organization scope, which is the whole of the tenant boundary on a table that carries no
+ * foreign key to the records it describes.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(StatusTransitionRecorder.class)
+class StatusTransitionRecorderIT extends AbstractIntegrationTest {
+
+    private static final String PROJECT = "PROJECT";
+
+    @Autowired
+    private StatusTransitionRecorder recorder;
+
+    @Autowired
+    private StatusTransitionRepository repository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    /**
+     * The opening entry names no earlier status and is marked as a creation, which is what makes
+     * "created in this state" tellable from "moved into this state" afterwards.
+     */
+    @Test
+    void recordCreation_writesAnEntryWithNoEarlierStatus() {
+        Organization org = persistOrganization("Creation Org");
+
+        recorder.recordCreation(PROJECT, 101L, org, "upcoming", persistUser("Aneesh Johny", "kc-aneesh"));
+        em.flush();
+        em.clear();
+
+        StatusTransition entry = onlyEntry(PROJECT, 101L, org);
+        assertThat(entry.getFromStatus()).isNull();
+        assertThat(entry.getToStatus()).isEqualTo("upcoming");
+        assertThat(entry.getSource()).isEqualTo(StatusTransitionSource.CREATION);
+        assertThat(entry.getOccurredAt()).isNotNull();
+    }
+
+    /**
+     * The actor's name is stored beside the id at the time of writing, so renaming or removing the
+     * user later does not rewrite what the trail says happened.
+     */
+    @Test
+    void recordChange_snapshotsTheActorsNameBesideTheirId() {
+        Organization org = persistOrganization("Actor Org");
+        User actor = persistUser("Anand Rajashekar", "kc-anand");
+
+        recorder.recordChange(PROJECT, 102L, org, "upcoming", "approved", actor, "Signed off");
+        em.flush();
+        em.clear();
+
+        StatusTransition entry = onlyEntry(PROJECT, 102L, org);
+        assertThat(entry.getChangedBy()).isEqualTo(actor.getId());
+        assertThat(entry.getChangedByName()).isEqualTo("Anand Rajashekar");
+        assertThat(entry.getSource()).isEqualTo(StatusTransitionSource.UPDATE);
+        assertThat(entry.getNote()).isEqualTo("Signed off");
+    }
+
+    /**
+     * A save that left the status where it was is not a transition. Dropping it here rather than
+     * at each caller is what lets a caller record unconditionally on every write without filling
+     * the trail with entries whose two ends are the same.
+     */
+    @Test
+    void recordChange_writesNothingWhenTheStatusDidNotMove() {
+        Organization org = persistOrganization("No-op Org");
+
+        StatusTransition written = recorder.recordChange(
+                PROJECT, 103L, org, "open", "open", null, null);
+        em.flush();
+
+        assertThat(written).isNull();
+        assertThat(repository.countByEntityTypeAndEntityIdAndOrganization_Id(PROJECT, 103L, org.getId()))
+                .isZero();
+    }
+
+    /**
+     * The trail carries no foreign key to the record it describes, so the organization column is
+     * the whole of its tenant scope. Two organizations that happen to number a project the same
+     * must not see each other's history, and the finder is organization-explicit for that reason.
+     */
+    @Test
+    void aTrailIsReadOnlyWithinItsOwnOrganization() {
+        Organization mine = persistOrganization("Mine");
+        Organization theirs = persistOrganization("Theirs");
+
+        recorder.recordChange(PROJECT, 27L, mine, "upcoming", "approved", null, null);
+        recorder.recordChange(PROJECT, 27L, theirs, "upcoming", "cancelled", null, null);
+        em.flush();
+        em.clear();
+
+        assertThat(onlyEntry(PROJECT, 27L, mine).getToStatus()).isEqualTo("approved");
+        assertThat(onlyEntry(PROJECT, 27L, theirs).getToStatus()).isEqualTo("cancelled");
+    }
+
+    /**
+     * Newest first, because the head of the trail is the entry that explains the status the record
+     * is in now, and a capped read from the other end would leave it off the page.
+     */
+    @Test
+    void aTrailIsReadNewestFirst() {
+        Organization org = persistOrganization("Ordering Org");
+
+        recorder.recordCreation(PROJECT, 104L, org, "upcoming", null);
+        recorder.recordChange(PROJECT, 104L, org, "upcoming", "open", null, null);
+        recorder.recordChange(PROJECT, 104L, org, "open", "approved", null, null);
+        em.flush();
+        em.clear();
+
+        Page<StatusTransition> page = repository
+                .findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+                        PROJECT, 104L, org.getId(), PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).extracting(StatusTransition::getToStatus)
+                .containsExactly("approved", "open", "upcoming");
+        assertThat(page.getTotalElements()).isEqualTo(3);
+    }
+
+    /** Entries for one record do not leak into another record's trail. */
+    @Test
+    void aTrailHoldsOnlyItsOwnRecordsEntries() {
+        Organization org = persistOrganization("Separation Org");
+
+        recorder.recordChange(PROJECT, 105L, org, "upcoming", "approved", null, null);
+        recorder.recordChange(PROJECT, 106L, org, "upcoming", "cancelled", null, null);
+        recorder.recordChange("SITE_TRANSFER", 105L, org, "PENDING", "COMPLETED", null, null);
+        em.flush();
+        em.clear();
+
+        assertThat(onlyEntry(PROJECT, 105L, org).getToStatus()).isEqualTo("approved");
+        assertThat(onlyEntry("SITE_TRANSFER", 105L, org).getToStatus()).isEqualTo("COMPLETED");
+    }
+
+    private StatusTransition onlyEntry(String entityType, Long entityId, Organization org) {
+        Page<StatusTransition> page = repository
+                .findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+                        entityType, entityId, org.getId(), PageRequest.of(0, 10));
+        assertThat(page.getContent()).hasSize(1);
+        return page.getContent().get(0);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").replace("-", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private User persistUser(String name, String keycloakId) {
+        User user = new User();
+        user.setKeycloakId(keycloakId);
+        user.setName(name);
+        em.persist(user);
+        return user;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectApprovalStateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectApprovalStateTest.java
@@ -10,10 +10,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.events.ProjectApprovedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -55,6 +57,12 @@ class ProjectApprovalStateTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private UserContextService userContextService;
+
+    @Mock
+    private StatusTransitionRecorder statusTransitionRecorder;
 
     @InjectMocks
     private ProjectService service;

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreateStatusTest.java
@@ -15,6 +15,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -26,6 +29,7 @@ import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.util.Optional;
 
@@ -70,6 +74,14 @@ class ProjectCreateStatusTest {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private CustomerRepository customerRepository;
+    @Mock
+    private UserContextService userContextService;
+    @Mock
+    private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock
+    private StatusTransitionRepository statusTransitionRepository;
+    @Mock
+    private StatusTransitionMapper statusTransitionMapper;
 
     private ProjectService service;
 
@@ -79,7 +91,8 @@ class ProjectCreateStatusTest {
         Validator validator = factory.getValidator();
         service = new ProjectService(repository, organizationRepository, employeeRepository,
                 attachmentService, projectMapper, employeeMapper, eventPublisher,
-                customerRepository, new PayloadValidator(validator));
+                customerRepository, new PayloadValidator(validator), userContextService,
+                statusTransitionRecorder, statusTransitionRepository, statusTransitionMapper);
 
         TenantContext.setCurrentOrgId(1L);
         Organization organization = new Organization();

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectCreationValidationTest.java
@@ -17,11 +17,15 @@ import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
 import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 
 /**
@@ -55,6 +59,14 @@ class ProjectCreationValidationTest {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private CustomerRepository customerRepository;
+    @Mock
+    private UserContextService userContextService;
+    @Mock
+    private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock
+    private StatusTransitionRepository statusTransitionRepository;
+    @Mock
+    private StatusTransitionMapper statusTransitionMapper;
 
     private ProjectService service;
 
@@ -64,7 +76,8 @@ class ProjectCreationValidationTest {
         validator = factory.getValidator();
         service = new ProjectService(repository, organizationRepository, employeeRepository,
                 attachmentService, projectMapper, employeeMapper, eventPublisher,
-                customerRepository, new PayloadValidator(validator));
+                customerRepository, new PayloadValidator(validator), userContextService,
+                statusTransitionRecorder, statusTransitionRepository, statusTransitionMapper);
     }
 
     private ProjectCreationDto validDto() {

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectPartialUpdateDateTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectPartialUpdateDateTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
@@ -17,6 +18,7 @@ import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -49,6 +51,12 @@ class ProjectPartialUpdateDateTest {
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private CustomerRepository customerRepository;
     @Mock private Validator validator;
+
+    @Mock
+    private UserContextService userContextService;
+
+    @Mock
+    private StatusTransitionRecorder statusTransitionRecorder;
 
     @InjectMocks private ProjectService service;
 

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectStatusHistoryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectStatusHistoryTest.java
@@ -1,0 +1,333 @@
+package org.tornotron.echno_backend.project;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A project's status has to be answerable after the fact: when it last moved, who moved it, and
+ * whether it was created holding a status or patched into it.
+ *
+ * <p>The question came from a project found approved with no compliance inspections, where it was
+ * impossible to tell whether it had been created approved or patched there. Approval is the
+ * transition with behaviour behind it, since it draws up the compliance inspections, and until
+ * now nothing recorded that it had happened at all. These pin what is recorded, what is
+ * deliberately not recorded, and the actor on both.
+ *
+ * <p>Plain Mockito with a real validator and no Spring context, following the other tests on this
+ * service.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectStatusHistoryTest {
+
+    private static final Long ORG_ID = 1L;
+    private static final Long PROJECT_ID = 7L;
+    private static final Long ACTOR_ID = 31L;
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private ProjectRepository repository;
+    @Mock
+    private OrganizationRepository organizationRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private ProjectMapper projectMapper;
+    @Mock
+    private EmployeeMapper employeeMapper;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private CustomerRepository customerRepository;
+    @Mock
+    private UserContextService userContextService;
+    @Mock
+    private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock
+    private StatusTransitionRepository statusTransitionRepository;
+    @Mock
+    private StatusTransitionMapper statusTransitionMapper;
+
+    private ProjectService service;
+    private Organization organization;
+    private User actor;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new ProjectService(repository, organizationRepository, employeeRepository,
+                attachmentService, projectMapper, employeeMapper, eventPublisher,
+                customerRepository, new PayloadValidator(validator), userContextService,
+                statusTransitionRecorder, statusTransitionRepository, statusTransitionMapper);
+
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        organization = new Organization();
+        organization.setId(ORG_ID);
+
+        actor = new User();
+        actor.setId(ACTOR_ID);
+        actor.setName("Anand Rajashekar");
+
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization));
+        when(repository.existsProjectByProjectName(anyString())).thenReturn(false);
+        when(repository.save(any(Project.class))).thenAnswer(call -> {
+            Project saved = call.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(PROJECT_ID);
+            }
+            return saved;
+        });
+        when(userContextService.getCurrentUser()).thenReturn(actor);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    /**
+     * The trail opens on the status the project was created in. Without this entry a project's
+     * first recorded status would be whatever it was patched to, and "created in this state" and
+     * "moved into this state" would be indistinguishable, which is the exact confusion the trail
+     * exists to end.
+     */
+    @Test
+    void addProject_opensTheTrailOnTheStatusTheProjectWasCreatedIn() {
+        ProjectCreationDto dto = validDto();
+        dto.setStatus(ProjectCreationStatus.onHold);
+
+        service.addProject(dto, null);
+
+        verify(statusTransitionRecorder).recordCreation(
+                eq(ProjectService.HISTORY_ENTITY_TYPE), eq(PROJECT_ID), eq(organization),
+                eq(ProjectCreationStatus.onHold.name()), eq(actor));
+    }
+
+    /** The default status is recorded as the created status, not left blank. */
+    @Test
+    void addProject_recordsTheDefaultStatusWhenThePayloadNamesNone() {
+        ProjectCreationDto dto = validDto();
+        dto.setStatus(null);
+
+        service.addProject(dto, null);
+
+        verify(statusTransitionRecorder).recordCreation(
+                anyString(), any(), any(), eq(ProjectCreationStatus.upcoming.name()), any());
+    }
+
+    /**
+     * The transition the whole thing was built for. It has to name both ends, the organization the
+     * project belongs to, and the user who made it: "approved" with no actor answers half of the
+     * question a client asks.
+     */
+    @Test
+    void approvingAProject_recordsTheTransitionWithBothStatusesAndTheActor() {
+        Project project = draftProject(ProjectCreationStatus.upcoming);
+
+        patch(project, Map.of("status", ProjectCreationStatus.approved.name()));
+
+        verify(statusTransitionRecorder).recordChange(
+                eq(ProjectService.HISTORY_ENTITY_TYPE), eq(PROJECT_ID), eq(organization),
+                eq(ProjectCreationStatus.upcoming.name()),
+                eq(ProjectCreationStatus.approved.name()),
+                eq(actor), isNull());
+    }
+
+    /**
+     * Recording is not limited to approval. Approval is the transition that carries behaviour, but
+     * a project put on hold or cancelled raises the same question of who did it and when.
+     */
+    @Test
+    void anyOtherStatusChange_isRecordedToo() {
+        Project project = draftProject(ProjectCreationStatus.open);
+
+        patch(project, Map.of("status", ProjectCreationStatus.cancelled.name()));
+
+        verify(statusTransitionRecorder).recordChange(
+                anyString(), any(), any(),
+                eq(ProjectCreationStatus.open.name()),
+                eq(ProjectCreationStatus.cancelled.name()),
+                any(), any());
+    }
+
+    /**
+     * A patch that touched no status still reaches the recorder, with the two ends equal. Which
+     * of the two decides that no entry is written matters: the service does not try to work out
+     * whether the status moved, so no caller can forget to, and
+     * {@code StatusTransitionRecorderIT} pins that an entry whose ends are equal is dropped.
+     *
+     * <p>The write stamp is set either way, because a patch that renamed the project is still a
+     * write somebody made.
+     */
+    @Test
+    void aPatchThatChangesNoStatus_stampsTheWriteAndLeavesTheRecorderToDropIt() {
+        Project project = draftProject(ProjectCreationStatus.open);
+
+        patch(project, Map.of("projectName", "Renamed"));
+
+        verify(statusTransitionRecorder).recordChange(
+                anyString(), any(), any(),
+                eq(ProjectCreationStatus.open.name()),
+                eq(ProjectCreationStatus.open.name()),
+                any(), any());
+        assertThat(project.getUpdatedAt()).isNotNull();
+        assertThat(project.getUpdatedBy()).isEqualTo(ACTOR_ID);
+    }
+
+    /**
+     * An approval the project's state does not allow is refused, and nothing reaches the trail. A
+     * recorded approval that did not happen is worse than no record at all.
+     */
+    @Test
+    void aRefusedApproval_recordsNothing() {
+        Project project = draftProject(ProjectCreationStatus.upcoming);
+        project.setProjectAddress("Chennai");
+        project.setProjectState(null);
+
+        assertThatThrownBy(() -> patch(project, Map.of("status", ProjectCreationStatus.approved.name())))
+                .hasMessageContaining("cannot be approved without a state");
+
+        verify(statusTransitionRecorder, never()).recordChange(
+                anyString(), any(), any(), any(), any(), any(), any());
+    }
+
+    /**
+     * The create path stamps the creator as well as the writer. {@code created_at} has been on the
+     * project all along and never said who made it.
+     */
+    @Test
+    void addProject_stampsTheCreatorAndTheWriter() {
+        service.addProject(validDto(), null);
+
+        Project saved = savedProject();
+        assertThat(saved.getCreatedBy()).isEqualTo(ACTOR_ID);
+        assertThat(saved.getUpdatedBy()).isEqualTo(ACTOR_ID);
+        assertThat(saved.getUpdatedAt()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+
+    /**
+     * Nothing here requires a user. A write from a background path leaves the actor empty rather
+     * than failing, the way {@code AssetMovement.movedBy} does, because a status that moved with
+     * no recorded actor is still worth recording.
+     */
+    @Test
+    void aWriteWithNoUserContext_recordsTheTransitionWithNoActor() {
+        when(userContextService.getCurrentUser()).thenReturn(null);
+        Project project = draftProject(ProjectCreationStatus.upcoming);
+
+        patch(project, Map.of("status", ProjectCreationStatus.closed.name()));
+
+        verify(statusTransitionRecorder).recordChange(
+                anyString(), any(), any(), anyString(), anyString(), isNull(), isNull());
+        assertThat(project.getUpdatedBy()).isNull();
+    }
+
+    /**
+     * A patch that sets the state and approves in one call still records one transition, judged on
+     * the state the patch is setting. The recording runs after the whole patch, like the approval
+     * hook it follows.
+     */
+    @Test
+    void aPatchThatSetsTheStateAndApprovesTogether_recordsOneTransition() {
+        Project project = draftProject(ProjectCreationStatus.upcoming);
+        project.setProjectAddress("Chennai");
+        project.setProjectState(null);
+
+        Map<String, Object> updates = new LinkedHashMap<>();
+        updates.put("status", ProjectCreationStatus.approved.name());
+        updates.put("projectState", "Tamil Nadu");
+
+        patch(project, updates);
+
+        verify(statusTransitionRecorder).recordChange(
+                anyString(), any(), any(),
+                eq(ProjectCreationStatus.upcoming.name()),
+                eq(ProjectCreationStatus.approved.name()),
+                any(), any());
+    }
+
+    private void patch(Project project, Map<String, Object> updates) {
+        when(repository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(Optional.of(project));
+        service.partialUpdateAProject(updates, PROJECT_ID, null, "PROJECT");
+    }
+
+    private Project draftProject(ProjectCreationStatus status) {
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setProjectName("Draft");
+        project.setProjectAddress("12 Mount Road, Mylapore, Tamil Nadu");
+        project.setProjectState("Tamil Nadu");
+        project.setStatus(status);
+        project.setOrganization(organization);
+        return project;
+    }
+
+    private ProjectCreationDto validDto() {
+        ProjectCreationDto dto = new ProjectCreationDto();
+        dto.setProjectName("Riverside Tower");
+        dto.setProjectAddress("12 Mount Road, Mylapore, Tamil Nadu");
+        dto.setProjectState("Tamil Nadu");
+        return dto;
+    }
+
+    private Project savedProject() {
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        verify(repository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectStatusHistoryTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectStatusHistoryTest.java
@@ -20,6 +20,7 @@ import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
@@ -65,6 +66,7 @@ class ProjectStatusHistoryTest {
     private static final Long ORG_ID = 1L;
     private static final Long PROJECT_ID = 7L;
     private static final Long ACTOR_ID = 31L;
+    private static final Long EMPLOYEE_ID = 55L;
 
     private static ValidatorFactory factory;
 
@@ -299,6 +301,67 @@ class ProjectStatusHistoryTest {
                 eq(ProjectCreationStatus.upcoming.name()),
                 eq(ProjectCreationStatus.approved.name()),
                 any(), any());
+    }
+
+    /**
+     * The team is part of the project, so changing it is a write like any other. A stamp that
+     * covered only the field patch would report a project as untouched since last month while its
+     * team was rebuilt yesterday, which is a wrong answer rather than a missing one.
+     */
+    @Test
+    void addingAnEmployeeToTheTeam_stampsTheWrite() {
+        Project project = draftProject(ProjectCreationStatus.open);
+        Employee employee = teamMember();
+        when(repository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(Optional.of(project));
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee));
+
+        service.addEmployeeToProject(PROJECT_ID, EMPLOYEE_ID);
+
+        assertThat(project.getUpdatedAt()).isNotNull();
+        assertThat(project.getUpdatedBy()).isEqualTo(ACTOR_ID);
+    }
+
+    /** The same on the way out. */
+    @Test
+    void removingAnEmployeeFromTheTeam_stampsTheWrite() {
+        Project project = draftProject(ProjectCreationStatus.open);
+        Employee employee = teamMember();
+        project.getEmployees().add(employee);
+        when(repository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(Optional.of(project));
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee));
+
+        service.removeEmployeeFromProject(PROJECT_ID, EMPLOYEE_ID);
+
+        assertThat(project.getUpdatedAt()).isNotNull();
+        assertThat(project.getUpdatedBy()).isEqualTo(ACTOR_ID);
+    }
+
+    /**
+     * A team change is not a status change, so it must not appear in the status trail. The trail
+     * is only readable if what is in it is what it says it holds.
+     */
+    @Test
+    void changingTheTeam_recordsNoStatusTransition() {
+        Project project = draftProject(ProjectCreationStatus.open);
+        Employee employee = teamMember();
+        when(repository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(Optional.of(project));
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee));
+
+        service.addEmployeeToProject(PROJECT_ID, EMPLOYEE_ID);
+
+        verify(statusTransitionRecorder, never()).recordChange(
+                anyString(), any(), any(), any(), any(), any(), any());
+    }
+
+    private Employee teamMember() {
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE_ID);
+        employee.setEmployeeName("Site Engineer");
+        employee.setOrganization(organization);
+        return employee;
     }
 
     private void patch(Project project, Map<String, Object> updates) {


### PR DESCRIPTION
Closes #565. The design was posted on the issue first: https://github.com/tornotron/echno-backend/issues/565#issuecomment-5469636996

## The gap, which is two gaps

A project recorded `created_at` and nothing else about its own history. No `updated_at`, no `created_by`, no `updated_by`, and no audit, revision or history table anywhere in the schema. Two different questions were unanswerable, and they need different answers:

1. **"When did this last change, and who touched it?"** A last-write stamp.
2. **"Who approved this, when, and was it created in that state or patched into it?"** A transition trail.

Neither answers the other. A stamp is overwritten by the next edit, so the approver's name survives only until somebody fixes a typo in the address. A trail says nothing about a project whose status has never moved.

## Scope: one shared table, per-module exposure

Seven records here carry a status enum with a gated transition: Project, StockAdjustment, ConstructionInvoice, AttendanceRegularization, SiteTransfer, Issue, PurchaseOrder. Three already record the actor on the document itself and all three do it differently (`Long` user ids on StockAdjustment, String usernames inherited from the finance `BaseEntity` on ConstructionInvoice, both at once on AttendanceRegularization). Four record nothing. A `project_status_history` with a project foreign key would be followed by a `site_transfer_status_history`, and by the sixth there would be six tables of identical shape drifting the way those actor columns already have.

So: **the storage and the writer are shared, the API is not.** One `status_transition` table keyed by `(entity_type, entity_id)` the way `attachment` already is, one `StatusTransitionRecorder`, and each module reads its own trail through its own endpoint under its own `@PreAuthorize`. A generic `GET /history/{type}/{id}` would need a registry of per-type read rules, because who may read a site transfer's history is not who may read a project's, and that registry is the half-general framework worth avoiding. Project is the first and so far only caller; the second is one call at its transition point plus one controller method.

## Mechanism: why not Envers

Envers would give the ability to ask what any field held on any past date. Nobody has asked for that. What it costs is not mainly the `_AUD` table per entity, it is tenant isolation: isolation here is fail-closed by construction, with `TenantIsolationLoadListener` registered against the `TenantScopedEntity` interface and the `orgFilter` switched on per transaction by `HibernateFilterConfig`. Envers reads through `AuditReader`, which queries the `_AUD` tables directly with the Hibernate filter not applied, and `REVINFO` is one global revision table with no organization column at all. Adopting it means a second, parallel tenant-scoping story for the audit read path, remembered on every query. A plain entity gets isolation by implementing an interface.

An event log solves delivery and replay rather than history, and would record only approval, since approval is the only project transition that publishes an event.

## What is recorded

Status transitions, plus a last-write stamp for everything else. Status is the only project field with behaviour behind it: `onApproval` publishes `ProjectApprovedEvent`, which draws up the compliance inspections. A change to the postal code carries nothing, and recording it costs a row per edit forever to answer a question nobody asks.

## What is here

- `project.created_by`, `project.updated_at`, `project.updated_by`, stamped on create and on every patch, and surfaced on `ProjectDto`.
- `status_transition` plus `StatusTransition`, `StatusTransitionRepository`, `StatusTransitionRecorder`, its DTO and mapper.
- `ProjectService` records the created status on create and every status change on patch, after the approval gate so a refused approval writes nothing. The service never works out whether the status moved: it records unconditionally and the recorder drops an entry whose two ends are equal, so no caller can forget.
- `GET /api/v1/project/web/{id}/status-history`, paged newest first, `PageQuery`-bound, under the same authorization as the other project reads.
- `073-project-change-history.xml`: the three columns, the table with its organization FK and indexes, and the baseline seed.
- `docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.

Append-only is a property of the type rather than a convention: the entity is `@Immutable` and the repository extends `Repository` rather than `JpaRepository`, so no delete surface exists at all. That is the `AssetMovementRepository` pattern.

Two deliberate departures from `asset_movement`:

- **No foreign key to the record it describes.** `asset_movement` refuses to let an asset be deleted while its ledger is non-empty, because a movement is a fact about a live asset. A status trail has to outlive the record: a cascade would erase the evidence of who approved a project the moment the project was deleted, and a restrict would make an approved project undeletable.
- **`note` is nullable**, where `asset_movement.reason` is required. An entry already names both of its ends; requiring prose on every one buys a column full of "changed status".

`changed_by_name` is snapshotted beside `changed_by` for the reason `asset_movement` snapshots its names: history that evaporates when a user is renamed is not history.

**The column that answers #549 is `source`.** `CREATION` against `UPDATE` is literally "created approved, or patched there".

## What this cannot answer

Stated plainly on the issue too, so nobody expects otherwise:

- For every project that exists today, the trail begins at the migration. Each gets one `BASELINE` entry naming the status it is observed to hold at that moment, with no actor and no earlier status.
- That entry is deliberately **not** dated at `created_at`. Dating the observed status at creation time would assert the project was created in that state, which is exactly the claim #549 could not check.
- **Project 27 stays unexplained.** Its baseline row says it was observed `approved` on the migration date, by nobody nameable. It will not say who approved it, when, or whether it was created that way. Both routes into that state are already closed (`5073609`, `5a16111`), so it cannot recur; the history is not recoverable.
- `created_by` is null on every pre-existing project, for the same reason.
- A change made directly against the database bypasses this, as it bypasses everything else.

## Tests

- `StatusTransitionRecorderIT`, against the real CockroachDB on the Liquibase-built schema (Hibernate runs `ddl-auto: validate`, so the context starts only if entity and table agree): the opening entry, the no-op that must not become an entry, the snapshotted actor, newest-first ordering, one record's entries not leaking into another's, and two organizations numbering a project the same not seeing each other's trail.
- `ProjectStatusHistoryTest`: the created status opens the trail, both ends and the actor are recorded on approval and on every other transition, a refused approval records nothing, a patch with no status change still stamps the write, and a write with no user context records the transition with no actor.
- The four existing project tests take the two new collaborators as mocks; nothing about their assertions changed.

Verified on the lab box: full `./gradlew test jacocoTestCoverageVerification` green (test heap 524 MB of 2048). Negative proof: with the `recordStatusChange` call removed, 5 of the 9 new tests fail on "Wanted but not invoked".

## Follow-ups, not in scope here

- Second callers, one at a time, each at its own transition point with its own endpoint. SiteTransfer and PurchaseOrder first, since they record nothing at all today.
- The `echno-core` type and the `echno-web` screen. The backend change is purely additive, so nothing breaks in the meantime.
- Whether the bespoke `approvedBy`/`submittedBy` columns keep being written once the shared trail exists. My view is yes for now: those modules' own screens read them, and collapsing them is a separate change with its own risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project status-history tracking for creations and status changes.
  - Added a paginated endpoint to view a project’s status history.
  - Project details now include creator and last-update information.
  - Existing projects receive an initial baseline history entry.

- **Bug Fixes**
  - Prevented history entries for unchanged project statuses.

- **Documentation**
  - Updated the API specification with status-history schemas and endpoint details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->