### PR TITLE
Report leave balances as figures a person can act on

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveAccrualService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveAccrualService.java
@@ -20,6 +20,10 @@ import java.util.List;
  * transactions for months not yet accrued, and refreshes the balance's
  * accrued / used / pending figures.
  *
+ * The refreshed figures are rebuilt from the ledger and the request rows rather than
+ * adjusted in place, so they also carry the manual ADJUSTMENT transactions; every
+ * figure is rounded through {@link LeaveDays} before it is stored.
+ *
  * Extracted from {@link LeaveBalanceService}, which keeps the balance-query and
  * summary responsibilities. The methods here run inside the caller's transaction
  * (they are invoked from {@code @Transactional} balance methods), so they carry no
@@ -82,15 +86,27 @@ public class LeaveAccrualService {
             totalAccrued = Math.min(totalAccrued, policy.getAnnualQuota());
         }
 
-        balance.setAccrued(totalAccrued);
+        // A manual adjustment is applied straight to accrued or used and recorded as an
+        // ADJUSTMENT transaction. Recomputing from the accrual ledger and the request rows
+        // alone would drop it, so the same month an adjustment was granted it would silently
+        // disappear the next time a new month rolled over. Folding the adjustments back in
+        // here keeps them, and matches how adjustBalance applies them: a credit raises
+        // accrued, a debit raises used. The annual-quota cap applies to accrual only:
+        // a manual grant above the quota is deliberate.
+        double adjustmentCredits = LeaveDays.round(
+                transactionRepository.sumAdjustmentCredits(balance.getId()));
+        double adjustmentDebits = LeaveDays.round(
+                transactionRepository.sumAdjustmentDebits(balance.getId()));
+
+        balance.setAccrued(LeaveDays.round(totalAccrued + adjustmentCredits));
 
         Double usedDays = requestRepository.sumApprovedDaysByEmployeePolicyYear(
                 employee.getId(), policy.getId(), year);
         Double pendingDays = requestRepository.sumPendingDaysByEmployeePolicyYear(
                 employee.getId(), policy.getId(), year);
 
-        balance.setUsed(usedDays != null ? usedDays : 0.0);
-        balance.setPending(pendingDays != null ? pendingDays : 0.0);
+        balance.setUsed(LeaveDays.round(LeaveDays.round(usedDays) + adjustmentDebits));
+        balance.setPending(LeaveDays.round(pendingDays));
         balance.setLastCalculationMonth(currentMonth);
         balance.setLastCalculatedAt(LocalDateTime.now());
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalance.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalance.java
@@ -20,8 +20,10 @@ import java.util.List;
  *
  * <p>One row per employee/policy/year (enforced by a unique constraint). Available balance is
  * {@code openingBalance + accrued - used}; bookable balance subtracts {@code pending} on top,
- * so a request in flight cannot be double-booked. The last-calculation fields let the accrual
- * service skip recomputation until a new month rolls over.
+ * so a request in flight cannot be double-booked. Both are rounded through {@link LeaveDays},
+ * because a monthly accrual of {@code annualQuota / 12} does not generally divide evenly and
+ * the raw difference would otherwise carry a long floating-point tail. The last-calculation
+ * fields let the accrual service skip recomputation until a new month rolls over.
  */
 @Entity
 @Data
@@ -93,11 +95,11 @@ public class LeaveBalance implements TenantScopedEntity {
 
     @Transient
     public Double getAvailableBalance() {
-        return openingBalance + accrued - used;
+        return LeaveDays.round(openingBalance + accrued - used);
     }
 
     @Transient
     public Double getBookableBalance() {
-        return getAvailableBalance() - pending;
+        return LeaveDays.round(getAvailableBalance() - pending);
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveBalanceService.java
@@ -168,9 +168,14 @@ public class LeaveBalanceService {
         summary.setEmployeeName(employee.getEmployeeName());
         summary.setYear(year);
         summary.setBalances(balances.stream().map(leaveBalanceMapper::toDto).collect(Collectors.toList()));
-        summary.setTotalAvailable(balances.stream().mapToDouble(LeaveBalance::getAvailableBalance).sum());
-        summary.setTotalUsed(balances.stream().mapToDouble(LeaveBalance::getUsed).sum());
-        summary.setTotalPending(balances.stream().mapToDouble(LeaveBalance::getPending).sum());
+        // Rounded again after the sum: adding several rounded figures can still land on a
+        // value the double type cannot hold exactly, and this total goes straight to a screen.
+        summary.setTotalAvailable(LeaveDays.round(
+                balances.stream().mapToDouble(LeaveBalance::getAvailableBalance).sum()));
+        summary.setTotalUsed(LeaveDays.round(
+                balances.stream().mapToDouble(LeaveBalance::getUsed).sum()));
+        summary.setTotalPending(LeaveDays.round(
+                balances.stream().mapToDouble(LeaveBalance::getPending).sum()));
         return summary;
     }
 
@@ -230,12 +235,12 @@ public class LeaveBalanceService {
                 .orElseGet(() -> initializeBalance(employee, policy, year));
 
         double balanceBefore = balance.getAvailableBalance();
-        double balanceAfter = balanceBefore + dto.getDays();
+        double balanceAfter = LeaveDays.round(balanceBefore + dto.getDays());
 
         if (dto.getDays() > 0) {
-            balance.setAccrued(balance.getAccrued() + dto.getDays());
+            balance.setAccrued(LeaveDays.round(balance.getAccrued() + dto.getDays()));
         } else {
-            balance.setUsed(balance.getUsed() + Math.abs(dto.getDays()));
+            balance.setUsed(LeaveDays.round(balance.getUsed() + Math.abs(dto.getDays())));
         }
 
         balance = balanceRepository.save(balance);

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveDays.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveDays.java
@@ -1,0 +1,47 @@
+package org.tornotron.echno_backend.leave;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Rounding for leave-day figures.
+ *
+ * <p>Day counts are held as {@code double}, and a monthly accrual of
+ * {@code annualQuota / 12} rarely divides evenly: a 91-day quota accrued for eight
+ * months produces {@code 60.666666666666664}, which is a binary-floating-point
+ * artefact of a value that is itself recurring. Every figure the balance reports is
+ * therefore rounded to {@link #SCALE} decimal places before it is stored or
+ * returned, so no such artefact reaches the API or the screen.
+ *
+ * <p>Rounding is HALF_UP on the reported figure only. The accrual ledger keeps the
+ * exact monthly amounts, so a year's twelve monthly accruals still add up to the
+ * annual quota.
+ */
+public final class LeaveDays {
+
+    /** Decimal places a reported day figure carries. */
+    public static final int SCALE = 2;
+
+    private LeaveDays() {
+    }
+
+    /**
+     * Rounds a day count to the reported precision.
+     *
+     * @param days The raw day count.
+     * @return The count rounded to {@link #SCALE} decimal places.
+     */
+    public static double round(double days) {
+        return BigDecimal.valueOf(days).setScale(SCALE, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    /**
+     * Rounds a day count that may be absent, treating absence as zero.
+     *
+     * @param days The raw day count, possibly null.
+     * @return The rounded count, or {@code 0.0} when the count is null.
+     */
+    public static double round(Double days) {
+        return days == null ? 0.0 : round(days.doubleValue());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyRepository.java
@@ -19,9 +19,16 @@ public interface LeavePolicyRepository extends JpaRepository<LeavePolicy, Long> 
 
     boolean existsByOrganizationIdAndLeaveTypeCode(Long organizationId, String leaveTypeCode);
 
+    /**
+     * The active policies an employee is eligible for, by gender and length of service.
+     *
+     * <p>The gender comparison is case-insensitive: a policy is configured as {@code FEMALE}
+     * while an employee record holds {@code Female}, and an exact match would quietly make
+     * such a policy apply to nobody.
+     */
     @Query("SELECT lp FROM LeavePolicy lp WHERE lp.organization.id = :orgId " +
            "AND lp.isActive = true " +
-           "AND (lp.applicableGenders = 'ALL' OR lp.applicableGenders = :gender) " +
+           "AND (UPPER(lp.applicableGenders) = 'ALL' OR UPPER(lp.applicableGenders) = UPPER(:gender)) " +
            "AND (lp.minServiceMonths IS NULL OR lp.minServiceMonths <= :serviceMonths) " +
            "ORDER BY lp.displayOrder ASC")
     List<LeavePolicy> findApplicablePolicies(

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveTransactionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveTransactionRepository.java
@@ -48,6 +48,20 @@ public interface LeaveTransactionRepository extends JpaRepository<LeaveTransacti
             @Param("balanceId") Long balanceId,
             @Param("type") TransactionType type);
 
+    /** Total days granted by manual adjustments on this balance, as a positive figure. */
+    @Query("SELECT COALESCE(SUM(CASE WHEN lt.days > 0 THEN lt.days ELSE 0 END), 0) " +
+           "FROM LeaveTransaction lt " +
+           "WHERE lt.leaveBalance.id = :balanceId " +
+           "AND lt.transactionType = org.tornotron.echno_backend.leave.enums.TransactionType.ADJUSTMENT")
+    Double sumAdjustmentCredits(@Param("balanceId") Long balanceId);
+
+    /** Total days taken back by manual adjustments on this balance, as a positive figure. */
+    @Query("SELECT COALESCE(SUM(CASE WHEN lt.days < 0 THEN -lt.days ELSE 0 END), 0) " +
+           "FROM LeaveTransaction lt " +
+           "WHERE lt.leaveBalance.id = :balanceId " +
+           "AND lt.transactionType = org.tornotron.echno_backend.leave.enums.TransactionType.ADJUSTMENT")
+    Double sumAdjustmentDebits(@Param("balanceId") Long balanceId);
+
     boolean existsByLeaveBalanceIdAndTransactionTypeAndReferenceMonthAndReferenceYear(
             Long balanceId, TransactionType type, Integer month, Integer year);
 }

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveAccrualServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveAccrualServiceTest.java
@@ -293,6 +293,83 @@ class LeaveAccrualServiceTest {
         assertThat(balance.getPending()).isEqualTo(1.5);
     }
 
+    @Test
+    void recalculate_quotaThatDoesNotDivideByTwelve_isReportedRounded() {
+        // Joined in May, so months 5..12 of the past year accrue: eight twelfths of a
+        // 91-day quota. That is 60.666666666666664 as a double, which is what reached the
+        // My Leaves screen.
+        Employee employee = employee(LocalDateTime.of(PAST_YEAR, 5, 4, 0, 0));
+        LeaveBalance balance = balance(employee, policy(null, 91.0), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+
+        service.recalculate(balance);
+
+        assertThat(balance.getAccrued()).isEqualTo(60.67);
+        verify(transactionRepository, times(8)).save(any(LeaveTransaction.class));
+    }
+
+    @Test
+    void recalculate_manualCredit_survivesTheRecalculation() {
+        // A manual adjustment is applied to the balance and recorded as an ADJUSTMENT
+        // transaction. Rebuilding accrued from the accrual ledger alone used to drop it the
+        // first time a new month rolled over.
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(transactionRepository.sumAdjustmentCredits(BALANCE_ID)).thenReturn(3.0);
+
+        service.recalculate(balance);
+
+        // 12 months x 1.0 accrued, plus the 3 days granted by hand
+        assertThat(balance.getAccrued()).isEqualTo(15.0);
+    }
+
+    @Test
+    void recalculate_manualDebit_survivesTheRecalculation() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(requestRepository.sumApprovedDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(4.0);
+        when(transactionRepository.sumAdjustmentDebits(BALANCE_ID)).thenReturn(2.5);
+
+        service.recalculate(balance);
+
+        // 4 days of approved leave plus the 2.5 days taken back by hand
+        assertThat(balance.getUsed()).isEqualTo(6.5);
+    }
+
+    @Test
+    void recalculate_manualCredit_isNotCappedByTheAnnualQuota() {
+        // The cap belongs to accrual. A grant above the quota is a deliberate act.
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(5.0, 20.0), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(transactionRepository.sumAdjustmentCredits(BALANCE_ID)).thenReturn(4.0);
+
+        service.recalculate(balance);
+
+        assertThat(balance.getAccrued()).isEqualTo(24.0);
+    }
+
+    @Test
+    void recalculate_halfDaysUsedAndPending_areCarriedExactly() {
+        Employee employee = employee(LocalDateTime.of(2018, 1, 1, 0, 0));
+        LeaveBalance balance = balance(employee, policy(1.0, null), PAST_YEAR);
+        stubNoPriorAccrualsNoAttendance();
+        when(requestRepository.sumApprovedDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(3.5);
+        when(requestRepository.sumPendingDaysByEmployeePolicyYear(anyLong(), anyLong(), anyInt()))
+                .thenReturn(0.5);
+
+        service.recalculate(balance);
+
+        assertThat(balance.getUsed()).isEqualTo(3.5);
+        assertThat(balance.getPending()).isEqualTo(0.5);
+        assertThat(balance.getAvailableBalance()).isEqualTo(8.5);
+        assertThat(balance.getBookableBalance()).isEqualTo(8.0);
+    }
+
     private Attendance attendanceWith(AttendanceStatus status) {
         return Attendance.builder().status(status).build();
     }

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveBalanceTest.java
@@ -1,0 +1,55 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the two derived figures on {@link LeaveBalance}: available
+ * (opening + accrued - used) and bookable (available - pending). The cases cover the
+ * half-day arithmetic these figures have to survive, and the recurring accrual that
+ * put a sixteen-digit number on the My Leaves screen.
+ */
+class LeaveBalanceTest {
+
+    private LeaveBalance balance(double opening, double accrued, double used, double pending) {
+        LeaveBalance balance = new LeaveBalance();
+        balance.setOpeningBalance(opening);
+        balance.setAccrued(accrued);
+        balance.setUsed(used);
+        balance.setPending(pending);
+        return balance;
+    }
+
+    @Test
+    void availableBalance_isOpeningPlusAccruedMinusUsed() {
+        assertThat(balance(2.0, 9.0, 3.0, 0.0).getAvailableBalance()).isEqualTo(8.0);
+    }
+
+    @Test
+    void availableBalance_carriesHalfDaysExactly() {
+        // Three and a half days taken out of ten leaves six and a half.
+        assertThat(balance(0.0, 10.0, 3.5, 0.0).getAvailableBalance()).isEqualTo(6.5);
+    }
+
+    @Test
+    void availableBalance_recurringAccrualMinusAHalfDay_hasNoFloatingPointTail() {
+        // Eight months of a 91-day quota, less one half-day taken.
+        LeaveBalance balance = balance(0.0, 91.0 / 12.0 * 8, 0.5, 0.0);
+
+        assertThat(balance.getAvailableBalance()).isEqualTo(60.17);
+    }
+
+    @Test
+    void bookableBalance_subtractsPending() {
+        assertThat(balance(0.0, 10.0, 2.0, 1.5).getBookableBalance()).isEqualTo(6.5);
+    }
+
+    @Test
+    void bookableBalance_withAHalfDayPendingOnARecurringAccrual_hasNoFloatingPointTail() {
+        LeaveBalance balance = balance(0.0, 91.0 / 12.0 * 8, 0.0, 0.5);
+
+        assertThat(balance.getAvailableBalance()).isEqualTo(60.67);
+        assertThat(balance.getBookableBalance()).isEqualTo(60.17);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveDaysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveDaysTest.java
@@ -1,0 +1,59 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link LeaveDays}. The cases are the ones that reached a screen:
+ * a quota that does not divide by twelve, a sum of half-days, and the difference of
+ * two rounded figures.
+ */
+class LeaveDaysTest {
+
+    @Test
+    void round_recurringMonthlyAccrual_losesTheFloatingPointTail() {
+        // Eight months of a 91-day annual quota, the figure that reached the My Leaves screen.
+        double eightMonthsOfNinetyOne = 91.0 / 12.0 * 8;
+
+        assertThat(eightMonthsOfNinetyOne).isNotEqualTo(60.67);
+        assertThat(LeaveDays.round(eightMonthsOfNinetyOne)).isEqualTo(60.67);
+    }
+
+    @Test
+    void round_halfDayFigures_areUntouched() {
+        assertThat(LeaveDays.round(0.5)).isEqualTo(0.5);
+        assertThat(LeaveDays.round(10.5)).isEqualTo(10.5);
+        assertThat(LeaveDays.round(0.0)).isEqualTo(0.0);
+    }
+
+    @Test
+    void round_wholeDays_stayWhole() {
+        assertThat(LeaveDays.round(12.0)).isEqualTo(12.0);
+        assertThat(LeaveDays.round(91.0)).isEqualTo(91.0);
+    }
+
+    @Test
+    void round_isHalfUp() {
+        assertThat(LeaveDays.round(1.005)).isEqualTo(1.01);
+        assertThat(LeaveDays.round(1.004)).isEqualTo(1.0);
+    }
+
+    @Test
+    void round_negativeFigures_roundAwayFromZeroOnTheHalf() {
+        assertThat(LeaveDays.round(-0.005)).isEqualTo(-0.01);
+        assertThat(LeaveDays.round(-2.5)).isEqualTo(-2.5);
+    }
+
+    @Test
+    void round_absentFigure_isZero() {
+        assertThat(LeaveDays.round((Double) null)).isEqualTo(0.0);
+    }
+
+    @Test
+    void round_boxedFigure_isRoundedLikeThePrimitive() {
+        Double raw = 60.666666666666664;
+
+        assertThat(LeaveDays.round(raw)).isEqualTo(60.67);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyEligibilityIT.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeavePolicyEligibilityIT.java
@@ -1,0 +1,124 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the eligibility query on {@link LeavePolicyRepository}, run against
+ * a real CockroachDB (see {@link AbstractIntegrationTest}).
+ *
+ * <p>Employee records hold a gender in title case ("Female"), because that is what the
+ * registration form writes, while a leave policy is configured with a code-style value
+ * ("FEMALE"). An exact string comparison therefore matched neither way round, so a policy
+ * restricted to one gender applied to nobody and every policy had to be left as ALL,
+ * which is why every employee was offered maternity leave. These tests pin the comparison as
+ * case-insensitive, and cover the service-months gate alongside it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LeavePolicyEligibilityIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private LeavePolicyRepository policyRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findApplicablePolicies_matchesGenderRegardlessOfCase() {
+        Organization org = persistOrganization("Eligibility Case Org");
+        persistPolicy(org, "CL", "Casual Leave", "ALL", 0);
+        persistPolicy(org, "ML", "Maternity Leave", "FEMALE", 0);
+        em.flush();
+        em.clear();
+
+        List<LeavePolicy> forFemale = policyRepository.findApplicablePolicies(org.getId(), "Female", 24);
+
+        assertThat(forFemale).extracting(LeavePolicy::getLeaveTypeCode)
+                .containsExactlyInAnyOrder("CL", "ML");
+    }
+
+    @Test
+    void findApplicablePolicies_excludesAPolicyForAnotherGender() {
+        Organization org = persistOrganization("Eligibility Exclusion Org");
+        persistPolicy(org, "CL", "Casual Leave", "ALL", 0);
+        persistPolicy(org, "ML", "Maternity Leave", "FEMALE", 0);
+        em.flush();
+        em.clear();
+
+        List<LeavePolicy> forMale = policyRepository.findApplicablePolicies(org.getId(), "Male", 24);
+
+        assertThat(forMale).extracting(LeavePolicy::getLeaveTypeCode).containsExactly("CL");
+    }
+
+    @Test
+    void findApplicablePolicies_withoutAGender_stillOffersThePoliciesOpenToEveryone() {
+        Organization org = persistOrganization("Eligibility Null Gender Org");
+        persistPolicy(org, "CL", "Casual Leave", "ALL", 0);
+        persistPolicy(org, "ML", "Maternity Leave", "FEMALE", 0);
+        em.flush();
+        em.clear();
+
+        List<LeavePolicy> forUnknown = policyRepository.findApplicablePolicies(org.getId(), null, 24);
+
+        assertThat(forUnknown).extracting(LeavePolicy::getLeaveTypeCode).containsExactly("CL");
+    }
+
+    @Test
+    void findApplicablePolicies_withholdsAPolicyUntilTheServiceMonthsAreMet() {
+        Organization org = persistOrganization("Eligibility Service Org");
+        persistPolicy(org, "CL", "Casual Leave", "ALL", 0);
+        persistPolicy(org, "EL", "Earned Leave", "ALL", 12);
+        em.flush();
+        em.clear();
+
+        assertThat(policyRepository.findApplicablePolicies(org.getId(), "Male", 6))
+                .extracting(LeavePolicy::getLeaveTypeCode).containsExactly("CL");
+        assertThat(policyRepository.findApplicablePolicies(org.getId(), "Male", 18))
+                .extracting(LeavePolicy::getLeaveTypeCode).containsExactlyInAnyOrder("CL", "EL");
+    }
+
+    @Test
+    void findApplicablePolicies_leavesAnInactivePolicyOut() {
+        Organization org = persistOrganization("Eligibility Inactive Org");
+        LeavePolicy retired = persistPolicy(org, "SL", "Sick Leave", "ALL", 0);
+        retired.setIsActive(false);
+        em.flush();
+        em.clear();
+
+        assertThat(policyRepository.findApplicablePolicies(org.getId(), "Male", 24)).isEmpty();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private LeavePolicy persistPolicy(
+            Organization org, String code, String name, String genders, int minServiceMonths) {
+        LeavePolicy policy = new LeavePolicy();
+        policy.setOrganization(org);
+        policy.setLeaveTypeCode(code);
+        policy.setLeaveTypeName(name);
+        policy.setAnnualQuota(12.0);
+        policy.setApplicableGenders(genders);
+        policy.setMinServiceMonths(minServiceMonths);
+        policy.setIsActive(true);
+        em.persist(policy);
+        return policy;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestValidatorDaysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestValidatorDaysTest.java
@@ -1,0 +1,154 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.leave.enums.HalfDayType;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link LeaveRequestValidator#calculateTotalDays}, the arithmetic that
+ * decides how many days a leave request costs. Neither collaborator is touched by it, so
+ * both are mocked and never stubbed.
+ *
+ * <p>The rule being pinned: a request that starts on the second half of its first day, or
+ * ends on the first half of its last day, gives half a day back. A first half on the first
+ * day, or a second half on the last, describes a leave with a gap in the middle and is
+ * ignored, which is why the apply form does not offer those combinations.
+ *
+ * <p>The count is of <em>calendar</em> days. A leave spanning a weekend or a public holiday
+ * costs those days too; nothing here consults a working-day calendar. That is the behaviour
+ * as built, and the weekend cases below record it deliberately rather than by omission.
+ */
+@ExtendWith(MockitoExtension.class)
+class LeaveRequestValidatorDaysTest {
+
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveBalanceService balanceService;
+
+    private LeaveRequestValidator validator;
+
+    // 2026-08-24 is a Monday, so the week runs Mon 24 ... Fri 28, Sat 29, Sun 30.
+    private static final LocalDate MONDAY = LocalDate.of(2026, 8, 24);
+    private static final LocalDate TUESDAY = LocalDate.of(2026, 8, 25);
+    private static final LocalDate FRIDAY = LocalDate.of(2026, 8, 28);
+    private static final LocalDate NEXT_MONDAY = LocalDate.of(2026, 8, 31);
+
+    @BeforeEach
+    void setUp() {
+        validator = new LeaveRequestValidator(requestRepository, balanceService);
+    }
+
+    private double days(LocalDate start, HalfDayType startType, LocalDate end, HalfDayType endType) {
+        return validator.calculateTotalDays(start, startType, end, endType);
+    }
+
+    // --- a period that starts and ends on the same day -----------------------
+
+    @Test
+    void oneDay_withNoHalfChosen_isAWholeDay() {
+        assertThat(days(MONDAY, null, MONDAY, null)).isEqualTo(1.0);
+        assertThat(days(MONDAY, HalfDayType.FULL_DAY, MONDAY, HalfDayType.FULL_DAY))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void oneDay_firstHalf_isHalfADay() {
+        assertThat(days(MONDAY, HalfDayType.FIRST_HALF, MONDAY, HalfDayType.FIRST_HALF))
+                .isEqualTo(0.5);
+    }
+
+    @Test
+    void oneDay_secondHalf_isHalfADay() {
+        assertThat(days(MONDAY, HalfDayType.SECOND_HALF, MONDAY, HalfDayType.SECOND_HALF))
+                .isEqualTo(0.5);
+    }
+
+    @Test
+    void oneDay_withAHalfOnOnlyOneEnd_isStillHalfADay() {
+        assertThat(days(MONDAY, HalfDayType.FIRST_HALF, MONDAY, null)).isEqualTo(0.5);
+        assertThat(days(MONDAY, null, MONDAY, HalfDayType.SECOND_HALF)).isEqualTo(0.5);
+    }
+
+    @Test
+    void oneDay_withOppositeHalvesOnEachEnd_isHalfADayNotAWholeOne() {
+        // The combination the apply form used to allow on a single date: second half as the
+        // first day, first half as the last. It is one date, so it can only be half a
+        // day, never the whole day it read as on screen.
+        assertThat(days(MONDAY, HalfDayType.SECOND_HALF, MONDAY, HalfDayType.FIRST_HALF))
+                .isEqualTo(0.5);
+    }
+
+    // --- a period across several days ---------------------------------------
+
+    @Test
+    void twoWholeDays_countTwo() {
+        assertThat(days(MONDAY, null, TUESDAY, null)).isEqualTo(2.0);
+    }
+
+    @Test
+    void startingAtMidday_givesBackHalfTheFirstDay() {
+        assertThat(days(MONDAY, HalfDayType.SECOND_HALF, TUESDAY, null)).isEqualTo(1.5);
+    }
+
+    @Test
+    void endingAtMidday_givesBackHalfTheLastDay() {
+        assertThat(days(MONDAY, null, TUESDAY, HalfDayType.FIRST_HALF)).isEqualTo(1.5);
+    }
+
+    @Test
+    void aHalfDayAtEachEndOfThePeriod_givesBackAWholeDay() {
+        assertThat(days(MONDAY, HalfDayType.SECOND_HALF, TUESDAY, HalfDayType.FIRST_HALF))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void aHalfOnTheWrongEndOfThePeriod_changesNothing() {
+        // Leaving on the morning of the first day, or returning on the afternoon of the
+        // last, describes a leave with a hole in the middle. The total ignores it, which is
+        // why the apply form does not offer these two.
+        assertThat(days(MONDAY, HalfDayType.FIRST_HALF, TUESDAY, null)).isEqualTo(2.0);
+        assertThat(days(MONDAY, null, TUESDAY, HalfDayType.SECOND_HALF)).isEqualTo(2.0);
+    }
+
+    @Test
+    void halfDaysOnEitherSideOfAWeekend_stillCountTheWeekend() {
+        // Friday afternoon through Monday morning. Four calendar days, less a half at each
+        // end, is three: the Saturday and the Sunday are charged to the balance. Whether
+        // that is the intended policy is a question for the organization, not the code.
+        // It is recorded here so that changing it is a deliberate act.
+        assertThat(days(FRIDAY, HalfDayType.SECOND_HALF, NEXT_MONDAY, HalfDayType.FIRST_HALF))
+                .isEqualTo(3.0);
+    }
+
+    @Test
+    void aPeriodSpanningAWeekend_countsCalendarDays() {
+        assertThat(days(FRIDAY, null, NEXT_MONDAY, null)).isEqualTo(4.0);
+    }
+
+    @Test
+    void aFullWorkingWeek_countsFiveDays() {
+        assertThat(days(MONDAY, null, FRIDAY, null)).isEqualTo(5.0);
+    }
+
+    @Test
+    void aFullWorkingWeekStartingAtMidday_countsFourAndAHalf() {
+        assertThat(days(MONDAY, HalfDayType.SECOND_HALF, FRIDAY, null)).isEqualTo(4.5);
+    }
+
+    // --- a period that cannot exist ------------------------------------------
+
+    @Test
+    void aPeriodThatEndsBeforeItStarts_isRefused() {
+        assertThatThrownBy(() -> days(TUESDAY, null, MONDAY, null))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("cannot be after end date");
+    }
+}


### PR DESCRIPTION
Closes the balance-arithmetic half of ClickUp [86d45vcge](https://app.clickup.com/t/86d45vcge) and [86d45vbv2](https://app.clickup.com/t/86d45vbv2). The display half is [echno-web#352](https://github.com/tornotron/echno-web/pull/352).

## What was wrong

**The sixteen-digit balance.** My Leaves showed `90.66666666666666` days available and `60.666666666666664` of maternity leave. Both figures are arithmetically real: a monthly accrual is `annualQuota / 12`, and a 91-day quota accrued for eight months is two thirds of 91, which neither decimal notation nor a `double` can hold exactly. Nothing rounded it before it left the API.

Every day figure the balance reports now goes through `LeaveDays.round` (two places, HALF_UP). The accrual ledger keeps the exact monthly amounts, so twelve months still add up to the annual quota; only the reported figure is rounded, and half days are untouched.

**Manual adjustments were silently erased.** `LeaveBalanceService.adjustBalance` applies an adjustment straight to `accrued` or `used` and records an `ADJUSTMENT` transaction. `LeaveAccrualService.recalculate` then rebuilt those two figures from the accrual ledger and the request rows alone, so the first time a new month rolled over every adjustment an administrator had made disappeared. The recalculation now folds the adjustments back in. The annual-quota cap stays on accrual only, so a deliberate grant above the quota survives.

**The eligibility gate matched nobody.** `findApplicablePolicies` compared an employee's gender to a policy's `applicableGenders` exactly. Employee records hold `Female` (what the registration form writes) while a policy is configured `FEMALE`, so any policy restricted to one gender applied to no one, and every policy had to be left as `ALL`. That is why maternity leave appears on every employee's balance. The comparison now ignores case. The web PR adds the form fields that make it settable.

## Tests

`calculateTotalDays`, the arithmetic that decides how many days a request costs, had **no tests at all**. `LeaveRequestValidatorDaysTest` covers it: a period that starts and ends on the same day (including the opposite-halves combination from Anand's screenshot, which returns 0.5 and never a whole day), a half day at each end of a multi-day period, a half on the end that changes nothing, and half days either side of a weekend.

That last one records that the count is of **calendar** days: Friday afternoon to Monday morning costs 3 days, with the Saturday and Sunday charged to the balance. Whether it should is a question for the organization, not the code, so it is pinned rather than changed. Raised on the ClickUp ticket.

Every other new test was confirmed to fail against `development` before the fix and pass after:

| Test | Fails without |
|---|---|
| `recalculate_quotaThatDoesNotDivideByTwelve_isReportedRounded` | rounding |
| `availableBalance_recurringAccrualMinusAHalfDay_hasNoFloatingPointTail` | rounding |
| `bookableBalance_withAHalfDayPendingOnARecurringAccrual_hasNoFloatingPointTail` | rounding |
| `recalculate_manualCredit_survivesTheRecalculation` | adjustment fold-in |
| `recalculate_manualDebit_survivesTheRecalculation` | adjustment fold-in |
| `recalculate_manualCredit_isNotCappedByTheAnnualQuota` | adjustment fold-in |
| `findApplicablePolicies_matchesGenderRegardlessOfCase` | case-insensitive match |

64 tests in `org.tornotron.echno_backend.leave.*` pass, including the new CockroachDB integration test. `openApiSnapshot` passes unchanged: no controller or DTO was touched, so `docs/openapi.json` needs no regeneration. No schema change, so no changelog entry.