### PR TITLE
Take who wrote, raised, created and approved from the session

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7032,23 +7032,23 @@
         "type": "object"
       },
       "IssueCommentCreationDto": {
+        "description": "Payload to leave a comment on an issue. The author is taken from the signed-in session, not from the request.",
         "properties": {
-          "authorId": {
-            "format": "int64",
-            "type": "integer"
-          },
           "comment": {
+            "description": "The comment text.",
+            "example": "Rebar spacing on the east face still needs checking.",
             "maxLength": 500,
             "minLength": 0,
             "type": "string"
           },
           "issueId": {
+            "description": "Id of the issue being commented on.",
+            "example": 108,
             "format": "int64",
             "type": "integer"
           }
         },
         "required": [
-          "authorId",
           "issueId"
         ],
         "type": "object"
@@ -7096,10 +7096,6 @@
       "IssueCreationDto": {
         "properties": {
           "assignedToId": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "createdById": {
             "format": "int64",
             "type": "integer"
           },
@@ -8014,14 +8010,8 @@
         "type": "object"
       },
       "LeaveApprovalActionDto": {
-        "description": "Payload for an approve, reject or delegate action on a leave request.",
+        "description": "Payload for an approve, reject or delegate action on a leave request. Who is acting is taken from the signed-in session, not from the request.",
         "properties": {
-          "approverId": {
-            "description": "Id of the employee performing the action.",
-            "example": 5,
-            "format": "int64",
-            "type": "integer"
-          },
           "comments": {
             "description": "Comments on the action.",
             "example": "Approved, please plan handover before you leave",
@@ -8036,9 +8026,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "approverId"
-        ],
         "type": "object"
       },
       "LeaveApprovalDto": {
@@ -16397,7 +16384,7 @@
         "type": "object"
       },
       "TaskCreationDto": {
-        "description": "Payload to create a task under a project. Sent as the JSON data part of the multipart create request.",
+        "description": "Payload to create a task under a project. Sent as the JSON data part of the multipart create request. The creator is taken from the signed-in session, not from the request.",
         "properties": {
           "assigneeIds": {
             "description": "Ids of the employees assigned to the task. Optional; a task may start with nobody assigned.",
@@ -16414,12 +16401,6 @@
           "categoryId": {
             "description": "Id of the category the task is filed under.",
             "example": 3,
-            "format": "int64",
-            "type": "integer"
-          },
-          "creatorId": {
-            "description": "Id of the employee creating the task.",
-            "example": 5,
             "format": "int64",
             "type": "integer"
           },
@@ -16479,7 +16460,6 @@
         },
         "required": [
           "categoryId",
-          "creatorId",
           "progress",
           "projectId"
         ],
@@ -54186,7 +54166,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue create or admin authority"
+            "description": "Caller lacks the issue create or admin authority, or has no employee record in the current tenant, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -54430,7 +54410,7 @@
                 }
               }
             },
-            "description": "Caller lacks the issue-comment create or admin authority"
+            "description": "Caller lacks the issue-comment create or admin authority, or has no employee record in the current tenant, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -54674,7 +54654,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -55356,7 +55336,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -58903,7 +58883,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -59267,7 +59247,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave approve or admin authority"
+            "description": "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -59506,7 +59486,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave approve or admin authority"
+            "description": "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -59629,7 +59609,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -59993,7 +59973,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -60232,7 +60212,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -95613,7 +95593,7 @@
                 }
               }
             },
-            "description": "Caller lacks the task create or admin authority"
+            "description": "Caller lacks the task create or admin authority, or has no employee record in the current tenant, so the record would name nobody"
           },
           "404": {
             "content": {
@@ -95957,7 +95937,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentController.java
@@ -45,7 +45,7 @@ public class IssueCommentController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment create or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue-comment create or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentControllerWeb.java
@@ -46,7 +46,7 @@ public class IssueCommentControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Comment created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No issue with the given id")
     })
     public ResponseEntity<IssueCommentSimpleDto> createIssueComment(@Valid @RequestBody IssueCommentCreationDto issueCommentCreationDto) {

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentService.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/IssueCommentService.java
@@ -12,8 +12,8 @@ import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentSimpleDto;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.service.FileStorageService;
-import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.IssueRepository;
 
 import java.util.List;
@@ -24,23 +24,36 @@ public class IssueCommentService {
 
     private final IssueCommentRepository issueCommentRepository;
     private final IssueRepository issueRepository;
-    private final EmployeeRepository employeeRepository;
+    private final CurrentEmployeeService currentEmployeeService;
     private final IssueCommentMapper issueCommentMapper;
 
-    public IssueCommentService(IssueCommentRepository issueCommentRepository, IssueRepository issueRepository, EmployeeRepository employeeRepository, IssueCommentMapper issueCommentMapper) {
+    public IssueCommentService(IssueCommentRepository issueCommentRepository, IssueRepository issueRepository, CurrentEmployeeService currentEmployeeService, IssueCommentMapper issueCommentMapper) {
         this.issueCommentRepository = issueCommentRepository;
         this.issueRepository = issueRepository;
-        this.employeeRepository = employeeRepository;
+        this.currentEmployeeService = currentEmployeeService;
         this.issueCommentMapper = issueCommentMapper;
     }
 
+    /**
+     * Posts a comment on an issue, attributed to the signed-in caller.
+     *
+     * <p>The author is resolved from the session rather than read off the payload. An
+     * {@code authorId} the caller sends is not an author, it is a claim: the endpoint's guard is
+     * tenant membership, so the only check the old code could make was that the id named some
+     * employee of the tenant, and every member could therefore leave a comment in a colleague's
+     * name. A comment is read as its author's own statement, so the field it is stored under has
+     * to come from the session that wrote it.
+     *
+     * @param issueCommentCreationDto The comment text and the issue it belongs to.
+     * @return The saved comment.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *     employee record in this organization, so the comment would name nobody.
+     * @throws ResourceNotFoundException if the issue is not in this organization.
+     */
     @Transactional
     public IssueCommentSimpleDto addIssueComment(IssueCommentCreationDto issueCommentCreationDto) {
         IssueComment issueComment = new IssueComment();
-        if(!employeeRepository.existsByIdAndOrganization_Id(issueCommentCreationDto.getAuthorId(), TenantContext.getCurrentOrgId())) {
-            throw new ResourceNotFoundException("Author (employee) with ID " + issueCommentCreationDto.getAuthorId() + " was not found in this organization");
-        }
-        issueComment.setAuthorId(issueCommentCreationDto.getAuthorId());
+        issueComment.setAuthorId(currentEmployeeService.requireCurrentEmployee("comment on an issue").getId());
         issueComment.setComment(issueCommentCreationDto.getComment());
         if(issueCommentCreationDto.getIssueId() != null) {
             var issue = issueRepository.findByIdAndOrganization_Id(issueCommentCreationDto.getIssueId(), TenantContext.getCurrentOrgId())

--- a/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/IssueComment/dto/IssueCommentCreationDto.java
@@ -1,21 +1,32 @@
 package org.tornotron.echno_backend.IssueComment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
-
+/**
+ * Payload to leave a comment on an issue.
+ *
+ * <p>There is no author field. The author is the signed-in caller, resolved from the session in
+ * {@code IssueCommentService.addIssueComment}. It used to be an {@code authorId} the caller sent,
+ * checked only for being an employee of the tenant, so any member could post a comment in a
+ * colleague's name; a comment is read as its author's own statement, and nobody legitimately
+ * writes one as somebody else. Clients that still send {@code authorId} keep working, because a
+ * property no payload declares is ignored rather than refused.
+ */
+@Schema(description = "Payload to leave a comment on an issue. The author is taken from the "
+        + "signed-in session, not from the request.")
 @Data
 public class IssueCommentCreationDto {
 
+    @Schema(description = "The comment text.", example = "Rebar spacing on the east face still needs checking.")
     @NotBlank(message = "comment is required")
     @Size(max = 500, message = "Comment must not exceed 500 characters")
     private String comment;
 
+    @Schema(description = "Id of the issue being commented on.", example = "108")
     @NotNull
     private Long issueId;
-
-    @NotNull(message = "author is required")
-    private Long authorId;
 }

--- a/src/main/java/org/tornotron/echno_backend/common/service/CurrentEmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/CurrentEmployeeService.java
@@ -1,0 +1,76 @@
+package org.tornotron.echno_backend.common.service;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+/**
+ * Resolves the authenticated caller to their {@link Employee} record in the current tenant.
+ *
+ * <p>This exists so that a field naming who did something can be filled in from the session
+ * rather than from the request. A record that says who wrote it, raised it or approved it is read
+ * as that person's own statement, and where that id comes off the payload it is whatever the
+ * caller typed: the guard on the endpoint answers whether the caller may act at all, never
+ * whether the name on the record is theirs.
+ *
+ * <p>Chat, attendance and leave each grew their own copy of this lookup. This is the one the
+ * attribution fields share, so "who is calling" is answered the same way everywhere and a new
+ * endpoint has something to reach for.
+ */
+@Service
+public class CurrentEmployeeService {
+
+    private final UserContextService userContextService;
+    private final EmployeeRepository employeeRepository;
+
+    public CurrentEmployeeService(UserContextService userContextService,
+                                  EmployeeRepository employeeRepository) {
+        this.userContextService = userContextService;
+        this.employeeRepository = employeeRepository;
+    }
+
+    /**
+     * The caller's employee record in the current tenant, empty when the session resolves to no
+     * user row or that user has no employee record in this organization.
+     *
+     * <p>Both are ordinary states rather than faults. {@code UserContextService} resolves the JWT
+     * subject against {@code users_table.keycloak_id}, and an account created straight in the
+     * Keycloak console has no such row; an account that does have one may still hold no employee
+     * record in this organization, which is the shape a bootstrap administrator has.
+     */
+    public Optional<Employee> currentEmployee() {
+        Long userId = userContextService.getCurrentUserId();
+        if (userId == null) {
+            return Optional.empty();
+        }
+        return employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId());
+    }
+
+    /**
+     * The caller's employee record, or a refusal naming what could not be done without one.
+     *
+     * <p>Failing closed is the point. The alternative, letting the caller name themselves, is how
+     * these fields worked before: an account with no employee record could post a comment, raise
+     * an issue or act on an approval under any colleague's id, which is the forgery this lookup
+     * removes. Chat already refuses the same caller for the same reason, and the self-approval
+     * rule refuses an approval that would name nobody. An account that needs to do these things
+     * is given an employee record in the organization, which is what every other employee-centric
+     * part of the product already asks of it.
+     *
+     * @param action What the caller was trying to do, named in the refusal, for example
+     *     "comment on an issue".
+     * @return The caller's employee record in the current tenant.
+     * @throws AccessDeniedException if the caller has no employee record here.
+     */
+    public Employee requireCurrentEmployee(String action) {
+        return currentEmployee().orElseThrow(() -> new AccessDeniedException(
+                "You have no employee record in this organization, so there is nobody to record as "
+                        + "having done this. Ask an administrator to add you to the organization as an "
+                        + "employee before you " + action + "."));
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueController.java
@@ -82,7 +82,7 @@ public class IssueController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the issue create or admin authority, or has no employee record in the current tenant, so the record would name nobody")
     })
     public ResponseEntity<IssueSimpleDto> createIssue(
             @Parameter(schema = @Schema(implementation = IssueCreationDto.class))

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueControllerWeb.java
@@ -150,7 +150,7 @@ public class IssueControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Issue created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid issue JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody")
     })
     public ResponseEntity<IssueSimpleDto> createIssue(
             @Parameter(schema = @Schema(implementation = IssueCreationDto.class))

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
@@ -72,6 +73,7 @@ public class IssueService {
     private final AttachmentService attachmentService;
     private final IssueMapper issueMapper;
     private final EmployeeRepository employeeRepository;
+    private final CurrentEmployeeService currentEmployeeService;
     private final PayloadValidator payloadValidator;
 
     /**
@@ -81,15 +83,18 @@ public class IssueService {
      * @param taskRepository     The repository used to resolve the task an issue is raised against.
      * @param attachmentService  The service for attachment operations.
      * @param issueMapper        The mapper between issues and their DTOs.
-     * @param employeeRepository The repository used to resolve the creator and the assignee.
+     * @param employeeRepository The repository used to resolve the assignee.
+     * @param currentEmployeeService Resolves the caller to the employee an issue is recorded as
+     *                           having been raised by.
      * @param payloadValidator   Runs the create payload's own constraints.
      */
-    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository, PayloadValidator payloadValidator) {
+    public IssueService(IssueRepository issueRepository, TaskRepository taskRepository, AttachmentService attachmentService, IssueMapper issueMapper, EmployeeRepository employeeRepository, CurrentEmployeeService currentEmployeeService, PayloadValidator payloadValidator) {
         this.issueRepository = issueRepository;
         this.taskRepository = taskRepository;
         this.attachmentService = attachmentService;
         this.issueMapper = issueMapper;
         this.employeeRepository = employeeRepository;
+        this.currentEmployeeService = currentEmployeeService;
         this.payloadValidator = payloadValidator;
     }
 
@@ -99,13 +104,21 @@ public class IssueService {
      * <p>The issue starts {@link IssueStatus#open}, whether the payload says so or says nothing,
      * and any other starting value is refused: see {@link #requireCreatableStatus}.
      *
+     * <p>Who raised it is the signed-in caller, not a {@code createdById} on the payload. The
+     * endpoint is open to every member of the tenant, so a creator id the caller sent could only
+     * ever be checked for naming some employee of that tenant, and an issue "raised by" a site
+     * engineer is read as their report. See
+     * {@link org.tornotron.echno_backend.common.service.CurrentEmployeeService}.
+     *
      * @param issueCreationDto DTO containing the details for the new issue.
      * @param attachments      Files uploaded with the issue, or null when there are none.
      * @return The created issue.
      * @throws ConstraintViolationException if the payload fails its own constraints.
      * @throws InvalidRequestException if the payload asks for a status other than open.
-     * @throws ResourceNotFoundException if the task, the creator or the assignee is not found in
-     *                                   this organization.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *                                   employee record in this organization.
+     * @throws ResourceNotFoundException if the task or the assignee is not found in this
+     *                                   organization.
      */
     @Transactional
     public IssueSimpleDto addIssue(IssueCreationDto issueCreationDto, List<MultipartFile> attachments) {
@@ -113,8 +126,7 @@ public class IssueService {
         requireCreatableStatus(issueCreationDto.getStatus());
         Task task = taskRepository.findByIdAndOrganization_Id(issueCreationDto.getTaskId(), TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task with ID " + issueCreationDto.getTaskId() + " was not found in this organization"));
-        Employee creator = employeeRepository.findByIdAndOrganizationId(issueCreationDto.getCreatedById(), TenantContext.getCurrentOrgId())
-                .orElseThrow(() -> new ResourceNotFoundException("Creator (employee) with ID " + issueCreationDto.getCreatedById() + " was not found in this organization"));
+        Employee creator = currentEmployeeService.requireCurrentEmployee("raise an issue");
         Issue issue = new Issue();
         issue.setTitle(issueCreationDto.getTitle());
         issue.setDescription(issueCreationDto.getDescription());

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -54,7 +54,15 @@ public class IssueCreationDto {
             example = "open", allowableValues = {"open"})
     private IssueStatus status;
 
-    private Long createdById;
-
+    /**
+     * The assignee. Optional, and the only person on this payload the caller names: an issue may
+     * be raised for somebody else to fix.
+     *
+     * <p>There is deliberately no field for who raised it. That is the signed-in caller, stamped
+     * in {@code IssueService.addIssue}. It used to be a {@code createdById} the caller sent,
+     * checked only for being an employee of the tenant, so any member could raise an issue
+     * recorded as somebody else's. Clients that still send it keep working, because a property no
+     * payload declares is ignored rather than refused.
+     */
     private Long assignedToId;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
@@ -44,7 +44,7 @@ public class LeaveApprovalController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> approve(
@@ -63,7 +63,7 @@ public class LeaveApprovalController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> reject(
@@ -82,7 +82,7 @@ public class LeaveApprovalController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> delegate(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
@@ -43,7 +43,7 @@ public class LeaveApprovalControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> approve(
@@ -62,7 +62,7 @@ public class LeaveApprovalControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> reject(
@@ -81,7 +81,7 @@ public class LeaveApprovalControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> delegate(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -8,6 +8,7 @@ import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
@@ -42,6 +43,7 @@ public class LeaveApprovalService {
     private final LeaveBalanceRepository balanceRepository;
     private final LeaveTransactionRepository transactionRepository;
     private final EmployeeRepository employeeRepository;
+    private final CurrentEmployeeService currentEmployeeService;
     private final LeaveCalendarService calendarService;
     private final NotificationService notificationService;
     private final LeaveRequestMapper leaveRequestMapper;
@@ -52,6 +54,7 @@ public class LeaveApprovalService {
             LeaveBalanceRepository balanceRepository,
             LeaveTransactionRepository transactionRepository,
             EmployeeRepository employeeRepository,
+            CurrentEmployeeService currentEmployeeService,
             @Lazy LeaveCalendarService calendarService,
             @Lazy NotificationService notificationService,
             LeaveRequestMapper leaveRequestMapper) {
@@ -60,6 +63,7 @@ public class LeaveApprovalService {
         this.balanceRepository = balanceRepository;
         this.transactionRepository = transactionRepository;
         this.employeeRepository = employeeRepository;
+        this.currentEmployeeService = currentEmployeeService;
         this.calendarService = calendarService;
         this.notificationService = notificationService;
         this.leaveRequestMapper = leaveRequestMapper;
@@ -172,8 +176,11 @@ public class LeaveApprovalService {
      * levels remain the next approver is notified; otherwise the request is approved, pending days
      * are moved to used, a deduction ledger entry is posted, and calendar entries are created.
      *
+     * <p>The approver is the signed-in caller, not an id on the payload: see
+     * {@link #resolveActingApprover}.
+     *
      * @param requestId The ID of the leave request being approved.
-     * @param dto The approver's ID and optional comments.
+     * @param dto Optional comments on the decision.
      * @return The updated leave request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is not pending approval or the caller is not the current approver.
@@ -187,7 +194,7 @@ public class LeaveApprovalService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 
-        validateApprover(request, dto.getApproverId());
+        validateApprover(request, resolveActingApprover());
 
         LeaveApproval approval = getPendingApproval(request.getId(), request.getCurrentApprovalLevel());
 
@@ -213,7 +220,7 @@ public class LeaveApprovalService {
      * restored to the balance, and the employee is notified.
      *
      * @param requestId The ID of the leave request being rejected.
-     * @param dto The approver's ID and optional comments.
+     * @param dto Optional comments on the decision.
      * @return The updated leave request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
      * @throws InvalidRequestException if the request is not pending approval or the caller is not the current approver.
@@ -224,7 +231,7 @@ public class LeaveApprovalService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 
-        validateApprover(request, dto.getApproverId());
+        validateApprover(request, resolveActingApprover());
 
         LeaveApproval approval = getPendingApproval(request.getId(), request.getCurrentApprovalLevel());
 
@@ -252,7 +259,7 @@ public class LeaveApprovalService {
      * request's current approver becomes the delegate, who is notified.
      *
      * @param requestId The ID of the leave request being delegated.
-     * @param dto The delegating approver's ID, the target delegate ID, and optional comments.
+     * @param dto The target delegate ID, and optional comments.
      * @return The updated leave request.
      * @throws InvalidRequestException if no delegate ID is supplied, the request is not pending approval, or the caller is not the current approver.
      * @throws ResourceNotFoundException if the request or the delegate is not found in this organization.
@@ -267,7 +274,8 @@ public class LeaveApprovalService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 
-        validateApprover(request, dto.getApproverId());
+        Long actingApproverId = resolveActingApprover();
+        validateApprover(request, actingApproverId);
 
         Employee delegateTo = employeeRepository.findByIdAndOrganizationId(dto.getDelegateToId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
@@ -286,13 +294,13 @@ public class LeaveApprovalService {
         delegatedApproval.setApprover(delegateTo);
         delegatedApproval.setApprovalLevel(request.getCurrentApprovalLevel());
         delegatedApproval.setAction(ApprovalAction.PENDING);
-        delegatedApproval.setDelegatedFromId(dto.getApproverId());
+        delegatedApproval.setDelegatedFromId(actingApproverId);
         approvalRepository.save(delegatedApproval);
 
         request.setCurrentApprover(delegateTo);
         requestRepository.save(request);
 
-        notificationService.sendDelegationNotification(request, delegateTo, dto.getApproverId());
+        notificationService.sendDelegationNotification(request, delegateTo, actingApproverId);
 
         return leaveRequestMapper.toDto(request);
     }
@@ -346,6 +354,29 @@ public class LeaveApprovalService {
                 .orElse(false);
     }
 
+    /**
+     * The employee acting on this request, taken from the session.
+     *
+     * <p>It used to be an {@code approverId} on the payload, compared against the request's
+     * current approver. That comparison says the id sent names the right person, never that the
+     * caller is that person: the endpoints are gated on the system-admin and hr-admin roles, so
+     * any holder of either could send the current approver's id and have the decision recorded
+     * under that approver's name. An approval is the accountability on the days it moves, and it
+     * has to name whoever actually gave it.
+     *
+     * <p>The consequence is deliberate: an administrator who is not the current approver can no
+     * longer act on a request at all, where before they could act as the approver. Unsticking a
+     * request whose approver is unavailable is a real need, but the answer to it is a reassignment
+     * that records the administrator, not one that writes their decision in somebody else's name.
+     *
+     * @return The caller's employee id in the current tenant.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *     employee record here, so the decision would name nobody.
+     */
+    private Long resolveActingApprover() {
+        return currentEmployeeService.requireCurrentEmployee("act on a leave request").getId();
+    }
+
     private void validateApprover(LeaveRequest request, Long approverId) {
         if (request.getStatus() != LeaveStatus.PENDING_APPROVAL) {
             throw new InvalidRequestException(
@@ -355,7 +386,7 @@ public class LeaveApprovalService {
         if (request.getCurrentApprover() == null ||
             !request.getCurrentApprover().getId().equals(approverId)) {
             throw new InvalidRequestException(
-                    "Employee with ID " + approverId + " is not the current approver for leave request " + request.getId());
+                    "You are not the current approver for leave request " + request.getId());
         }
     }
 

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalActionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveApprovalActionDto.java
@@ -1,17 +1,24 @@
 package org.tornotron.echno_backend.leave.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
-@Schema(description = "Payload for an approve, reject or delegate action on a leave request.")
+/**
+ * Payload for an approve, reject or delegate action on a leave request.
+ *
+ * <p>There is no approver field. Whoever is acting is the signed-in caller, resolved from the
+ * session in {@code LeaveApprovalService}. It used to be an {@code approverId} the caller sent,
+ * compared against the request's current approver, which establishes that the id names the right
+ * person and nothing about who sent it: these endpoints are gated on the system-admin and
+ * hr-admin roles, so any holder of either could pass the current approver's id and have the
+ * decision recorded under that approver's name. Clients that still send {@code approverId} keep
+ * working, because a property no payload declares is ignored rather than refused.
+ */
+@Schema(description = "Payload for an approve, reject or delegate action on a leave request. Who is "
+        + "acting is taken from the signed-in session, not from the request.")
 @Data
 public class LeaveApprovalActionDto {
-
-    @Schema(description = "Id of the employee performing the action.", example = "5")
-    @NotNull(message = "Approver ID is required")
-    private Long approverId;
 
     @Schema(description = "Comments on the action.", example = "Approved, please plan handover before you leave")
     @Size(max = 1000, message = "Comments must not exceed 1000 characters")

--- a/src/main/java/org/tornotron/echno_backend/task/TaskController.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskController.java
@@ -78,7 +78,7 @@ public class TaskController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Task created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task create or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the task create or admin authority, or has no employee record in the current tenant, so the record would name nobody")
     })
     public ResponseEntity<TaskSimpleDto> createTask(
             @Parameter(schema = @Schema(implementation = TaskCreationDto.class))

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -76,7 +76,7 @@ public class TaskControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Task created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The data part is not valid task JSON, or a field failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody")
     })
     public ResponseEntity<TaskSimpleDto> createTask(
             @Parameter(schema = @Schema(implementation = TaskCreationDto.class))

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -23,6 +23,7 @@ import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.project.ProjectProgressCalculator;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -73,6 +74,7 @@ public class TaskService {
     private final ProjectRepository projectRepository;
     private final CategoryRepository categoryRepository;
     private final AttachmentService attachmentService;
+    private final CurrentEmployeeService currentEmployeeService;
     private final TaskMapper taskMapper;
     private final PayloadValidator payloadValidator;
 
@@ -84,6 +86,8 @@ public class TaskService {
      * @param projectRepository  The repository for project data access.
      * @param categoryRepository The repository for category data access.
      * @param attachmentService  The service for attachment operations.
+     * @param currentEmployeeService Resolves the caller to the employee a task is recorded as
+     *                           having been created by.
      * @param taskMapper         The mapper between tasks and their DTOs.
      * @param payloadValidator   Runs the create payload's own constraints.
      */
@@ -92,6 +96,7 @@ public class TaskService {
                        ProjectRepository projectRepository,
                        CategoryRepository categoryRepository,
                        AttachmentService attachmentService,
+                       CurrentEmployeeService currentEmployeeService,
                        TaskMapper taskMapper,
                        PayloadValidator payloadValidator) {
         this.taskRepository = taskRepository;
@@ -99,6 +104,7 @@ public class TaskService {
         this.projectRepository = projectRepository;
         this.categoryRepository = categoryRepository;
         this.attachmentService = attachmentService;
+        this.currentEmployeeService = currentEmployeeService;
         this.taskMapper = taskMapper;
         this.payloadValidator = payloadValidator;
     }
@@ -107,9 +113,16 @@ public class TaskService {
      * Creates a new task.
      *
      * @param taskCreationDto DTO containing the details for the new task.
+     * <p>The creator is the signed-in caller, stamped here rather than read off the payload. The
+     * endpoint is role-gated, so the forgery this closes needed a role that may manage tasks
+     * already; what it bought was a task recorded as somebody else's, which no client has ever
+     * asked for. See {@link org.tornotron.echno_backend.common.service.CurrentEmployeeService}.
+     *
      * @throws ConstraintViolationException if the payload fails its own constraints.
-     * @throws ResourceNotFoundException if the creator, project, or category is not found.
-     * @throws InvalidRequestException if required fields like creatorId, projectId, or categoryId are missing,
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *                                 employee record in this organization.
+     * @throws ResourceNotFoundException if the project or category is not found.
+     * @throws InvalidRequestException if required fields like projectId or categoryId are missing,
      *                                 or if assigned employees do not belong to the project's organization.
      * @throws DatabaseOperationException if there is an error saving the task.
      */
@@ -124,12 +137,7 @@ public class TaskService {
         task.setProgress(taskCreationDto.getProgress());
         task.setStatus(TaskStatus.valueOf(taskCreationDto.getStatus()));
 
-        if (taskCreationDto.getCreatorId() != null) {
-            task.setCreator(employeeRepository.findByIdAndOrganizationId(taskCreationDto.getCreatorId(), TenantContext.getCurrentOrgId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Creator (employee) with ID " + taskCreationDto.getCreatorId() + " was not found in this organization")));
-        } else {
-            throw new InvalidRequestException("A creatorId is required to create a task");
-        }
+        task.setCreator(currentEmployeeService.requireCurrentEmployee("create a task"));
         if (taskCreationDto.getProjectId() != null) {
             var project = projectRepository.findByIdAndOrganization_Id(taskCreationDto.getProjectId(),TenantContext.getCurrentOrgId())
                     .orElseThrow(() -> new ResourceNotFoundException("Project with ID " + taskCreationDto.getProjectId() + " was not found in this organization"));

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskCreationDto.java
@@ -11,8 +11,19 @@ import lombok.Data;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * Payload to create a task under a project.
+ *
+ * <p>There is no creator field. The creator is the signed-in caller, stamped in
+ * {@code TaskService.addTask}. It used to be a {@code creatorId} the caller sent, checked only
+ * for naming an employee of the tenant, so anyone who could reach the endpoint could record a
+ * task as having been set up by a colleague. Assigning work to somebody else is what
+ * {@code assigneeIds} is for, and is unaffected. Clients that still send {@code creatorId} keep
+ * working, because a property no payload declares is ignored rather than refused.
+ */
 @Schema(description = "Payload to create a task under a project. Sent as the JSON data part of the "
-        + "multipart create request.")
+        + "multipart create request. The creator is taken from the signed-in session, not from the "
+        + "request.")
 @Data
 public class TaskCreationDto {
     @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
@@ -31,10 +42,6 @@ public class TaskCreationDto {
     @Schema(description = "Longer description of the work to be done.",
             example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
     private String description;
-
-    @Schema(description = "Id of the employee creating the task.", example = "5")
-    @NotNull(message = "creatorId is required(type: Long)")
-    private Long creatorId;
 
     @Schema(description = "Id of the project the task belongs to.", example = "42")
     @NotNull(message = "projectId is required(type: Long)")

--- a/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentAuthorAttributionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/IssueComment/IssueCommentAuthorAttributionTest.java
@@ -1,0 +1,137 @@
+package org.tornotron.echno_backend.IssueComment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.IssueComment.dto.IssueCommentCreationDto;
+import org.tornotron.echno_backend.IssueComment.mapper.IssueCommentMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.Issue;
+import org.tornotron.echno_backend.issue.IssueRepository;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who a comment is recorded as having been written by.
+ *
+ * <p>It used to be an {@code authorId} on the payload. The endpoint is open to every member of
+ * the tenant and the only check made on that id was that it named some employee of the tenant, so
+ * any member could post a comment in a colleague's name. A comment on an issue is read as its
+ * author's own statement, and once the compliance module reads issues, a forged one feeds it.
+ *
+ * <p>The author now comes from the session. The payload a deployed client sends is replayed here
+ * verbatim, {@code authorId} and all, so what these pin is both halves of the change: the key is
+ * accepted rather than refused, and the comment is stored under the caller rather than under the
+ * id the key carried. On the old code the stored author is 99.
+ */
+@ExtendWith(MockitoExtension.class)
+class IssueCommentAuthorAttributionTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 99L;
+    private static final Long ISSUE_ID = 11L;
+
+    /** Exactly what echno-core's {@code createIssueCommentToJson} puts on the wire today. */
+    private static final String DEPLOYED_CLIENT_PAYLOAD =
+            "{\"issueId\":11,\"comment\":\"Rebar spacing on the east face still needs checking.\",\"authorId\":99}";
+
+    @Mock private IssueCommentRepository issueCommentRepository;
+    @Mock private IssueRepository issueRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private IssueCommentMapper issueCommentMapper;
+
+    /** The mapper Spring Boot's Jackson auto-configuration builds, which is what binds the body. */
+    private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private IssueCommentService service() {
+        return new IssueCommentService(issueCommentRepository, issueRepository,
+                currentEmployeeService, issueCommentMapper);
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        return employee;
+    }
+
+    private void issueExists() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        Issue issue = new Issue();
+        issue.setId(ISSUE_ID);
+        issue.setOrganization(organization);
+        lenient().when(issueRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(issue));
+    }
+
+    private IssueCommentCreationDto deployedClientPayload() throws Exception {
+        return objectMapper.readValue(DEPLOYED_CLIENT_PAYLOAD, IssueCommentCreationDto.class);
+    }
+
+    @Test
+    void anAuthorIdFromAnOlderClientIsAcceptedRatherThanRefused() throws Exception {
+        IssueCommentCreationDto dto = deployedClientPayload();
+
+        assertThat(dto.getIssueId()).isEqualTo(ISSUE_ID);
+        assertThat(dto.getComment()).startsWith("Rebar spacing");
+    }
+
+    @Test
+    void theCommentIsStoredUnderTheCallerNotUnderTheIdTheCallerSent() throws Exception {
+        issueExists();
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenReturn(employee(CALLER_EMPLOYEE_ID));
+        when(issueCommentRepository.save(any(IssueComment.class))).thenAnswer(call -> call.getArgument(0));
+
+        service().addIssueComment(deployedClientPayload());
+
+        ArgumentCaptor<IssueComment> saved = ArgumentCaptor.forClass(IssueComment.class);
+        verify(issueCommentRepository).save(saved.capture());
+        assertThat(saved.getValue().getAuthorId())
+                .isEqualTo(CALLER_EMPLOYEE_ID)
+                .isNotEqualTo(COLLEAGUE_EMPLOYEE_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordCannotCommentAtAll() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        IssueCommentCreationDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service().addIssueComment(dto))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(issueCommentRepository, never()).save(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreateStatusTest.java
@@ -17,6 +17,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
@@ -32,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,6 +62,8 @@ class IssueCreateStatusTest {
     private IssueMapper issueMapper;
     @Mock
     private EmployeeRepository employeeRepository;
+    @Mock
+    private CurrentEmployeeService currentEmployeeService;
 
     private IssueService service;
 
@@ -68,7 +72,8 @@ class IssueCreateStatusTest {
         factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();
         service = new IssueService(issueRepository, taskRepository, attachmentService,
-                issueMapper, employeeRepository, new PayloadValidator(validator));
+                issueMapper, employeeRepository, currentEmployeeService,
+                new PayloadValidator(validator));
 
         TenantContext.setCurrentOrgId(1L);
         Organization organization = new Organization();
@@ -77,8 +82,7 @@ class IssueCreateStatusTest {
         task.setOrganization(organization);
         when(taskRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
                 .thenReturn(Optional.of(task));
-        when(employeeRepository.findByIdAndOrganizationId(anyLong(), anyLong()))
-                .thenReturn(Optional.of(new Employee()));
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(new Employee());
         when(issueRepository.save(any(Issue.class))).thenAnswer(call -> call.getArgument(0));
     }
 
@@ -100,7 +104,6 @@ class IssueCreateStatusTest {
         dto.setDescription("Voids visible along the north edge of the pour after stripping.");
         dto.setType("quality");
         dto.setTaskId(11L);
-        dto.setCreatedById(5L);
         return dto;
     }
 

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreationValidationTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
@@ -48,6 +49,8 @@ class IssueCreationValidationTest {
     private IssueMapper issueMapper;
     @Mock
     private EmployeeRepository employeeRepository;
+    @Mock
+    private CurrentEmployeeService currentEmployeeService;
 
     private IssueService service;
 
@@ -56,7 +59,8 @@ class IssueCreationValidationTest {
         factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         service = new IssueService(issueRepository, taskRepository, attachmentService,
-                issueMapper, employeeRepository, new PayloadValidator(validator));
+                issueMapper, employeeRepository, currentEmployeeService,
+                new PayloadValidator(validator));
     }
 
     @AfterAll
@@ -73,7 +77,6 @@ class IssueCreationValidationTest {
         dto.setType("quality");
         dto.setStatus(IssueStatus.open);
         dto.setTaskId(11L);
-        dto.setCreatedById(5L);
         return dto;
     }
 

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueCreatorAttributionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueCreatorAttributionTest.java
@@ -1,0 +1,156 @@
+package org.tornotron.echno_backend.issue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who an issue is recorded as having been raised by.
+ *
+ * <p>It used to be a {@code createdById} on the payload, and the endpoint is open to every member
+ * of the tenant, so the only check that id could carry was that it named some employee of the
+ * tenant. An issue "raised by" the site engineer is read as their report, and the compliance
+ * module reads issues.
+ *
+ * <p>The creator now comes from the session. The JSON part a deployed client sends is replayed
+ * here verbatim, {@code createdById} and all, so these pin both halves: the key is accepted
+ * rather than refused, and the issue is stored under the caller. On the old code the stored
+ * creator is employee 99.
+ */
+@ExtendWith(MockitoExtension.class)
+class IssueCreatorAttributionTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 99L;
+
+    /** Exactly what echno-core's {@code createIssueToJson} puts in the multipart data part today. */
+    private static final String DEPLOYED_CLIENT_PAYLOAD = """
+            {"title":"Honeycombing on the block A raft",
+             "description":"Voids visible along the north edge of the pour after stripping.",
+             "type":"quality","taskId":11,"createdById":99}
+            """;
+
+    private static ValidatorFactory factory;
+
+    @Mock private IssueRepository issueRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private IssueMapper issueMapper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+
+    private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+
+    private IssueService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        service = new IssueService(issueRepository, taskRepository, attachmentService, issueMapper,
+                employeeRepository, currentEmployeeService,
+                new PayloadValidator(factory.getValidator()));
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        Task task = new Task();
+        task.setOrganization(organization);
+        lenient().when(taskRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(task));
+        lenient().when(issueRepository.save(any(Issue.class))).thenAnswer(call -> call.getArgument(0));
+        // Employee 99 is a real colleague of this tenant, resolvable by id. That is the whole
+        // point: the id the payload carries is not refused for being unknown, it is not consulted.
+        lenient().when(employeeRepository.findByIdAndOrganizationId(anyLong(), anyLong()))
+                .thenAnswer(call -> Optional.of(employee(call.getArgument(0))));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private IssueCreationDto deployedClientPayload() throws Exception {
+        return objectMapper.readValue(DEPLOYED_CLIENT_PAYLOAD, IssueCreationDto.class);
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        return employee;
+    }
+
+    @Test
+    void aCreatedByIdFromAnOlderClientIsAcceptedRatherThanRefused() throws Exception {
+        IssueCreationDto dto = deployedClientPayload();
+
+        assertThat(dto.getTaskId()).isEqualTo(11L);
+        assertThat(dto.getType()).isEqualTo("quality");
+    }
+
+    @Test
+    void theIssueIsRaisedByTheCallerNotByTheIdTheCallerSent() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenReturn(employee(CALLER_EMPLOYEE_ID));
+
+        service.addIssue(deployedClientPayload(), null);
+
+        ArgumentCaptor<Issue> saved = ArgumentCaptor.forClass(Issue.class);
+        verify(issueRepository).save(saved.capture());
+        assertThat(saved.getValue().getCreatedBy().getId())
+                .isEqualTo(CALLER_EMPLOYEE_ID)
+                .isNotEqualTo(COLLEAGUE_EMPLOYEE_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordCannotRaiseAnIssue() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        IssueCreationDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service.addIssue(dto, null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(issueRepository, never()).save(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
@@ -15,6 +15,7 @@ import org.mockito.quality.Strictness;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.payload.PayloadValidator;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
@@ -64,6 +65,8 @@ class IssuePartialUpdateKeysTest {
     private IssueMapper issueMapper;
     @Mock
     private EmployeeRepository employeeRepository;
+    @Mock
+    private CurrentEmployeeService currentEmployeeService;
 
     private IssueService service;
     private Issue existing;
@@ -73,7 +76,8 @@ class IssuePartialUpdateKeysTest {
         factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();
         service = new IssueService(issueRepository, taskRepository, attachmentService,
-                issueMapper, employeeRepository, new PayloadValidator(validator));
+                issueMapper, employeeRepository, currentEmployeeService,
+                new PayloadValidator(validator));
 
         TenantContext.setCurrentOrgId(1L);
 

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -51,6 +53,7 @@ class LeaveApprovalServiceTest {
     @Mock private LeaveBalanceRepository balanceRepository;
     @Mock private LeaveTransactionRepository transactionRepository;
     @Mock private EmployeeRepository employeeRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
     @Mock private LeaveCalendarService calendarService;
     @Mock private NotificationService notificationService;
     @Mock private LeaveRequestMapper leaveRequestMapper;
@@ -62,6 +65,7 @@ class LeaveApprovalServiceTest {
                 balanceRepository,
                 transactionRepository,
                 employeeRepository,
+                currentEmployeeService,
                 calendarService,
                 notificationService,
                 leaveRequestMapper);
@@ -175,10 +179,9 @@ class LeaveApprovalServiceTest {
                 .thenReturn(Optional.empty());
         when(leaveRequestMapper.toDto(request)).thenReturn(new LeaveRequestDto());
 
-        LeaveApprovalActionDto action = new LeaveApprovalActionDto();
-        action.setApproverId(lineManager.getId());
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(lineManager);
 
-        service.approve(REQUEST_ID, action);
+        service.approve(REQUEST_ID, new LeaveApprovalActionDto());
 
         // maxApprovalLevel == 1, so the first approval finalizes rather than advancing.
         assertThat(request.getStatus()).isEqualTo(LeaveStatus.APPROVED);

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverAttributionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverAttributionTest.java
@@ -1,0 +1,239 @@
+package org.tornotron.echno_backend.leave;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+import org.tornotron.echno_backend.leave.enums.ApprovalAction;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who a leave decision is recorded as having been made by.
+ *
+ * <p>Approve, reject and delegate took an {@code approverId} on the payload and compared it with
+ * the request's current approver. That comparison establishes that the id names the right person
+ * and nothing at all about who sent it. The endpoints are gated on the system-admin and hr-admin
+ * roles, so any holder of either could pass the current approver's id and have the decision
+ * written under that approver's name, on the record that moves an employee's leave balance.
+ *
+ * <p>The acting approver now comes from the session. The payload a deployed client sends is
+ * replayed verbatim, {@code approverId} and all, so these pin that the key is accepted rather
+ * than refused and that it no longer decides anything. On the old code
+ * {@link #anAdminWhoIsNotTheApproverCanNoLongerActInTheApproversName} passes the check and
+ * approves the request.
+ */
+@ExtendWith(MockitoExtension.class)
+class LeaveApproverAttributionTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long REQUEST_ID = 42L;
+    private static final Long APPROVER_EMPLOYEE_ID = 2L;
+    private static final Long ADMIN_EMPLOYEE_ID = 8L;
+
+    /** Exactly what the web client's approval action puts on the wire today. */
+    private static final String DEPLOYED_CLIENT_PAYLOAD =
+            "{\"approverId\":2,\"comments\":\"Approved, please plan handover before you leave\"}";
+
+    @Mock private LeaveApprovalRepository approvalRepository;
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private LeaveTransactionRepository transactionRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private LeaveCalendarService calendarService;
+    @Mock private NotificationService notificationService;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+
+    private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+
+    private Employee approver;
+    private LeaveRequest request;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+
+        approver = new Employee();
+        approver.setId(APPROVER_EMPLOYEE_ID);
+        approver.setOrganization(organization);
+
+        Employee applicant = new Employee();
+        applicant.setId(1L);
+        applicant.setOrganization(organization);
+
+        LeavePolicy policy = new LeavePolicy();
+        policy.setId(3L);
+        policy.setOrganization(organization);
+
+        request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setOrganization(organization);
+        request.setEmployee(applicant);
+        request.setLeavePolicy(policy);
+        request.setStartDate(LocalDate.of(2026, 6, 1));
+        request.setStatus(LeaveStatus.PENDING_APPROVAL);
+        request.setCurrentApprovalLevel(1);
+        request.setMaxApprovalLevel(1);
+        request.setCurrentApprover(approver);
+
+        LeaveApproval pending = new LeaveApproval();
+        pending.setLeaveRequest(request);
+        pending.setOrganization(organization);
+        pending.setApprover(approver);
+        pending.setApprovalLevel(1);
+        pending.setAction(ApprovalAction.PENDING);
+
+        lenient().when(requestRepository.lockByIdAndOrganizationId(eq(REQUEST_ID), any()))
+                .thenReturn(Optional.of(request));
+        lenient().when(approvalRepository.findFirstByLeaveRequestIdAndApprovalLevelAndActionOrderByCreatedAtDesc(
+                        eq(REQUEST_ID), eq(1), eq(ApprovalAction.PENDING)))
+                .thenReturn(Optional.of(pending));
+        lenient().when(balanceRepository.findByEmployeeIdAndLeavePolicyIdAndYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(Optional.empty());
+        lenient().when(leaveRequestMapper.toDto(request)).thenReturn(new LeaveRequestDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private LeaveApprovalService service() {
+        return new LeaveApprovalService(
+                approvalRepository,
+                requestRepository,
+                balanceRepository,
+                transactionRepository,
+                employeeRepository,
+                currentEmployeeService,
+                calendarService,
+                notificationService,
+                leaveRequestMapper);
+    }
+
+    private LeaveApprovalActionDto deployedClientPayload() throws Exception {
+        return objectMapper.readValue(DEPLOYED_CLIENT_PAYLOAD, LeaveApprovalActionDto.class);
+    }
+
+    private Employee admin() {
+        Employee admin = new Employee();
+        admin.setId(ADMIN_EMPLOYEE_ID);
+        return admin;
+    }
+
+    @Test
+    void anApproverIdFromAnOlderClientIsAcceptedRatherThanRefused() throws Exception {
+        LeaveApprovalActionDto dto = deployedClientPayload();
+
+        assertThat(dto.getComments()).startsWith("Approved, please plan handover");
+    }
+
+    @Test
+    void theCurrentApproverActingOnTheirOwnQueueIsStillServed() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(approver);
+
+        service().approve(REQUEST_ID, deployedClientPayload());
+
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.APPROVED);
+        ArgumentCaptor<LeaveApproval> saved = ArgumentCaptor.forClass(LeaveApproval.class);
+        verify(approvalRepository).save(saved.capture());
+        assertThat(saved.getValue().getApprover()).isEqualTo(approver);
+        assertThat(saved.getValue().getAction()).isEqualTo(ApprovalAction.APPROVED);
+    }
+
+    /**
+     * The case the payload field bought, and the one it should never have: the payload names the
+     * real approver and the session is somebody else who holds the role gate.
+     */
+    @Test
+    void anAdminWhoIsNotTheApproverCanNoLongerActInTheApproversName() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(admin());
+
+        LeaveApprovalActionDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service().approve(REQUEST_ID, dto))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("not the current approver");
+
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.PENDING_APPROVAL);
+        verify(approvalRepository, never()).save(any());
+    }
+
+    @Test
+    void rejectIsSettledOnTheSessionToo() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(admin());
+
+        LeaveApprovalActionDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service().reject(REQUEST_ID, dto))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("not the current approver");
+
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.PENDING_APPROVAL);
+        verify(approvalRepository, never()).save(any());
+    }
+
+    @Test
+    void delegateRecordsWhoDelegatedFromTheSession() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(approver);
+        when(requestRepository.findByIdAndOrganization_Id(eq(REQUEST_ID), any()))
+                .thenReturn(Optional.of(request));
+        Employee delegate = new Employee();
+        delegate.setId(9L);
+        when(employeeRepository.findByIdAndOrganizationId(eq(9L), any()))
+                .thenReturn(Optional.of(delegate));
+
+        LeaveApprovalActionDto dto = deployedClientPayload();
+        dto.setDelegateToId(9L);
+        service().delegate(REQUEST_ID, dto);
+
+        ArgumentCaptor<LeaveApproval> saved = ArgumentCaptor.forClass(LeaveApproval.class);
+        verify(approvalRepository, org.mockito.Mockito.times(2)).save(saved.capture());
+        assertThat(saved.getAllValues().get(1).getDelegatedFromId()).isEqualTo(APPROVER_EMPLOYEE_ID);
+        verify(notificationService).sendDelegationNotification(request, delegate, APPROVER_EMPLOYEE_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordCannotDecideAnything() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        LeaveApprovalActionDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service().approve(REQUEST_ID, dto))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(request.getStatus()).isEqualTo(LeaveStatus.PENDING_APPROVAL);
+        verify(approvalRepository, never()).save(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskCreationValidationTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.category.CategoryRepository;
 import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.task.dto.TaskCreationDto;
@@ -52,6 +53,8 @@ class TaskCreationValidationTest {
     @Mock
     private AttachmentService attachmentService;
     @Mock
+    private CurrentEmployeeService currentEmployeeService;
+    @Mock
     private TaskMapper taskMapper;
 
     private TaskService service;
@@ -61,7 +64,8 @@ class TaskCreationValidationTest {
         factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         service = new TaskService(taskRepository, employeeRepository, projectRepository,
-                categoryRepository, attachmentService, taskMapper, new PayloadValidator(validator));
+                categoryRepository, attachmentService, currentEmployeeService, taskMapper,
+                new PayloadValidator(validator));
     }
 
     @AfterAll
@@ -75,7 +79,6 @@ class TaskCreationValidationTest {
         TaskCreationDto dto = new TaskCreationDto();
         dto.setTitle("Pour foundation slab, block A");
         dto.setStatus("upcoming");
-        dto.setCreatorId(5L);
         dto.setProjectId(42L);
         dto.setCategoryId(3L);
         dto.setProgress(0.0);
@@ -111,17 +114,6 @@ class TaskCreationValidationTest {
 
         assertThatThrownBy(() -> service.addTask(dto, null))
                 .isInstanceOf(ConstraintViolationException.class);
-    }
-
-    @Test
-    void addTask_rejectsAMissingCreatorId() {
-        TaskCreationDto dto = validDto();
-        dto.setCreatorId(null);
-
-        assertThatThrownBy(() -> service.addTask(dto, null))
-                .isInstanceOf(ConstraintViolationException.class);
-
-        verify(taskRepository, never()).save(ArgumentMatchers.any());
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/task/TaskCreatorAttributionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskCreatorAttributionTest.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.category.Category;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.task.dto.TaskCreationDto;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who a task is recorded as having been created by.
+ *
+ * <p>Lower stakes than the issue and comment cases, because these endpoints are gated on the
+ * system-admin and project-manager roles: only somebody already trusted to manage tasks could
+ * misattribute one. It is the same defect all the same, and the field bought nothing. Assigning
+ * work to somebody else is what {@code assigneeIds} is for and is untouched.
+ *
+ * <p>The JSON part a deployed client sends is replayed verbatim, {@code creatorId} and all. On the
+ * old code the stored creator is employee 99.
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskCreatorAttributionTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 7L;
+    private static final Long COLLEAGUE_EMPLOYEE_ID = 99L;
+
+    /** Exactly what echno-core's task create serializer puts in the multipart data part today. */
+    private static final String DEPLOYED_CLIENT_PAYLOAD = """
+            {"title":"Pour foundation slab, block A","status":"upcoming","progress":0.0,
+             "projectId":42,"categoryId":3,"creatorId":99}
+            """;
+
+    private static ValidatorFactory factory;
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private TaskMapper taskMapper;
+
+    private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+
+    private TaskService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        service = new TaskService(taskRepository, employeeRepository, projectRepository,
+                categoryRepository, attachmentService, currentEmployeeService, taskMapper,
+                new PayloadValidator(factory.getValidator()));
+        TenantContext.setCurrentOrgId(ORG_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        Project project = new Project();
+        project.setOrganization(organization);
+        lenient().when(projectRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(project));
+        lenient().when(categoryRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(new Category()));
+        lenient().when(taskRepository.save(any(Task.class))).thenAnswer(call -> call.getArgument(0));
+        // Employee 99 is a real colleague of this tenant, resolvable by id. That is the whole
+        // point: the id the payload carries is not refused for being unknown, it is not consulted.
+        lenient().when(employeeRepository.findByIdAndOrganizationId(anyLong(), anyLong()))
+                .thenAnswer(call -> Optional.of(employee(call.getArgument(0))));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private TaskCreationDto deployedClientPayload() throws Exception {
+        return objectMapper.readValue(DEPLOYED_CLIENT_PAYLOAD, TaskCreationDto.class);
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        return employee;
+    }
+
+    @Test
+    void aCreatorIdFromAnOlderClientIsAcceptedRatherThanRefused() throws Exception {
+        TaskCreationDto dto = deployedClientPayload();
+
+        assertThat(dto.getProjectId()).isEqualTo(42L);
+        assertThat(dto.getCategoryId()).isEqualTo(3L);
+    }
+
+    @Test
+    void theTaskIsCreatedByTheCallerNotByTheIdTheCallerSent() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenReturn(employee(CALLER_EMPLOYEE_ID));
+
+        service.addTask(deployedClientPayload(), null);
+
+        ArgumentCaptor<Task> saved = ArgumentCaptor.forClass(Task.class);
+        verify(taskRepository).save(saved.capture());
+        assertThat(saved.getValue().getCreator().getId())
+                .isEqualTo(CALLER_EMPLOYEE_ID)
+                .isNotEqualTo(COLLEAGUE_EMPLOYEE_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordCannotCreateATask() throws Exception {
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        TaskCreationDto dto = deployedClientPayload();
+        assertThatThrownBy(() -> service.addTask(dto, null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(taskRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
Closes #598. The recommendation and the evidence behind it are on the issue; this is the build.

## What was reachable

Four create/action payloads named the person the record would be attributed to, and the server stored what it was given.

| Endpoint | Field | Guard | What a caller could do |
|---|---|---|---|
| `POST /issues/comments/web` | `authorId` | tenant membership | post a comment in any colleague's name |
| `POST /issues/web` | `createdById` | tenant membership | raise an issue recorded as any colleague's report |
| `POST /tasks/web` | `creatorId` | `system-admin` / `project-manager` | create a task recorded as a colleague's |
| `POST /leave-approvals/web/{approve,reject,delegate}` | `approverId` | `system-admin` / `hr-admin` | approve, reject or delegate under the current approver's name |

None of these is privilege escalation, which is why they were separated out of #589 and #599. What they buy is a record that says somebody else did it, on records people are meant to rely on: a comment is read as its author's statement, an issue "raised by" the site engineer is read as their report and feeds the compliance module, and a leave approval is the accountability on the days it moves.

The `approverId` case was left to the self-approval thread. That thread landed as `32098d7` and did not touch leave approval, which does not go through `SelfApprovalPolicy` at all, so it is folded in here.

## The fix

All four come from the session now, through one new `CurrentEmployeeService` rather than a fourth private copy of the user-to-employee lookup that chat, attendance and leave each grew.

The fields are **removed** rather than kept and enforced, because create-on-behalf-of is not something this product does. Every call site in `echno-web` sets these to the signed-in employee's own id, there are only three create sites and three approval sites in the whole app, and no form anywhere offers a creator, author or reporter to pick. The only employee picker near these flows fills `delegateToId`, a different field for a different concept, untouched here.

A caller with no employee record in the tenant is now refused rather than allowed to name somebody else. That was the open question on the issue, and the answer already existed: `ChatService` refuses the same caller for the same reason, and `SelfApprovalPolicy` refuses an approval that would name nobody.

## Deploy sequencing

**Safe to ship alone, ahead of any client work.** Spring Boot leaves `FAIL_ON_UNKNOWN_PROPERTIES` disabled and nothing overrides it, so the deployed client keeps sending all four keys, the server ignores them, and the value each carried was the caller's own id anyway. Same shape as `c7ff4ca`. Each test class replays the exact payload the client sends today and asserts it binds, so this is pinned rather than assumed.

The reverse would have needed a coordinated release: refusing a value the client sends, which is what keeping the field would have meant for the no-employee-record account.

`echno-core` should drop the four fields from its create DTOs, and the task **edit** page should stop sending `creatorId` in its update payload, where it would otherwise rewrite the creator to whoever is editing. The backend has never applied that key, so nothing is corrupted. Both filed on `echno-web`.

## Deliberate behaviour change

An administrator who is not the current approver can no longer act on a leave request, where before they could act as the approver. Unsticking a request whose approver is away is a real need, but the answer is a reassignment that records the administrator, not a decision written in somebody else's name. Separate ticket if it turns out to be wanted.

## Tests

Four new classes, 15 cases. Eleven fail against the old behaviour, verified by reconstructing it and re-running: the three attribution cases store employee 99 where the caller is 7, and the leave cases let an administrator approve, reject and delegate in the approver's name. The three `...FromAnOlderClientIsAcceptedRatherThanRefused` cases pass on both, which is their point: they pin the contract compatibility, not the fix.

Full suite green on `.116` (test heap 26% of the 2048m cap). `docs/openapi.json` regenerated: four properties removed, three `required` lists shortened.
