### PR TITLE
Prove actuator moves cleanly onto its own management port

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,8 +13,9 @@ regexTarget = "match"
 regexes = ['''keycloak-db:5432/keycloak''']
 
 [[allowlists]]
-description = "Full-context redis boot ITs, one against a reachable redis and one against an unreachable one. Their @SpringBootTest properties are dummy stand-ins for the deployment environment (object store, keycloak, encryption key) so the context can start; none are real credentials."
+description = "Full-context boot ITs: two redis ones (reachable and unreachable) and the management-port split. All three carry the same block of @SpringBootTest properties, which are dummy stand-ins for the deployment environment (object store, keycloak, encryption key) so the context can start; none are real credentials."
 paths = [
   '''src/test/java/org/tornotron/echno_backend/common/configuration/RedisFullContextBootIT\.java''',
   '''src/test/java/org/tornotron/echno_backend/common/configuration/RedisUnreachableBootIT\.java''',
+  '''src/test/java/org/tornotron/echno_backend/common/configuration/ManagementPortSeparationIT\.java''',
 ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,31 @@ digital-ocean:
 encryption:
   secret-key: ${ENCRYPTION_SECRET_KEY}
 
+# There is deliberately no management.server.port here, and where it is set instead
+# is worth knowing before changing anything under this key.
+#
+# /actuator cannot be closed in SecurityConfig: the kubelet readiness, liveness and
+# startup probes and the compose healthcheck all reach it with no credential, so the
+# path is permitAll and any authentication requirement there stops the pods passing
+# their probes. Moving actuator to a second port is what takes it off the public
+# internet instead. The Service and the Ingress publish server.port and nothing else,
+# so a request arriving through the edge has no route to actuator, while a probe
+# addresses the pod by port number and is unaffected. Both IIT Madras stagings set
+# MANAGEMENT_SERVER_PORT=8081; ManagementPortSeparationIT is the guard that the split
+# leaves health and prometheus reachable and leaves nothing behind on server.port.
+#
+# It stays unset here rather than defaulting to server.port for two reasons. This
+# repository and echno-deployment release on separate pipelines, so no single commit
+# can move the application and the probes at the same instant, and a shipped value
+# that differed from server.port would break the healthcheck of every deployment that
+# had not already moved. And the property is not inert when it is set to the same
+# number: Spring Boot compares the configured values to decide whether to start a
+# second web server, and setting it at all splits the ports for anything that moves
+# server.port and leaves this alone, every @SpringBootTest on a random port included
+# (measured: the ports came back different). Unset is the only value that means
+# "whatever server.port is". Each environment opts in with the environment variable,
+# which is plain Spring Boot relaxed binding and needs no entry here to work.
+# See echno-backend#571.
 management:
   endpoint:
     prometheus:

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/ManagementPortSeparationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/ManagementPortSeparationIT.java
@@ -1,0 +1,158 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves that setting {@code management.server.port} to something other than {@code server.port}
+ * moves the whole actuator surface onto the management port and leaves nothing behind on the port
+ * the application serves the API on.
+ *
+ * <p>That split is the only control available for this exposure. {@code /actuator/**} is
+ * {@code permitAll} in {@link SecurityConfig} because the kubelet readiness, liveness and startup
+ * probes and the compose healthcheck all reach it without a credential, so the application cannot
+ * authenticate it, and the k8s ingress controller ships with snippet annotations disabled, so the
+ * ingress cannot 404 it either. What closes it is that the Service and the Ingress publish
+ * {@code server.port} alone: with actuator on a second port, an external request has no route to
+ * it, while a probe addressing the pod by port number still does. See echno-backend#571.
+ *
+ * <p>Two things are asserted, and both matter. That the management port still answers
+ * {@code /actuator/health/liveness} is what says the probes survive the move, which is the way this
+ * change can take a staging down: a pod whose probes point at a port nothing serves fails them
+ * forever and is restarted forever. That the same paths no longer answer on the server port is the
+ * fix itself; without it the change is cosmetic and actuator is still on the routed port.
+ *
+ * <p>The port is 0 here rather than 8081 so the test binds a free one and never collides with
+ * whatever is running on the machine. The deployed environments set the real number through
+ * {@code MANAGEMENT_SERVER_PORT}. {@code application.yml} sets no value at all, because setting one
+ * is what makes Spring Boot start a second web server and unset is the only value that follows
+ * {@code server.port}, so this test is the only place the split is exercised.
+ *
+ * <p>The context is closed after the class because it holds a second web server, which is worth
+ * releasing rather than keeping in the shared context cache for the rest of the run.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "management.server.port=0",
+        // The kubelet probes address /actuator/health/liveness and /actuator/health/readiness, and
+        // those two group endpoints exist only when the health probes are enabled. Spring Boot turns
+        // them on by itself when it detects it is running on Kubernetes, which is why they answer on
+        // the cluster and not in a plain JVM. Enabled here so the test exercises the paths the probes
+        // actually use rather than a shape only this JVM has.
+        "management.endpoint.health.probes.enabled=true",
+        "BACKEND_API_VERSION=v1",
+        "DIGITAL_OCEAN_SPACES_URI=http://localhost:9000",
+        "DIGITAL_OCEAN_SPACES_KEY_ID=test",
+        "DIGITAL_OCEAN_SPACES_KEY_SECRET=test",
+        "DIGITAL_OCEAN_SPACES_BUCKET_NAME=test-bucket",
+        "DIGITAL_OCEAN_SPACES_CDN_ENDPOINT=http://localhost:9000",
+        "ENCRYPTION_SECRET_KEY=0123456789abcdef0123456789abcdef",
+        "KEYCLOAK_BACKEND_ADMIN_EMAIL=admin@test.local",
+        "KEYCLOAK_BACKEND_ADMIN_FIRST_NAME=Test",
+        "KEYCLOAK_BACKEND_ADMIN_LAST_NAME=Admin",
+        "KEYCLOAK_BACKEND_ADMIN_PASSWORD=pw",
+        "KEYCLOAK_BACKEND_ADMIN_USERNAME=admin",
+        "KEYCLOAK_BACKEND_CLIENT=backend",
+        "KEYCLOAK_BACKEND_REDIRECT_URI=http://localhost/*",
+        "KEYCLOAK_BACKEND_REDIRECT_URI_APIDOG=http://localhost/webjars/*",
+        "KEYCLOAK_BACKEND_SECRET=secret",
+        "KEYCLOAK_BACKEND_SERVICE_EMAIL=svc@test.local",
+        "KEYCLOAK_BACKEND_SERVICE_FIRST_NAME=Test",
+        "KEYCLOAK_BACKEND_SERVICE_LAST_NAME=Service",
+        "KEYCLOAK_BACKEND_SERVICE_PASSWORD=pw",
+        "KEYCLOAK_BACKEND_SERVICE_USERNAME=svc",
+        "KEYCLOAK_BACKEND_WEB_ORIGIN=http://localhost",
+        "KEYCLOAK_FRONTEND_CLIENT=frontend",
+        "KEYCLOAK_FRONTEND_REDIRECT_URI=http://localhost/*",
+        "KEYCLOAK_FRONTEND_WEB_ORIGIN=http://localhost",
+        "KEYCLOAK_INITIALIZER_APPLICATION_REALM=echno-realm",
+        "KEYCLOAK_INITIALIZER_CLIENT_ID=admin-cli",
+        "KEYCLOAK_INITIALIZER_MASTER_REALM=master",
+        "KEYCLOAK_INITIALIZER_PASSWORD=pw",
+        "KEYCLOAK_INITIALIZER_URL=http://localhost:0",
+        "KEYCLOAK_INITIALIZER_USERNAME=admin",
+        "SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI=http://localhost:0/realms/echno-realm"
+})
+class ManagementPortSeparationIT extends AbstractIntegrationTest {
+
+    @LocalServerPort
+    int serverPort;
+
+    @LocalManagementPort
+    int managementPort;
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    void managementPortIsNotTheServerPort() {
+        assertThat(managementPort).isNotEqualTo(serverPort);
+    }
+
+    /**
+     * All three paths, because two different consumers use two different ones: the kubelet probes
+     * address the liveness and readiness groups, and the compose healthcheck greps the aggregate
+     * {@code /actuator/health} for UP.
+     */
+    @Test
+    void probesAndHealthcheckStillReachHealthOnTheManagementPort() {
+        for (String path : new String[]{"/actuator/health", "/actuator/health/liveness",
+                "/actuator/health/readiness"}) {
+            ResponseEntity<String> response = rest.getForEntity(managementUrl(path), String.class);
+
+            assertThat(response.getStatusCode()).as("%s", path).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).as("%s", path).contains("UP");
+        }
+    }
+
+    @Test
+    void metricsStillReachPrometheusOnTheManagementPort() {
+        ResponseEntity<String> metrics =
+                rest.getForEntity(managementUrl("/actuator/prometheus"), String.class);
+
+        assertThat(metrics.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(metrics.getBody()).contains("jvm_memory_used_bytes");
+    }
+
+    /**
+     * The status is asserted as "not a success" rather than as one exact code on purpose. Once
+     * actuator has moved, {@code /actuator/**} on the server port matches no handler, and this
+     * application answers an unmatched path under a permitAll prefix with 500 and the body
+     * {@code No static resource actuator/...}: the global handler treats Spring's
+     * {@code NoResourceFoundException} as unexpected rather than mapping it to 404. That is worth
+     * tidying separately, and pinning this test to 500 would make the tidy-up look like a
+     * regression. What this test is for is the security property, which is that no actuator payload
+     * comes back, so the body is checked too and not only the code.
+     */
+    @Test
+    void nothingActuatorAnswersOnTheServerPort() {
+        for (String path : new String[]{"/actuator", "/actuator/health", "/actuator/health/liveness",
+                "/actuator/info", "/actuator/prometheus"}) {
+            ResponseEntity<String> response =
+                    rest.getForEntity("http://localhost:" + serverPort + path, String.class);
+
+            assertThat(response.getStatusCode().is2xxSuccessful())
+                    .as("%s must not succeed on the server port", path)
+                    .isFalse();
+            assertThat(response.getBody())
+                    .as("%s must return no actuator payload on the server port", path)
+                    .doesNotContain("jvm_memory_used_bytes")
+                    .doesNotContain("\"status\":\"UP\"")
+                    .doesNotContain("_links");
+        }
+    }
+
+    private String managementUrl(String path) {
+        return "http://localhost:" + managementPort + path;
+    }
+}


### PR DESCRIPTION
Closes the application half of #571. The deployment half is a separate PR in `echno-deployment`.

## Why nothing is set here

The fix for #571 is `MANAGEMENT_SERVER_PORT`, which moves the whole actuator surface onto a port the k8s Service and Ingress do not publish. That variable is plain Spring Boot relaxed binding, so it needs no entry in `application.yml` to work, and it deliberately does not get one.

Setting the key is not inert even when the number matches `server.port`. Boot compares the configured values to decide whether to start a second web server, so any shipped value splits the ports for anything that moves `server.port` and leaves this alone. Measured, not assumed: with `management.server.port: ${MANAGEMENT_SERVER_PORT:${server.port}}` in place, a `@SpringBootTest(webEnvironment = RANDOM_PORT)` came back with management on 43207 and the server on 38427. Unset is the only value that means "whatever `server.port` is", which is what keeps the shipped default identical to today's behaviour. That matters because this repo and `echno-deployment` release on separate pipelines: a default that differed would break the compose healthcheck of any deployment that had not moved its probes in the same instant, and no single commit can move both.

So what lands here is the comment that records the decision, and the test that makes the mechanism verifiable.

## What the test checks

`ManagementPortSeparationIT` boots the whole application with the ports split (`management.server.port=0`, so it binds a free one) and asserts both halves of the trade:

- on the management port, `/actuator/health`, `/actuator/health/liveness`, `/actuator/health/readiness` and `/actuator/prometheus` all answer 200. That is what says the kubelet probes and the compose healthcheck survive the move, which is the way this change can take a staging down: a pod whose probes point at a port nothing serves fails them forever and is restarted forever.
- on the server port, none of those paths returns a success or any actuator payload. That is the fix; without it the change is cosmetic.

Two things the run turned up that are worth recording:

- the liveness and readiness group endpoints exist only when health probes are enabled, which Boot does by itself when it detects Kubernetes. The test sets `management.endpoint.health.probes.enabled=true` so it exercises the paths the probes actually use rather than a shape only a plain JVM has.
- an unmatched path under a permitAll prefix answers **500**, not 404, with `No static resource actuator/env.` in the body. That is why `/actuator/env` reads 500 in the issue's table. It is the global handler treating `NoResourceFoundException` as unexpected, worth tidying on its own ticket; the test asserts "no success and no actuator payload" rather than one exact code so that tidy-up does not look like a regression.

## Verification

Run on `lab-node-116-f`:

```
./gradlew test --tests '*ManagementPortSeparationIT*'
BUILD SUCCESSFUL - 4 tests, 0 failures
Test heap: 233 MB live of a 2048 MB cap (11% used), 1 context loaded
```

No controller or DTO change, so `docs/openapi.json` is untouched. No Liquibase changelog.

Refs #571