### PR TITLE
Make the PDF report render for tenants that have indents

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.tornotron.echno_backend.common.response.SubscriptionErrorResponse;
 
@@ -412,6 +413,58 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleFileUploadException(FileUploadException ex, WebRequest request) {
         logger.error("File upload failed: ", ex);
         return problem(HttpStatus.INTERNAL_SERVER_ERROR, "File Upload Failed", ex.getMessage(), request);
+    }
+
+    /**
+     * A report that could not be rendered, answered with the document that failed.
+     *
+     * <p>Still a 500, because nothing the caller sent is at fault and there is nothing
+     * for them to correct. What changes is that the body names the template and carries
+     * the underlying reason instead of "An unexpected error occurred", which is what a
+     * broken template expression used to look like from the outside.
+     */
+    @ExceptionHandler(ReportRenderingException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ProblemDetail handleReportRenderingException(ReportRenderingException ex, WebRequest request) {
+        logger.error("Report rendering failed: ", ex);
+        return problem(HttpStatus.INTERNAL_SERVER_ERROR, "Report Generation Failed", ex.getMessage(), request);
+    }
+
+    /**
+     * A path or query parameter that could not be converted to the type the handler takes.
+     *
+     * <p>Without this the exception fell through to the catch-all and a mistyped URL came
+     * back as a 500. {@code GET /api/v1/indents/web/paginated} is the case that prompted
+     * it: there is no {@code /paginated} route on that controller, so "paginated" binds to
+     * {@code /{id}}, fails to convert to a {@code Long}, and the caller is told the server
+     * broke rather than that the value is wrong. The caller sent the value, so the value is
+     * safe to quote back at them, and naming the parameter is the difference between a
+     * usable answer and a guess.
+     *
+     * <p>An enum parameter lists what it will accept, matching what
+     * {@link #handleIllegalArgumentException} already does for the same mistake made
+     * somewhere the binder does not catch it, so the API answers a bad enum the same way
+     * wherever it arrives.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ProblemDetail handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex,
+                                                          WebRequest request) {
+        logger.warn("Parameter type mismatch: ", ex);
+        Class<?> required = ex.getRequiredType();
+        String expected;
+        if (required == null) {
+            expected = ".";
+        } else if (required.isEnum()) {
+            expected = ", which expects one of: " + Arrays.stream(required.getEnumConstants())
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", ")) + ".";
+        } else {
+            expected = ", which expects a value of type " + required.getSimpleName() + ".";
+        }
+        String detail = "\"" + ex.getValue() + "\" is not a valid value for the parameter '"
+                + ex.getName() + "'" + expected;
+        return problem(HttpStatus.BAD_REQUEST, "Invalid Parameter", detail, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/org/tornotron/echno_backend/common/exception/ReportRenderingException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/ReportRenderingException.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.common.exception;
+
+/**
+ * Raised when a report could not be turned into a PDF: the template failed to
+ * evaluate, or the renderer failed to write the document.
+ *
+ * <p>It exists because the failure it wraps used to arrive at the caller as
+ * "Unknown error occurred", with nothing naming the document that failed. A
+ * template expression that cannot evaluate is a defect in a specific template,
+ * and it usually only shows up once a tenant has the data that reaches the
+ * offending row, so the one thing the failure has to carry is which template and
+ * which expression. This puts both in the message and in the log line, and
+ * separates a broken report from any other server fault.
+ */
+public class ReportRenderingException extends RuntimeException {
+
+    public ReportRenderingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
+++ b/src/main/java/org/tornotron/echno_backend/pdfGeneration/ReportController.java
@@ -1,11 +1,12 @@
 package org.tornotron.echno_backend.pdfGeneration;
 
 import org.springframework.security.access.prepost.PreAuthorize;
-import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,14 +16,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
-import org.tornotron.echno_backend.category.CategoryService;
 import org.tornotron.echno_backend.common.conversions.DateConversion;
+import org.tornotron.echno_backend.common.exception.ReportRenderingException;
 import org.tornotron.echno_backend.indent.IndentService;
 import org.tornotron.echno_backend.organization.OrganizationService;
 import org.tornotron.echno_backend.project.ProjectService;
 import org.tornotron.echno_backend.task.TaskService;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.springframework.data.domain.Page;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
@@ -39,20 +39,24 @@ import org.tornotron.echno_backend.task.dto.TaskDto;
 )
 public class ReportController {
 
+    private static final Logger logger = LoggerFactory.getLogger(ReportController.class);
+
+    private static final String TEMPLATE = "report/report";
+
     private final OrganizationService organizationService;
     private final TaskService taskService;
     private final PdfReportService pdfReportService;
     private final SpringTemplateEngine pdfTemplateEngine;
-    private final CategoryService categoryService;
+    private final PdfRenderer pdfRenderer;
     private final DateConversion dateConversion;
     private final ProjectService projectService;
     private final IndentService indentService;
 
     public ReportController(TaskService taskService,
                             PdfReportService pdfReportService,
-                            CategoryService categoryService,
                             DateConversion dateConversion,
                             @Qualifier("pdfTemplateEngine") SpringTemplateEngine pdfTemplateEngine,
+                            PdfRenderer pdfRenderer,
                             ProjectService projectService,
                             OrganizationService organizationService,
                             IndentService indentService) {
@@ -60,9 +64,9 @@ public class ReportController {
         this.projectService = projectService;
         this.dateConversion = dateConversion;
         this.pdfReportService = pdfReportService;
-        this.categoryService = categoryService;
         this.taskService = taskService;
         this.pdfTemplateEngine = pdfTemplateEngine;
+        this.pdfRenderer = pdfRenderer;
         this.indentService = indentService;
     }
 
@@ -83,7 +87,6 @@ public class ReportController {
         ctx.setVariable("taskTotal", tasks.getTotalElements());
         ctx.setVariable("counts", pdfReportService.statusCount());
         ctx.setVariable("delayedCounts", pdfReportService.statusCount());
-        ctx.setVariable("category", categoryService);
         ctx.setVariable("dateConverter", dateConversion);
         ctx.setVariable("project",projectService);
         ctx.setVariable("organization",organizationService);
@@ -111,25 +114,47 @@ public class ReportController {
             @ApiResponse(responseCode = "500", description = "PDF rendering failed")
     })
     public ResponseEntity<byte[]> pdfReport() {
-        Context ctx = populateContext();
+        byte[] pdf = render(populateContext());
 
-        String html = pdfTemplateEngine.process("report/report", ctx);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=report.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
 
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            PdfRendererBuilder builder = new PdfRendererBuilder();
-            builder.withHtmlContent(html, "classpath:/templates/");
-            builder.toStream(os);
-            builder.run();
+    /**
+     * Renders the report and says what went wrong when it cannot.
+     *
+     * <p>Each half used to lose the one fact worth keeping. An expression the template
+     * cannot evaluate escaped unhandled and arrived as "An unexpected error occurred",
+     * logged as "Unknown error occurred", with nothing naming the document. The write
+     * half was worse: caught into a bare 500 with an empty body and a
+     * {@code // Log the exception} comment standing in for the logging. That is how a
+     * report which has never rendered for any tenant holding an indent went unnoticed.
+     * Both now name the template, in the log line and in the response.
+     *
+     * <p>The bytes come from the shared {@link PdfRenderer} rather than a
+     * {@code PdfRendererBuilder} assembled here, which is what every other report in
+     * the codebase already does. The private copy this replaces had drifted: it never
+     * called {@code useFastMode()}, so this one endpoint ran on a different renderer
+     * path from the rest for no reason anyone chose.
+     */
+    private byte[] render(Context ctx) {
+        String html;
+        try {
+            html = pdfTemplateEngine.process(TEMPLATE, ctx);
+        } catch (RuntimeException e) {
+            logger.error("Template {} failed to evaluate", TEMPLATE, e);
+            throw new ReportRenderingException(
+                    "The " + TEMPLATE + " template could not be evaluated: " + e.getMessage(), e);
+        }
 
-            byte[] pdf = os.toByteArray();
-
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=report.pdf")
-                    .contentType(MediaType.APPLICATION_PDF)
-                    .body(pdf);
-        } catch (IOException e) {
-            // Log the exception
-            return ResponseEntity.internalServerError().build();
+        try {
+            return pdfRenderer.render(html);
+        } catch (IOException | RuntimeException e) {
+            logger.error("Template {} evaluated but could not be written as a PDF", TEMPLATE, e);
+            throw new ReportRenderingException(
+                    "The " + TEMPLATE + " document could not be written as a PDF: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/resources/templates/report/report.html
+++ b/src/main/resources/templates/report/report.html
@@ -55,12 +55,8 @@
     <div class="task-block" th:classappend="${task.getProgress() == 100 ? 'completed' : (task.getProgress() > 0 ? 'inprogress' : 'notstarted')}">
         <div class="section-heading">
             Task Created: <span th:text="${dateConverter.convertDateToString(task.getUpdatedAt())}"></span>
-            <span class="category-span">Category: <span th:text="${category.getACategory(task.getCategory().getId()).getName()}"></span></span>
+            <span class="category-span">Category: <span th:text="${task.category?.name ?: '-'}"></span></span>
         </div>
-<!--        <div class="section-title">-->
-<!--            Task Created: <span th:text="${dateConverter.convertDateToString(task.getUpdatedAt())}"></span>-->
-<!--            <span class="category-span">Category: <span th:text="${category.getACategory(task.getCategoryId()).getName()}"></span></span>-->
-<!--        </div>-->
 
         <table class="task-table">
             <tr>
@@ -127,7 +123,7 @@
                                 <tr>
                                     <td>
                                         <p class="font-medium text-gray-500">Created By</p>
-                                        <p class="text-gray-800" th:text="${indent.createdBy.name}"></p>
+                                        <p class="text-gray-800" th:text="${indent.createdBy?.employeeName ?: '-'}"></p>
                                     </td>
                                 </tr>
                             </table>

--- a/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandlerTest.java
@@ -10,11 +10,14 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -200,5 +203,60 @@ class GlobalExceptionHandlerTest {
         assertThat(pd.getDetail())
                 .startsWith("Invalid value 'BOGUS' provided for enum 'AccountType'. Available values:")
                 .contains("ASSET");
+    }
+
+    /**
+     * The case that prompted the handler: {@code GET /api/v1/indents/web/paginated} has no
+     * {@code /paginated} route, so "paginated" binds to {@code /{id}} and fails to convert.
+     * That used to fall through to the catch-all and answer 500, telling the caller the server
+     * had broken when the value was simply wrong.
+     */
+    @Test
+    void pathParameterOfTheWrongType_isA400NamingTheParameterAndTheValue() {
+        MethodArgumentTypeMismatchException ex = mock(MethodArgumentTypeMismatchException.class);
+        when(ex.getValue()).thenReturn("paginated");
+        when(ex.getName()).thenReturn("id");
+        doReturn(Long.class).when(ex).getRequiredType();
+
+        ProblemDetail pd = handler.handleMethodArgumentTypeMismatch(
+                ex, requestWithPath("uri=/api/v1/indents/web/paginated"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(pd.getTitle()).isEqualTo("Invalid Parameter");
+        assertThat(pd.getDetail()).isEqualTo(
+                "\"paginated\" is not a valid value for the parameter 'id', "
+                        + "which expects a value of type Long.");
+        assertThat(pd.getProperties()).containsEntry("details", "uri=/api/v1/indents/web/paginated");
+    }
+
+    @Test
+    void enumParameterOfTheWrongType_listsWhatItAccepts() {
+        MethodArgumentTypeMismatchException ex = mock(MethodArgumentTypeMismatchException.class);
+        when(ex.getValue()).thenReturn("BOGUS");
+        when(ex.getName()).thenReturn("status");
+        doReturn(IndentStatus.class).when(ex).getRequiredType();
+
+        ProblemDetail pd = handler.handleMethodArgumentTypeMismatch(
+                ex, requestWithPath("uri=/api/v1/indents/web"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(pd.getDetail())
+                .startsWith("\"BOGUS\" is not a valid value for the parameter 'status', "
+                        + "which expects one of:")
+                .contains("ON_SITE")
+                .contains("CANCELLED");
+    }
+
+    @Test
+    void reportRenderingFailure_isA500NamingTheTemplate() {
+        ProblemDetail pd = handler.handleReportRenderingException(
+                new ReportRenderingException(
+                        "Could not build the report/report report: Exception evaluating SpringEL expression",
+                        new IllegalStateException("boom")),
+                requestWithPath("uri=/api/v1/generate-report/pdf"));
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(pd.getTitle()).isEqualTo("Report Generation Failed");
+        assertThat(pd.getDetail()).contains("report/report");
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/pdfGeneration/ReportPdfRenderTest.java
+++ b/src/test/java/org/tornotron/echno_backend/pdfGeneration/ReportPdfRenderTest.java
@@ -1,0 +1,181 @@
+package org.tornotron.echno_backend.pdfGeneration;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.thymeleaf.context.IContext;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.tornotron.echno_backend.category.dto.CategoryDto;
+import org.tornotron.echno_backend.common.configuration.ThymeleafConfig;
+import org.tornotron.echno_backend.common.conversions.DateConversion;
+import org.tornotron.echno_backend.common.exception.ReportRenderingException;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.indent.IndentService;
+import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
+import org.tornotron.echno_backend.organization.OrganizationService;
+import org.tornotron.echno_backend.project.ProjectService;
+import org.tornotron.echno_backend.task.TaskService;
+import org.tornotron.echno_backend.task.dto.TaskDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The consolidated PDF report, rendered through the real Thymeleaf template and the
+ * real openhtmltopdf pipeline.
+ *
+ * <p>The indent rows are the point of this file. {@code report/report} asked each
+ * indent for {@code createdBy.name}, a property {@code EmployeeDto} does not have,
+ * so the render aborted on the first indent it reached and the endpoint answered 500
+ * for every tenant holding one. It went unnoticed because a tenant with no indents
+ * never enters that loop, and on staging only one organization had any. A test that
+ * renders the report with an empty indent list therefore proves nothing: every case
+ * here carries indents.
+ *
+ * <p>The populated indent mirrors the staging rows that failed: an indent numbered in
+ * the {@code IND-2026-nnnnnn} series, raised against a project by an employee. The
+ * second one carries no creator at all, which the schema allows
+ * ({@code indent.created_by_id} is nullable) and which would abort the same document
+ * the same way if the expression were merely renamed rather than guarded.
+ *
+ * <p>No Spring context, following the sibling PDF tests: the template engine comes
+ * from its configuration class and every service is a mock, so the suite JVM gains no
+ * cached context from this file.
+ */
+class ReportPdfRenderTest {
+
+    private final TaskService taskService = mock(TaskService.class);
+    private final PdfReportService pdfReportService = mock(PdfReportService.class);
+    private final ProjectService projectService = mock(ProjectService.class);
+    private final OrganizationService organizationService = mock(OrganizationService.class);
+    private final IndentService indentService = mock(IndentService.class);
+
+    private final ReportController controller = new ReportController(
+            taskService, pdfReportService, new DateConversion(),
+            new ThymeleafConfig().pdfTemplateEngine(), new PdfRenderer(),
+            projectService, organizationService, indentService);
+
+    @Test
+    void reportRenders_whenTheTenantHasIndents() throws Exception {
+        given(List.of(task(1L, "Slab shuttering, block C", category("Formwork"))),
+                List.of(indent(1L, "IND-2026-000001", IndentStatus.ON_SITE, employee("Echno Admin"))));
+
+        ResponseEntity<byte[]> response = controller.pdfReport();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_PDF);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(new String(response.getBody(), 0, 5)).isEqualTo("%PDF-");
+
+        String text = textOf(response.getBody());
+        assertThat(text).contains("IND-2026-000001");
+        assertThat(text).contains("Echno Admin");
+        assertThat(text).contains("Formwork");
+    }
+
+    @Test
+    void reportRenders_whenAnIndentHasNoCreatorAndATaskHasNoCategory() throws Exception {
+        given(List.of(task(1L, "Rebar tying, block C", null)),
+                List.of(indent(2L, "IND-2026-000002", IndentStatus.ORDERED, null)));
+
+        ResponseEntity<byte[]> response = controller.pdfReport();
+
+        String text = textOf(response.getBody());
+        assertThat(text).contains("IND-2026-000002");
+        assertThat(text).contains("Rebar tying, block C");
+    }
+
+    /**
+     * The diagnosability half. A template that cannot evaluate used to escape as an
+     * unhandled exception and reach the caller as "An unexpected error occurred",
+     * which named neither the document nor the expression. The failure now says which
+     * template it was and carries the engine's own reason.
+     */
+    @Test
+    void aTemplateFailure_namesTheTemplateRatherThanArrivingAsAnUnknownError() {
+        SpringTemplateEngine broken = mock(SpringTemplateEngine.class);
+        when(broken.process(eq("report/report"), any(IContext.class)))
+                .thenThrow(new TemplateProcessingException(
+                        "Exception evaluating SpringEL expression: \"indent.createdBy.name\""));
+        ReportController withBrokenTemplate = new ReportController(
+                taskService, pdfReportService, new DateConversion(),
+                broken, new PdfRenderer(), projectService, organizationService, indentService);
+        given(List.of(), List.of(indent(1L, "IND-2026-000001", IndentStatus.ON_SITE, employee("Echno Admin"))));
+
+        assertThatThrownBy(withBrokenTemplate::pdfReport)
+                .isInstanceOf(ReportRenderingException.class)
+                .hasMessageContaining("report/report")
+                .hasMessageContaining("indent.createdBy.name");
+    }
+
+    private void given(List<TaskDto> tasks, List<IndentDto> indents) {
+        Page<TaskDto> taskPage = page(tasks);
+        Page<IndentDto> indentPage = page(indents);
+        when(taskService.getAllTasks(0, UnpagedResultCap.MAX_ROWS)).thenReturn(taskPage);
+        when(indentService.getAllIndents(0, UnpagedResultCap.MAX_ROWS)).thenReturn(indentPage);
+        when(pdfReportService.statusCount())
+                .thenReturn(Map.of("COMPLETED", 2L, "IN_PROGRESS", 5L, "NOT_STARTED", 1L));
+    }
+
+    private <T> Page<T> page(List<T> content) {
+        return new PageImpl<>(content, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), content.size());
+    }
+
+    private String textOf(byte[] pdf) throws Exception {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            return new PDFTextStripper().getText(document);
+        }
+    }
+
+    private EmployeeDto employee(String name) {
+        EmployeeDto employee = new EmployeeDto();
+        employee.setId(4L);
+        employee.setEmployeeName(name);
+        return employee;
+    }
+
+    private CategoryDto category(String name) {
+        CategoryDto category = new CategoryDto();
+        category.setId(3L);
+        category.setName(name);
+        return category;
+    }
+
+    private TaskDto task(Long id, String title, CategoryDto category) {
+        TaskDto task = new TaskDto();
+        task.setId(id);
+        task.setTitle(title);
+        task.setProgress(45.0);
+        task.setCategory(category);
+        task.setUpdatedAt(LocalDateTime.of(2026, 8, 20, 9, 30));
+        return task;
+    }
+
+    private IndentDto indent(Long id, String number, IndentStatus status, EmployeeDto createdBy) {
+        IndentDto indent = new IndentDto();
+        indent.setId(id);
+        indent.setIndentNumber(number);
+        indent.setStatus(status);
+        indent.setCreatedBy(createdBy);
+        indent.setProjectId(5L);
+        indent.setCreatedAt(LocalDateTime.of(2026, 8, 18, 11, 0));
+        return indent;
+    }
+}


### PR DESCRIPTION
Closes #605.

## Why this went unnoticed, which is the bigger half of it

The report endpoint has never worked for a tenant holding an indent. Here is what the staging box actually logged when it failed, pulled from Loki:

```
2026-08-30T20:02:42Z  ERROR  org.tornotron...GlobalExceptionHandler
message: "Unknown error occurred: "
stack_trace: org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating
  SpringEL expression: "indent.createdBy.name" (template: "report/report" - line 130, col 66)
```

The log line said **"Unknown error occurred"**. The template, the line and the expression existed only inside a stack trace nobody had reason to open, and the caller was told "An unexpected error occurred". A broken report that names neither the document nor the field is a broken report that stays broken, and this one did, for as long as it took someone to run a smoke check by hand.

So the more valuable half of this PR is that a render failure is now diagnosable, and the field rename is the smaller half. Two paths, each losing the one fact worth keeping:

- an expression the template could not evaluate escaped unhandled to the catch-all, as above;
- the write half was caught into a bare `internalServerError().build()`, an empty body, and a `// Log the exception` comment standing where the logging should have been. That path logged **nothing at all**.

Both now raise `ReportRenderingException`, which names the template and carries the engine's own reason, logged against `ReportController` rather than the catch-all, and answered as a `Report Generation Failed` problem. Still a 500: nothing the caller sent is at fault.

## The break itself

`report/report` line 130 asked each indent for `createdBy.name`. `EmployeeDto` has no `name`; the field is `employeeName`. The expression could never evaluate, so the render aborted on the first indent row.

It looked data-dependent because a tenant with no indents never enters that loop. Checked against the staging database: organization 2 holds 5 indents (all raised by employee 4, "Echno Admin"), organization 1 holds none. That is the whole of the "only one tenant is affected" mystery. Every real client will have indents.

## Null-guarding, and how far it goes

Renaming the property alone would have left the same fault one row away. `indent.created_by_id` is nullable, so an indent with no resolvable creator aborts the document exactly as before. The guard is the fix, not a nicety:

```html
th:text="${indent.createdBy?.employeeName ?: '-'}"
```

The rule applied across the template: a report is a whole-document render, so one absent optional field must not cost the entire document. It prints a placeholder instead.

## Line 58, which is the better catch

Auditing the rest of the template for the same shape turned up something worse than the reported bug:

```html
th:text="${category.getACategory(task.getCategory().getId()).getName()}"
```

Three faults in one expression. It dereferences `task.getCategory()`, which is nullable (`task.category_id` is nullable), so a task with no category aborts the whole document. It then reaches a `CategoryService` bean that the controller had put into the template context, and executes a **tenant-scoped database query per task row from inside a view**, which also throws `ResourceNotFoundException` rather than returning null if the row is missing. And it does all of that to fetch a `name` that `CategoryDto` already carries, because `TaskMapper` maps the category through `CategoryMapper`.

It is now `${task.category?.name ?: '-'}`. The `category` context variable and the `CategoryService` injection go with it, along with a commented-out duplicate of the same expression that would have broken if anyone restored it.

**Does anything else in the template layer do this?** No. `report/report` is the only template that was ever handed a live service bean, and the only one that calls application code from inside a view. Across all five templates the only other method invocations are Thymeleaf's own `#lists.isEmpty` and `#strings`; the inspection, NCR and invoice reports all resolve their values in Java first (`ReportText.*`, `money()`, `nameOf()`) and hand the template finished strings. This one template was the outlier, and it no longer is.

Everything else in it already survives a null: `#strings` is null-safe, SpringEL's comparison operators handle a null `progress`, and `DateConversion.convertDateToString` returns null rather than throwing.

## The shared renderer

`ReportController` built its own `PdfRendererBuilder` inline. It was the only PDF path in the codebase doing so, and the copy had drifted, missing the `useFastMode()` that `PdfRenderer` sets for every other report.

Folded in here rather than deferred, because it is not a refactor: six lines are replaced by a call to a component that already exists, nothing moves, no new type appears, and the drift is part of the same story as the bug, an endpoint nobody exercised quietly diverging from its neighbours. The change that genuinely is a refactor, extracting a `ReportPdfService` so this controller stops assembling template context, is deliberately not attempted here.

## Also: a bad path answering 500 instead of 400

`GET /api/v1/indents/web/paginated` returned 500. There is no `/paginated` route on that controller, so "paginated" binds to `/{id}`, fails to convert to a `Long`, and `MethodArgumentTypeMismatchException` fell through to the catch-all. Same class of fault as the one above, a mistyped URL telling the caller the server had broken, so it is fixed here rather than filed: one handler answering 400, naming the parameter and the offending value, and listing the accepted constants when the parameter is an enum, to match what `handleIllegalArgumentException` already does for the same mistake arriving elsewhere. It applies to every path and query parameter in the API.

## Tests

`ReportPdfRenderTest` renders through the real template and the real openhtmltopdf pipeline, no Spring context, following the sibling PDF tests. Every case carries indents, because a case with an empty indent list passes on the broken code and proves nothing. Verified to fail on the unfixed template with the production error string above, and to pass with the fix.

- a populated indent shaped like the staging rows, asserting the creator's name, the indent number and the category all extract from the produced PDF
- an indent with no creator and a task with no category, the null cases the schema allows
- a template failure, asserting it arrives naming the template rather than as an unknown error

Two cases in `GlobalExceptionHandlerTest` for the parameter-mismatch response, one for the report-rendering response.

## Verification against real data

Organization 2's exact live rows (8 tasks, 5 indents, read from the staging database) render to a valid three-page PDF 1.6 with all five creator names resolved and every category shown.

The HTTP-level check against `backend.echno.in` was **not** made: it needs an authenticated organization-2 session, and the routes to that account's password were blocked, so it was left alone rather than worked around by resetting a password or granting a role. The evidence here is the same causal chain without the transport: the deployed artifact carries the defect, the live rows are the failing input, and the fixed template renders them. A 200 on its own would in any case not have shown that the five creator names resolved.

## Not changed

`project` and `organization` are still put into the template context and still unused by it. That predates this change and is left alone.

The indent status badge is clipped off the right page edge, prints the raw enum (`ON_SITE` rather than "On site"), and its colour coding silently never applies to `ON_SITE`, because the template compares `#strings.toLowerCase(indent.status)` against `'on-site'` while the enum lowercases to `on_site`. Nobody had seen this document before, so none of it had ever been observed. All cosmetic, none of it blocks the render, and it is layout work rather than a bug fix: filed as #612.
