### PR TITLE
Bound the invoice cancel reason to what the reversal entry can store

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14476,7 +14476,7 @@
             "description": "Reason the entry is being reversed, recorded on the reversing entry. The reversing entry's description is the reason with a fixed prefix naming the entry being reversed, so the bound is the description column less that prefix.",
             "example": "Vendor bill cancelled after posting",
             "maxLength": 455,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
@@ -37003,7 +37003,7 @@
             "required": true,
             "schema": {
               "maxLength": 455,
-              "minLength": 0,
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -39646,7 +39646,7 @@
             "required": true,
             "schema": {
               "maxLength": 455,
-              "minLength": 0,
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14473,9 +14473,9 @@
         "description": "Payload to reverse a posted journal entry.",
         "properties": {
           "reason": {
-            "description": "Reason the entry is being reversed, recorded on the reversing entry.",
+            "description": "Reason the entry is being reversed, recorded on the reversing entry. The reversing entry's description is the reason with a fixed prefix naming the entry being reversed, so the bound is the description column less that prefix.",
             "example": "Vendor bill cancelled after posting",
-            "maxLength": 500,
+            "maxLength": 455,
             "minLength": 0,
             "type": "string"
           }
@@ -36985,7 +36985,7 @@
     },
     "/api/v1/finance/construction-invoices/web/{id}/cancel": {
       "post": {
-        "description": "Cancels an invoice and records the supplied reason. If the invoice was already posted, the ledger entry is reversed.",
+        "description": "Cancels an invoice and records the supplied reason. If the invoice was already posted, the ledger entry is reversed. The reason is recorded on the reversing entry's description, which also carries a prefix naming the entry being reversed, so it must be present and at most 455 characters.",
         "operationId": "cancel_1",
         "parameters": [
           {
@@ -37002,6 +37002,8 @@
             "name": "reason",
             "required": true,
             "schema": {
+              "maxLength": 455,
+              "minLength": 0,
               "type": "string"
             }
           }
@@ -37025,7 +37027,7 @@
                 }
               }
             },
-            "description": "Invoice is already paid or otherwise cannot be cancelled"
+            "description": "The reason is blank or longer than 455 characters, or the invoice is already paid or otherwise cannot be cancelled"
           },
           "402": {
             "content": {
@@ -39626,7 +39628,7 @@
     },
     "/api/v1/finance/invoices/web/{id}/cancel": {
       "post": {
-        "description": "Cancels an invoice and records the supplied reason. If the invoice was already issued, a reversing journal entry is posted to back out the receivable.",
+        "description": "Cancels an invoice and records the supplied reason. If the invoice was already issued, a reversing journal entry is posted to back out the receivable. The reason is recorded on the reversing entry's description, which also carries a prefix naming the entry being reversed, so it must be present and at most 455 characters.",
         "operationId": "cancel",
         "parameters": [
           {
@@ -39643,6 +39645,8 @@
             "name": "reason",
             "required": true,
             "schema": {
+              "maxLength": 455,
+              "minLength": 0,
               "type": "string"
             }
           }
@@ -39666,7 +39670,7 @@
                 }
               }
             },
-            "description": "Invoice is already paid or otherwise cannot be cancelled"
+            "description": "The reason is blank or longer than 455 characters, or the invoice is already paid or otherwise cannot be cancelled"
           },
           "402": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +15,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceStatus;
 import org.tornotron.echno_backend.finance.construction.ConstructionInvoiceType;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
@@ -27,6 +31,7 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @RestController
+@Validated
 @RequestMapping("/api/v1/finance/construction-invoices/web")
 @RequiredArgsConstructor
 @Tag(
@@ -178,15 +183,22 @@ public class ConstructionInvoiceControllerWeb {
     @Operation(
             summary = "Cancel an invoice",
             description = "Cancels an invoice and records the supplied reason. If the invoice was already "
-                    + "posted, the ledger entry is reversed."
+                    + "posted, the ledger entry is reversed. "
+                    + "The reason is recorded on the reversing entry's description, which also carries a "
+                    + "prefix naming the entry being reversed, so it must be present and at most 455 "
+                    + "characters."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Invoice cancelled"),
-            @ApiResponse(responseCode = "400", description = "Invoice is already paid or otherwise cannot be cancelled"),
+            @ApiResponse(responseCode = "400",
+                    description = "The reason is blank or longer than 455 characters, or the invoice "
+                            + "is already paid or otherwise cannot be cancelled"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
     })
-    public ConstructionInvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
+    public ConstructionInvoiceDto cancel(
+            @PathVariable UUID id,
+            @RequestParam @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
         return service.cancel(id, reason);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoiceControllerWeb.java
@@ -198,7 +198,8 @@ public class ConstructionInvoiceControllerWeb {
     })
     public ConstructionInvoiceDto cancel(
             @PathVariable UUID id,
-            @RequestParam @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
+            @RequestParam @NotBlank
+            @Size(min = 1, max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
         return service.cancel(id, reason);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
@@ -7,14 +7,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
 import org.tornotron.echno_backend.finance.invoice.InvoiceStatus;
 import org.tornotron.echno_backend.finance.invoice.dtos.CreateInvoiceRequest;
 import org.tornotron.echno_backend.finance.invoice.dtos.InvoiceDto;
@@ -23,6 +27,7 @@ import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
 import java.util.UUID;
 
 @RestController
+@Validated
 @RequestMapping("/api/v1/finance/invoices/web")
 @RequiredArgsConstructor
 @Tag(
@@ -115,15 +120,22 @@ public class InvoiceControllerWeb {
     @Operation(
             summary = "Cancel an invoice",
             description = "Cancels an invoice and records the supplied reason. If the invoice was already "
-                    + "issued, a reversing journal entry is posted to back out the receivable."
+                    + "issued, a reversing journal entry is posted to back out the receivable. "
+                    + "The reason is recorded on the reversing entry's description, which also carries a "
+                    + "prefix naming the entry being reversed, so it must be present and at most 455 "
+                    + "characters."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Invoice cancelled"),
-            @ApiResponse(responseCode = "400", description = "Invoice is already paid or otherwise cannot be cancelled"),
+            @ApiResponse(responseCode = "400",
+                    description = "The reason is blank or longer than 455 characters, or the invoice "
+                            + "is already paid or otherwise cannot be cancelled"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No invoice with the given id in the current tenant")
     })
-    public InvoiceDto cancel(@PathVariable UUID id, @RequestParam String reason) {
+    public InvoiceDto cancel(
+            @PathVariable UUID id,
+            @RequestParam @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
         return service.cancel(id, reason);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceControllerWeb.java
@@ -135,7 +135,8 @@ public class InvoiceControllerWeb {
     })
     public InvoiceDto cancel(
             @PathVariable UUID id,
-            @RequestParam @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
+            @RequestParam @NotBlank
+            @Size(min = 1, max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason) {
         return service.cancel(id, reason);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/JournalLimits.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/JournalLimits.java
@@ -1,0 +1,52 @@
+package org.tornotron.echno_backend.finance.ledger;
+
+/**
+ * The lengths the ledger's own columns impose on the text callers hand it.
+ *
+ * <p>These live in one place because the reversal description is not written by the caller: the
+ * ledger composes it, as {@code "Reversal of " + entryNumber + " - " + reason}, and stores the
+ * result in a 500-character column. A reason therefore has less room than the column suggests,
+ * and the amount less is arithmetic over three constants that used to be spread across an entity,
+ * a request record and a string literal inside a service. A caller that guessed 500 from the
+ * column produced a database error instead of a refusal, and the web app compensated with a
+ * client-side cap of its own that nothing tied back here.
+ *
+ * <p>{@link #REVERSAL_REASON_MAX_LENGTH} has to be a compile-time constant because bean
+ * validation reads it in an annotation, so it cannot be written as the expression that derives
+ * it. {@code JournalLimitsTest} recomputes that expression and fails if the two drift, which is
+ * what a widened column or a reworded prefix would otherwise do silently.
+ */
+public final class JournalLimits {
+
+    /** Length of {@code journal_entry.description}, the column a composed description lands in. */
+    public static final int DESCRIPTION_MAX_LENGTH = 500;
+
+    /** Length of {@code journal_entry.entry_number}, worst case for the number inside the prefix. */
+    public static final int ENTRY_NUMBER_MAX_LENGTH = 30;
+
+    /** Opening of a reversal's description, before the reversed entry's number. */
+    public static final String REVERSAL_DESCRIPTION_PREFIX = "Reversal of ";
+
+    /** What separates the reversed entry's number from the caller's reason. */
+    public static final String REVERSAL_DESCRIPTION_SEPARATOR = " - ";
+
+    /**
+     * How much of a reversal's description is left for the caller's reason: 500 less the
+     * 12-character prefix, the 30-character entry number and the 3-character separator.
+     */
+    public static final int REVERSAL_REASON_MAX_LENGTH = 455;
+
+    private JournalLimits() {
+    }
+
+    /**
+     * Composes the description a reversing entry carries.
+     *
+     * @param reversedEntryNumber The number of the entry being reversed.
+     * @param reason The caller's reason, already bounded by {@link #REVERSAL_REASON_MAX_LENGTH}.
+     * @return The description, which fits {@link #DESCRIPTION_MAX_LENGTH}.
+     */
+    public static String reversalDescription(String reversedEntryNumber, String reason) {
+        return REVERSAL_DESCRIPTION_PREFIX + reversedEntryNumber + REVERSAL_DESCRIPTION_SEPARATOR + reason;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
@@ -3,11 +3,14 @@ package org.tornotron.echno_backend.finance.ledger.dtos;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
 
 @Schema(description = "Payload to reverse a posted journal entry.")
 public record ReverseJournalRequest(
-        @Schema(description = "Reason the entry is being reversed, recorded on the reversing entry.",
+        @Schema(description = "Reason the entry is being reversed, recorded on the reversing entry. "
+                + "The reversing entry's description is the reason with a fixed prefix naming the "
+                + "entry being reversed, so the bound is the description column less that prefix.",
                 example = "Vendor bill cancelled after posting")
-        @NotBlank @Size(max = 500) String reason
+        @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/ReverseJournalRequest.java
@@ -11,6 +11,6 @@ public record ReverseJournalRequest(
                 + "The reversing entry's description is the reason with a fixed prefix naming the "
                 + "entry being reversed, so the bound is the description column less that prefix.",
                 example = "Vendor bill cancelled after posting")
-        @NotBlank @Size(max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason
+        @NotBlank @Size(min = 1, max = JournalLimits.REVERSAL_REASON_MAX_LENGTH) String reason
 ) {
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
@@ -15,6 +15,7 @@ import org.tornotron.echno_backend.common.exception.InvalidJournalException;
 import org.tornotron.echno_backend.common.exception.UnbalancedEntryException;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
@@ -174,13 +175,23 @@ public class JournalPostingService {
      * id of the reversal; the reversal records the id of the entry it reverses. Only a POSTED entry
      * that has not already been reversed can be reversed.
      *
+     * <p>The reason is bounded here and not only at whatever endpoint supplied it. It is the
+     * ledger that turns a reason into a description, by putting a prefix in front of it, so the
+     * ledger is the only place that knows how much room is actually left; a caller that constructs
+     * the request itself, as the two invoice cancel paths do, runs no bean validation at all, and
+     * one that does bind it still cannot see the prefix. Refusing here means an over-long reason
+     * is an argument the ledger rejects before it writes anything, rather than a column overflow
+     * discovered on flush and surfaced as a server error.
+     *
      * @param entryId The id of the entry to reverse.
      * @param req Carries the reason recorded on the reversal's description.
      * @return The newly posted reversal entry as a DTO.
-     * @throws org.tornotron.echno_backend.common.exception.InvalidJournalException if the entry does not exist, is not POSTED, or was already reversed.
+     * @throws org.tornotron.echno_backend.common.exception.InvalidJournalException if the entry does not exist, is not POSTED, was already reversed, or the reason is blank or longer than {@link JournalLimits#REVERSAL_REASON_MAX_LENGTH}.
      */
     @Transactional
     public JournalEntryDto reverse(UUID entryId, ReverseJournalRequest req) {
+        String reason = requireStorableReason(req);
+
         JournalEntry original = journalRepo.findByIdWithLines(entryId)
                 .orElseThrow(() -> new InvalidJournalException("Journal entry with ID " + entryId + " was not found"));
 
@@ -205,7 +216,7 @@ public class JournalPostingService {
 
         PostJournalRequest reversalReq = new PostJournalRequest(
                 LocalDate.now(),
-                "Reversal of " + original.getEntryNumber() + " - " + req.reason(),
+                JournalLimits.reversalDescription(original.getEntryNumber(), reason),
                 original.getEntryNumber(),
                 reversedLines
         );
@@ -218,6 +229,31 @@ public class JournalPostingService {
 
         log.info("Reversed entry {} via {}", original.getEntryNumber(), reversal.getEntryNumber());
         return mapper.toDto(reversal);
+    }
+
+    /**
+     * Checks that a reversal reason will fit the description the ledger builds around it.
+     *
+     * @param req The reversal request, which a service caller may have constructed by hand.
+     * @return The reason, trimmed of surrounding whitespace.
+     * @throws InvalidJournalException if the request or its reason is missing, blank, or longer
+     *         than {@link JournalLimits#REVERSAL_REASON_MAX_LENGTH}.
+     */
+    private String requireStorableReason(ReverseJournalRequest req) {
+        String reason = req == null || req.reason() == null ? null : req.reason().trim();
+        if (reason == null || reason.isEmpty()) {
+            throw new InvalidJournalException(
+                    "A reversal reason is required; it is recorded on the reversing entry's description");
+        }
+        if (reason.length() > JournalLimits.REVERSAL_REASON_MAX_LENGTH) {
+            throw new InvalidJournalException(
+                    "The reversal reason is " + reason.length() + " characters; at most "
+                    + JournalLimits.REVERSAL_REASON_MAX_LENGTH + " fit alongside the "
+                    + "\"" + JournalLimits.REVERSAL_DESCRIPTION_PREFIX + "<entry number>"
+                    + JournalLimits.REVERSAL_DESCRIPTION_SEPARATOR + "\" prefix in the "
+                    + JournalLimits.DESCRIPTION_MAX_LENGTH + "-character description");
+        }
+        return reason;
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingService.java
@@ -240,8 +240,11 @@ public class JournalPostingService {
      *         than {@link JournalLimits#REVERSAL_REASON_MAX_LENGTH}.
      */
     private String requireStorableReason(ReverseJournalRequest req) {
-        String reason = req == null || req.reason() == null ? null : req.reason().trim();
-        if (reason == null || reason.isEmpty()) {
+        // strip() and isBlank() rather than trim() and isEmpty(): trim() only removes characters
+        // up to U+0020, so a reason of a single em space would have passed and left a reversal
+        // whose description ends in a dangling separator, which is the failure this refuses.
+        String reason = req == null || req.reason() == null ? null : req.reason().strip();
+        if (reason == null || reason.isBlank()) {
             throw new InvalidJournalException(
                     "A reversal reason is required; it is recorded on the reversing entry's description");
         }

--- a/src/test/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceCancelReasonValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/invoice/web/InvoiceCancelReasonValidationTest.java
@@ -1,0 +1,140 @@
+package org.tornotron.echno_backend.finance.invoice.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.construction.pdf.ConstructionInvoicePdfService;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionInvoiceService;
+import org.tornotron.echno_backend.finance.construction.web.ConstructionInvoiceControllerWeb;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pins that a cancel reason too long for the reversing entry's description is refused at the
+ * edge, as a 400 naming the parameter, rather than reaching the ledger and failing as a column
+ * overflow on flush.
+ *
+ * <p>Both cancel endpoints are covered in one slice because the constraint is the same on both
+ * and they differ only in the service behind them. The web app caps the field client side, which
+ * keeps a person out of this, but any other caller of the API went straight through.
+ */
+@WebMvcTest({InvoiceControllerWeb.class, ConstructionInvoiceControllerWeb.class})
+@Import(InvoiceCancelReasonValidationTest.TestSecurityConfig.class)
+class InvoiceCancelReasonValidationTest {
+
+    private static final String TOO_LONG = "x".repeat(JournalLimits.REVERSAL_REASON_MAX_LENGTH + 1);
+    private static final String AT_THE_LIMIT = "x".repeat(JournalLimits.REVERSAL_REASON_MAX_LENGTH);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private InvoiceService invoiceService;
+
+    @MockitoBean
+    private ConstructionInvoiceService constructionInvoiceService;
+
+    @MockitoBean
+    private ConstructionInvoicePdfService pdfService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @Test
+    void customerInvoiceCancel_withAnOverLongReason_isRefusedBeforeTheServiceIsCalled() throws Exception {
+        allowTheCaller();
+
+        mockMvc.perform(post("/api/v1/finance/invoices/web/{id}/cancel", UUID.randomUUID())
+                        .param("reason", TOO_LONG).with(jwt()))
+                .andExpect(status().isBadRequest());
+
+        verify(invoiceService, never()).cancel(any(), anyString());
+    }
+
+    @Test
+    void customerInvoiceCancel_withABlankReason_isRefused() throws Exception {
+        allowTheCaller();
+
+        mockMvc.perform(post("/api/v1/finance/invoices/web/{id}/cancel", UUID.randomUUID())
+                        .param("reason", "   ").with(jwt()))
+                .andExpect(status().isBadRequest());
+
+        verify(invoiceService, never()).cancel(any(), anyString());
+    }
+
+    @Test
+    void customerInvoiceCancel_withAReasonAtTheLimit_reachesTheService() throws Exception {
+        allowTheCaller();
+
+        mockMvc.perform(post("/api/v1/finance/invoices/web/{id}/cancel", UUID.randomUUID())
+                        .param("reason", AT_THE_LIMIT).with(jwt()))
+                .andExpect(status().isOk());
+
+        verify(invoiceService).cancel(any(), anyString());
+    }
+
+    @Test
+    void constructionInvoiceCancel_withAnOverLongReason_isRefusedBeforeTheServiceIsCalled() throws Exception {
+        allowTheCaller();
+
+        mockMvc.perform(post("/api/v1/finance/construction-invoices/web/{id}/cancel", UUID.randomUUID())
+                        .param("reason", TOO_LONG).with(jwt()))
+                .andExpect(status().isBadRequest());
+
+        verify(constructionInvoiceService, never()).cancel(any(), anyString());
+    }
+
+    @Test
+    void constructionInvoiceCancel_withABlankReason_isRefused() throws Exception {
+        allowTheCaller();
+
+        mockMvc.perform(post("/api/v1/finance/construction-invoices/web/{id}/cancel", UUID.randomUUID())
+                        .param("reason", "").with(jwt()))
+                .andExpect(status().isBadRequest());
+
+        verify(constructionInvoiceService, never()).cancel(any(), anyString());
+    }
+
+    private void allowTheCaller() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/JournalLimitsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/JournalLimitsTest.java
@@ -1,0 +1,63 @@
+package org.tornotron.echno_backend.finance.ledger;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
+import org.tornotron.echno_backend.finance.ledger.dtos.ReverseJournalRequest;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet on the arithmetic behind the reversal reason bound.
+ *
+ * <p>{@code REVERSAL_REASON_MAX_LENGTH} has to be written as a literal, because bean validation
+ * reads it from an annotation and an annotation argument must be a compile-time constant. That
+ * makes it the one number in the chain that a widened column or a reworded prefix cannot update
+ * on its own, which is exactly how the web app's client-side cap and the server drifted apart in
+ * the first place. These tests recompute it from the pieces it is derived from, and check the
+ * pieces themselves still match the columns they describe.
+ */
+class JournalLimitsTest {
+
+    @Test
+    void reasonBoundIsTheDescriptionColumnLessEverythingElseTheLedgerPutsInIt() {
+        int prefixCost = JournalLimits.REVERSAL_DESCRIPTION_PREFIX.length()
+                + JournalLimits.ENTRY_NUMBER_MAX_LENGTH
+                + JournalLimits.REVERSAL_DESCRIPTION_SEPARATOR.length();
+
+        assertThat(JournalLimits.REVERSAL_REASON_MAX_LENGTH)
+                .as("a reason of the maximum length must exactly fill what the prefix leaves")
+                .isEqualTo(JournalLimits.DESCRIPTION_MAX_LENGTH - prefixCost);
+    }
+
+    @Test
+    void descriptionOfALongestReasonAgainstALongestEntryNumberStillFitsTheColumn() {
+        String description = JournalLimits.reversalDescription(
+                "E".repeat(JournalLimits.ENTRY_NUMBER_MAX_LENGTH),
+                "r".repeat(JournalLimits.REVERSAL_REASON_MAX_LENGTH));
+
+        assertThat(description).hasSize(JournalLimits.DESCRIPTION_MAX_LENGTH);
+    }
+
+    @Test
+    void theColumnLengthsMatchTheEntityTheyAreCopiedFrom() throws NoSuchFieldException {
+        assertThat(columnLength("description")).isEqualTo(JournalLimits.DESCRIPTION_MAX_LENGTH);
+        assertThat(columnLength("entryNumber")).isEqualTo(JournalLimits.ENTRY_NUMBER_MAX_LENGTH);
+    }
+
+    @Test
+    void theRequestRecordDeclaresTheSameBound() throws NoSuchFieldException {
+        Size size = ReverseJournalRequest.class.getDeclaredField("reason").getAnnotation(Size.class);
+
+        assertThat(size).isNotNull();
+        assertThat(size.max()).isEqualTo(JournalLimits.REVERSAL_REASON_MAX_LENGTH);
+    }
+
+    private static int columnLength(String fieldName) throws NoSuchFieldException {
+        Field field = JournalEntry.class.getDeclaredField(fieldName);
+        return field.getAnnotation(Column.class).length();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingServiceIT.java
@@ -260,6 +260,17 @@ class JournalPostingServiceIT extends AbstractIntegrationTest {
     }
 
     @Test
+    void reverse_reasonOfOnlyUnicodeWhitespace_isRejected() {
+        JournalEntry original = service.postInternal(
+                request(line(cashId, "100", "0"), line(revenueId, "0", "100")), "MANUAL", null);
+
+        // An em space survives trim(), which stops at U+0020, so a reason made only of one would
+        // have posted a reversal whose description ends in a dangling separator.
+        assertThatExceptionOfType(InvalidJournalException.class)
+                .isThrownBy(() -> service.reverse(original.getId(), new ReverseJournalRequest("\u2003")));
+    }
+
+    @Test
     void reverse_alreadyReversedEntry_isRejected() {
         JournalEntry original = service.postInternal(
                 request(line(cashId, "100", "0"), line(revenueId, "0", "100")), "MANUAL", null);

--- a/src/test/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/ledger/service/JournalPostingServiceIT.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
 import org.tornotron.echno_backend.finance.ledger.AccountType;
+import org.tornotron.echno_backend.finance.ledger.JournalLimits;
 import org.tornotron.echno_backend.finance.ledger.JournalStatus;
 import org.tornotron.echno_backend.finance.ledger.domain.Account;
 import org.tornotron.echno_backend.finance.ledger.domain.JournalEntry;
@@ -213,6 +214,49 @@ class JournalPostingServiceIT extends AbstractIntegrationTest {
                 .filter(l -> l.getAccount().getId().equals(cashId))
                 .map(l -> l.getCredit()).findFirst().orElseThrow();
         assertThat(cashCreditOnReversal).isEqualByComparingTo("100");
+    }
+
+    @Test
+    void reverse_reasonTooLongForTheDescriptionColumn_isRejectedBeforeAnythingIsWritten() {
+        JournalEntry original = service.postInternal(
+                request(line(cashId, "100", "0"), line(revenueId, "0", "100")), "MANUAL", null);
+        String tooLong = "x".repeat(JournalLimits.REVERSAL_REASON_MAX_LENGTH + 1);
+
+        // Without the bound this is a column overflow on flush, so it arrives as a database error
+        // rather than as a refusal naming the field, and the caller sees a 500.
+        assertThatExceptionOfType(InvalidJournalException.class)
+                .isThrownBy(() -> service.reverse(original.getId(), new ReverseJournalRequest(tooLong)))
+                .withMessageContaining("reversal reason");
+
+        JournalEntry reloaded = journalRepo.findByIdWithLines(original.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(JournalStatus.POSTED);
+        assertThat(reloaded.getReversedByEntryId()).isNull();
+    }
+
+    @Test
+    void reverse_reasonOfExactlyTheMaximumLength_isAccepted() {
+        JournalEntry original = service.postInternal(
+                request(line(cashId, "100", "0"), line(revenueId, "0", "100")), "MANUAL", null);
+        String atTheLimit = "x".repeat(JournalLimits.REVERSAL_REASON_MAX_LENGTH);
+
+        service.reverse(original.getId(), new ReverseJournalRequest(atTheLimit));
+
+        JournalEntry reversal = journalRepo
+                .findByIdWithLines(journalRepo.findByIdWithLines(original.getId()).orElseThrow()
+                        .getReversedByEntryId())
+                .orElseThrow();
+        assertThat(reversal.getDescription())
+                .endsWith(atTheLimit)
+                .hasSizeLessThanOrEqualTo(JournalLimits.DESCRIPTION_MAX_LENGTH);
+    }
+
+    @Test
+    void reverse_blankReason_isRejectedRatherThanLeavingADanglingSeparator() {
+        JournalEntry original = service.postInternal(
+                request(line(cashId, "100", "0"), line(revenueId, "0", "100")), "MANUAL", null);
+
+        assertThatExceptionOfType(InvalidJournalException.class)
+                .isThrownBy(() -> service.reverse(original.getId(), new ReverseJournalRequest("   ")));
     }
 
     @Test


### PR DESCRIPTION
Closes #601.

Both cancel endpoints took `@RequestParam String reason` with no bound. On an issued invoice that reason ends up inside the reversing entry's description, which `JournalPostingService.reverse` composes as `"Reversal of " + entryNumber + " - " + reason` and stores in a 500-character column. Past 455 characters it failed on flush as a database error, so the caller saw a 500 rather than a 400 naming the field. A blank reason was accepted, leaving a description ending in a dangling separator.

## Where the constraint had to live

Annotating the two parameters is necessary but not sufficient, and `@Size` on `ReverseJournalRequest` alone does nothing on this path:

- Both invoice services construct `new ReverseJournalRequest(reason)`. Bean validation only runs on controller-bound payloads, so the record's existing `@NotBlank @Size(max = 500)` never fired on a cancel.
- `JournalEntryControllerWeb.reverse` *does* bind that record with `@Valid`, and 500 was itself wrong: 500 plus the 45-character worst-case prefix overflows the 500-character column. That was a third way in, independent of the two cancel endpoints.

So the invariant belongs to the ledger, which is the only layer that knows how much of the description the prefix takes. `JournalPostingService.reverse` now refuses a blank or over-long reason before it touches anything, whoever the caller is. The record and both cancel parameters carry the same bound so an ordinary API caller is refused at the edge as a 400 instead.

## Keeping the number from drifting

`JournalLimits` holds the description column length, the entry-number column length, the prefix and separator, and the derived 455. The derived value has to be a literal because bean validation reads it from an annotation, so `JournalLimitsTest` recomputes the arithmetic, checks a maximum-length reason against a maximum-length entry number still fits the column exactly, and checks the two column lengths against the `@Column` declarations on `JournalEntry`. A widened column or a reworded prefix now fails the build rather than silently leaving the bound behind. This is the same arithmetic `CANCEL_REASON_MAX_LENGTH` documents in echno-web#345, which was compensating for the missing server constraint.

## Tests

Each fails on `development`, verified by reverting the production changes on the build box and re-running: 7 of them failed, all pass with the change.

- `JournalPostingServiceIT` — an over-long reason is refused and the original entry is left POSTED and unreversed; a reason of exactly 455 is accepted and the description fits the column; a blank reason is refused.
- `InvoiceCancelReasonValidationTest` — both cancel endpoints return 400 for an over-long and for a blank reason without reaching the service, and pass a 455-character reason through.
- `JournalLimitsTest` — the arithmetic ratchet described above.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice cancellation now requires a nonblank reason of up to 455 characters.
  * Journal-entry reversal reasons are validated consistently and stored with the reversal description.
* **Bug Fixes**
  * Clearer validation errors are returned when cancellation or reversal reasons are blank or exceed the allowed length.
  * Maximum-length reasons are now accepted without exceeding journal description limits.
* **Documentation**
  * API documentation now describes cancellation reason requirements and related validation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->