### PR TITLE
Settle attendance authorization on the record, not on the id the caller sent

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20854,7 +20854,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the attendance record belongs to nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -21071,7 +21071,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the attendance record belongs to nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -22984,7 +22984,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee named nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -23111,7 +23111,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the record belongs to nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -23807,7 +23807,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee named nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -23934,7 +23934,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee the record belongs to nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -73220,7 +73220,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee involved nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {
@@ -73459,7 +73459,7 @@
                 }
               }
             },
-            "description": "Caller is not a member of the current tenant"
+            "description": "Caller is neither the employee involved nor a holder of an attendance record-management role"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -48,6 +48,8 @@ public class AttendanceController {
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // Ownership is settled in AttendanceService against the employee the payload names:
+    // the employee id travels inside the multipart data part, where this guard cannot read it.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Check in for the day",
@@ -58,7 +60,7 @@ public class AttendanceController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Check-in recorded"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of an attendance record-management role")
     })
     public ResponseEntity<AttendanceResponseDto> checkIn(
             @Parameter(schema = @Schema(implementation = AttendanceCheckInDto.class))
@@ -71,6 +73,8 @@ public class AttendanceController {
 
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // Ownership is settled in AttendanceService against the stored attendance record's
+    // employee: the payload names only an attendance id, which is the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Record a clock event",
@@ -81,7 +85,7 @@ public class AttendanceController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Clock event recorded"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid clock event JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the record belongs to nor a holder of an attendance record-management role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -48,6 +48,8 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping(value = "/check-in",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // Ownership is settled in AttendanceService against the employee the payload names:
+    // the employee id travels inside the multipart data part, where this guard cannot read it.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Check in for the day",
@@ -58,7 +60,7 @@ public class AttendanceControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Check-in recorded"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid check-in JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of an attendance record-management role")
     })
     public ResponseEntity<AttendanceResponseDto> checkIn(
             @Parameter(schema = @Schema(implementation = AttendanceCheckInDto.class))
@@ -69,6 +71,8 @@ public class AttendanceControllerWeb {
     }
 
     @PostMapping(value = "/clock-event",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // Ownership is settled in AttendanceService against the stored attendance record's
+    // employee: the payload names only an attendance id, which is the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Record a clock event",
@@ -79,7 +83,7 @@ public class AttendanceControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Clock event recorded"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid clock event JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee the record belongs to nor a holder of an attendance record-management role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> recordClockEvent(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
@@ -37,6 +37,8 @@ public class AttendanceRegularizationController {
     }
 
     @PostMapping("/request")
+    // Ownership is settled in AttendanceRegularizationService against the stored attendance
+    // record's employee: the payload names only an attendance id, which is the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Submit a regularization request",
@@ -48,7 +50,7 @@ public class AttendanceRegularizationController {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
             @ApiResponse(responseCode = "400", description = "attendanceId, reason or missingEvents is missing or invalid"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the attendance record belongs to nor a holder of an attendance record-management role"),
             @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
     })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
@@ -37,6 +37,8 @@ public class AttendanceRegularizationControllerWeb {
     }
 
     @PostMapping("/request")
+    // Ownership is settled in AttendanceRegularizationService against the stored attendance
+    // record's employee: the payload names only an attendance id, which is the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Submit a regularization request",
@@ -48,7 +50,7 @@ public class AttendanceRegularizationControllerWeb {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Regularization request submitted"),
             @ApiResponse(responseCode = "400", description = "attendanceId, reason or missingEvents is missing or invalid"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee the attendance record belongs to nor a holder of an attendance record-management role"),
             @ApiResponse(responseCode = "404", description = "No attendance record with the given attendanceId")
     })
     public ResponseEntity<AttendanceRegularizationDto> submitRequest(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.attendance;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import jakarta.validation.ValidationException;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -20,6 +21,7 @@ import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -65,6 +67,7 @@ public class AttendanceService {
     private final FileStorageService fileStorageService;
     private final UserContextService userContextService;
     private final PayloadValidator payloadValidator;
+    private final AttendanceSecurityService attendanceSecurity;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              ShiftTimingRepository shiftTimingRepository,
@@ -78,7 +81,8 @@ public class AttendanceService {
                              AttachmentService attachmentService,
                              FileStorageService fileStorageService,
                              UserContextService userContextService,
-                             PayloadValidator payloadValidator) {
+                             PayloadValidator payloadValidator,
+                             AttendanceSecurityService attendanceSecurity) {
         this.attendanceRepository = attendanceRepository;
         this.shiftTimingRepository = shiftTimingRepository;
         this.employeeRepository = employeeRepository;
@@ -92,6 +96,31 @@ public class AttendanceService {
         this.fileStorageService = fileStorageService;
         this.userContextService = userContextService;
         this.payloadValidator = payloadValidator;
+        this.attendanceSecurity = attendanceSecurity;
+    }
+
+    /**
+     * Refuses the call unless the caller is the employee the attendance belongs to, or holds an
+     * attendance record-management role.
+     *
+     * <p>This lives here rather than in the {@code @PreAuthorize} guard for the same reason the
+     * leave family's check does ({@code LeaveRequestService}): the guard can only see what the
+     * caller sent. A check-in names its employee inside the multipart {@code data} part, and a
+     * clock event names an attendance record whose owner only the database knows, so the employee
+     * id the annotation could read is an argument, not evidence. Left at tenant membership, any
+     * member could fabricate a colleague's check-in or clock them out.
+     *
+     * @param employeeId The employee the record belongs to, read off the stored record where one
+     *     exists rather than off the request.
+     * @throws AccessDeniedException if the caller is neither that employee nor a record manager.
+     */
+    private void requireActorMayRecordFor(Long employeeId) {
+        if (attendanceSecurity.canRecordFor(employeeId)) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Attendance can only be recorded for yourself, unless you hold an attendance "
+                        + "record-management role");
     }
 
     /**
@@ -107,10 +136,13 @@ public class AttendanceService {
      * @return The created attendance record.
      * @throws ResourceNotFoundException if the organization, employee, project, or shift is not found.
      * @throws jakarta.validation.ValidationException if a required photo or location is missing, the photo is not an image, or a record already exists for the day.
+     * @throws AccessDeniedException if the caller is neither the employee named nor a holder of an
+     *     attendance record-management role.
      */
     @Transactional
     public AttendanceResponseDto checkIn(AttendanceCheckInDto dto, MultipartFile photo) {
         payloadValidator.requireValid(dto);
+        requireActorMayRecordFor(dto.getEmployeeId());
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -245,6 +277,8 @@ public class AttendanceService {
      * @return The updated attendance record.
      * @throws ResourceNotFoundException if the organization or attendance record is not found.
      * @throws jakarta.validation.ValidationException if a required photo or location is missing, the photo is not an image, or the event breaks the allowed sequence.
+     * @throws AccessDeniedException if the caller is neither the employee the record belongs to
+     *     nor a holder of an attendance record-management role.
      */
     @Transactional
     public AttendanceResponseDto recordClockEvent(AttendanceClockEventDto dto, MultipartFile photo) {
@@ -256,6 +290,8 @@ public class AttendanceService {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(dto.getAttendanceId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Attendance record with ID " + dto.getAttendanceId() + " was not found"));
+
+        requireActorMayRecordFor(attendance.getEmployeeId());
 
         AttendanceSettings settings = settingsService.resolveEffectiveSettings(orgId, attendance.getProjectId());
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
@@ -36,6 +36,8 @@ public class MovementRecordController {
     }
 
     @PostMapping
+    // Ownership is settled in MovementRecordService against both the employee named and the
+    // stored attendance record's employee: ids on the request are the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Log a movement",
@@ -45,7 +47,7 @@ public class MovementRecordController {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Movement record created"),
             @ApiResponse(responseCode = "400", description = "attendanceId, movementType, fromLocation, startTime or purpose is missing or invalid"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee involved nor a holder of an attendance record-management role"),
             @ApiResponse(responseCode = "404", description = "No attendance record or employee with the given id")
     })
     public ResponseEntity<MovementRecordDto> create(

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
@@ -37,6 +37,8 @@ public class MovementRecordControllerWeb {
     }
 
     @PostMapping
+    // Ownership is settled in MovementRecordService against both the employee named and the
+    // stored attendance record's employee: ids on the request are the caller's word.
     @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Log a movement",
@@ -46,7 +48,7 @@ public class MovementRecordControllerWeb {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Movement record created"),
             @ApiResponse(responseCode = "400", description = "attendanceId, movementType, fromLocation, startTime or purpose is missing or invalid"),
-            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the employee involved nor a holder of an attendance record-management role"),
             @ApiResponse(responseCode = "404", description = "No attendance record or employee with the given id")
     })
     public ResponseEntity<MovementRecordDto> create(

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance.service;
 
 import jakarta.validation.ValidationException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.attendance.*;
@@ -11,6 +12,7 @@ import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMap
 import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -56,6 +58,7 @@ public class AttendanceRegularizationService {
     private final AttendanceRegularizationMapper regularizationMapper;
     private final UserContextService userContextService;
     private final SelfApprovalPolicy selfApprovalPolicy;
+    private final AttendanceSecurityService attendanceSecurity;
 
     public AttendanceRegularizationService(AttendanceRegularizationRepository regularizationRepository,
                                             AttendanceRepository attendanceRepository,
@@ -65,7 +68,8 @@ public class AttendanceRegularizationService {
                                             AttendanceCalculationService calculationService,
                                             AttendanceRegularizationMapper regularizationMapper,
                                             UserContextService userContextService,
-                                            SelfApprovalPolicy selfApprovalPolicy) {
+                                            SelfApprovalPolicy selfApprovalPolicy,
+                                            AttendanceSecurityService attendanceSecurity) {
         this.regularizationRepository = regularizationRepository;
         this.attendanceRepository = attendanceRepository;
         this.organizationRepository = organizationRepository;
@@ -75,6 +79,7 @@ public class AttendanceRegularizationService {
         this.regularizationMapper = regularizationMapper;
         this.userContextService = userContextService;
         this.selfApprovalPolicy = selfApprovalPolicy;
+        this.attendanceSecurity = attendanceSecurity;
     }
 
     /** Who the authenticated caller is, as recorded on a request: a display name, their platform
@@ -99,6 +104,8 @@ public class AttendanceRegularizationService {
      * @throws ResourceNotFoundException if the organization or the attendance record is not found.
      * @throws ValidationException if self-service regularization is off for the project, the
      *         monthly cap is reached, or a request is already pending for that record.
+     * @throws AccessDeniedException if the caller is neither the employee the attendance record
+     *         belongs to nor a holder of an attendance record-management role.
      */
     @Transactional
     public AttendanceRegularizationDto submitRequest(RegularizationRequestDto dto) {
@@ -111,6 +118,17 @@ public class AttendanceRegularizationService {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(dto.getAttendanceId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Attendance record with ID " + dto.getAttendanceId() + " was not found"));
+
+        // The attendance record is chosen by the caller, so who it belongs to is settled here
+        // against the stored record: its own employee, or someone holding a record-management
+        // role. On a project configured to auto-approve, the corrections below are applied
+        // immediately, so without this check any member of the tenant could rewrite a
+        // colleague's clock events there.
+        if (!attendanceSecurity.canRecordFor(attendance.getEmployeeId())) {
+            throw new AccessDeniedException(
+                    "A regularization can only be raised on your own attendance, unless you hold "
+                            + "an attendance record-management role");
+        }
 
         AttendanceSettings settings = settingsService.resolveEffectiveSettings(orgId, attendance.getProjectId());
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance.service;
 
 import jakarta.validation.ValidationException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.attendance.*;
@@ -8,6 +9,7 @@ import org.tornotron.echno_backend.attendance.dto.MovementRecordCreationDto;
 import org.tornotron.echno_backend.attendance.dto.MovementRecordDto;
 import org.tornotron.echno_backend.attendance.mapper.MovementRecordMapper;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -28,23 +30,52 @@ public class MovementRecordService {
     private final OrganizationRepository organizationRepository;
     private final AttendanceSettingsService settingsService;
     private final MovementRecordMapper movementRecordMapper;
+    private final AttendanceSecurityService attendanceSecurity;
 
     public MovementRecordService(MovementRecordRepository movementRecordRepository,
                                   AttendanceRepository attendanceRepository,
                                   EmployeeRepository employeeRepository,
                                   OrganizationRepository organizationRepository,
                                   AttendanceSettingsService settingsService,
-                                  MovementRecordMapper movementRecordMapper) {
+                                  MovementRecordMapper movementRecordMapper,
+                                  AttendanceSecurityService attendanceSecurity) {
         this.movementRecordRepository = movementRecordRepository;
         this.attendanceRepository = attendanceRepository;
         this.employeeRepository = employeeRepository;
         this.organizationRepository = organizationRepository;
         this.settingsService = settingsService;
         this.movementRecordMapper = movementRecordMapper;
+        this.attendanceSecurity = attendanceSecurity;
     }
 
+    /**
+     * Refuses the call unless the caller is the given employee or holds an attendance
+     * record-management role. See {@link AttendanceSecurityService#canRecordFor}.
+     */
+    private void requireActorMayRecordFor(Long employeeId) {
+        if (attendanceSecurity.canRecordFor(employeeId)) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Movements can only be recorded for yourself, unless you hold an attendance "
+                        + "record-management role");
+    }
+
+    /**
+     * Logs a movement on an attendance record.
+     *
+     * <p>The employee named on the call and the employee the attendance record belongs to must
+     * each be the caller or fall under the caller's record-management role. Both ids arrive from
+     * the request, so checking them here against the caller is what stops one member of the
+     * tenant writing movements onto a colleague's attendance trail; the {@code @PreAuthorize}
+     * guard on the handlers only sees the caller's word.
+     *
+     * @throws AccessDeniedException if the caller is neither the employee involved nor a holder
+     *     of an attendance record-management role.
+     */
     @Transactional
     public MovementRecordDto addMovement(MovementRecordCreationDto dto, Long employeeId) {
+        requireActorMayRecordFor(employeeId);
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization with ID " + orgId + " was not found"));
@@ -56,6 +87,10 @@ public class MovementRecordService {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(dto.getAttendanceId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Attendance record with ID " + dto.getAttendanceId() + " was not found"));
+
+        if (!attendance.getEmployeeId().equals(employeeId)) {
+            requireActorMayRecordFor(attendance.getEmployeeId());
+        }
 
         AttendanceSettings settings = settingsService.resolveEffectiveSettings(orgId, attendance.getProjectId());
 

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
@@ -58,4 +58,17 @@ public class AttendanceSecurityService {
     public boolean canViewEmployeeRecords(Long employeeId) {
         return orgSecurity.isSelfOrHasAnyOrgRole(employeeId, recordManagementRoles);
     }
+
+    /**
+     * Record or correct attendance for one employee: the employee themselves, or a manager / HR.
+     *
+     * <p>Same policy as {@link #canViewEmployeeRecords}, named separately because the write
+     * endpoints resolve the employee from the stored record (or, on a check-in, from the payload)
+     * in the service rather than from an annotation: the id on the request is the caller's word,
+     * not evidence, so the {@code @PreAuthorize} guard on those handlers only checks tenant
+     * membership and the services call this with the id the record actually names.
+     */
+    public boolean canRecordFor(Long employeeId) {
+        return orgSecurity.isSelfOrHasAnyOrgRole(employeeId, recordManagementRoles);
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
@@ -1,0 +1,299 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRegularizationRepository;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.MovementRecordRepository;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.dto.AttendanceCheckInDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceClockEventDto;
+import org.tornotron.echno_backend.attendance.dto.MovementRecordCreationDto;
+import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
+import org.tornotron.echno_backend.attendance.enums.MovementType;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.attendance.mapper.MovementRecordMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who may record attendance, and against whose record.
+ *
+ * <p>Check-in, clock events and movements were guarded by tenant membership alone while the
+ * employee, or the attendance record, arrived as an id on the request. The services loaded
+ * whatever the id named and never asked who was calling, so any member of a tenant could
+ * fabricate a colleague's check-in, clock them out, log movements on their trail, or file a
+ * regularization against their record; on a project configured to auto-approve regularizations
+ * the corrections were applied on the spot. The same shape the leave family had
+ * ({@code LeaveRequestActorAuthorizationTest}), in the module that feeds worked hours.
+ *
+ * <p>What settles it now is the record (or, on a check-in, the employee the payload names),
+ * checked in the service against the caller: the employee themselves, or a holder of an
+ * attendance record-management role. These tests fail on the old code by the write going
+ * through.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceActorAuthorizationTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 8L;
+    private static final Long ATTENDANCE_ID = 781L;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private MovementRecordRepository movementRecordRepository;
+    @Mock private MovementRecordMapper movementRecordMapper;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private AttendanceService attendanceService() {
+        return new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity);
+    }
+
+    private MovementRecordService movementRecordService() {
+        return new MovementRecordService(movementRecordRepository, attendanceRepository,
+                employeeRepository, organizationRepository, settingsService, movementRecordMapper,
+                attendanceSecurity);
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        return organization;
+    }
+
+    /** A colleague's attendance for the day, the record the caller has no business writing to. */
+    private Attendance colleaguesAttendance() {
+        Attendance attendance = new Attendance();
+        attendance.setId(ATTENDANCE_ID);
+        attendance.setEmployeeId(COLLEAGUE_EMPLOYEE_ID);
+        attendance.setEmployeeName("Colleague");
+        attendance.setProjectId(12L);
+        attendance.setOrganization(organization());
+        return attendance;
+    }
+
+    private AttendanceCheckInDto checkInDto(Long employeeId) {
+        AttendanceCheckInDto dto = new AttendanceCheckInDto();
+        dto.setEmployeeId(employeeId);
+        dto.setProjectId(12L);
+        dto.setEventTimestamp(LocalDateTime.of(2026, 8, 31, 9, 2));
+        return dto;
+    }
+
+    private AttendanceClockEventDto clockEventDto() {
+        AttendanceClockEventDto dto = new AttendanceClockEventDto();
+        dto.setAttendanceId(ATTENDANCE_ID);
+        dto.setEventType(ClockEventType.LUNCH_BREAK_START);
+        dto.setEventTimestamp(LocalDateTime.of(2026, 8, 31, 13, 0));
+        return dto;
+    }
+
+    private MovementRecordCreationDto movementDto() {
+        MovementRecordCreationDto dto = new MovementRecordCreationDto();
+        dto.setAttendanceId(ATTENDANCE_ID);
+        dto.setMovementType(MovementType.SITE_TRAVEL);
+        dto.setFromLocation("Block A");
+        dto.setStartTime(LocalDateTime.of(2026, 8, 31, 11, 0));
+        dto.setPurpose("Material delivery");
+        return dto;
+    }
+
+    /** Nobody in particular: a plain member of the tenant, no record-management role. */
+    private void callerMayRecordOnlyFor(Long employeeId) {
+        lenient().when(attendanceSecurity.canRecordFor(any(Long.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0).equals(employeeId));
+    }
+
+    @Test
+    void checkIn_isRefused_forSomebodyElse() {
+        // The hole as it stood: any member of the tenant naming a colleague's employee id in the
+        // multipart data part fabricated a day of attendance for them.
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+
+        assertThatThrownBy(() -> attendanceService().checkIn(checkInDto(COLLEAGUE_EMPLOYEE_ID), null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        // Refused before anything is looked up, so nothing is written.
+        verifyNoInteractions(organizationRepository, employeeRepository, attendanceRepository);
+    }
+
+    @Test
+    void checkIn_isAllowed_forYourself() {
+        // The ordinary case keeps working. Stops at the tenant lookup, mocked empty, which is
+        // past the guard: what matters is that the refusal is not an authorization one.
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> attendanceService().checkIn(checkInDto(CALLER_EMPLOYEE_ID), null))
+                .isNotInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void recordClockEvent_isRefused_onSomebodyElsesRecord() {
+        // The sharper half: the payload names only an attendance id, so the old guard had no
+        // employee to check at all and any member could clock a colleague out.
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesAttendance()));
+
+        assertThatThrownBy(() -> attendanceService().recordClockEvent(clockEventDto(), null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendanceRepository, never()).save(any());
+        verifyNoInteractions(sequenceValidator);
+    }
+
+    @Test
+    void recordClockEvent_isAllowed_onYourOwnRecord() {
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+        Attendance own = colleaguesAttendance();
+        own.setEmployeeId(CALLER_EMPLOYEE_ID);
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(own));
+        when(settingsService.resolveEffectiveSettings(ORG_ID, 12L))
+                .thenReturn(AttendanceSettings.builder().geolocationRequired(false).build());
+        when(attendanceRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        attendanceService().recordClockEvent(clockEventDto(), null);
+
+        verify(attendanceRepository).save(any());
+    }
+
+    @Test
+    void addMovement_isRefused_forSomebodyElse() {
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+
+        assertThatThrownBy(() -> movementRecordService().addMovement(movementDto(), COLLEAGUE_EMPLOYEE_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(organizationRepository, employeeRepository, attendanceRepository,
+                movementRecordRepository);
+    }
+
+    @Test
+    void addMovement_isRefused_whenYourIdIsPassedWithSomebodyElsesAttendance() {
+        // Naming yourself does not help when the attendance trail being written to is not yours:
+        // the record's own employee is read back off the store and checked too.
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+        when(employeeRepository.findByIdAndOrganizationId(CALLER_EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(new Employee()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesAttendance()));
+
+        assertThatThrownBy(() -> movementRecordService().addMovement(movementDto(), CALLER_EMPLOYEE_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(movementRecordRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRegularization_isRefused_onSomebodyElsesRecord() {
+        // A regularization rewrites clock events; on a project set to auto-approve it does so
+        // immediately. So filing one against a colleague's record is the same hole as the
+        // clock-event one, and it is settled the same way, off the stored record.
+        callerMayRecordOnlyFor(CALLER_EMPLOYEE_ID);
+        AttendanceRegularizationRepository regularizationRepository =
+                org.mockito.Mockito.mock(AttendanceRegularizationRepository.class);
+        AttendanceRegularizationMapper regularizationMapper =
+                org.mockito.Mockito.mock(AttendanceRegularizationMapper.class);
+        SelfApprovalPolicy selfApprovalPolicy = org.mockito.Mockito.mock(SelfApprovalPolicy.class);
+        AttendanceRegularizationService regularizationService = new AttendanceRegularizationService(
+                regularizationRepository, attendanceRepository, organizationRepository,
+                employeeRepository, settingsService, calculationService, regularizationMapper,
+                userContextService, selfApprovalPolicy, attendanceSecurity);
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+        when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(colleaguesAttendance()));
+        RegularizationRequestDto dto = new RegularizationRequestDto();
+        dto.setAttendanceId(ATTENDANCE_ID);
+        dto.setReason("Forgot to clock out");
+
+        assertThatThrownBy(() -> regularizationService.submitRequest(dto))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(regularizationRepository);
+        verify(attendanceRepository, never()).save(any());
+    }
+
+    /**
+     * The wiring that keeps HR and managers able to act for others: {@code canRecordFor} is the
+     * same self-or-role policy as viewing, over the configured record-management roles.
+     */
+    @Test
+    void canRecordFor_asksTheSelfOrRolePolicy_withTheRecordManagementRoles() {
+        OrganizationSecurityService orgSecurity = org.mockito.Mockito.mock(OrganizationSecurityService.class);
+        AttendanceSecurityService security = new AttendanceSecurityService(
+                orgSecurity,
+                new String[] {"system-admin", "hr-admin"},
+                new String[] {"system-admin", "hr-admin", "project-manager"});
+        when(orgSecurity.isSelfOrHasAnyOrgRole(COLLEAGUE_EMPLOYEE_ID,
+                "system-admin", "hr-admin", "project-manager")).thenReturn(true);
+
+        org.assertj.core.api.Assertions.assertThat(security.canRecordFor(COLLEAGUE_EMPLOYEE_ID)).isTrue();
+        verify(orgSecurity).isSelfOrHasAnyOrgRole(COLLEAGUE_EMPLOYEE_ID,
+                "system-admin", "hr-admin", "project-manager");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
@@ -20,6 +20,7 @@ import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
 import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
@@ -29,6 +30,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
@@ -59,6 +61,7 @@ class AttendancePayloadValidationTest {
     @Mock private AttachmentService attachmentService;
     @Mock private FileStorageService fileStorageService;
     @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
 
     private AttendanceService service;
 
@@ -69,7 +72,10 @@ class AttendancePayloadValidationTest {
         service = new AttendanceService(attendanceRepository, shiftTimingRepository,
                 employeeRepository, organizationRepository, projectRepository, settingsService,
                 calculationService, sequenceValidator, attendanceMapper, attachmentService,
-                fileStorageService, userContextService, new PayloadValidator(validator));
+                fileStorageService, userContextService, new PayloadValidator(validator),
+                attendanceSecurity);
+        // Not the concern here: every payload test should fail on the payload, not on who is calling.
+        lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     }
 
     @AfterAll

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
@@ -23,6 +23,7 @@ import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMap
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -84,6 +85,7 @@ class AttendanceRegularizationSelfApprovalTest {
     @Mock private AttendanceRegularizationMapper regularizationMapper;
     @Mock private UserContextService userContextService;
     @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private AttendanceSecurityService attendanceSecurity;
 
     private AttendanceRegularizationService service;
 
@@ -92,7 +94,10 @@ class AttendanceRegularizationSelfApprovalTest {
         TenantContext.setCurrentOrgId(ORG);
         service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
                 organizationRepository, employeeRepository, settingsService, calculationService,
-                regularizationMapper, userContextService, new SelfApprovalPolicy(orgSecurity));
+                regularizationMapper, userContextService, new SelfApprovalPolicy(orgSecurity),
+                attendanceSecurity);
+        // Not the concern here: these tests exercise the self-approval rule, not who may raise.
+        org.mockito.Mockito.lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -24,6 +24,7 @@ import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
 import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -80,6 +81,7 @@ class AttendanceRegularizationServiceTest {
     @Mock private AttendanceRegularizationMapper regularizationMapper;
     @Mock private UserContextService userContextService;
     @Mock private SelfApprovalPolicy selfApprovalPolicy;
+    @Mock private AttendanceSecurityService attendanceSecurity;
 
     private AttendanceRegularizationService service;
 
@@ -88,7 +90,9 @@ class AttendanceRegularizationServiceTest {
         TenantContext.setCurrentOrgId(ORG);
         service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
                 organizationRepository, employeeRepository, settingsService, calculationService,
-                regularizationMapper, userContextService, selfApprovalPolicy);
+                regularizationMapper, userContextService, selfApprovalPolicy, attendanceSecurity);
+        // Not the concern here: these tests exercise the lifecycle, not who may raise a request.
+        lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
         // The session is the requesting employee unless a test says otherwise.
         signedInAs(REQUESTER_USER_ID, REQUESTER_EMP_ID, REQUESTER);
     }

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -19,6 +19,7 @@ import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
 import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.service.FileStorageService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -60,6 +61,7 @@ class AttendanceServiceApprovalTest {
     @Mock private AttachmentService attachmentService;
     @Mock private FileStorageService fileStorageService;
     @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
 
     private AttendanceService service;
 
@@ -70,7 +72,8 @@ class AttendanceServiceApprovalTest {
                 organizationRepository, projectRepository, settingsService, calculationService,
                 sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
                 userContextService,
-                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()));
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity);
     }
 
     @AfterEach


### PR DESCRIPTION
Found validating #589 against the rest of the codebase. The question that PR answers for leave, who may act on a record when the id that names it comes from the caller, was never asked in the attendance family, and attendance is the module that feeds worked hours.

## What was reachable

All of these were guarded by `@orgSecurity.isMemberOfCurrentTenant()` alone, on both the web and non-web controllers:

**Check-in.** `POST /attendance/check-in` carries its employee id inside the multipart `data` part. `AttendanceService.checkIn` loads whatever employee that names and never asks who is calling, so any member of the tenant could fabricate a full day of a colleague's attendance, GPS, device and selfie fields included.

**Clock events.** `POST /attendance/clock-event` names only an attendance id. The service loads the record and appends the event, so passing a colleague's attendance id clocked them out, or inserted breaks, and their worked totals were recomputed from it.

**Regularizations.** The requester is already taken from the session (c7ff4ca), but the record being corrected is still the caller's word. On a project configured to auto-approve, `submitRequest` applies the corrected events immediately, so any member could rewrite a colleague's clock events there in one call; with approval required they could still open requests against anybody's records.

**Movements.** `POST /movement-records` takes an employee id on the query string and an attendance id in the body, and checked neither, so movements could be written onto a colleague's trail, or logged against your own trail in a colleague's name.

The UI pins all of these to the signed-in employee; the API is the layer that has to hold, and it did not.

## The fix

The same placement as #589, and for the same reason: `@PreAuthorize` can only read what the caller sent, and on a check-in the employee id sits inside a JSON multipart part the annotation cannot even reach. `AttendanceSecurityService` gains `canRecordFor`, the write-side twin of `canViewEmployeeRecords`: the employee themselves, or the configured record-management roles (`system-admin`, `hr-admin`, `project-manager` by default). The services refuse before writing, checking the id the record actually names: the payload's employee on check-in, the stored record's employee on clock events and regularizations, and both on movements. Managers and HR keep acting for others, which is coherent: the same roles could already mark absent, delete records, and process regularizations outright.

## Tests

`AttendanceActorAuthorizationTest`, eight cases: check-in for a colleague, a clock event on their record, a movement in their name, a movement onto their trail behind your own id, and a regularization against their record all refused with nothing written; your own check-in and clock event still going through; and the wiring that keeps the record-management roles able to act for others. The five refusals fail with the service checks removed, by the write succeeding.

Full suite green on `.116`, and `docs/openapi.json` regenerated for the eight changed 403 descriptions.

The remaining instances of the shape are attribution-only (issue `createdById`, issue-comment `authorId`, task `creatorId`): the record is real but its author is the caller's word. Those need an API-contract decision rather than a guard, and are filed separately.
