### PR TITLE
Name the people a document's approval stamps point at

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3027,7 +3027,7 @@
             "type": "integer"
           },
           "approvedByName": {
-            "description": "Name of the user that approved the invoice. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never approved.",
+            "description": "Name of the user that approved the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never approved.",
             "example": "Aneesh Johny",
             "type": "string"
           },
@@ -3122,7 +3122,7 @@
             "type": "integer"
           },
           "paymentRecordedByName": {
-            "description": "Name of the user that recorded the most recent payment. Reads \"User #<id>\" when the account has since been deleted; null only when no payment has been recorded.",
+            "description": "Name of the user that recorded the most recent payment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when no payment has been recorded.",
             "example": "Anand Rajashekar",
             "type": "string"
           },
@@ -3189,7 +3189,7 @@
             "type": "integer"
           },
           "submittedByName": {
-            "description": "Name of the user that submitted the invoice. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never submitted.",
+            "description": "Name of the user that submitted the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never submitted.",
             "example": "Anand Rajashekar",
             "type": "string"
           },
@@ -15200,7 +15200,7 @@
             "type": "integer"
           },
           "approvedByName": {
-            "description": "Name of the user who approved the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
+            "description": "Name of the user who approved the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
             "example": "Aneesh Johny",
             "type": "string"
           },
@@ -15286,7 +15286,7 @@
             "type": "integer"
           },
           "processedByName": {
-            "description": "Name of the user who processed the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
+            "description": "Name of the user who processed the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
             "example": "Aneesh Johny",
             "type": "string"
           },
@@ -15314,7 +15314,7 @@
             "type": "integer"
           },
           "rejectedByName": {
-            "description": "Name of the user who rejected the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
+            "description": "Name of the user who rejected the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
             "example": "Aneesh Johny",
             "type": "string"
           },
@@ -15341,7 +15341,7 @@
             "type": "integer"
           },
           "submittedByName": {
-            "description": "Name of the user who submitted the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
+            "description": "Name of the user who submitted the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
             "example": "Anand Rajashekar",
             "type": "string"
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3026,6 +3026,11 @@
             "format": "int64",
             "type": "integer"
           },
+          "approvedByName": {
+            "description": "Name of the user that approved the invoice. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never approved.",
+            "example": "Aneesh Johny",
+            "type": "string"
+          },
           "arInvoiceId": {
             "description": "AR invoice raised for this invoice on approval. Present on a sales or service invoice whose project has a client; null otherwise.",
             "example": "1c9d4b7a-0f2e-4a63-8b11-5d7c2e9f4a88",
@@ -3116,6 +3121,11 @@
             "format": "int64",
             "type": "integer"
           },
+          "paymentRecordedByName": {
+            "description": "Name of the user that recorded the most recent payment. Reads \"User #<id>\" when the account has since been deleted; null only when no payment has been recorded.",
+            "example": "Anand Rajashekar",
+            "type": "string"
+          },
           "paymentStatus": {
             "description": "Settlement status derived from paid and outstanding amounts.",
             "enum": [
@@ -3177,6 +3187,11 @@
             "example": 5,
             "format": "int64",
             "type": "integer"
+          },
+          "submittedByName": {
+            "description": "Name of the user that submitted the invoice. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never submitted.",
+            "example": "Anand Rajashekar",
+            "type": "string"
           },
           "subtotal": {
             "description": "Sum of line amounts before tax and discount.",
@@ -15179,10 +15194,15 @@
             "type": "string"
           },
           "approvedBy": {
-            "description": "Id of the employee who approved the adjustment.",
+            "description": "Id of the user who approved the adjustment.",
             "example": 3,
             "format": "int64",
             "type": "integer"
+          },
+          "approvedByName": {
+            "description": "Name of the user who approved the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
+            "example": "Aneesh Johny",
+            "type": "string"
           },
           "countMethod": {
             "description": "Method used to perform the physical count.",
@@ -15260,10 +15280,15 @@
             "type": "string"
           },
           "processedBy": {
-            "description": "Id of the employee who processed the adjustment.",
+            "description": "Id of the user who processed the adjustment.",
             "example": 3,
             "format": "int64",
             "type": "integer"
+          },
+          "processedByName": {
+            "description": "Name of the user who processed the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
+            "example": "Aneesh Johny",
+            "type": "string"
           },
           "projectId": {
             "description": "Id of the project the adjustment applies to.",
@@ -15283,10 +15308,15 @@
             "type": "string"
           },
           "rejectedBy": {
-            "description": "Id of the employee who rejected the adjustment, if it was rejected.",
+            "description": "Id of the user who rejected the adjustment, if it was rejected.",
             "example": 3,
             "format": "int64",
             "type": "integer"
+          },
+          "rejectedByName": {
+            "description": "Name of the user who rejected the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
+            "example": "Aneesh Johny",
+            "type": "string"
           },
           "rejectionReason": {
             "description": "Reason given for rejecting the adjustment.",
@@ -15305,10 +15335,15 @@
             "type": "string"
           },
           "submittedBy": {
-            "description": "Id of the employee who submitted the adjustment.",
+            "description": "Id of the user who submitted the adjustment.",
             "example": 18,
             "format": "int64",
             "type": "integer"
+          },
+          "submittedByName": {
+            "description": "Name of the user who submitted the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
+            "example": "Anand Rajashekar",
+            "type": "string"
           },
           "totalAdjustmentValue": {
             "description": "Total monetary value of the adjustment across all line items.",

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -88,8 +88,9 @@ public record ConstructionInvoiceDto(
         @Schema(description = "User id that submitted the invoice for approval.", example = "5")
         Long submittedBy,
 
-        @Schema(description = "Name of the user that submitted the invoice. Reads \"User #<id>\" when the "
-                + "account has since been deleted; null only when the invoice was never submitted.",
+        @Schema(description = "Name of the user that submitted the invoice, or their email where the "
+                + "account carries no name. Reads \"User #<id>\" when the account has since been "
+                + "deleted; null only when the invoice was never submitted.",
                 example = "Anand Rajashekar")
         String submittedByName,
 
@@ -99,8 +100,9 @@ public record ConstructionInvoiceDto(
         @Schema(description = "User id that approved the invoice.", example = "2")
         Long approvedBy,
 
-        @Schema(description = "Name of the user that approved the invoice. Reads \"User #<id>\" when the "
-                + "account has since been deleted; null only when the invoice was never approved.",
+        @Schema(description = "Name of the user that approved the invoice, or their email where the "
+                + "account carries no name. Reads \"User #<id>\" when the account has since been "
+                + "deleted; null only when the invoice was never approved.",
                 example = "Aneesh Johny")
         String approvedByName,
 
@@ -110,9 +112,9 @@ public record ConstructionInvoiceDto(
         @Schema(description = "User id that recorded the most recent payment.", example = "5")
         Long paymentRecordedBy,
 
-        @Schema(description = "Name of the user that recorded the most recent payment. Reads "
-                + "\"User #<id>\" when the account has since been deleted; null only when no payment has "
-                + "been recorded.",
+        @Schema(description = "Name of the user that recorded the most recent payment, or their email "
+                + "where the account carries no name. Reads \"User #<id>\" when the account has since "
+                + "been deleted; null only when no payment has been recorded.",
                 example = "Anand Rajashekar")
         String paymentRecordedByName,
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -88,17 +88,33 @@ public record ConstructionInvoiceDto(
         @Schema(description = "User id that submitted the invoice for approval.", example = "5")
         Long submittedBy,
 
+        @Schema(description = "Name of the user that submitted the invoice. Reads \"User #<id>\" when the "
+                + "account has since been deleted; null only when the invoice was never submitted.",
+                example = "Anand Rajashekar")
+        String submittedByName,
+
         @Schema(description = "Timestamp the invoice was submitted.", example = "2026-08-02T09:15:00Z")
         Instant submittedAt,
 
         @Schema(description = "User id that approved the invoice.", example = "2")
         Long approvedBy,
 
+        @Schema(description = "Name of the user that approved the invoice. Reads \"User #<id>\" when the "
+                + "account has since been deleted; null only when the invoice was never approved.",
+                example = "Aneesh Johny")
+        String approvedByName,
+
         @Schema(description = "Timestamp the invoice was approved.", example = "2026-08-03T11:40:00Z")
         Instant approvedAt,
 
         @Schema(description = "User id that recorded the most recent payment.", example = "5")
         Long paymentRecordedBy,
+
+        @Schema(description = "Name of the user that recorded the most recent payment. Reads "
+                + "\"User #<id>\" when the account has since been deleted; null only when no payment has "
+                + "been recorded.",
+                example = "Anand Rajashekar")
+        String paymentRecordedByName,
 
         @Schema(description = "Ledger journal entry posted when the invoice was approved.",
                 example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionInvoiceMapper.java
@@ -1,16 +1,38 @@
 package org.tornotron.echno_backend.finance.construction.mapper;
 
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoiceLine;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceLineDto;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
+/**
+ * Maps {@link ConstructionInvoice} and its lines to their DTOs.
+ *
+ * <p>The invoice records who submitted, approved and paid it as a user id and nothing else, so the
+ * names come from the {@link UserNameLookup} the caller hands in rather than from the invoice.
+ * That is the shape {@code MaterialMapper.toWithStockDto} established and
+ * {@code MapperDatabaseAccessTest} enforces: whatever a mapper cannot reach from the object it was
+ * given, the caller reads once for the whole page and passes in.
+ */
 @Mapper(componentModel = "spring")
 public interface ConstructionInvoiceMapper {
 
-    ConstructionInvoiceDto toDto(ConstructionInvoice invoice);
+    /**
+     * Converts an invoice, taking its stamp names from the supplied lookup.
+     *
+     * @param invoice The invoice to convert.
+     * @param names The names read for every user id on the set of invoices being mapped.
+     * @return The invoice DTO.
+     */
+    @Mapping(target = "submittedByName", expression = "java(names.nameOf(invoice.getSubmittedBy()))")
+    @Mapping(target = "approvedByName", expression = "java(names.nameOf(invoice.getApprovedBy()))")
+    @Mapping(target = "paymentRecordedByName",
+            expression = "java(names.nameOf(invoice.getPaymentRecordedBy()))")
+    ConstructionInvoiceDto toDto(ConstructionInvoice invoice, @Context UserNameLookup names);
 
     @Mapping(source = "costCategory.id", target = "costCategoryId")
     @Mapping(source = "costCategory.name", target = "costCategoryName")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceService.java
@@ -45,12 +45,16 @@ import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * CRUD, list, and the approval + ledger-posting lifecycle for construction invoices.
@@ -92,10 +96,11 @@ public class ConstructionInvoiceService {
     private final CustomerRepository customerRepository;
     private final InvoiceService invoiceService;
     private final SelfApprovalPolicy selfApprovalPolicy;
+    private final UserNameDirectory userNameDirectory;
 
     @Transactional(readOnly = true)
     public ConstructionInvoiceDto findById(UUID id) {
-        return mapper.toDto(invoiceRepo.findByIdWithLines(id)
+        return toDto(invoiceRepo.findByIdWithLines(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Construction invoice with ID " + id + " was not found")));
     }
@@ -106,10 +111,11 @@ public class ConstructionInvoiceService {
                                                 ConstructionInvoiceStatus status,
                                                 ConstructionInvoiceType type,
                                                 Pageable pageable) {
-        return invoiceRepo.findAll(
-                        ConstructionInvoiceSpecifications.withFilters(projectId, vendorId, status, type),
-                        pageable)
-                .map(mapper::toDto);
+        Page<ConstructionInvoice> invoices = invoiceRepo.findAll(
+                ConstructionInvoiceSpecifications.withFilters(projectId, vendorId, status, type),
+                pageable);
+        UserNameLookup names = namesFor(invoices.getContent());
+        return invoices.map(invoice -> mapper.toDto(invoice, names));
     }
 
     @Transactional
@@ -141,7 +147,7 @@ public class ConstructionInvoiceService {
 
         ConstructionInvoice saved = invoiceRepo.save(inv);
         log.info("Created construction invoice {}", saved.getInvoiceNumber());
-        return mapper.toDto(saved);
+        return toDto(saved);
     }
 
     @Transactional
@@ -191,7 +197,7 @@ public class ConstructionInvoiceService {
 
         ConstructionInvoice saved = invoiceRepo.saveAndFlush(inv);
         log.info("Updated construction invoice {}", saved.getInvoiceNumber());
-        return mapper.toDto(saved);
+        return toDto(saved);
     }
 
     /**
@@ -224,12 +230,12 @@ public class ConstructionInvoiceService {
             postAndApprove(inv);
             log.info("Auto-approved construction invoice {} under threshold {} on submit",
                     inv.getInvoiceNumber(), threshold);
-            return mapper.toDto(inv);
+            return toDto(inv);
         }
 
         inv.setStatus(ConstructionInvoiceStatus.PENDING);
         log.info("Submitted construction invoice {} for approval", inv.getInvoiceNumber());
-        return mapper.toDto(inv);
+        return toDto(inv);
     }
 
     /**
@@ -266,7 +272,7 @@ public class ConstructionInvoiceService {
                 ApprovalParty.ofUser(userContextService.getCurrentUserId()),
                 "Construction invoice " + inv.getInvoiceNumber());
         postAndApprove(inv);
-        return mapper.toDto(inv);
+        return toDto(inv);
     }
 
     /**
@@ -482,7 +488,7 @@ public class ConstructionInvoiceService {
 
         inv.setStatus(ConstructionInvoiceStatus.CANCELLED);
         log.info("Cancelled construction invoice {}: {}", inv.getInvoiceNumber(), reason);
-        return mapper.toDto(inv);
+        return toDto(inv);
     }
 
     /**
@@ -518,7 +524,7 @@ public class ConstructionInvoiceService {
 
         log.info("Recorded payment of {} on construction invoice {} (balance {})",
                 payment, inv.getInvoiceNumber(), balance);
-        return mapper.toDto(inv);
+        return toDto(inv);
     }
 
     private ConstructionInvoice requireInvoice(UUID id) {
@@ -598,5 +604,33 @@ public class ConstructionInvoiceService {
         return costCategoryRepository.findScopedById(costCategoryId)
                 .orElseThrow(() -> new InvalidRequestException(
                         "Cost category with ID " + costCategoryId + " was not found"));
+    }
+
+    /**
+     * Converts one invoice, resolving its stamp names first.
+     *
+     * @param invoice The invoice to convert.
+     * @return The invoice DTO, with the submitter, approver and payment recorder named.
+     */
+    private ConstructionInvoiceDto toDto(ConstructionInvoice invoice) {
+        return mapper.toDto(invoice, namesFor(List.of(invoice)));
+    }
+
+    /**
+     * Reads the display names for every stamp on the invoices about to be mapped.
+     *
+     * <p>One call covers a whole page, so the query count does not follow the row count. The
+     * mapper cannot do this for itself: the invoice holds only the user id, and a lookup inside
+     * the conversion would cost a round trip per stamp per row with nothing at the call site to
+     * show it, which is what {@code MapperDatabaseAccessTest} exists to prevent.
+     *
+     * @param invoices The invoices being converted.
+     * @return Their stamp names, with an id that no longer resolves reading as a placeholder.
+     */
+    private UserNameLookup namesFor(Collection<ConstructionInvoice> invoices) {
+        return userNameDirectory.namesFor(invoices.stream()
+                .flatMap(invoice -> Stream.of(invoice.getSubmittedBy(), invoice.getApprovedBy(),
+                        invoice.getPaymentRecordedBy()))
+                .toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -29,11 +29,15 @@ import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Stock-adjustment documents: draft, browse, edit, and post to the stock ledger.
@@ -85,6 +89,7 @@ public class StockAdjustmentService {
     private final InventoryTransactionRepository inventoryTransactionRepository;
     private final UserContextService userContextService;
     private final SelfApprovalPolicy selfApprovalPolicy;
+    private final UserNameDirectory userNameDirectory;
 
     public StockAdjustmentService(StockAdjustmentRepository stockAdjustmentRepository,
                                   StockAdjustmentMapper stockAdjustmentMapper,
@@ -95,7 +100,8 @@ public class StockAdjustmentService {
                                   InventoryService inventoryService,
                                   InventoryTransactionRepository inventoryTransactionRepository,
                                   UserContextService userContextService,
-                                  SelfApprovalPolicy selfApprovalPolicy) {
+                                  SelfApprovalPolicy selfApprovalPolicy,
+                                  UserNameDirectory userNameDirectory) {
         this.stockAdjustmentRepository = stockAdjustmentRepository;
         this.stockAdjustmentMapper = stockAdjustmentMapper;
         this.tenantEntityHelper = tenantEntityHelper;
@@ -106,6 +112,7 @@ public class StockAdjustmentService {
         this.inventoryTransactionRepository = inventoryTransactionRepository;
         this.userContextService = userContextService;
         this.selfApprovalPolicy = selfApprovalPolicy;
+        this.userNameDirectory = userNameDirectory;
     }
 
     /** Status a document carries once its movements are on the ledger. */
@@ -156,7 +163,7 @@ public class StockAdjustmentService {
         stockAdjustment.setSubmittedAt(LocalDateTime.now());
         applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
-        return stockAdjustmentMapper.toDto(saved);
+        return stockAdjustmentMapper.toDto(saved, namesFor(saved));
     }
 
     @Transactional(readOnly = true)
@@ -165,15 +172,16 @@ public class StockAdjustmentService {
                 .findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Stock adjustment with ID " + id + " was not found in this organization"));
-        return stockAdjustmentMapper.toDto(stockAdjustment);
+        return stockAdjustmentMapper.toDto(stockAdjustment, namesFor(stockAdjustment));
     }
 
 
     @Transactional(readOnly = true)
     public Page<StockAdjustmentDto> getAll(int pageNo, int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return stockAdjustmentRepository.findAll(pageable)
-                .map(stockAdjustmentMapper::toDto);
+        Page<StockAdjustment> adjustments = stockAdjustmentRepository.findAll(pageable);
+        UserNameLookup names = namesFor(adjustments.getContent());
+        return adjustments.map(adjustment -> stockAdjustmentMapper.toDto(adjustment, names));
     }
 
     /**
@@ -205,7 +213,7 @@ public class StockAdjustmentService {
         // saveAndFlush before mapping so the freshly inserted line-item ids are populated
         // on the returned DTO (documented gotcha: without the flush the child ids are null).
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
-        return stockAdjustmentMapper.toDto(saved);
+        return stockAdjustmentMapper.toDto(saved, namesFor(saved));
     }
 
     /**
@@ -364,7 +372,7 @@ public class StockAdjustmentService {
         stockAdjustment.setProcessedAt(postedAt);
 
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
-        return stockAdjustmentMapper.toDto(saved);
+        return stockAdjustmentMapper.toDto(saved, namesFor(saved));
     }
 
     /**
@@ -431,7 +439,7 @@ public class StockAdjustmentService {
         stockAdjustment.setRejectionReason(statedReason);
 
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
-        return stockAdjustmentMapper.toDto(saved);
+        return stockAdjustmentMapper.toDto(saved, namesFor(saved));
     }
 
     /**
@@ -624,5 +632,33 @@ public class StockAdjustmentService {
         return materialRepository.findByIdAndOrganization_Id(materialId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Material with ID " + materialId + " was not found in this organization"));
+    }
+
+    /**
+     * Reads the display names for every workflow stamp on the adjustments about to be mapped.
+     *
+     * <p>One call covers a whole page, so the query count does not follow the row count. The
+     * mapper cannot do this for itself: a document holds only the user id, and a lookup inside
+     * the conversion would cost a round trip per stamp per row with nothing at the call site to
+     * show it, which is what {@code MapperDatabaseAccessTest} exists to prevent.
+     *
+     * @param adjustments The adjustments being converted.
+     * @return Their stamp names, with an id that no longer resolves reading as a placeholder.
+     */
+    private UserNameLookup namesFor(Collection<StockAdjustment> adjustments) {
+        return userNameDirectory.namesFor(adjustments.stream()
+                .flatMap(adjustment -> Stream.of(adjustment.getSubmittedBy(), adjustment.getApprovedBy(),
+                        adjustment.getRejectedBy(), adjustment.getProcessedBy()))
+                .toList());
+    }
+
+    /**
+     * Reads the display names for the workflow stamps on one adjustment.
+     *
+     * @param adjustment The adjustment being converted.
+     * @return Its stamp names.
+     */
+    private UserNameLookup namesFor(StockAdjustment adjustment) {
+        return namesFor(List.of(adjustment));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -62,20 +62,32 @@ public class StockAdjustmentDto {
     @Schema(description = "Method used to perform the physical count.", example = "FULL_COUNT")
     private String countMethod;
 
-    @Schema(description = "Id of the employee who submitted the adjustment.", example = "18")
+    @Schema(description = "Id of the user who submitted the adjustment.", example = "18")
     private Long submittedBy;
+
+    @Schema(description = "Name of the user who submitted the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
+            example = "Anand Rajashekar")
+    private String submittedByName;
 
     @Schema(description = "Date and time the adjustment was submitted.", example = "2026-01-15T10:00:00")
     private LocalDateTime submittedAt;
 
-    @Schema(description = "Id of the employee who approved the adjustment.", example = "3")
+    @Schema(description = "Id of the user who approved the adjustment.", example = "3")
     private Long approvedBy;
+
+    @Schema(description = "Name of the user who approved the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
+            example = "Aneesh Johny")
+    private String approvedByName;
 
     @Schema(description = "Date and time the adjustment was approved.", example = "2026-01-16T09:00:00")
     private LocalDateTime approvedAt;
 
-    @Schema(description = "Id of the employee who rejected the adjustment, if it was rejected.", example = "3")
+    @Schema(description = "Id of the user who rejected the adjustment, if it was rejected.", example = "3")
     private Long rejectedBy;
+
+    @Schema(description = "Name of the user who rejected the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
+            example = "Aneesh Johny")
+    private String rejectedByName;
 
     @Schema(description = "Date and time the adjustment was rejected, if it was rejected.", example = "2026-01-16T09:00:00")
     private LocalDateTime rejectedAt;
@@ -83,8 +95,12 @@ public class StockAdjustmentDto {
     @Schema(description = "Reason given for rejecting the adjustment.", example = "Variance not supported by the count sheet")
     private String rejectionReason;
 
-    @Schema(description = "Id of the employee who processed the adjustment.", example = "3")
+    @Schema(description = "Id of the user who processed the adjustment.", example = "3")
     private Long processedBy;
+
+    @Schema(description = "Name of the user who processed the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
+            example = "Aneesh Johny")
+    private String processedByName;
 
     @Schema(description = "Date and time the adjustment was processed.", example = "2026-01-16T11:00:00")
     private LocalDateTime processedAt;

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -65,7 +65,9 @@ public class StockAdjustmentDto {
     @Schema(description = "Id of the user who submitted the adjustment.", example = "18")
     private Long submittedBy;
 
-    @Schema(description = "Name of the user who submitted the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
+    @Schema(description = "Name of the user who submitted the adjustment, or their email where the "
+            + "account carries no name. Reads \"User #<id>\" when the account has since been "
+            + "deleted; null only when the adjustment was never submitted.",
             example = "Anand Rajashekar")
     private String submittedByName;
 
@@ -75,7 +77,9 @@ public class StockAdjustmentDto {
     @Schema(description = "Id of the user who approved the adjustment.", example = "3")
     private Long approvedBy;
 
-    @Schema(description = "Name of the user who approved the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
+    @Schema(description = "Name of the user who approved the adjustment, or their email where the "
+            + "account carries no name. Reads \"User #<id>\" when the account has since been "
+            + "deleted; null only when the adjustment was never approved.",
             example = "Aneesh Johny")
     private String approvedByName;
 
@@ -85,7 +89,9 @@ public class StockAdjustmentDto {
     @Schema(description = "Id of the user who rejected the adjustment, if it was rejected.", example = "3")
     private Long rejectedBy;
 
-    @Schema(description = "Name of the user who rejected the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
+    @Schema(description = "Name of the user who rejected the adjustment, or their email where the "
+            + "account carries no name. Reads \"User #<id>\" when the account has since been "
+            + "deleted; null only when the adjustment was never rejected.",
             example = "Aneesh Johny")
     private String rejectedByName;
 
@@ -98,7 +104,9 @@ public class StockAdjustmentDto {
     @Schema(description = "Id of the user who processed the adjustment.", example = "3")
     private Long processedBy;
 
-    @Schema(description = "Name of the user who processed the adjustment. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
+    @Schema(description = "Name of the user who processed the adjustment, or their email where the "
+            + "account carries no name. Reads \"User #<id>\" when the account has since been "
+            + "deleted; null only when the adjustment was never processed.",
             example = "Aneesh Johny")
     private String processedByName;
 

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/mapper/StockAdjustmentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/mapper/StockAdjustmentMapper.java
@@ -1,25 +1,52 @@
 package org.tornotron.echno_backend.stockAdjustment.mapper;
 
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.stockAdjustment.StockAdjustment;
 import org.tornotron.echno_backend.stockAdjustment.StockAdjustmentLineItem;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemDto;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
 /**
  * Maps {@link StockAdjustment} and its line items to their DTOs. Location, project,
  * organization and material references flatten to id (+ name).
+ *
+ * <p>The workflow stamps flatten the same way, but their names cannot come from the adjustment:
+ * it holds only the user id. They are read from the {@link UserNameLookup} the caller hands in,
+ * which is the shape {@code MaterialMapper.toWithStockDto} established and
+ * {@code MapperDatabaseAccessTest} enforces. Resolving them here instead would cost one query per
+ * stamp per row, and the call site would show nothing.
+ *
+ * <p>{@code physicalCountBy} is deliberately left alone. It is set from the creation payload and
+ * holds an employee id, not a user id, so this lookup would name the wrong person for it. That
+ * confusion is precisely what put a stranger's name against an approval on the web app.
  */
 @Mapper(componentModel = "spring")
 public interface StockAdjustmentMapper {
 
+    /**
+     * Converts an adjustment, taking its workflow stamp names from the supplied lookup.
+     *
+     * @param stockAdjustment The adjustment to convert.
+     * @param names The names read for every user id on the set of adjustments being mapped.
+     * @return The adjustment DTO.
+     */
     @Mapping(source = "location.id", target = "locationId")
     @Mapping(source = "location.locationName", target = "locationName")
     @Mapping(source = "project.id", target = "projectId")
     @Mapping(source = "project.projectName", target = "projectName")
     @Mapping(source = "organization.id", target = "organizationId")
-    StockAdjustmentDto toDto(StockAdjustment stockAdjustment);
+    @Mapping(target = "submittedByName",
+            expression = "java(names.nameOf(stockAdjustment.getSubmittedBy()))")
+    @Mapping(target = "approvedByName",
+            expression = "java(names.nameOf(stockAdjustment.getApprovedBy()))")
+    @Mapping(target = "rejectedByName",
+            expression = "java(names.nameOf(stockAdjustment.getRejectedBy()))")
+    @Mapping(target = "processedByName",
+            expression = "java(names.nameOf(stockAdjustment.getProcessedBy()))")
+    StockAdjustmentDto toDto(StockAdjustment stockAdjustment, @Context UserNameLookup names);
 
     @Mapping(source = "material.id", target = "materialId")
     @Mapping(source = "material.materialName", target = "materialName")

--- a/src/main/java/org/tornotron/echno_backend/user/UserDisplayName.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserDisplayName.java
@@ -1,0 +1,34 @@
+package org.tornotron.echno_backend.user;
+
+/**
+ * The parts of a user row a document needs in order to say who did something.
+ *
+ * <p>A projection rather than the entity: resolving a page of approval stamps wants three columns
+ * and nothing else, and loading {@link User} would drag its attachments and employments behind it
+ * for a string.
+ *
+ * @param id The user's id, the value a document's {@code *By} column holds.
+ * @param name The user's name.
+ * @param email The user's email, used when the name is missing.
+ */
+public record UserDisplayName(Long id, String name, String email) {
+
+    /**
+     * The best name this row can offer.
+     *
+     * <p>{@code name} is non-null in the schema but not guaranteed non-empty, and email is the
+     * only other thing every account has, so it is what a nameless row falls back to rather than
+     * an empty string that would render as a gap on the screen.
+     *
+     * @return The name, or the email when the name is blank, or null when the row has neither.
+     */
+    public String bestEffortName() {
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        if (email != null && !email.isBlank()) {
+            return email;
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/user/UserNameDirectory.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserNameDirectory.java
@@ -1,0 +1,67 @@
+package org.tornotron.echno_backend.user;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Resolves user ids to the names shown against them on a document.
+ *
+ * <p>Its own service rather than a method on {@link UserService} because the two answer different
+ * questions. {@code UserService} manages accounts: it provisions Keycloak identities, stores
+ * attachments and enforces who may read whom. This reads three columns so a screen can print a
+ * name, and every service that maps a document with an approval stamp needs it, so it is kept
+ * small and free of everything those callers would otherwise drag in.
+ *
+ * <p>The read is deliberately not scoped to the caller's tenant. A stamp is only ever reached
+ * through a document the caller has already been authorised to read, and the person who approved
+ * it may since have left the organization; scoping the name would blank exactly the historical
+ * records the stamp exists for. What comes back is a display name and nothing else, which is
+ * already visible to anyone who can read the document.
+ */
+@Service
+public class UserNameDirectory {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Constructs the directory.
+     *
+     * @param userRepository The repository the names are read from.
+     */
+    public UserNameDirectory(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Reads the display names for a whole set of user ids in one query.
+     *
+     * <p>This is what a caller uses before mapping a page. Passing the result down as a MapStruct
+     * {@code @Context} keeps the query count off the row count, which is the shape
+     * {@code MaterialStockLookup} established and {@code MapperDatabaseAccessTest} enforces.
+     *
+     * @param userIds The stamped ids about to be mapped; duplicates and nulls are ignored.
+     * @return A lookup over their names, empty when no ids were given.
+     */
+    @Transactional(readOnly = true)
+    public UserNameLookup namesFor(Collection<Long> userIds) {
+        Set<Long> ids = distinctIds(userIds);
+        if (ids.isEmpty()) {
+            return UserNameLookup.none();
+        }
+        return UserNameLookup.of(userRepository.findDisplayNamesByIdIn(ids));
+    }
+
+    private static Set<Long> distinctIds(Collection<Long> userIds) {
+        if (userIds == null) {
+            return Set.of();
+        }
+        Set<Long> ids = new LinkedHashSet<>();
+        userIds.stream().filter(Objects::nonNull).forEach(ids::add);
+        return ids;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/user/UserNameLookup.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserNameLookup.java
@@ -1,0 +1,109 @@
+package org.tornotron.echno_backend.user;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * The display names for a whole page of user ids, read once and handed to the mapper.
+ *
+ * <p>Documents stamp who did something as a user id: {@code submittedBy}, {@code approvedBy},
+ * {@code rejectedBy}, {@code processedBy}. Nothing in the API turned one back into a name, so the
+ * web app tried the employee lookup, which is keyed by employee id and carries no user id at all.
+ * That missed for most ids and, where an employee id happened to equal a user id, put a different
+ * person's name against an approval. Rendering {@code User #<id>} instead (echno-web#346, #349)
+ * stopped the wrong name but left a number on the screen.
+ *
+ * <p>This is the batched read that resolves them without putting a query in the conversion path.
+ * The rule from #522 is that a mapper converts the object it was handed and asks nobody anything,
+ * enforced by {@code MapperDatabaseAccessTest}: a lookup done per row costs a round trip per row
+ * and the call site shows none of it. So the service collects every user id on the page, resolves
+ * them in one query, and passes the answer down as a MapStruct {@code @Context}, exactly as
+ * {@code MaterialStockLookup} does for stock.
+ *
+ * <p>{@link #nameOf} never returns null for a non-null id. A stamp on a historical document has to
+ * render even when the user row behind it is gone, and an id that resolves to nothing would
+ * otherwise leave a blank cell where an approver's name belongs. The placeholder says plainly that
+ * the account no longer exists rather than implying nobody approved the document.
+ */
+public final class UserNameLookup {
+
+    private static final UserNameLookup EMPTY = new UserNameLookup(Map.of());
+
+    private final Map<Long, String> byUserId;
+
+    private UserNameLookup(Map<Long, String> byUserId) {
+        this.byUserId = byUserId;
+    }
+
+    /**
+     * A lookup holding nothing, so every id falls back to its placeholder.
+     *
+     * <p>For the paths that map a document which carries no stamps yet, and for tests.
+     *
+     * @return The empty lookup.
+     */
+    public static UserNameLookup none() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a lookup from the rows of a batched read.
+     *
+     * @param rows The user rows found, at most one per id. Rows with no usable name are dropped,
+     *             so they read as an unresolved id rather than as a blank.
+     * @return A lookup over those rows.
+     */
+    public static UserNameLookup of(Collection<UserDisplayName> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return EMPTY;
+        }
+        Map<Long, String> names = rows.stream()
+                .filter(row -> row.id() != null && row.bestEffortName() != null)
+                .collect(Collectors.toMap(UserDisplayName::id, UserDisplayName::bestEffortName,
+                        (first, second) -> first));
+        return names.isEmpty() ? EMPTY : new UserNameLookup(names);
+    }
+
+    /**
+     * The name to show against a user id.
+     *
+     * @param userId The stamped user id, which is null where the document was never submitted,
+     *               approved or rejected.
+     * @return The user's name; the placeholder {@code User #<id>} where the id does not resolve,
+     *         which is what a deleted account leaves behind; null only where the id itself is null.
+     */
+    public String nameOf(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+        String name = byUserId.get(userId);
+        return name != null ? name : placeholderFor(userId);
+    }
+
+    /**
+     * What stands in for a user id that no longer resolves to a row.
+     *
+     * @param userId The unresolved user id.
+     * @return The placeholder.
+     */
+    public static String placeholderFor(Long userId) {
+        return "User #" + userId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof UserNameLookup lookup && byUserId.equals(lookup.byUserId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(byUserId);
+    }
+
+    @Override
+    public String toString() {
+        return "UserNameLookup" + byUserId.keySet();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.organization.Organization;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,6 +54,23 @@ public interface UserRepository extends JpaRepository<User,Long> {
             + "WHERE e.organization.id = :organizationId AND e.user.id IN :userIds")
     List<User> findUsersByOrganizationIdAndIdIn(@Param("organizationId") Long organizationId,
                                                 @Param("userIds") List<Long> userIds);
+
+    /**
+     * Reads just enough of the given users to print a name against a document stamp.
+     *
+     * <p>Not scoped to an organization, and not {@code findAllById}. Not scoped because the ids
+     * come from {@code submittedBy} / {@code approvedBy} columns on a document the caller has
+     * already been authorised to read, and the approver may have left the organization since;
+     * scoping would blank the historical records the stamp exists for. Not {@code findAllById}
+     * because that returns whole {@link User} entities, and a page of stamps wants three columns,
+     * not each user's attachments and employments.
+     *
+     * @param userIds The user ids to resolve.
+     * @return One row per id that still exists; ids with no row simply do not come back.
+     */
+    @Query("SELECT new org.tornotron.echno_backend.user.UserDisplayName(u.id, u.name, u.email) "
+            + "FROM User u WHERE u.id IN :userIds")
+    List<UserDisplayName> findDisplayNamesByIdIn(@Param("userIds") Collection<Long> userIds);
 
     /**
      * Finds a user by their name.

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceAutoApprovalIT.java
@@ -60,7 +60,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         JournalPostingService.class, JournalEntryMapperImpl.class, ConstructionPostingProperties.class,
         InvoicePostingProperties.class, UserContextService.class, ChartOfAccountsSeeder.class,
         PostingAccountResolver.class, FinanceSettingsService.class,
-        SelfApprovalPolicy.class, OrganizationSecurityService.class})
+        SelfApprovalPolicy.class, OrganizationSecurityService.class,
+        org.tornotron.echno_backend.user.UserNameDirectory.class})
 class ConstructionInvoiceAutoApprovalIT extends AbstractIntegrationTest {
 
     // Total of the built invoice: 10 * 100 = 1000 subtotal, 18% tax = 180, gross 1180.

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoicePostingIT.java
@@ -79,7 +79,8 @@ import static org.mockito.Mockito.when;
         InvoicePostingProperties.class, ChartOfAccountsSeeder.class,
         org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
         org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class,
-        SelfApprovalPolicy.class, OrganizationSecurityService.class})
+        SelfApprovalPolicy.class, OrganizationSecurityService.class,
+        org.tornotron.echno_backend.user.UserNameDirectory.class})
 class ConstructionInvoicePostingIT extends AbstractIntegrationTest {
 
     private static final long PROJECT_ID = 4001L;

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionInvoiceServiceIT.java
@@ -60,7 +60,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         InvoicePostingProperties.class, UserContextService.class,
         org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver.class,
         org.tornotron.echno_backend.finance.settings.FinanceSettingsService.class,
-        SelfApprovalPolicy.class, OrganizationSecurityService.class})
+        SelfApprovalPolicy.class, OrganizationSecurityService.class,
+        org.tornotron.echno_backend.user.UserNameDirectory.class})
 class ConstructionInvoiceServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/pdf/ConstructionInvoicePdfServiceTest.java
@@ -62,7 +62,7 @@ class ConstructionInvoicePdfServiceTest {
                 null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
                 null,
                 null);
 
@@ -88,7 +88,10 @@ class ConstructionInvoicePdfServiceTest {
                 new BigDecimal("76275.00"), new BigDecimal("40000.00"), new BigDecimal("36275.00"),
                 "Net 30", "BANK_TRANSFER", "29ABCDE1234F1Z5", "CGST_SGST",
                 "Second progress claim for tower B", "Payable within 30 days of receipt.",
-                5L, null, 2L, null, 5L, UUID.randomUUID(), null,
+                5L, "Anand Rajashekar", null,
+                2L, "Aneesh Johny", null,
+                5L, "Anand Rajashekar",
+                UUID.randomUUID(), null,
                 null,
                 List.of(line));
     }

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceArMaterializationTest.java
@@ -35,6 +35,7 @@ import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -68,6 +69,7 @@ class ConstructionInvoiceArMaterializationTest {
     private static final long PROJECT_ID = 41L;
 
     @Mock private ConstructionInvoiceRepository invoiceRepo;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private EntryNumberGenerator numberGen;
     @Mock private ConstructionInvoiceMapper mapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
@@ -95,7 +97,7 @@ class ConstructionInvoiceArMaterializationTest {
         service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
                 journalRepo, postingService, postingAccountResolver, financeSettingsService,
                 projectRepository, userContextService, costCategoryRepository, customerRepository,
-                invoiceService, selfApprovalPolicy);
+                invoiceService, selfApprovalPolicy, userNameDirectory);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceSelfApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceSelfApprovalTest.java
@@ -30,6 +30,7 @@ import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolve
 import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -60,6 +61,7 @@ class ConstructionInvoiceSelfApprovalTest {
     private static final long OTHER_APPROVER = 32L;
 
     @Mock private ConstructionInvoiceRepository invoiceRepo;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private EntryNumberGenerator numberGen;
     @Mock private ConstructionInvoiceMapper mapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
@@ -82,7 +84,7 @@ class ConstructionInvoiceSelfApprovalTest {
         service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
                 journalRepo, postingService, postingAccountResolver, financeSettingsService,
                 projectRepository, userContextService, costCategoryRepository, customerRepository,
-                invoiceService, new SelfApprovalPolicy(orgSecurity));
+                invoiceService, new SelfApprovalPolicy(orgSecurity), userNameDirectory);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionInvoiceStampNameTest.java
@@ -1,0 +1,173 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.budget.repositories.CostCategoryRepository;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionInvoice;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionInvoiceDto;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapper;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionInvoiceMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionInvoiceRepository;
+import org.tornotron.echno_backend.finance.invoice.service.InvoiceService;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.finance.ledger.repositories.JournalEntryRepository;
+import org.tornotron.echno_backend.finance.ledger.service.JournalPostingService;
+import org.tornotron.echno_backend.finance.posting.service.PostingAccountResolver;
+import org.tornotron.echno_backend.finance.settings.FinanceSettingsService;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserDisplayName;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins that a construction invoice comes back naming who submitted, approved and paid it, and
+ * that a page costs one directory read whatever its size.
+ *
+ * <p>The counterpart to {@code StockAdjustmentStampNameTest}: the same stamps, the same fix, and
+ * the same reason the mapper cannot resolve them for itself. The real mapper is used so the test
+ * would catch a name that came from a query inside the conversion rather than from the lookup the
+ * caller passed in.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionInvoiceStampNameTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long SUBMITTER = 31L;
+    private static final long APPROVER = 32L;
+    private static final long DELETED_USER = 33L;
+
+    @Mock private ConstructionInvoiceRepository invoiceRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private JournalEntryRepository journalRepo;
+    @Mock private JournalPostingService postingService;
+    @Mock private PostingAccountResolver postingAccountResolver;
+    @Mock private FinanceSettingsService financeSettingsService;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private CostCategoryRepository costCategoryRepository;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private InvoiceService invoiceService;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private UserNameDirectory userNameDirectory;
+
+    private final ConstructionInvoiceMapper mapper = new ConstructionInvoiceMapperImpl();
+
+    private ConstructionInvoiceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionInvoiceService(invoiceRepo, numberGen, mapper, tenantEntityHelper,
+                journalRepo, postingService, postingAccountResolver, financeSettingsService,
+                projectRepository, userContextService, costCategoryRepository, customerRepository,
+                invoiceService, new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void readingOneInvoice_namesTheSubmitterTheApproverAndThePaymentRecorder() {
+        UUID id = UUID.randomUUID();
+        when(invoiceRepo.findByIdWithLines(id))
+                .thenReturn(Optional.of(invoice(id, SUBMITTER, APPROVER, SUBMITTER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"),
+                new UserDisplayName(APPROVER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        ConstructionInvoiceDto dto = service.findById(id);
+
+        assertThat(dto.submittedByName()).isEqualTo("Anand Rajashekar");
+        assertThat(dto.approvedByName()).isEqualTo("Aneesh Johny");
+        assertThat(dto.paymentRecordedByName()).isEqualTo("Anand Rajashekar");
+    }
+
+    @Test
+    void anUnpaidInvoiceHasNoPaymentRecorderRatherThanAPlaceholder() {
+        UUID id = UUID.randomUUID();
+        when(invoiceRepo.findByIdWithLines(id))
+                .thenReturn(Optional.of(invoice(id, SUBMITTER, null, null)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"))));
+
+        ConstructionInvoiceDto dto = service.findById(id);
+
+        assertThat(dto.approvedByName()).isNull();
+        assertThat(dto.paymentRecordedByName()).isNull();
+    }
+
+    @Test
+    void anApproverWhoseAccountIsGone_stillRendersOnTheInvoice() {
+        UUID id = UUID.randomUUID();
+        when(invoiceRepo.findByIdWithLines(id))
+                .thenReturn(Optional.of(invoice(id, SUBMITTER, DELETED_USER, null)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"))));
+
+        ConstructionInvoiceDto dto = service.findById(id);
+
+        assertThat(dto.approvedByName()).isEqualTo("User #" + DELETED_USER);
+    }
+
+    @Test
+    void listingAPage_readsTheDirectoryOnceForEveryStampOnIt() {
+        List<ConstructionInvoice> page = List.of(
+                invoice(UUID.randomUUID(), SUBMITTER, APPROVER, null),
+                invoice(UUID.randomUUID(), SUBMITTER, APPROVER, SUBMITTER),
+                invoice(UUID.randomUUID(), DELETED_USER, APPROVER, null));
+        when(invoiceRepo.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(page));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"),
+                new UserDisplayName(APPROVER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        List<ConstructionInvoiceDto> dtos =
+                service.findAll(null, null, null, null, Pageable.unpaged()).getContent();
+
+        ArgumentCaptor<Collection<Long>> asked = ArgumentCaptor.captor();
+        verify(userNameDirectory, times(1)).namesFor(asked.capture());
+        assertThat(asked.getValue()).contains(SUBMITTER, APPROVER, DELETED_USER);
+        assertThat(dtos).extracting(ConstructionInvoiceDto::approvedByName)
+                .containsExactly("Aneesh Johny", "Aneesh Johny", "Aneesh Johny");
+        assertThat(dtos.get(2).submittedByName()).isEqualTo("User #" + DELETED_USER);
+    }
+
+    private ConstructionInvoice invoice(UUID id, Long submittedBy, Long approvedBy,
+                                        Long paymentRecordedBy) {
+        ConstructionInvoice invoice = new ConstructionInvoice();
+        invoice.setId(id);
+        invoice.setSubmittedBy(submittedBy);
+        invoice.setApprovedBy(approvedBy);
+        invoice.setPaymentRecordedBy(paymentRecordedBy);
+        return invoice;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionInvoicePdfAuthzTest.java
@@ -90,7 +90,7 @@ class ConstructionInvoicePdfAuthzTest {
                 null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
                 null,
                 List.of());
     }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -26,6 +26,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -66,6 +67,7 @@ class StockAdjustmentApprovalTest {
     private static final Long DRAFTER = 43L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -87,7 +89,7 @@ class StockAdjustmentApprovalTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity));
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
 
         organization = new Organization();
         organization.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDt
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.util.Optional;
 
@@ -47,6 +48,7 @@ class StockAdjustmentCreateStatusTest {
     private static final Long ORG = 100L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -65,7 +67,7 @@ class StockAdjustmentCreateStatusTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity));
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(call -> {
             Organization org = new Organization();
             org.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDt
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -60,6 +61,7 @@ class StockAdjustmentRejectionTest {
     private static final Long DRAFTER = 43L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -79,7 +81,7 @@ class StockAdjustmentRejectionTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                selfApprovalPolicy);
+                selfApprovalPolicy, userNameDirectory);
 
         organization = new Organization();
         organization.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -25,6 +25,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +57,7 @@ class StockAdjustmentServiceTest {
     private static final Long SESSION_USER = 77L;
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -74,7 +76,7 @@ class StockAdjustmentServiceTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity));
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
             Organization org = new Organization();
             org.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentStampNameTest.java
@@ -1,0 +1,154 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapperImpl;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserDisplayName;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins that a stock adjustment comes back naming the people who acted on it, and that a page
+ * costs one directory read however many rows it has.
+ *
+ * <p>The stamps hold user ids. The web app used to resolve them through the employee lookup,
+ * which is keyed by employee id and carries no user id, so it missed for most ids and, where an
+ * employee id happened to equal a user id, put a different person's name against an approval.
+ * echno-web#346 and #349 replaced that with {@code User #<id>}, honest but useless.
+ *
+ * <p>The real mapper is used here rather than a mock, because what is being checked is that the
+ * conversion reads the names out of the lookup it was handed instead of asking for them itself:
+ * a lookup inside the conversion would cost a round trip per stamp per row and the call site
+ * would show nothing, which is the shape {@code MapperDatabaseAccessTest} forbids.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentStampNameTest {
+
+    private static final Long ORG = 100L;
+    private static final Long SUBMITTER = 41L;
+    private static final Long APPROVER = 42L;
+    private static final Long DELETED_USER = 43L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private UserNameDirectory userNameDirectory;
+
+    private final StockAdjustmentMapper mapper = new StockAdjustmentMapperImpl();
+
+    private StockAdjustmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, mapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void readingOneAdjustment_namesTheSubmitterAndTheApprover() {
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(1L, ORG))
+                .thenReturn(Optional.of(adjustment(1L, SUBMITTER, APPROVER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"),
+                new UserDisplayName(APPROVER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        StockAdjustmentDto dto = service.getById(1L);
+
+        assertThat(dto.getSubmittedByName()).isEqualTo("Anand Rajashekar");
+        assertThat(dto.getApprovedByName()).isEqualTo("Aneesh Johny");
+        // approvedBy also stamps processedBy on approval, so the same name lands on both.
+        assertThat(dto.getProcessedByName()).isEqualTo("Aneesh Johny");
+        assertThat(dto.getRejectedByName()).as("a document that was never rejected has no rejector")
+                .isNull();
+    }
+
+    @Test
+    void anApproverWhoseAccountIsGone_stillRendersOnTheDocument() {
+        when(stockAdjustmentRepository.findByIdAndOrganization_Id(1L, ORG))
+                .thenReturn(Optional.of(adjustment(1L, SUBMITTER, DELETED_USER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"))));
+
+        StockAdjustmentDto dto = service.getById(1L);
+
+        assertThat(dto.getApprovedBy()).isEqualTo(DELETED_USER);
+        assertThat(dto.getApprovedByName()).isEqualTo("User #" + DELETED_USER);
+    }
+
+    @Test
+    void listingAPage_readsTheDirectoryOnceForEveryStampOnIt() {
+        List<StockAdjustment> page = List.of(
+                adjustment(1L, SUBMITTER, APPROVER),
+                adjustment(2L, SUBMITTER, APPROVER),
+                adjustment(3L, DELETED_USER, APPROVER));
+        when(stockAdjustmentRepository.findAll(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(page));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(SUBMITTER, "Anand Rajashekar", "anand@echno.test"),
+                new UserDisplayName(APPROVER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        List<StockAdjustmentDto> dtos = service.getAll(0, 20).getContent();
+
+        ArgumentCaptor<Collection<Long>> asked = ArgumentCaptor.captor();
+        verify(userNameDirectory, times(1)).namesFor(asked.capture());
+        assertThat(asked.getValue())
+                .as("every stamp on the page goes in one request, ids repeated across rows included")
+                .contains(SUBMITTER, APPROVER, DELETED_USER);
+        assertThat(dtos).extracting(StockAdjustmentDto::getApprovedByName)
+                .containsExactly("Aneesh Johny", "Aneesh Johny", "Aneesh Johny");
+        assertThat(dtos.get(2).getSubmittedByName()).isEqualTo("User #" + DELETED_USER);
+    }
+
+    private StockAdjustment adjustment(Long id, Long submittedBy, Long approvedBy) {
+        StockAdjustment adjustment = new StockAdjustment();
+        adjustment.setId(id);
+        adjustment.setSubmittedBy(submittedBy);
+        adjustment.setApprovedBy(approvedBy);
+        adjustment.setProcessedBy(approvedBy);
+        return adjustment;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/user/UserNameLookupTest.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserNameLookupTest.java
@@ -1,0 +1,77 @@
+package org.tornotron.echno_backend.user;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a name means when a document says who approved it.
+ *
+ * <p>The answer has to hold in three awkward cases and not just the ordinary one: an account with
+ * no employee record behind it, an account whose name column is empty, and an account that has
+ * since been deleted while the document it stamped is still on the screen. None of them may
+ * produce a blank cell, because a blank against an approval reads as nobody having approved it.
+ */
+class UserNameLookupTest {
+
+    @Test
+    void resolvesAnIdToTheUsersName() {
+        UserNameLookup names = UserNameLookup.of(
+                List.of(new UserDisplayName(7L, "Aneesh Johny", "aneesh@echno.test")));
+
+        assertThat(names.nameOf(7L)).isEqualTo("Aneesh Johny");
+    }
+
+    @Test
+    void fallsBackToTheEmailWhenTheNameIsEmpty() {
+        // name is non-null in the schema but not guaranteed non-empty, and email is the only
+        // other thing every account has.
+        UserNameLookup names = UserNameLookup.of(
+                List.of(new UserDisplayName(7L, "   ", "aneesh@echno.test")));
+
+        assertThat(names.nameOf(7L)).isEqualTo("aneesh@echno.test");
+    }
+
+    @Test
+    void readsAsAPlaceholderWhenTheAccountIsGone() {
+        // A deleted user still has to render on the historical document it stamped. The
+        // placeholder says the account no longer exists; a blank would say nobody approved it.
+        UserNameLookup names = UserNameLookup.of(
+                List.of(new UserDisplayName(7L, "Aneesh Johny", "aneesh@echno.test")));
+
+        assertThat(names.nameOf(404L)).isEqualTo("User #404");
+    }
+
+    @Test
+    void readsAsAPlaceholderWhenNothingWasResolvedAtAll() {
+        assertThat(UserNameLookup.none().nameOf(9L)).isEqualTo("User #9");
+    }
+
+    @Test
+    void isNullOnlyWhenTheStampItselfIsNull() {
+        // An unapproved document has no approver, which is a different thing from an approver
+        // whose account is gone, and the two must not render the same.
+        UserNameLookup names = UserNameLookup.of(
+                List.of(new UserDisplayName(7L, "Aneesh Johny", "aneesh@echno.test")));
+
+        assertThat(names.nameOf(null)).isNull();
+    }
+
+    @Test
+    void aRowWithNeitherNameNorEmailReadsAsThePlaceholder() {
+        UserNameLookup names = UserNameLookup.of(List.of(new UserDisplayName(7L, "", null)));
+
+        assertThat(names.nameOf(7L)).isEqualTo("User #7");
+    }
+
+    @Test
+    void toleratesDuplicateRowsForTheSameId() {
+        UserNameLookup names = UserNameLookup.of(List.of(
+                new UserDisplayName(7L, "First", null),
+                new UserDisplayName(7L, "Second", null)));
+
+        assertThat(names.nameOf(7L)).isEqualTo("First");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/user/UserRepositoryIT.java
@@ -62,6 +62,53 @@ class UserRepositoryIT extends AbstractIntegrationTest {
                 .containsExactlyInAnyOrder(a1.getId(), a2.getId());
     }
 
+    @Test
+    void findDisplayNamesByIdIn_resolvesAUserWhoHasNoEmployeeRecord() {
+        // The stamp on a document is a user id, so the name has to come from the user row.
+        // Resolving it through the employee lookup, as the web app used to, misses exactly this
+        // account: a user with no employment, which is the shape a QA raiser or a bootstrap
+        // administrator has.
+        User withoutEmployment = persistUser("raiser");
+        em.flush();
+        em.clear();
+
+        List<UserDisplayName> found =
+                userRepository.findDisplayNamesByIdIn(List.of(withoutEmployment.getId()));
+
+        assertThat(found).singleElement()
+                .extracting(UserDisplayName::name).isEqualTo("raiser");
+    }
+
+    @Test
+    void findDisplayNamesByIdIn_isNotScopedToAnOrganization() {
+        // A document outlives the approver's employment. Scoping the name read would blank the
+        // approver on exactly the historical records the stamp exists for.
+        Organization orgA = persistOrganization("Org C");
+        User member = persistUser("member");
+        User outsider = persistUser("outsider");
+        persistEmployee(orgA, member);
+        em.flush();
+        em.clear();
+
+        List<UserDisplayName> found = userRepository.findDisplayNamesByIdIn(
+                List.of(member.getId(), outsider.getId()));
+
+        assertThat(found).extracting(UserDisplayName::id)
+                .containsExactlyInAnyOrder(member.getId(), outsider.getId());
+    }
+
+    @Test
+    void findDisplayNamesByIdIn_omitsAnIdWithNoRow() {
+        User present = persistUser("present");
+        em.flush();
+        em.clear();
+
+        List<UserDisplayName> found =
+                userRepository.findDisplayNamesByIdIn(List.of(present.getId(), 999_999L));
+
+        assertThat(found).extracting(UserDisplayName::id).containsExactly(present.getId());
+    }
+
     private Organization persistOrganization(String name) {
         Organization org = new Organization();
         org.setOrganizationName(name);


### PR DESCRIPTION
Closes #596.

`submittedBy` / `approvedBy` / `rejectedBy` / `processedBy` on `StockAdjustmentDto` and `submittedBy` / `approvedBy` / `paymentRecordedBy` on `ConstructionInvoiceDto` are stamped from the session, so they hold a **user** id, and nothing the client could call turned one into a name. The web app resolved them through the employee lookup, which is keyed by employee id and carries no user id at all: it missed for most ids and, where an employee id happened to equal a user id, printed a different person's name against an approval. echno-web#346 and #349 replaced that with `User #<id>`, which is honest and useless.

## The shape, and why

**Name fields alongside the ids on the DTOs**, resolved by the service in one batched read and passed into the mapper as a MapStruct `@Context`.

- **Not a batch lookup endpoint.** It costs a second request per screen, and it is a new authorization decision on top of a display problem: `GET /user/web/all` is `system-admin` / `hr-admin` only, so a lookup endpoint either keeps that restriction, in which case an ordinary approver still sees a number, or opens a user-directory read to every role that can see a document. Each screen would also have to know which ids to ask for and cache the answers separately.
- **Not resolved in the mapper**, at least not the naive way. #522 item A settled that a mapper converts what it is handed and asks nobody anything, enforced by `architecture/MapperDatabaseAccessTest`: a lookup in the conversion path costs a round trip per stamp per row and the call site shows none of it.
- **So: batched in the service, handed down as a `@Context`**, which is the `MaterialMapper.toWithStockDto` shape the rule points at. `UserNameDirectory.namesFor` reads every stamped id on the page in one query; `UserNameLookup` is a plain map the mapper reads. `StockAdjustmentStampNameTest` and `ConstructionInvoiceStampNameTest` pin that a three-row page costs exactly one directory call, using the real generated mappers so a name that came from a query rather than from the lookup would show up.

`physicalCountBy` on the stock adjustment is deliberately left as a bare id: it comes from the creation payload and holds an **employee** id, so naming it from this lookup would reintroduce exactly the wrong-person bug.

## What a name means, and how it degrades

Three cases, none of which may render blank, because a blank against an approval reads as nobody having approved it.

1. **A user with no employee record** — the QA raiser account, and any bootstrap administrator. The read is keyed on the `users` row, not on employment, so it resolves like any other. This is the case the old employee-keyed attempt could never handle. Covered in `UserRepositoryIT`.
2. **A user whose name column is empty.** `name` is non-null in the schema but not guaranteed non-empty, so it falls back to the email, which is the only other thing every account has.
3. **A deleted or deactivated user on a historical document.** `deleteAnUser` is a hard delete, so the row is simply gone. The name field then carries `User #<id>` rather than null, so the client renders one field unconditionally and never has to hold the branch, and the `User #<id>` string lives in one place instead of being reimplemented per screen. `nameOf` returns null only when the stamp itself is null, which distinguishes "never approved" from "approver's account is gone".

The read is also **not tenant scoped**, deliberately: a stamp is only reached through a document the caller is already authorised to read, and the approver may have left the organization since. Scoping it would blank exactly the historical records the stamp exists for. What comes back is a display name, already visible to anyone who can read the document.

## Tests

`UserNameLookupTest`, `UserRepositoryIT` (three new cases), `StockAdjustmentStampNameTest`, `ConstructionInvoiceStampNameTest`. Reverting the production change removes the API the tests are written against, so the guard was verified by mutation instead: making an unresolved id return null, and making the page resolve per row, fails 7 of them; both restored, all pass. Full suite green on the build box (heap 25% of the 2048m cap).

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`, and re-verified after rebasing onto the current `development`.

## Follow-up

`echno-core` response types need the new fields added by hand (additive, so nothing breaks meanwhile), and the web placeholders are tracked separately on `echno-web`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice records now include display names for submitters, approvers, and payment recorders.
  * Stock adjustments now include display names for users who submitted, approved, rejected, or processed them.
  * Deleted accounts display as `User #<id>`, while actions that never occurred remain null.
* **Documentation**
  * Updated API documentation to describe the new display-name fields and user references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->