### PR TITLE
Drop the stdout print of the Keycloak subject on every identity lookup

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/user/UserContextService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserContextService.java
@@ -26,7 +26,6 @@ public class UserContextService {
 //    @Cacheable(value = "userContext", key = "#root.methodName + '_' + @userContextService.getCurrentKeycloakId()")
     public Long getCurrentUserId() {
         String keycloakId = getCurrentKeycloakId();
-        System.out.println(keycloakId);
         if (keycloakId == null) {
             return null;
         }


### PR DESCRIPTION
Found in the retro review of #592 (the review standing in for CodeRabbit, whose quota is exhausted).

`UserContextService.getCurrentUserId()` carried a bare `System.out.println(keycloakId)`. Every authenticated request resolves identity through this method, usually more than once, so the container log gets one unstructured Keycloak subject id per call, outside logback: no level, no shape, straight into the Loki pipeline. It was a debug leftover and nothing reads it.

It matters a little more since #592, because the self-approval rule now takes the approver's identity from exactly this method on every approval.

One line removed, no behaviour change, so there is no test to write for it: the method's existing tests pin the return values, and asserting the absence of a stdout write would test nothing. No controller or DTO touched, `docs/openapi.json` unchanged.