### PR TITLE
Stop the partial-update endpoints dropping what they are sent in silence

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7315,24 +7315,6 @@
             "example": "Spacing measured at 220 mm against a specified 200 mm across grid C.",
             "type": "string"
           },
-          "issueType": {
-            "deprecated": true,
-            "description": "Category of the issue, under the name the web client currently sends. Deprecated alias of type; send type instead.",
-            "enum": [
-              "technical",
-              "design",
-              "quality",
-              "safety",
-              "material",
-              "equipment",
-              "labour",
-              "weather",
-              "permit",
-              "coordination",
-              "other"
-            ],
-            "type": "string"
-          },
           "status": {
             "description": "Lifecycle status of the issue.",
             "enum": [
@@ -16758,6 +16740,24 @@
       "TaskUpdateFieldsDto": {
         "description": "Fields a partial task update may change. Every field is optional; only the fields present in the request are applied, and a field sent as null is cleared. Keys not listed here are ignored.",
         "properties": {
+          "assigneeIds": {
+            "description": "Employees the task is assigned to. Replaces the existing assignees rather than adding to them, so a shorter list unassigns and an empty list or a null clears the task. Every id must belong to an employee of the caller's organization.",
+            "example": [
+              12,
+              31
+            ],
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "categoryId": {
+            "description": "Work category the task belongs to. Cannot be cleared: a task is created with a category and a task without one is a state creation cannot produce.",
+            "example": 4,
+            "format": "int64",
+            "type": "integer"
+          },
           "description": {
             "description": "Longer description of the work to be done.",
             "example": "Complete formwork, reinforcement and concrete pour for the block A raft.",

--- a/src/main/java/org/tornotron/echno_backend/common/payload/PartialUpdateKeys.java
+++ b/src/main/java/org/tornotron/echno_backend/common/payload/PartialUpdateKeys.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.common.payload;
+
+import org.slf4j.Logger;
+
+import java.util.Set;
+
+/**
+ * What a partial-update endpoint does with a key it has no field for.
+ *
+ * <p>These endpoints take their body as a {@code Map<String, Object>} and apply it with a
+ * {@code switch} over the keys, because a partial update has to tell a field left out from a field
+ * sent as an explicit null and a bean cannot. The cost is that an unrecognised key is not an error:
+ * it falls off the end of the switch, the caller is answered 200, and nothing changed. Changing an
+ * issue's type through the product did nothing for months for exactly that reason, and the same
+ * shape sits under every other update in this family.
+ *
+ * <p>So every one of them ends in a {@code default} branch that comes here. The key is logged at
+ * WARN naming the entity and the row, which turns a silent drop into something a log search finds.
+ *
+ * <p><b>Why this warns rather than refusing.</b> A 400 would be the stronger answer and is the
+ * wrong one here: the deployed web client puts keys in these payloads that the endpoints have no
+ * field for and never had, starting with the {@code attachments: []} it sends on every multipart
+ * update to distinguish "no upload" from "untouched". Refusing an unknown key would turn ordinary
+ * edits into failures the moment this deployed. The keys that are known to arrive on every request
+ * are named per service instead, so the warning stays worth reading rather than firing on the two
+ * things already understood. What actually enforces the contract is the request-contract check in
+ * echno-core, which runs in CI and fails on a name neither side has agreed to; this is the runtime
+ * backstop for whatever reaches the endpoint another way.
+ */
+public final class PartialUpdateKeys {
+
+    private PartialUpdateKeys() {
+    }
+
+    /**
+     * Logs a key a partial update carried that the endpoint has no field for.
+     *
+     * @param log               The calling service's logger, so the warning carries its name.
+     * @param entity            What is being updated, lower case, e.g. {@code "task"}.
+     * @param id                The id of the row being updated; may be null on a create-like path.
+     * @param key               The key that was dropped.
+     * @param deliberatelyDropped Keys this endpoint is known to receive and drops on purpose. These
+     *                          are not logged.
+     */
+    public static void reportUnknown(Logger log, String entity, Object id, String key,
+                                     Set<String> deliberatelyDropped) {
+        if (deliberatelyDropped.contains(key)) {
+            return;
+        }
+        log.warn("Ignoring '{}' on the update of {} {}: this endpoint changes no such field, so the "
+                        + "caller was told the update succeeded and nothing about that field "
+                        + "changed. Either the client is sending the wrong name or the field "
+                        + "belongs here and does not exist yet.", key, entity, id);
+    }
+
+    /**
+     * Logs a key a partial update carried that the endpoint has no field for, where nothing is
+     * dropped on purpose.
+     *
+     * @param log    The calling service's logger.
+     * @param entity What is being updated, lower case.
+     * @param id     The id of the row being updated.
+     * @param key    The key that was dropped.
+     */
+    public static void reportUnknown(Logger log, String entity, Object id, String key) {
+        reportUnknown(log, entity, id, key, Set.of());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeRepository.java
@@ -73,6 +73,22 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     @Query("SELECT e FROM Employee e JOIN FETCH e.user WHERE e.id = :id AND e.organization.id = :orgId")
     Optional<Employee> findByIdAndOrganizationIdWithUser(@Param("id") Long id, @Param("orgId") Long orgId);
 
+    /**
+     * Finds the employees among the given ids that belong to one organization.
+     *
+     * <p>Resolves a whole set of assignees in a single query and drops anyone outside the
+     * organization, so the caller can compare what came back with what it asked for and name the
+     * ids that are not assignable rather than reading the organization's entire roster to find out.
+     *
+     * @param ids   The employee ids to resolve.
+     * @param orgId The organization the employees must belong to.
+     * @return The matching employees; ids outside the organization or absent altogether are simply
+     *         not in the result.
+     */
+    @Query("SELECT e FROM Employee e WHERE e.id IN :ids AND e.organization.id = :orgId")
+    List<Employee> findAllByIdInAndOrganizationId(@Param("ids") Collection<Long> ids,
+                                                  @Param("orgId") Long orgId);
+
     @Query("SELECT e FROM Employee e WHERE e.user.id = :userId AND e.organization.id = :orgId")
     Optional<Employee> findByUserIdAndOrganizationId(@Param("userId") Long userId, @Param("orgId") Long orgId);
     /**

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -372,6 +373,14 @@ public class EmployeeService {
                                     "Manager with ID " + managerId + " was not found in this organization"));
                     employeeHierarchyService.validateManager(employee, manager);
                     employee.setManager(manager);
+                    break;
+                default:
+                    // Nothing is dropped on purpose here. The keys echno-core sends that this
+                    // endpoint has no field for (address, experience, gender, organizationId,
+                    // qualification, skills) all arrive only when a caller sets them, and five of
+                    // them are real columns on User reachable through PATCH /user/web/{id}. A
+                    // warning naming the key is exactly the signal wanted. See echno-core#57.
+                    PartialUpdateKeys.reportUnknown(log, "employee", employee.getId(), key);
                     break;
             }
         });

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.issue;
 import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -44,7 +45,8 @@ public class IssueService {
 
     /**
      * Keys the web client puts in an issue update that this endpoint has no field for, and drops
-     * on purpose rather than noisily.
+     * on purpose rather than noisily. See {@link PartialUpdateKeys} for why the rest are warned
+     * about rather than refused.
      *
      * <p>{@code attachments} is the client telling the difference between "no upload" and
      * "untouched": it sets {@code attachments: []} on every update, and the files themselves
@@ -57,7 +59,7 @@ public class IssueService {
      * changed nothing. Naming the two known ones here is what keeps that warning worth reading.
      * Both are on the list in echno-core#57, and this set shrinks as that list is worked down.
      */
-    private static final Set<String> SILENTLY_DROPPED_UPDATE_KEYS = Set.of("attachments", "priority");
+    private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments", "priority");
 
     /**
      * The state an issue starts in, and the only one create accepts. It is what the web client's
@@ -286,7 +288,6 @@ public class IssueService {
                     issue.setDescription((String) value);
                     break;
                 case "type":
-                case "issueType":
                     issue.setType(parseIssueType((String) value));
                     break;
                 case "status":
@@ -299,12 +300,8 @@ public class IssueService {
                     issue.setAssignedTo(assignee);
                     break;
                 default:
-                    if (!SILENTLY_DROPPED_UPDATE_KEYS.contains(key)) {
-                        log.warn("Ignoring '{}' on the update of issue {}: this endpoint changes no such "
-                                + "field, so the caller was told the update succeeded and nothing about that "
-                                + "field changed. Either the client is sending the wrong name or the field "
-                                + "belongs here and does not exist yet.", key, issue.getId());
-                    }
+                    PartialUpdateKeys.reportUnknown(log, "issue", issue.getId(), key,
+                            DELIBERATELY_DROPPED_UPDATE_KEYS);
                     break;
             }
         });

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -1,6 +1,5 @@
 package org.tornotron.echno_backend.issue.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,17 +29,15 @@ public class IssueCreationDto {
     private String description;
 
     /**
-     * The canonical name is {@code type}, which is what the column and the entity call it.
+     * The name the column, the entity and now every client use.
      *
-     * <p>The alias is transitional. Published versions of echno-core send {@code issueType} and
-     * reach the deployed web app only through a package release, so the name cannot change on
-     * both sides at once: the backend accepts either until every client has moved, and the
-     * update path in {@code IssueService} takes both for the same reason. Once echno-web is
-     * running a core that sends {@code type}, the alias and that second case both go.
+     * <p>It carried a {@code @JsonAlias("issueType")} for one release, because echno-core sent the
+     * field under that name and reaches the deployed web app only through a package release, so
+     * the name could not change on both sides at once. echno-core 2.2.0 sends {@code type} and the
+     * deployed web app is on it, so the alias is gone and this is the only name accepted.
      */
     @NotNull
     @Enumerated(EnumType.STRING)
-    @JsonAlias("issueType")
     private String type;
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
@@ -29,21 +29,6 @@ public class IssueUpdateFieldsDto {
     @Schema(description = "Category of the issue.")
     private IssueType type;
 
-    /**
-     * The same field under the name every published echno-core sends it as. It is here because the
-     * endpoint really does accept it, and a schema that left it out would be describing an
-     * endpoint that does not exist.
-     *
-     * <p>Transitional, and the reason it exists is the ordering: echno-core reaches the deployed
-     * web app only through a package release, so the name cannot change on both sides at once.
-     * It goes, along with the second case in {@code IssueService.partialUpdateAnIssue} and the
-     * {@code @JsonAlias} on {@link IssueCreationDto}, once echno-web is running a core that sends
-     * {@code type}.
-     */
-    @Schema(description = "Category of the issue, under the name the web client currently sends. "
-            + "Deprecated alias of type; send type instead.", deprecated = true)
-    private IssueType issueType;
-
     @Schema(description = "Lifecycle status of the issue.")
     private IssueStatus status;
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.leave;
 
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
  */
 @Service
 @Validated
+@Slf4j
 public class LeavePolicyService {
 
     private final LeavePolicyRepository policyRepository;
@@ -251,6 +254,9 @@ public class LeavePolicyService {
                 case "multiLevelApprovalEnabled" -> policy.setMultiLevelApprovalEnabled((Boolean) value);
                 case "displayOrder" -> policy.setDisplayOrder(
                         value != null ? ((Number) value).intValue() : null);
+                // Nothing is dropped on purpose here: echno-core sends this endpoint no key it
+                // does not declare. See echno-core#57.
+                default -> PartialUpdateKeys.reportUnknown(log, "leave policy", policyId, key);
             }
         });
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -3,6 +3,8 @@ package org.tornotron.echno_backend.leave;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
  */
 @Service
 @Validated
+@Slf4j
 public class LeaveRequestService {
 
     private final LeaveRequestRepository requestRepository;
@@ -308,6 +311,9 @@ public class LeaveRequestService {
                 case "handoverToId" -> request.setHandoverToId(
                         value != null ? ((Number) value).longValue() : null);
                 case "handoverNotes" -> request.setHandoverNotes((String) value);
+                // Nothing is dropped on purpose here: echno-core sends this endpoint no key it
+                // does not declare. See echno-core#57.
+                default -> PartialUpdateKeys.reportUnknown(log, "leave request", requestId, key);
             }
         });
 

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -340,6 +341,13 @@ public class OrganizationService {
                     break;
                 case "organizationLogo":
                     organization.setOrganizationLogo((String) value);
+                    break;
+                default:
+                    // Nothing is dropped on purpose here. The one key echno-core sends that this
+                    // endpoint has no field for is isActive, behind an "Active Organization"
+                    // checkbox that no route can currently honour, and a warning naming it is the
+                    // point. See echno-core#57.
+                    PartialUpdateKeys.reportUnknown(log, "organization", organization.getId(), key);
                     break;
             }
         });

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -1,5 +1,7 @@
 package org.tornotron.echno_backend.project;
 
+import lombok.extern.slf4j.Slf4j;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -40,6 +42,7 @@ import org.tornotron.echno_backend.user.UserContextService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -48,9 +51,28 @@ import java.util.stream.Collectors;
  * Handles business logic related to project creation, retrieval, updates, and deletion.
  */
 @Service
+@Slf4j
 public class ProjectService {
 
     private static final String PROJECTS_FOLDER = "projects";
+
+    /**
+     * Keys the web client puts in a project update that this endpoint has no field for, and drops
+     * on purpose rather than noisily. See {@link PartialUpdateKeys} for why the rest are warned
+     * about rather than refused.
+     *
+     * <p>{@code attachments} is the only one: the client sets {@code attachments: []} on every
+     * multipart update so the backend can tell "no upload" from "untouched", and the files
+     * themselves travel as their own part.
+     *
+     * <p>{@code organizationId} is deliberately not here even though the client sends it on every
+     * update, because it is the one key worth a warning every time. The organization comes from
+     * {@code TenantContext}, and honouring a value from the payload would be a tenant-isolation
+     * hole. {@code description} and {@code employees} are warned about too: both are on the list
+     * in echno-core#57, description as a form field that writes to a concept no layer has, members
+     * as something the project-employee routes already do properly.
+     */
+    private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments");
 
     /**
      * The state a project starts in when the create payload names none. It is what the web
@@ -339,6 +361,10 @@ public class ProjectService {
                     } else {
                         throw new IllegalArgumentException("Latitude must be between -90 and 90");
                     }
+                    break;
+                default:
+                    PartialUpdateKeys.reportUnknown(log, "project", project.getId(), key,
+                            DELIBERATELY_DROPPED_UPDATE_KEYS);
                     break;
             }
         });

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -1,6 +1,10 @@
 package org.tornotron.echno_backend.task;
 
 import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tornotron.echno_backend.category.Category;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -42,7 +46,27 @@ import java.util.stream.Collectors;
 @Service
 public class TaskService {
 
+    private static final Logger log = LoggerFactory.getLogger(TaskService.class);
+
     private static final String TASKS_FOLDER = "tasks";
+
+    /**
+     * Keys the web client puts in a task update that this endpoint has no field for, and drops on
+     * purpose rather than noisily. See {@link PartialUpdateKeys} for why the rest are warned about
+     * rather than refused.
+     *
+     * <p>{@code attachments} is the only one: the client sets {@code attachments: []} on every
+     * update so the backend can tell "no upload" from "untouched", and the files themselves travel
+     * as their own multipart part, so the key in the JSON part carries nothing to apply.
+     *
+     * <p>{@code creatorId}, {@code priority} and {@code projectId} are deliberately not here.
+     * They arrive only when a caller sets them, and each is on the list in echno-core#57 as
+     * something the client should stop sending: {@code creatorId} carries the editing user, so
+     * honouring it would rewrite a task's creator to whoever last touched it; {@code priority} has
+     * no column anywhere; and there is no "move task" screen behind {@code projectId}. A warning
+     * for each is the point.
+     */
+    private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments");
 
     private final TaskRepository taskRepository;
     private final EmployeeRepository employeeRepository;
@@ -319,8 +343,88 @@ public class TaskService {
                 case "tags":
                     updateTags(value, task);
                     break;
+                case "assigneeIds":
+                    task.setAssignees(resolveAssignees(value));
+                    break;
+                case "categoryId":
+                    task.setCategory(resolveCategory(value));
+                    break;
+                default:
+                    PartialUpdateKeys.reportUnknown(log, "task", task.getId(), key,
+                            DELIBERATELY_DROPPED_UPDATE_KEYS);
+                    break;
             }
         });
+    }
+
+    /**
+     * Resolves the replacement assignee set for a task update.
+     *
+     * <p>The list is the whole set, not an addition: the client sends every assignee the task
+     * should end up with, so a shorter list unassigns and an empty one or a null clears the task.
+     * That is the shape the edit form already submits.
+     *
+     * <p>Everyone named has to be an employee of the caller's organization, which is checked in one
+     * query rather than by trusting the ids. Reassignment used to be dropped here in silence, so an
+     * id belonging to another tenant reaching a task is the failure worth being loud about.
+     *
+     * @param value The raw {@code assigneeIds} value from the update map.
+     * @return The employees to assign, empty when the caller sent nothing to assign.
+     * @throws InvalidRequestException if the value is not a list of ids, or names anyone who is not
+     *                                 an employee of this organization.
+     */
+    private Set<Employee> resolveAssignees(Object value) {
+        if (value == null) {
+            return new HashSet<>();
+        }
+        if (!(value instanceof List<?> rawIds)) {
+            throw new InvalidRequestException("assigneeIds must be provided as a list of employee ids");
+        }
+        if (rawIds.isEmpty()) {
+            return new HashSet<>();
+        }
+
+        Set<Long> requested = new LinkedHashSet<>();
+        for (Object rawId : rawIds) {
+            if (!(rawId instanceof Number number)) {
+                throw new InvalidRequestException("Each assignee id must be a number");
+            }
+            requested.add(number.longValue());
+        }
+
+        List<Employee> found = employeeRepository.findAllByIdInAndOrganizationId(
+                requested, TenantContext.getCurrentOrgId());
+        if (found.size() != requested.size()) {
+            Set<Long> missing = new LinkedHashSet<>(requested);
+            found.forEach(employee -> missing.remove(employee.getId()));
+            throw new InvalidRequestException("Employee IDs " + missing
+                    + " are not members of this organization and cannot be assigned to this task");
+        }
+        return new HashSet<>(found);
+    }
+
+    /**
+     * Resolves the category a task update moves the task to.
+     *
+     * <p>Clearing is refused rather than allowed: {@code addTask} insists on a category, so a task
+     * with none is a state creation cannot produce and nothing downstream expects.
+     *
+     * @param value The raw {@code categoryId} value from the update map.
+     * @return The category to set.
+     * @throws InvalidRequestException if the value is null or not a number.
+     * @throws ResourceNotFoundException if no such category exists in this organization.
+     */
+    private Category resolveCategory(Object value) {
+        if (value == null) {
+            throw new InvalidRequestException("A task must have a category; categoryId cannot be cleared");
+        }
+        if (!(value instanceof Number number)) {
+            throw new InvalidRequestException("categoryId must be a number");
+        }
+        Long categoryId = number.longValue();
+        return categoryRepository.findByIdAndOrganization_Id(categoryId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Category with ID " + categoryId + " was not found in this organization"));
     }
 
     private void updateTags(Object rawTags, Task task) {

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
@@ -54,4 +54,15 @@ public class TaskUpdateFieldsDto {
     @Schema(description = "Free-form labels on the task. Replaces the existing labels rather than "
             + "adding to them, and must be a list of strings.", example = "[\"concrete\", \"block-a\"]")
     private List<String> tags;
+
+    @Schema(description = "Employees the task is assigned to. Replaces the existing assignees "
+            + "rather than adding to them, so a shorter list unassigns and an empty list or a null "
+            + "clears the task. Every id must belong to an employee of the caller's organization.",
+            example = "[12, 31]")
+    private List<Long> assigneeIds;
+
+    @Schema(description = "Work category the task belongs to. Cannot be cleared: a task is created "
+            + "with a category and a task without one is a state creation cannot produce.",
+            example = "4")
+    private Long categoryId;
 }

--- a/src/main/java/org/tornotron/echno_backend/user/UserService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PartialUpdateKeys;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -237,7 +238,10 @@ public class UserService {
                 case "profilePictureUrl" -> user.setProfilePictureUrl((String) value);
                 case "skills" -> user.setSkills(parseSkills(value));
                 case "certifications" -> user.setCertifications(parseCertifications(value));
-                default -> { }
+                // Nothing is dropped on purpose here: echno-core sends this endpoint no key it
+                // does not declare. The branch used to be an empty block, which is the same silent
+                // drop written down. See echno-core#57.
+                default -> PartialUpdateKeys.reportUnknown(logger, "user", user.getId(), key);
             }
         });
     }

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateDefaultBranchTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateDefaultBranchTest.java
@@ -1,0 +1,59 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tornotron.echno_backend.architecture.PartialUpdateSurfaces.UpdateSurface;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every partial-update switch has to say what it does with a key it does not know.
+ *
+ * <p>A {@code switch} over the keys of an update map with no {@code default} is not neutral. The
+ * key falls off the end, the endpoint answers 200, and the caller is told a change was made that
+ * was not. Changing an issue's type through the product did nothing for months for exactly that
+ * reason, and the same shape sat under seven more endpoints. It is invisible in review because
+ * there is nothing on the screen to see: the absence is the bug.
+ *
+ * <p>So this reads each update method's own source and fails when the switch has no {@code default}
+ * branch, or when that branch does not go through
+ * {@code org.tornotron.echno_backend.common.payload.PartialUpdateKeys}. Naming the helper matters
+ * as much as having the branch: a {@code default} that is an empty block is the same silent drop
+ * written down, and one of these was exactly that before.
+ *
+ * <p>What the branch then does with the key, warn or refuse, is a decision per endpoint and not
+ * something a test should fix. It is warn everywhere today, because the deployed web client puts
+ * keys in these payloads that no endpoint has a field for, so refusing would turn ordinary edits
+ * into failures. The reasoning is on {@code PartialUpdateKeys} and the per-service constants.
+ */
+class PartialUpdateDefaultBranchTest {
+
+    private static final String HELPER = "PartialUpdateKeys.reportUnknown";
+
+    static List<UpdateSurface> surfaces() {
+        return PartialUpdateSurfaces.surfaces();
+    }
+
+    @ParameterizedTest(name = "{0}''s update reports a key it has no field for")
+    @MethodSource("surfaces")
+    @DisplayName("A partial-update switch never drops an unrecognised key in silence")
+    void updateSwitchHasADefaultBranchThatReportsTheKey(UpdateSurface surface) throws IOException {
+        String body = PartialUpdateSurfaces.methodBody(surface);
+
+        assertThat(body)
+                .as("the update switch in %s has no default branch, so a key it does not name is "
+                        + "dropped and the caller is told the update succeeded",
+                        surface.serviceClass())
+                .containsPattern("default\\s*(->|:)");
+
+        assertThat(body)
+                .as("the default branch in %s has to report the key through %s; a branch that does "
+                        + "nothing is the same silent drop, only written down",
+                        surface.serviceClass(), HELPER)
+                .contains(HELPER);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSchemaContractTest.java
@@ -3,20 +3,11 @@ package org.tornotron.echno_backend.architecture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
-import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
-import org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto;
-import org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto;
-import org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto;
-import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
-import org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto;
-import org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto;
+import org.tornotron.echno_backend.architecture.PartialUpdateSurfaces.UpdateSurface;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -47,13 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * moved apart in either direction. Adding a key to a service switch without adding it to the schema
  * fails here, and so does the reverse.
  *
- * <p>Source rather than bytecode because a {@code switch} over strings compiles to a hash cascade
- * that no longer carries the labels in a form worth reconstructing. Plain JUnit rather than a
- * Spring context, because it reads two files and needs nothing else.
+ * <p>The list of surfaces and the source reading live in {@link PartialUpdateSurfaces}, shared with
+ * {@link PartialUpdateDefaultBranchTest}.
  */
 class PartialUpdateSchemaContractTest {
-
-    private static final Path SOURCE_ROOT = Path.of("src", "main", "java");
 
     /**
      * A {@code case} label in a string switch. Matches both the arrow and colon forms, since the
@@ -61,56 +49,8 @@ class PartialUpdateSchemaContractTest {
      */
     private static final Pattern CASE_LABEL = Pattern.compile("case\\s+\"([^\"]+)\"");
 
-    /**
-     * One partial-update surface: the schema class published for it, and the service method whose
-     * switch decides what it really accepts.
-     *
-     * @param schema The documentation-only class named as the endpoint's request schema.
-     * @param serviceClass Fully qualified name of the service holding the update method.
-     * @param methodSignature The opening text of the method declaration, used to find it in the
-     *                        source. Must be unique within the file.
-     */
-    private record UpdateSurface(Class<?> schema, String serviceClass, String methodSignature) {
-        @Override
-        public String toString() {
-            return schema.getSimpleName();
-        }
-    }
-
     static List<UpdateSurface> surfaces() {
-        return List.of(
-                new UpdateSurface(
-                        TaskUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.task.TaskService",
-                        "private void partialUpdateATask(Map<String, Object> updates, Task task)"),
-                new UpdateSurface(
-                        IssueUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.issue.IssueService",
-                        "private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue)"),
-                new UpdateSurface(
-                        ProjectUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.project.ProjectService",
-                        "private void partialUpdateAProject(Map<String, Object> updates, Project project)"),
-                new UpdateSurface(
-                        OrganizationUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.organization.OrganizationService",
-                        "private void partialUpdateAnOrganization(Map<String, Object> updates, Organization organization)"),
-                new UpdateSurface(
-                        UserUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.user.UserService",
-                        "private void applyUpdates(Map<String, Object> updates, User user)"),
-                new UpdateSurface(
-                        EmployeeUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.employee.EmployeeService",
-                        "private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee)"),
-                new UpdateSurface(
-                        LeavePolicyUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.leave.LeavePolicyService",
-                        "public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates)"),
-                new UpdateSurface(
-                        LeaveRequestUpdateFieldsDto.class,
-                        "org.tornotron.echno_backend.leave.LeaveRequestService",
-                        "public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates)"));
+        return PartialUpdateSurfaces.surfaces();
     }
 
     @ParameterizedTest(name = "{0} describes exactly the keys its service accepts")
@@ -131,7 +71,7 @@ class PartialUpdateSchemaContractTest {
 
     /** The keys the service's update switch names, read out of the method's own source. */
     private static Set<String> acceptedKeys(UpdateSurface surface) throws IOException {
-        String body = methodBody(surface);
+        String body = PartialUpdateSurfaces.methodBody(surface);
         Set<String> keys = new LinkedHashSet<>();
         Matcher matcher = CASE_LABEL.matcher(body);
         while (matcher.find()) {
@@ -151,44 +91,5 @@ class PartialUpdateSchemaContractTest {
                 .filter(field -> !Modifier.isStatic(field.getModifiers()))
                 .map(Field::getName)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * The text of the named method, from its declaration to its closing brace.
-     *
-     * <p>Brace counting is enough here and does not need a parser: these methods hold a switch over
-     * string literals and no brace ever appears inside one of them.
-     */
-    private static String methodBody(UpdateSurface surface) throws IOException {
-        Path source = SOURCE_ROOT.resolve(surface.serviceClass().replace('.', '/') + ".java");
-        assertThat(source)
-                .as("service source for %s, read relative to the project directory", surface.serviceClass())
-                .exists();
-        String text = Files.readString(source);
-
-        int start = text.indexOf(surface.methodSignature());
-        assertThat(start)
-                .as("method %s was not found in %s; if it has been renamed or its parameters "
-                        + "reformatted, update the signature this test looks for",
-                        surface.methodSignature(), source)
-                .isNotEqualTo(-1);
-        assertThat(text.indexOf(surface.methodSignature(), start + 1))
-                .as("method signature %s appears more than once in %s", surface.methodSignature(), source)
-                .isEqualTo(-1);
-
-        int cursor = text.indexOf('{', start);
-        int depth = 0;
-        for (int i = cursor; i < text.length(); i++) {
-            char character = text.charAt(i);
-            if (character == '{') {
-                depth++;
-            } else if (character == '}') {
-                depth--;
-                if (depth == 0) {
-                    return text.substring(cursor, i + 1);
-                }
-            }
-        }
-        throw new AssertionError("unbalanced braces after " + surface.methodSignature() + " in " + source);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSurfaces.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSurfaces.java
@@ -1,0 +1,135 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto;
+import org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto;
+import org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto;
+import org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto;
+import org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto;
+import org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every partial-update endpoint in the application, and the one place that list is written down.
+ *
+ * <p>These endpoints take their body as a {@code Map<String, Object>} and apply it with a
+ * {@code switch} over the keys. Two separate things have to be true of each of them and neither is
+ * visible from the map: the schema published for it names exactly the keys it applies
+ * ({@link PartialUpdateSchemaContractTest}), and a key it does not name is reported rather than
+ * dropped in silence ({@link PartialUpdateDefaultBranchTest}). Both read the service's own source,
+ * so both need the same list and the same way of finding a method in a file.
+ *
+ * <p>A new partial-update endpoint belongs here, and adding it makes both tests apply to it.
+ */
+final class PartialUpdateSurfaces {
+
+    private static final Path SOURCE_ROOT = Path.of("src", "main", "java");
+
+    private PartialUpdateSurfaces() {
+    }
+
+    /**
+     * One partial-update surface: the schema class published for it, and the service method whose
+     * switch decides what it really accepts.
+     *
+     * @param schema The documentation-only class named as the endpoint's request schema.
+     * @param serviceClass Fully qualified name of the service holding the update method.
+     * @param methodSignature The opening text of the method declaration, used to find it in the
+     *                        source. Must be unique within the file.
+     */
+    record UpdateSurface(Class<?> schema, String serviceClass, String methodSignature) {
+        @Override
+        public String toString() {
+            return schema.getSimpleName();
+        }
+    }
+
+    static List<UpdateSurface> surfaces() {
+        return List.of(
+                new UpdateSurface(
+                        TaskUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.task.TaskService",
+                        "private void partialUpdateATask(Map<String, Object> updates, Task task)"),
+                new UpdateSurface(
+                        IssueUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.issue.IssueService",
+                        "private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue)"),
+                new UpdateSurface(
+                        ProjectUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.project.ProjectService",
+                        "private void partialUpdateAProject(Map<String, Object> updates, Project project)"),
+                new UpdateSurface(
+                        OrganizationUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.organization.OrganizationService",
+                        "private void partialUpdateAnOrganization(Map<String, Object> updates, Organization organization)"),
+                new UpdateSurface(
+                        UserUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.user.UserService",
+                        "private void applyUpdates(Map<String, Object> updates, User user)"),
+                new UpdateSurface(
+                        EmployeeUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.employee.EmployeeService",
+                        "private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee)"),
+                new UpdateSurface(
+                        LeavePolicyUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.leave.LeavePolicyService",
+                        "public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates)"),
+                new UpdateSurface(
+                        LeaveRequestUpdateFieldsDto.class,
+                        "org.tornotron.echno_backend.leave.LeaveRequestService",
+                        "public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates)"));
+    }
+
+    /**
+     * The text of the surface's update method, from its declaration to its closing brace.
+     *
+     * <p>Source rather than bytecode because a {@code switch} over strings compiles to a hash
+     * cascade that no longer carries the labels in a form worth reconstructing.
+     *
+     * <p>Brace counting is enough here and does not need a parser: these methods hold a switch over
+     * string literals and no brace ever appears inside one of them.
+     *
+     * @param surface The surface whose method to read.
+     * @return The method's source text.
+     * @throws IOException if the service source cannot be read.
+     */
+    static String methodBody(UpdateSurface surface) throws IOException {
+        Path source = SOURCE_ROOT.resolve(surface.serviceClass().replace('.', '/') + ".java");
+        assertThat(source)
+                .as("service source for %s, read relative to the project directory", surface.serviceClass())
+                .exists();
+        String text = Files.readString(source);
+
+        int start = text.indexOf(surface.methodSignature());
+        assertThat(start)
+                .as("method %s was not found in %s; if it has been renamed or its parameters "
+                        + "reformatted, update the signature this test looks for",
+                        surface.methodSignature(), source)
+                .isNotEqualTo(-1);
+        assertThat(text.indexOf(surface.methodSignature(), start + 1))
+                .as("method signature %s appears more than once in %s", surface.methodSignature(), source)
+                .isEqualTo(-1);
+
+        int cursor = text.indexOf('{', start);
+        int depth = 0;
+        for (int i = cursor; i < text.length(); i++) {
+            char character = text.charAt(i);
+            if (character == '{') {
+                depth++;
+            } else if (character == '}') {
+                depth--;
+                if (depth == 0) {
+                    return text.substring(cursor, i + 1);
+                }
+            }
+        }
+        throw new AssertionError("unbalanced braces after " + surface.methodSignature() + " in " + source);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationDtoTest.java
@@ -12,23 +12,17 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /**
  * The create endpoint parses {@link IssueCreationDto} from a multipart string
  * part, so its Jackson binding is exercised directly rather than through
- * {@code @RequestBody}. The web client (echno-core) sends the domain category as
- * {@code issueType}; these tests pin that it binds to {@code type} (a mismatch
- * previously left {@code type} null and crashed create with a 500).
+ * {@code @RequestBody}.
+ *
+ * <p>The domain category is called {@code type} and nothing else. echno-core sent
+ * it as {@code issueType} until 2.2.0, and this payload carried a
+ * {@code @JsonAlias} for exactly as long as that client was deployed. These pin
+ * what is accepted now the alias is gone: the canonical name binds, and the old
+ * one does not quietly go on working.
  */
 class IssueCreationDtoTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
-
-    @Test
-    void bindsWebClientIssueTypeAliasOntoType() throws Exception {
-        IssueCreationDto dto = mapper.readValue(
-                "{\"title\":\"A title\",\"description\":\"A description\",\"issueType\":\"safety\",\"status\":\"open\"}",
-                IssueCreationDto.class);
-
-        assertThat(dto.getType()).isEqualTo("safety");
-        assertThat(dto.getStatus()).isEqualTo(IssueStatus.open);
-    }
 
     @Test
     void bindsCanonicalTypeField() throws Exception {
@@ -37,6 +31,25 @@ class IssueCreationDtoTest {
                 IssueCreationDto.class);
 
         assertThat(dto.getType()).isEqualTo("quality");
+        assertThat(dto.getStatus()).isEqualTo(IssueStatus.open);
+    }
+
+    /**
+     * The alias is gone, so a payload that names only {@code issueType} leaves
+     * {@code type} unset. Spring's mapper ignores the unknown key rather than
+     * failing on it, which is why the refusal has to come from {@code @NotNull}
+     * on {@code type} and not from binding. Asserted here so the removal shows up
+     * as a null rather than as a field that mysteriously still works.
+     */
+    @Test
+    void leavesTypeUnsetWhenOnlyTheRetiredNameIsSent() throws Exception {
+        ObjectMapper springMapper = Jackson2ObjectMapperBuilder.json().build();
+
+        IssueCreationDto dto = springMapper.readValue(
+                "{\"title\":\"A title\",\"description\":\"A description\",\"issueType\":\"safety\",\"status\":\"open\"}",
+                IssueCreationDto.class);
+
+        assertThat(dto.getType()).isNull();
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
@@ -37,15 +37,16 @@ import static org.mockito.Mockito.when;
  * the keys, so an unrecognised key is not a 400: it is dropped, and the caller is told the update
  * succeeded.
  *
- * <p>That is how changing an issue's type through the product came to do nothing. echno-core sends
+ * <p>That is how changing an issue's type through the product came to do nothing. echno-core sent
  * the field as {@code issueType}; the switch only named {@code type}. Create escaped it because
- * create binds a real DTO and {@code @JsonAlias("issueType")} catches the name there, and a map
- * has no property binding for an alias to attach to. So the two paths disagreed and only one of
- * them was wrong.
+ * create binds a real DTO and a {@code @JsonAlias} caught the name there, and a map has no
+ * property binding for an alias to attach to. So the two paths disagreed and only one of them was
+ * wrong. Both names were accepted here while the deployed client still sent the old one; echno-core
+ * 2.2.0 sends {@code type} and the compatibility half is gone.
  *
- * <p>These pin both halves: the update takes the name the client actually sends, and the keys the
- * endpoint has no field for stay dropped rather than becoming a rejection that would fail every
- * update the deployed web app makes.
+ * <p>These pin what is left: the update applies the canonical name, the retired one is treated like
+ * any other key nobody declared, and the keys the endpoint has no field for stay dropped rather
+ * than becoming a rejection that would fail every update the deployed web app makes.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -105,27 +106,18 @@ class IssuePartialUpdateKeysTest {
     }
 
     @Test
-    void update_changesTheTypeWhenTheClientNamesItIssueType() {
-        // The name every published echno-core sends. Before this was handled the call returned 200
-        // and the type stayed exactly as it was.
-        service.partialUpdateAnIssue(Map.of("issueType", "safety"), 7L, null, "ISSUE_ATTACHMENTS");
-
-        assertThat(existing.getType()).isEqualTo(IssueType.safety);
-    }
-
-    @Test
-    void update_stillChangesTheTypeUnderItsCanonicalName() {
+    void update_changesTheTypeUnderItsCanonicalName() {
         service.partialUpdateAnIssue(Map.of("type", "safety"), 7L, null, "ISSUE_ATTACHMENTS");
 
         assertThat(existing.getType()).isEqualTo(IssueType.safety);
     }
 
     @Test
-    void update_appliesTheOtherFieldsAlongsideTheAliasedOne() {
-        // Ordering matters here: the aliased key must not shadow or short-circuit the rest.
+    void update_appliesTheOtherFieldsAlongsideTheType() {
+        // Ordering matters here: no key may shadow or short-circuit the rest.
         Map<String, Object> updates = new LinkedHashMap<>();
         updates.put("title", "Honeycombing along the north edge");
-        updates.put("issueType", "safety");
+        updates.put("type", "safety");
         updates.put("status", "resolved");
 
         service.partialUpdateAnIssue(updates, 7L, null, "ISSUE_ATTACHMENTS");
@@ -133,6 +125,15 @@ class IssuePartialUpdateKeysTest {
         assertThat(existing.getTitle()).isEqualTo("Honeycombing along the north edge");
         assertThat(existing.getType()).isEqualTo(IssueType.safety);
         assertThat(existing.getStatus()).isEqualTo(IssueStatus.resolved);
+    }
+
+    @Test
+    void update_ignoresTheRetiredNameRatherThanApplyingIt() {
+        // The compatibility case is gone with the alias on the create payload. A caller still on a
+        // core older than 2.2.0 gets what any undeclared key gets: dropped, logged, and no change.
+        service.partialUpdateAnIssue(Map.of("issueType", "safety"), 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getType()).isEqualTo(IssueType.quality);
     }
 
     @Test
@@ -144,7 +145,7 @@ class IssuePartialUpdateKeysTest {
         updates.put("attachments", java.util.List.of());
         updates.put("priority", "high");
         updates.put("somethingNobodyDeclared", "x");
-        updates.put("issueType", "safety");
+        updates.put("type", "safety");
 
         service.partialUpdateAnIssue(updates, 7L, null, "ISSUE_ATTACHMENTS");
 

--- a/src/test/java/org/tornotron/echno_backend/task/TaskPartialUpdateAssignmentTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskPartialUpdateAssignmentTest.java
@@ -1,0 +1,184 @@
+package org.tornotron.echno_backend.task;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.category.Category;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reassigning a task, and moving it to another category, through the partial-update endpoint.
+ *
+ * <p>Neither used to work. Both are real relations on {@code Task}, both are accepted on create,
+ * and the edit page submits both from prefilled controls, but the update switch named neither and
+ * there is no assignee or category sub-resource to reach them another way. The call answered 200,
+ * so the failure read as a rendering glitch: {@code use-task-mutations.ts} leaves
+ * {@code assigneeIds} out of its optimistic patch and then invalidates, and the user watched the
+ * assignee list snap back to what it was. Recorded as the highest-value entry on echno-core#57.
+ *
+ * <p>Every test here fails without the two cases: the assignee ones by the set staying as it was,
+ * the category one by the category not moving.
+ *
+ * <p>Plain Mockito, no Spring context, so this adds nothing to the cached-context heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TaskPartialUpdateAssignmentTest {
+
+    private static final long ORG_ID = 1L;
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private TaskMapper taskMapper;
+
+    @InjectMocks private TaskService service;
+
+    private Task task;
+
+    private Task updateWith(Map<String, Object> updates) {
+        // The task needs a project only because saving rolls task progress up to it; the roll-up
+        // is not what this class is about.
+        Project project = new Project();
+        project.setId(3L);
+        task = new Task();
+        task.setProject(project);
+        task.setAssignees(new HashSet<>(Set.of(employee(11L))));
+        task.setCategory(category(4L));
+
+        TenantContext.setCurrentOrgId(ORG_ID);
+        try {
+            when(taskRepository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(task));
+            when(taskRepository.save(any(Task.class))).thenAnswer(call -> call.getArgument(0));
+            when(taskRepository.findByProject_Id(any())).thenReturn(List.of());
+            service.partialUpdateATask(updates, 7L, null, "TASK");
+        } finally {
+            TenantContext.clear();
+        }
+        return task;
+    }
+
+    private static Employee employee(long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        return employee;
+    }
+
+    private static Category category(long id) {
+        Category category = new Category();
+        category.setId(id);
+        return category;
+    }
+
+    @Test
+    @DisplayName("replaces the assignees with the list the client sent")
+    void appliesAssigneeIds() {
+        when(employeeRepository.findAllByIdInAndOrganizationId(any(), eq(ORG_ID)))
+                .thenReturn(List.of(employee(21L), employee(22L)));
+
+        Task updated = updateWith(Map.of("assigneeIds", List.of(21, 22)));
+
+        assertThat(updated.getAssignees()).extracting(Employee::getId)
+                .containsExactlyInAnyOrder(21L, 22L);
+    }
+
+    @Test
+    @DisplayName("an empty list unassigns the task rather than leaving it as it was")
+    void clearsAssigneesOnAnEmptyList() {
+        Task updated = updateWith(Map.of("assigneeIds", List.of()));
+
+        assertThat(updated.getAssignees()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("refuses an employee id from outside the caller's organization")
+    void refusesAnAssigneeFromAnotherOrganization() {
+        // The query is scoped to the tenant, so an id belonging elsewhere simply does not come
+        // back. Silently assigning nobody would repeat the bug this endpoint just stopped having.
+        when(employeeRepository.findAllByIdInAndOrganizationId(any(), eq(ORG_ID)))
+                .thenReturn(List.of(employee(21L)));
+
+        assertThatThrownBy(() -> updateWith(Map.of("assigneeIds", List.of(21, 99))))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    @DisplayName("moves the task to the category the client sent")
+    void appliesCategoryId() {
+        when(categoryRepository.findByIdAndOrganization_Id(eq(9L), anyLong()))
+                .thenReturn(Optional.of(category(9L)));
+
+        Task updated = updateWith(Map.of("categoryId", 9));
+
+        assertThat(updated.getCategory().getId()).isEqualTo(9L);
+    }
+
+    @Test
+    @DisplayName("refuses a category from outside the caller's organization")
+    void refusesACategoryFromAnotherOrganization() {
+        when(categoryRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> updateWith(Map.of("categoryId", 9)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("refuses to clear the category, which creation insists on")
+    void refusesToClearTheCategory() {
+        java.util.Map<String, Object> updates = new java.util.HashMap<>();
+        updates.put("categoryId", null);
+
+        assertThatThrownBy(() -> updateWith(updates))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be cleared");
+    }
+
+    @Test
+    @DisplayName("still accepts the keys it has no field for rather than refusing the request")
+    void acceptsTheKeysItHasNoFieldFor() {
+        // echno-core puts attachments: [] in the JSON part of every task update, and sends a
+        // creatorId, a priority and a projectId this endpoint has never applied. Refusing an
+        // unrecognised key would turn every task edit the deployed web app makes into a 400.
+        java.util.Map<String, Object> updates = new java.util.LinkedHashMap<>();
+        updates.put("attachments", List.of());
+        updates.put("creatorId", 5);
+        updates.put("priority", "high");
+        updates.put("projectId", 3);
+        updates.put("title", "Pour the block A raft");
+
+        assertThatCode(() -> updateWith(updates)).doesNotThrowAnyException();
+        assertThat(task.getTitle()).isEqualTo("Pour the block A raft");
+    }
+}


### PR DESCRIPTION
Works down the top of the worklist on [echno-core#57](https://github.com/tornotron/echno-core/issues/57): the `default` branch on the other seven map-based update endpoints, task `assigneeIds` and `categoryId`, and step 4 of #583.

## The shape

Eight endpoints take their update as a `Map<String, Object>` and apply it with a `switch` over the keys, because a partial update has to tell a field left out from one sent as an explicit null. The cost is that an unrecognised key is not an error. It falls off the end of the switch, the endpoint answers 200, and the caller is told a change was made that was not. That is how changing an issue's type through the product did nothing for months, and #583 gave issues a `default` branch. This gives the other seven one, through a shared `PartialUpdateKeys` helper rather than seven copies of the same log line.

## Warn, not reject, and it was checked per endpoint

| endpoint | keys the deployed client sends that it has no field for | branch |
|---|---|---|
| task | `attachments` (every request), `creatorId`, `priority`, `projectId` | warn; `attachments` named as a deliberate drop |
| project | `attachments` (every multipart request), `description`, `employees`, `organizationId` | warn; `attachments` named as a deliberate drop |
| employee | `address`, `experience`, `gender`, `organizationId`, `qualification`, `skills` | warn on all |
| organization | `isActive` | warn |
| user | none | warn |
| leave policy | none | warn |
| leave request | none | warn |

Rejecting would 400 every task and project edit the deployed web app makes, because of the `attachments: []` it sends on every multipart update to distinguish "no upload" from "untouched". The three with a clean client could reject, and do not: these are the same shape and an inconsistent family is its own hazard, and the enforcement that matters is the request-contract check in echno-core, which runs in CI and catches a name neither side agreed to before it ships. The runtime branch is the backstop for whatever reaches the endpoint another way.

`organizationId` on project is deliberately warned about on every request rather than named as a deliberate drop: the organization comes from `TenantContext`, and honouring a payload value would be a tenant-isolation hole, so it is the one worth seeing every time.

## Task assignment and category

The sharpest instance of the same fault, and the highest-value item on #57. Both are real relations on `Task`, both accepted on create, the edit page submits both from prefilled controls, and neither was in the update switch, with no assignee or category sub-resource to reach them another way. So reassigning a task did nothing and read as a rendering glitch: `use-task-mutations.ts` leaves `assigneeIds` out of its optimistic patch and then invalidates, so the user gets a success toast and watches the assignee list snap back.

- `assigneeIds` is the whole set, not an addition, which is what the form submits. An empty list or a null unassigns.
- Every id is checked against the caller's organization in one query, through a new `findAllByIdInAndOrganizationId`, and an id that is not assignable is named in the refusal rather than quietly skipped.
- `categoryId` moves the task. Clearing is refused, because `addTask` insists on a category and a task without one is a state creation cannot produce.

## The issueType shim

Step 4 of #583, and it is now unblocked: echno-core 2.2.0 sends `type`, and the deployed `echno-web` (`61412c34`, staging deploy 30 Aug) contains the lockfile bump to it. So the `@JsonAlias` on `IssueCreationDto`, the second `case` on the update, and the deprecated `issueType` field on `IssueUpdateFieldsDto` all come out. A caller still on an older core now gets `type` unset on create, which `@NotNull` refuses, and the old name treated like any other undeclared key on update.

## Tests

- `TaskPartialUpdateAssignmentTest` — seven tests. All the assignment and category ones fail without the two cases, by the set staying as it was and the category not moving.
- `PartialUpdateDefaultBranchTest` — reads each update method's own source and fails when the switch has no `default`, or when the branch does not go through the helper. That second half matters: `UserService`'s default was `default -> { }`, the same silent drop written down, and the test fails on it.
- `PartialUpdateSchemaContractTest` keeps working, and now shares the surface list with the new test through `PartialUpdateSurfaces`, so a ninth partial-update endpoint picks up both rules by being added in one place.
- Issue tests updated for the removal: the alias test is replaced by one asserting `type` is left unset when only the retired name is sent.

Verified by removing the fix on a scratch copy: nine tests fail, including both source-reading ones.

Full suite green on `10.24.6.116`; `docs/openapi.json` regenerated (`issueType` out of the issue update schema, `assigneeIds` and `categoryId` into the task one).