### PR TITLE
Scope the payable number to its organization, and hold the opening paid amount to the recorded one

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/payable/Payable.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/Payable.java
@@ -36,7 +36,13 @@ public class Payable implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "payable_number", nullable = false, unique = true)
+    /**
+     * The tenant's own reference for the amount owed, supplied by the caller. Unique per
+     * organization rather than globally: the constraint that enforces it is
+     * {@code uk_payable_org_number} in the schema, and it is composite, so it cannot be
+     * declared here as a column-level unique.
+     */
+    @Column(name = "payable_number", nullable = false)
     private String payableNumber;
 
     @Column(name = "contactor_name", nullable = false)

--- a/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/PayableService.java
@@ -35,7 +35,10 @@ import java.util.stream.Collectors;
  *
  * <p>On create it validates the referenced employee and project (both required) and the
  * optional vendor and goods-received note, all within the current organization, and
- * defaults the paid amount to zero. Recording a payment takes a pessimistic lock on the
+ * defaults the paid amount to zero. The payable number is unique within the organization,
+ * not across the estate: it is the tenant's own reference series, so two tenants may
+ * legitimately use the same one. An opening paid amount is held to the same ceiling
+ * recordPayment enforces. Recording a payment takes a pessimistic lock on the
  * payable so concurrent payments serialize their read-modify-write on the paid amount, and
  * rejects a payment that would push the paid total past the recorded amount.
  */
@@ -74,11 +77,30 @@ public class PayableService {
      *
      * @param creationDto The payable details, including the creating employee, project, and optional vendor and GRN.
      * @return The created payable DTO.
+     * @throws InvalidRequestException if the recorded amount is not positive, or the opening paid amount is negative or exceeds it.
      * @throws DuplicateResourceException if a payable with the same number already exists in the organization.
      * @throws ResourceNotFoundException if the employee, project, vendor, or goods-received note cannot be found in the organization.
      */
     @Transactional
     public PayableDto createPayable(PayableCreationDto creationDto) {
+        BigDecimal amountRecorded = creationDto.getAmountRecorded();
+        if (amountRecorded == null || amountRecorded.signum() <= 0) {
+            throw new InvalidRequestException("Amount recorded must be greater than zero");
+        }
+
+        // The opening paid amount is held to the same rule recordPayment enforces on every
+        // later payment. Without it a payable can be created already past its recorded
+        // amount, and since no payment may push the paid total any higher and the module has
+        // no update or delete endpoint, that negative balance would stand for good.
+        BigDecimal openingPaid = creationDto.getAmountPaid() != null ? creationDto.getAmountPaid() : BigDecimal.ZERO;
+        if (openingPaid.signum() < 0) {
+            throw new InvalidRequestException("Amount paid cannot be negative");
+        }
+        if (openingPaid.compareTo(amountRecorded) > 0) {
+            throw new InvalidRequestException(
+                    "Opening amount paid of " + openingPaid + " exceeds the recorded amount of " + amountRecorded);
+        }
+
         // Check for duplicate payable number
         if (payableRepository.existsByPayableNumberAndOrganization_Id(creationDto.getPayableNumber(),TenantContext.getCurrentOrgId())) {
             throw new DuplicateResourceException("Payable with number " + creationDto.getPayableNumber() + " already exists");
@@ -110,8 +132,8 @@ public class PayableService {
         payable.setPayableNumber(creationDto.getPayableNumber());
         payable.setContractorName(creationDto.getContractorName());
         payable.setContractType(ContractType.valueOf(creationDto.getContractType()));
-        payable.setAmountRecorded(creationDto.getAmountRecorded());
-        payable.setAmountPaid(creationDto.getAmountPaid() != null ? creationDto.getAmountPaid() : BigDecimal.ZERO);
+        payable.setAmountRecorded(amountRecorded);
+        payable.setAmountPaid(openingPaid);
         payable.setVendor(vendor);
         payable.setGoodsReceivedNote(grn);
         payable.setCreatedBy(createdBy);

--- a/src/main/java/org/tornotron/echno_backend/payable/dto/PayableCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/payable/dto/PayableCreationDto.java
@@ -2,6 +2,8 @@ package org.tornotron.echno_backend.payable.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -22,8 +24,17 @@ public class PayableCreationDto {
     private String contractType;
 
     @NotNull(message = "amount recorded is required")
+    @Positive(message = "amount recorded must be greater than zero")
     private BigDecimal amountRecorded;
 
+    /**
+     * The amount already settled when the payable is first recorded, for a debt that is
+     * being carried in part-paid rather than raised from nothing. Optional, defaults to
+     * zero, and may not exceed the recorded amount: every later payment goes through
+     * {@code recordPayment}, which refuses to push the paid total past the recorded one,
+     * so an opening figure above it would create a balance no payment could ever move.
+     */
+    @PositiveOrZero(message = "amount paid cannot be negative")
     private BigDecimal amountPaid;
 
     private Long vendorId;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -358,4 +358,7 @@
     <!-- v4.0 - Employees: drop the free-text reporting_manager; manager_id is the reporting line -->
     <include file="db/changelog/v4.0/074-drop-employee-reporting-manager.xml"/>
 
+    <!-- v4.0 - Payables: the number is the tenant's own series, so scope it to the organization -->
+    <include file="db/changelog/v4.0/075-payable-number-per-org-uniqueness.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/075-payable-number-per-org-uniqueness.xml
+++ b/src/main/resources/db/changelog/v4.0/075-payable-number-per-org-uniqueness.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="075-add-per-org-payable-number-uniqueness" author="echno">
+        <comment>
+            Payable was left out of 061, which moved the purchase order, site transfer, indent and
+            GRN numbers from a global unique constraint to a per-organization one. It has the same
+            disagreement: createPayable asks whether the number is already taken within the current
+            organization, while uk_payable_number reserves it across every organization at once. A
+            second tenant reusing a number the first has used gets past the service check and is
+            then rejected by a constraint over rows it cannot see, which both replaces the intended
+            409 with a constraint violation and tells that tenant something about another tenant's
+            numbering. Payable numbers are the customer's own reference series, so the overlap is
+            the normal case rather than an unlucky one.
+
+            Unlike the four documents in 061 these numbers are supplied by the caller rather than
+            allocated by the server, so there is no counter to seed alongside the constraint.
+
+            The per-organization constraint is added before the global one is dropped, so the
+            numbers are never unconstrained in between.
+        </comment>
+
+        <addUniqueConstraint tableName="payable"
+                             columnNames="organization_id, payable_number"
+                             constraintName="uk_payable_org_number"/>
+
+        <rollback>
+            <dropUniqueConstraint tableName="payable" constraintName="uk_payable_org_number"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="075-drop-global-payable-number-uniqueness" author="echno">
+        <comment>
+            Removes the cross-tenant constraint now that the per-tenant one above stands in its
+            place. DROP INDEX rather than DROP CONSTRAINT because CockroachDB backs a UNIQUE column
+            constraint with an index of the same name and that is how it is removed. This follows
+            061's fourth changeset exactly.
+        </comment>
+
+        <sql>
+            DROP INDEX IF EXISTS payable@uk_payable_number CASCADE;
+        </sql>
+
+        <rollback>
+            <comment>
+                Restoring a global unique constraint would fail on any data that has since made
+                use of the per-tenant scope, so the rollback does not pretend it can.
+            </comment>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableCreationDtoValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableCreationDtoValidationTest.java
@@ -1,0 +1,89 @@
+package org.tornotron.echno_backend.payable;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.payable.dto.PayableCreationDto;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Bean validation on the amounts a payable is created with.
+ *
+ * <p>Both figures used to carry no constraint beyond the recorded amount being present, so a
+ * payable could be raised for zero, or raised already paid past what it recorded. Neither can be
+ * corrected afterwards: the module has no update or delete endpoint, and recordPayment refuses
+ * any payment that would push the paid total past the recorded one, so a payable in either state
+ * is stuck there. The rules are checked here at the edge and again in the service.
+ */
+class PayableCreationDtoValidationTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void openValidator() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        factory.close();
+    }
+
+    private PayableCreationDto payable(BigDecimal amountRecorded, BigDecimal amountPaid) {
+        PayableCreationDto dto = new PayableCreationDto();
+        dto.setPayableNumber("PAY-2026-000001");
+        dto.setContractorName("ACME Contractors");
+        dto.setContractType("MATERIAL_SUPPLY");
+        dto.setAmountRecorded(amountRecorded);
+        dto.setAmountPaid(amountPaid);
+        dto.setProjectId(1L);
+        dto.setCreatedBy(1L);
+        return dto;
+    }
+
+    @Test
+    void zeroAmountRecorded_isRejected() {
+        assertThat(validator.validate(payable(BigDecimal.ZERO, null)))
+                .singleElement()
+                .satisfies(violation -> {
+                    assertThat(violation.getPropertyPath()).hasToString("amountRecorded");
+                    assertThat(violation.getMessage()).isEqualTo("amount recorded must be greater than zero");
+                });
+    }
+
+    @Test
+    void negativeAmountRecorded_isRejected() {
+        assertThat(validator.validate(payable(new BigDecimal("-1000.00"), null)))
+                .singleElement()
+                .satisfies(violation ->
+                        assertThat(violation.getPropertyPath()).hasToString("amountRecorded"));
+    }
+
+    @Test
+    void negativeAmountPaid_isRejected() {
+        assertThat(validator.validate(payable(new BigDecimal("1000.00"), new BigDecimal("-1.00"))))
+                .singleElement()
+                .satisfies(violation -> {
+                    assertThat(violation.getPropertyPath()).hasToString("amountPaid");
+                    assertThat(violation.getMessage()).isEqualTo("amount paid cannot be negative");
+                });
+    }
+
+    @Test
+    void absentAmountPaid_isAccepted() {
+        assertThat(validator.validate(payable(new BigDecimal("1000.00"), null))).isEmpty();
+    }
+
+    @Test
+    void openingAmountPaidWithinTheRecordedAmount_isAccepted() {
+        assertThat(validator.validate(payable(new BigDecimal("1000.00"), new BigDecimal("250.00")))).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableCreationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableCreationIT.java
@@ -1,0 +1,199 @@
+package org.tornotron.echno_backend.payable;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.payable.dto.PayableCreationDto;
+import org.tornotron.echno_backend.payable.dto.PayableDto;
+import org.tornotron.echno_backend.payable.mapper.PayableMapperImpl;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for {@link PayableService#createPayable} against a real CockroachDB, so the
+ * schema's own constraints are part of what is under test.
+ *
+ * <p>Two rules are pinned here. The payable number is the tenant's own reference series, so it is
+ * unique within an organization and free to repeat across organizations; it used to be unique
+ * across the whole estate, which turned a second tenant's ordinary numbering into a constraint
+ * violation and told them a number was taken by a tenant they cannot see. And the opening paid
+ * amount is held to the recorded amount, because nothing afterwards can bring an over-paid payable
+ * back: recordPayment refuses every further payment and the module has no update or delete.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({PayableService.class, PayableMapperImpl.class, EmployeeMapperImpl.class,
+        AttachmentMapperImpl.class, TenantEntityHelper.class,
+        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper.class})
+class PayableCreationIT extends AbstractIntegrationTest {
+
+    private static final String SHARED_NUMBER = "PAY-2026-000001";
+
+    @Autowired
+    private PayableService payableService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    // The attachment mapper in the payable mapper chain autowires this; nothing here
+    // touches file storage, so a mock satisfies the graph.
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
+    private Tenant first;
+    private Tenant second;
+
+    /** One organization with the project and employee a payable has to reference. */
+    private record Tenant(Long orgId, Long projectId, Long employeeId) {
+    }
+
+    @BeforeEach
+    void seed() {
+        first = persistTenant("first");
+        second = persistTenant("second");
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private Tenant persistTenant(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName("Payable Creation Org " + name);
+        org.setOrganizationAddress("addr");
+        org.setOrganizationEmail("payable-creation-" + name + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+
+        Project project = new Project();
+        project.setProjectName("Project " + name);
+        project.setOrganization(org);
+        entityManager.persist(project);
+
+        User user = new User();
+        user.setKeycloakId("kc-payable-creation-" + name);
+        user.setName("Payable Creator " + name);
+        entityManager.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName("Payable Creator " + name);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress("payable-creator-" + name + "@example.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        entityManager.persist(employee);
+
+        entityManager.flush();
+        return new Tenant(org.getId(), project.getId(), employee.getId());
+    }
+
+    private PayableCreationDto dtoFor(Tenant tenant, String payableNumber,
+                                      BigDecimal amountRecorded, BigDecimal amountPaid) {
+        PayableCreationDto dto = new PayableCreationDto();
+        dto.setPayableNumber(payableNumber);
+        dto.setContractorName("ACME Contractors");
+        dto.setContractType("MATERIAL_SUPPLY");
+        dto.setAmountRecorded(amountRecorded);
+        dto.setAmountPaid(amountPaid);
+        dto.setProjectId(tenant.projectId());
+        dto.setCreatedBy(tenant.employeeId());
+        return dto;
+    }
+
+    private PayableDto createAs(Tenant tenant, String payableNumber,
+                                BigDecimal amountRecorded, BigDecimal amountPaid) {
+        TenantContext.setCurrentOrgId(tenant.orgId());
+        return payableService.createPayable(dtoFor(tenant, payableNumber, amountRecorded, amountPaid));
+    }
+
+    // --- Payable number scope (issue #602) --------------------------------
+
+    @Test
+    void sameNumberInAnotherOrganization_isAccepted() {
+        createAs(first, SHARED_NUMBER, new BigDecimal("1000.00"), null);
+
+        assertThatNoException().isThrownBy(() ->
+                createAs(second, SHARED_NUMBER, new BigDecimal("2000.00"), null));
+
+        entityManager.flush();
+    }
+
+    @Test
+    void sameNumberTwiceInOneOrganization_isRejectedAsADuplicate() {
+        createAs(first, SHARED_NUMBER, new BigDecimal("1000.00"), null);
+
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(() ->
+                createAs(first, SHARED_NUMBER, new BigDecimal("2000.00"), null));
+    }
+
+    // --- Opening paid amount (issue #603) ---------------------------------
+
+    @Test
+    void openingAmountPaidAboveTheRecordedAmount_isRejected() {
+        assertThatExceptionOfType(InvalidRequestException.class).isThrownBy(() ->
+                createAs(first, "PAY-2026-000002", new BigDecimal("1000.00"), new BigDecimal("5000.00")));
+    }
+
+    @Test
+    void openingAmountPaidWithinTheRecordedAmount_isAccepted() {
+        PayableDto created = createAs(first, "PAY-2026-000003",
+                new BigDecimal("1000.00"), new BigDecimal("400.00"));
+
+        assertThat(created.getAmountPaid()).isEqualByComparingTo("400.00");
+        assertThat(created.getAmountDue()).isEqualByComparingTo("600.00");
+    }
+
+    @Test
+    void openingAmountPaidEqualToTheRecordedAmount_isAcceptedAndSettled() {
+        PayableDto created = createAs(first, "PAY-2026-000004",
+                new BigDecimal("1000.00"), new BigDecimal("1000.00"));
+
+        assertThat(created.getAmountDue()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void absentOpeningAmountPaid_defaultsToZero() {
+        PayableDto created = createAs(first, "PAY-2026-000005", new BigDecimal("1000.00"), null);
+
+        assertThat(created.getAmountPaid()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void negativeOpeningAmountPaid_isRejected() {
+        assertThatExceptionOfType(InvalidRequestException.class).isThrownBy(() ->
+                createAs(first, "PAY-2026-000006", new BigDecimal("1000.00"), new BigDecimal("-1.00")));
+    }
+
+    @Test
+    void nonPositiveAmountRecorded_isRejected() {
+        assertThatExceptionOfType(InvalidRequestException.class).isThrownBy(() ->
+                createAs(first, "PAY-2026-000007", BigDecimal.ZERO, null));
+    }
+}


### PR DESCRIPTION
Closes #602. Closes #603.

Both faults sit on `PayableService.createPayable`, which nothing else in the backend calls: the payables screen in echno-web #350 is its only caller today.

## #602 — the number was unique across every organization

`createPayable` asked whether the number was already taken **within** the current organization; `uk_payable_number` reserved it **across** every organization at once. A second tenant reusing a number the first had used passed the service check and was then rejected by a constraint over rows it cannot see, so the intended 409 arrived as a `DataIntegrityViolationException`, and the rejection itself told that tenant something about another tenant's numbering. Payable numbers are the customer's own reference series, so the overlap is the normal case rather than an unlucky one.

The composite key is what the rest of the schema already does for a tenant-scoped document: `inspections`, `ncrs`, `receipts`, `cost_category`, `leave_policy` and `posting_account_mapping` are all `(organization_id, <number>)`. More to the point, migration **061** already moved `purchase_order`, `site_transfer`, `indent` and `goods_received_note` off their global constraints for this exact reason. Payable was simply left out of it.

`075-payable-number-per-org-uniqueness.xml` does for payable what 061 did for those four: add `uk_payable_org_number`, then drop the global index, in that order so the numbers are never unconstrained in between. It has no counter to seed, because a payable number is supplied by the caller rather than allocated by the server.

Checked against live staging before writing it: `payable` holds **0 rows across 0 organizations** on `echno.in`, so there is nothing to deduplicate and the constraint cannot fail at deploy time.

## #603 — the opening `amountPaid` was stored unchecked

A payable could be created for 1000 already paid 5000. Nothing could bring it back: `recordPayment` refuses every payment that would push the paid total past the recorded amount, and the module has no update or delete endpoint, so the negative balance stands for good and shows on every ageing report.

**Kept the field, guarded it**, rather than refusing it outright. A debt carried in part-paid is a real thing to record, and refusing the field would leave no way to enter one. It is now held to the same ceiling `recordPayment` already enforces. `amountRecorded` is required to be positive for the same reason: a payable raised for zero is settled on arrival and can never take a payment. No caller is broken by either — nothing in the backend calls `createPayable`, and the web client already declines to send an opening `amountPaid` and already requires a positive `amountRecorded`.

Both amounts carry bean validation for the message the caller sees, and the service checks them again so a direct call cannot get past them.

## Tests

13 new tests; 7 of them fail without this change and pass with it. Verified by reverting the three production edits on the build box and re-running.

| Test | Without the fix |
|------|-----------------|
| `PayableCreationIT.sameNumberInAnotherOrganization_isAccepted` | FAILS — `duplicate key value violates unique constraint "uk_payable_number"` |
| `PayableCreationIT.openingAmountPaidAboveTheRecordedAmount_isRejected` | FAILS — accepted |
| `PayableCreationIT.negativeOpeningAmountPaid_isRejected` | FAILS — accepted |
| `PayableCreationIT.nonPositiveAmountRecorded_isRejected` | FAILS — accepted |
| `PayableCreationDtoValidationTest.zeroAmountRecorded_isRejected` | FAILS — no violation |
| `PayableCreationDtoValidationTest.negativeAmountRecorded_isRejected` | FAILS — no violation |
| `PayableCreationDtoValidationTest.negativeAmountPaid_isRejected` | FAILS — no violation |

The other six pin the behaviour that must survive the change: a duplicate within one organization is still a 409, an opening amount within or equal to the recorded one is still accepted, and an absent one still defaults to zero.

`./gradlew build` green on the build box; test heap 532 MB of the 2048 MB cap (26%). `openApiSnapshot -PupdateOpenApiSnapshot` produces no diff, so the committed document already matches.

## Not fixed here

The same global-unique-on-a-tenant-scoped-column shape survives on `issue.title`, `labour.email` / `phone_number` / `bank_account_number`, and `category.normalized_name`. Those are separate modules with their own callers; noting them for a follow-up rather than widening this change.