### PR TITLE
Offer the three deep list responses a projection that does not read the graph

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6095,6 +6095,80 @@
         },
         "type": "object"
       },
+      "IndentSummaryDto": {
+        "description": "An indent as it appears in a list: its own fields, who raised it and how many lines it has, without the lines themselves. The full view carries every requested item, and every item carries a whole material with its stock figures, so a page of indents reads the material catalogue to render a list of indent numbers.",
+        "properties": {
+          "createdAt": {
+            "description": "Timestamp the indent was created.",
+            "example": "2026-01-15T09:00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "createdById": {
+            "description": "Id of the employee who raised the indent. Null where the raiser is no longer recorded.",
+            "example": 18,
+            "format": "int64",
+            "type": "integer"
+          },
+          "createdByName": {
+            "description": "Name of the employee who raised the indent.",
+            "example": "Ramesh Kumar",
+            "type": "string"
+          },
+          "expectedOn": {
+            "description": "Date the materials are expected on site.",
+            "example": "2026-02-05T00:00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Indent id.",
+            "example": 42,
+            "format": "int64",
+            "type": "integer"
+          },
+          "indentNumber": {
+            "description": "Indent number.",
+            "example": "IND-2026-0015",
+            "type": "string"
+          },
+          "itemCount": {
+            "description": "How many item lines the indent has. Read for the whole page in one aggregate; the lines themselves are on the detail view.",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "description": "Id of the project the indent is raised for.",
+            "example": 3,
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectName": {
+            "description": "Name of the project.",
+            "example": "Asset Homes Perumbavoor Phase 2",
+            "type": "string"
+          },
+          "remarks": {
+            "description": "Free-text remarks on the indent.",
+            "example": "Required before slab pour on 2026-02-08",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current lifecycle status of the indent.",
+            "enum": [
+              "ON_SITE",
+              "DELAYED",
+              "PENDING",
+              "ORDERED",
+              "CANCELLED"
+            ],
+            "example": "PENDING",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "IndentUpdateDto": {
         "description": "Payload to partially update an indent's number, project, status, expected date or remarks.",
         "properties": {
@@ -11216,6 +11290,52 @@
         },
         "type": "object"
       },
+      "PageIndentSummaryDto": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/IndentSummaryDto"
+            },
+            "type": "array"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "numberOfElements": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "size": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "totalElements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "PageInspectionDto": {
         "properties": {
           "content": {
@@ -11727,6 +11847,52 @@
           "content": {
             "items": {
               "$ref": "#/components/schemas/ProjectDto"
+            },
+            "type": "array"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "numberOfElements": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "size": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "totalElements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PageProjectSummaryDto": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectSummaryDto"
             },
             "type": "array"
           },
@@ -13398,6 +13564,132 @@
             ],
             "example": "IN_PROGRESS",
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ProjectSummaryDto": {
+        "description": "A project as it appears in a list: every scalar field of the full project view, without the team, the tasks or the attachments. Progress still means what it means on the full view, the mean of the project's task progress, but it is read for the whole page in one aggregate rather than by loading each project's tasks.",
+        "properties": {
+          "createdAt": {
+            "description": "Creation timestamp.",
+            "example": "2026-08-01T09:00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "createdBy": {
+            "description": "Id of the user who created the project. Null on projects created before this was recorded.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
+          },
+          "customerId": {
+            "description": "Finance customer the project is billed to. Null when no client is set.",
+            "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Planned completion date of the project.",
+            "example": "2027-06-30T00:00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique project id.",
+            "example": 42,
+            "format": "int64",
+            "type": "integer"
+          },
+          "progress": {
+            "description": "Overall completion of the project, as a fraction from 0 to 1. The same figure the full project view reports.",
+            "example": 0.35,
+            "format": "double",
+            "type": "number"
+          },
+          "projectAddress": {
+            "description": "Street address of the site, as one line.",
+            "example": 12,
+            "type": "string"
+          },
+          "projectCity": {
+            "description": "Town or city the site is in. Null when not recorded.",
+            "example": "Chennai",
+            "type": "string"
+          },
+          "projectLatitude": {
+            "description": "Site latitude in decimal degrees.",
+            "example": 13.0827,
+            "format": "float",
+            "type": "number"
+          },
+          "projectLongitude": {
+            "description": "Site longitude in decimal degrees.",
+            "example": 80.2707,
+            "format": "float",
+            "type": "number"
+          },
+          "projectName": {
+            "description": "Project name.",
+            "example": "Tower B, Riverside Residences",
+            "type": "string"
+          },
+          "projectPostalCode": {
+            "description": "Postal (PIN) code of the site. Null when not recorded.",
+            "example": 600004,
+            "type": "string"
+          },
+          "projectState": {
+            "description": "Indian state or union territory the site is in, used to match statutory compliances. Null when not recorded.",
+            "example": "Tamil Nadu",
+            "type": "string"
+          },
+          "projectType": {
+            "description": "Construction category of the project.",
+            "enum": [
+              "RESIDENTIAL",
+              "COMMERCIAL",
+              "INDUSTRIAL",
+              "INFRASTRUCTURE",
+              "INSTITUTIONAL",
+              "MIXED_USE",
+              "OTHER"
+            ],
+            "example": "RESIDENTIAL",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "Planned start date of the project.",
+            "example": "2026-09-01T00:00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current project status.",
+            "enum": [
+              "open",
+              "closed",
+              "upcoming",
+              "completed",
+              "dropped",
+              "onHold",
+              "cancelled",
+              "approved"
+            ],
+            "example": "IN_PROGRESS",
+            "type": "string"
+          },
+          "updatedAt": {
+            "description": "When the project was last written. Null on projects not written since this was recorded.",
+            "example": "2026-08-28T16:41:12",
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedBy": {
+            "description": "Id of the user who last wrote the project.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -46861,6 +47153,137 @@
         ]
       }
     },
+    "/api/v1/indents/web/summary": {
+      "get": {
+        "description": "Returns a single page of indents without their item lines, each carrying how many lines it has and who raised it. Use this for lists; use the full listing or the detail endpoint when the lines are needed.",
+        "operationId": "getAllIndentSummaries",
+        "parameters": [
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageIndentSummaryDto"
+                }
+              }
+            },
+            "description": "Page of indent summaries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List indents as summaries, paginated",
+        "tags": [
+          "Indents (Web)"
+        ]
+      }
+    },
     "/api/v1/indents/web/{id}": {
       "delete": {
         "description": "Deletes the indent with the given id, along with its items.",
@@ -77363,6 +77786,124 @@
         ]
       }
     },
+    "/api/v1/organization/web/summary": {
+      "get": {
+        "description": "Returns the same organizations as the full listing, carrying only each organization's own fields: no projects, no employees, no attachments. This is what an organization picker needs.",
+        "operationId": "readAllOrganizationSummaries",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OrganizationSimpleDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "List of the caller's organizations, empty if they belong to none"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OrganizationSimpleDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Caller is not authenticated"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List the current user's organizations, without their contents",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
     "/api/v1/organization/web/{id}": {
       "delete": {
         "description": "Deletes the organization with the given id.",
@@ -80410,6 +80951,145 @@
           }
         },
         "summary": "List projects, paginated and filtered",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/v1/project/web/summary": {
+      "get": {
+        "description": "Returns a single page of projects carrying every scalar field of the full project view and none of its collections: no team, no tasks, no attachments. Progress is the same figure the full view reports. Use this for lists and tables; use the full listing when the response is read for its contents. pageSize is clamped to 500.",
+        "operationId": "readAllProjectSummaries",
+        "parameters": [
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageProjectSummaryDto"
+                }
+              }
+            },
+            "description": "Page of project summaries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List projects as summaries, paginated and filtered",
         "tags": [
           "Projects"
         ]

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentControllerWeb.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,6 +18,7 @@ import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemUpdateDto;
 import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.dto.IndentSummaryDto;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
@@ -68,6 +70,41 @@ public class IndentControllerWeb {
             @Valid @ParameterObject PageQuery pageQuery
     ) {
         return new ResponseEntity<>(indentService.getAllIndents(pageQuery.getPageNo(), pageQuery.getPageSize()).getContent(), HttpStatus.OK);
+    }
+
+    /**
+     * Retrieves a page of indents as summaries, for a list that does not read their lines.
+     *
+     * <p>The same indents, the same order and the same paging as {@link #getAllIndents(PageQuery)},
+     * carrying the indent's own fields, the id and name of whoever raised it, and how many lines it
+     * has. The lines themselves are on the detail view. That is the whole point: a line carries a
+     * full material and a material carries stock figures read from a further aggregate, so a page
+     * of indents was materialising a slice of the material catalogue to render a column of indent
+     * numbers.
+     *
+     * <p>It is an addition, not a replacement. {@link #getAllIndents(PageQuery)} is unchanged.
+     *
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
+     * @return A {@link ResponseEntity} containing the page of indent summaries.
+     */
+    @GetMapping("/summary")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List indents as summaries, paginated",
+            description = "Returns a single page of indents without their item lines, each "
+                    + "carrying how many lines it has and who raised it. Use this for lists; use "
+                    + "the full listing or the detail endpoint when the lines are needed."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of indent summaries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<IndentSummaryDto>> getAllIndentSummaries(
+            @Valid @ParameterObject PageQuery pageQuery
+    ) {
+        return new ResponseEntity<>(
+                indentService.getAllIndentsSummary(pageQuery.getPageNo(), pageQuery.getPageSize()),
+                HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/IndentService.java
@@ -20,12 +20,14 @@ import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.indent.dto.IndentUpdateDto;
 import org.tornotron.echno_backend.indentItem.IndentItem;
+import org.tornotron.echno_backend.indentItem.IndentItemCountLookup;
 import org.tornotron.echno_backend.indentItem.IndentItemRepository;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemUpdateDto;
 import org.tornotron.echno_backend.indent.dto.IndentCreationDto;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.dto.IndentSummaryDto;
 import org.tornotron.echno_backend.indent.enums.IndentStatus;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
 import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
@@ -200,6 +202,49 @@ public class IndentService {
         Page<Indent> indents = indentRepository.findAll(pageable);
         MaterialStockLookup stock = stockForIndents(indents.getContent());
         return indents.map(indent -> indentMapper.toDto(indent, stock));
+    }
+
+    /**
+     * Retrieves a page of indents as summaries: the indent's own fields, who raised it and how
+     * many lines it has.
+     *
+     * <p>The list projection of {@link #getAllIndents}. The full DTO carries every requested item,
+     * every item carries a whole material, and every material carries stock figures read from a
+     * further aggregate, so a page of indents materialises a slice of the material catalogue to
+     * render a column of indent numbers. The line count comes from one grouped read instead, and
+     * the raiser flattens to an id and a name rather than a full employee.
+     *
+     * <p>Offered alongside {@link #getAllIndents} rather than replacing it, for the same reason
+     * the project summary is: the published contract is hand-maintained, so which endpoints move
+     * over is a decision per endpoint.
+     *
+     * @param pageNo Zero-based page index.
+     * @param pageSize Number of indents per page.
+     * @return A page of indent summaries ordered by id ascending.
+     */
+    @Transactional(readOnly = true)
+    public Page<IndentSummaryDto> getAllIndentsSummary(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.ASC, "id"));
+        Page<Indent> indents = indentRepository.findAll(pageable);
+        IndentItemCountLookup itemCounts = itemCountsFor(indents.getContent());
+        return indents.map(indent -> indentMapper.toSummaryDto(indent, itemCounts));
+    }
+
+    /**
+     * Reads the line count for a whole page of indents, in one query.
+     *
+     * @param indents The indents being converted.
+     * @return Their line counts, with an indent that has no lines reading as zero.
+     */
+    private IndentItemCountLookup itemCountsFor(Collection<Indent> indents) {
+        List<Long> ids = indents.stream()
+                .map(Indent::getId)
+                .filter(Objects::nonNull)
+                .toList();
+        if (ids.isEmpty()) {
+            return IndentItemCountLookup.none();
+        }
+        return IndentItemCountLookup.of(indentItemRepository.countItemsByIndentIds(ids));
     }
 
 

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentSummaryDto.java
@@ -1,0 +1,50 @@
+package org.tornotron.echno_backend.indent.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "An indent as it appears in a list: its own fields, who raised it and how "
+        + "many lines it has, without the lines themselves. The full view carries every requested "
+        + "item, and every item carries a whole material with its stock figures, so a page of "
+        + "indents reads the material catalogue to render a list of indent numbers.")
+@Data
+public class IndentSummaryDto {
+
+    @Schema(description = "Indent id.", example = "42")
+    private Long id;
+
+    @Schema(description = "Indent number.", example = "IND-2026-0015")
+    private String indentNumber;
+
+    @Schema(description = "Timestamp the indent was created.", example = "2026-01-15T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "Id of the employee who raised the indent. Null where the raiser is no "
+            + "longer recorded.", example = "18")
+    private Long createdById;
+
+    @Schema(description = "Name of the employee who raised the indent.", example = "Ramesh Kumar")
+    private String createdByName;
+
+    @Schema(description = "Id of the project the indent is raised for.", example = "3")
+    private Long projectId;
+
+    @Schema(description = "Name of the project.", example = "Asset Homes Perumbavoor Phase 2")
+    private String projectName;
+
+    @Schema(description = "Current lifecycle status of the indent.", example = "PENDING")
+    private IndentStatus status;
+
+    @Schema(description = "Date the materials are expected on site.", example = "2026-02-05T00:00:00")
+    private LocalDateTime expectedOn;
+
+    @Schema(description = "Free-text remarks on the indent.", example = "Required before slab pour on 2026-02-08")
+    private String remarks;
+
+    @Schema(description = "How many item lines the indent has. Read for the whole page in one "
+            + "aggregate; the lines themselves are on the detail view.", example = "10")
+    private long itemCount;
+}

--- a/src/main/java/org/tornotron/echno_backend/indent/mapper/IndentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/mapper/IndentMapper.java
@@ -10,6 +10,8 @@ import org.mapstruct.MappingTarget;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.indent.Indent;
 import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.dto.IndentSummaryDto;
+import org.tornotron.echno_backend.indentItem.IndentItemCountLookup;
 import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
 import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
 
@@ -20,6 +22,14 @@ import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
  * {@link #emptyItemsIfNull} restores that (MapStruct would otherwise leave it null).
  *
  * <p>The stock lookup is carried through to the line items, which carry it on to the material.
+ *
+ * <p>{@link #toSummaryDto} is the list projection. It drops the lines entirely, which is what
+ * makes it worth having: a line carries a whole material, and a material carries stock figures
+ * read from a further aggregate, so a page of indents renders a column of indent numbers by
+ * materialising the catalogue. The one thing a list wants from the lines is how many there are,
+ * and that is counted for the whole page in one read. It also flattens the raiser to an id and a
+ * name rather than carrying a full employee, whose own DTO reaches a shift, a manager and a set
+ * of attachments.
  */
 @Mapper(componentModel = "spring", uses = {EmployeeMapper.class, IndentItemMapper.class})
 public interface IndentMapper {
@@ -35,6 +45,21 @@ public interface IndentMapper {
     @Mapping(source = "indent.project.id", target = "projectId")
     @Mapping(source = "indent.project.projectName", target = "projectName")
     IndentDto toDto(Indent indent, @Context MaterialStockLookup stock);
+
+    /**
+     * Converts an indent for a list, taking its line count from the supplied lookup.
+     *
+     * @param indent The indent to convert.
+     * @param itemCounts The line counts read for the whole page of indents being mapped. An indent
+     *                   absent from it reads as zero.
+     * @return The indent summary.
+     */
+    @Mapping(source = "indent.createdBy.id", target = "createdById")
+    @Mapping(source = "indent.createdBy.employeeName", target = "createdByName")
+    @Mapping(source = "indent.project.id", target = "projectId")
+    @Mapping(source = "indent.project.projectName", target = "projectName")
+    @Mapping(target = "itemCount", expression = "java(itemCounts.itemCountOf(indent.getId()))")
+    IndentSummaryDto toSummaryDto(Indent indent, @Context IndentItemCountLookup itemCounts);
 
     @AfterMapping
     default void emptyItemsIfNull(@MappingTarget IndentDto dto) {

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemCount.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemCount.java
@@ -1,0 +1,14 @@
+package org.tornotron.echno_backend.indentItem;
+
+/**
+ * How many item lines one indent has, as returned by the grouped read in
+ * {@link IndentItemRepository#countItemsByIndentIds}.
+ *
+ * <p>An indent with no lines produces no group, so it is absent from the result rather than
+ * present with a zero. {@link IndentItemCountLookup} turns that absence back into zero.
+ *
+ * @param indentId The indent this count belongs to.
+ * @param itemCount How many lines it has.
+ */
+public record IndentItemCount(Long indentId, long itemCount) {
+}

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemCountLookup.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemCountLookup.java
@@ -1,0 +1,72 @@
+package org.tornotron.echno_backend.indentItem;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The line count for a whole page of indents, read once and handed to the mapper.
+ *
+ * <p>A list of indents wants to say how many lines each one has. Reaching that through
+ * {@code indent.getItems().size()} loads every line of every indent on the page, and each line
+ * carries a material, so the page also pays for the material graph and its stock lookup. The
+ * count comes from one grouped read instead and travels down as a MapStruct {@code @Context},
+ * the shape {@link org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup}
+ * established.
+ */
+public final class IndentItemCountLookup {
+
+    private static final IndentItemCountLookup EMPTY = new IndentItemCountLookup(Map.of());
+
+    private final Map<Long, Long> byIndentId;
+
+    private IndentItemCountLookup(Map<Long, Long> byIndentId) {
+        this.byIndentId = byIndentId;
+    }
+
+    /**
+     * A lookup holding nothing, so every indent reads as having no lines.
+     *
+     * <p>For an indent that cannot have lines yet, and for tests.
+     *
+     * @return The empty lookup.
+     */
+    public static IndentItemCountLookup none() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a lookup from the rows of a grouped read.
+     *
+     * @param counts The per-indent counts, at most one row per indent.
+     * @return A lookup over those counts.
+     */
+    public static IndentItemCountLookup of(Collection<IndentItemCount> counts) {
+        if (counts == null || counts.isEmpty()) {
+            return EMPTY;
+        }
+        return new IndentItemCountLookup(counts.stream()
+                .filter(row -> row.indentId() != null)
+                .collect(Collectors.toMap(IndentItemCount::indentId, IndentItemCount::itemCount,
+                        (first, second) -> first)));
+    }
+
+    /**
+     * How many lines an indent has.
+     *
+     * @param indentId The indent to read, which may be null for an entity not yet persisted.
+     * @return The line count, or zero where the indent has none.
+     */
+    public long itemCountOf(Long indentId) {
+        return byIndentId.getOrDefault(indentId, 0L);
+    }
+
+    /**
+     * Whether the lookup holds no rows at all.
+     *
+     * @return {@code true} when every indent reads as having no lines.
+     */
+    public boolean isEmpty() {
+        return byIndentId.isEmpty();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemRepository.java
@@ -1,7 +1,10 @@
 package org.tornotron.echno_backend.indentItem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,4 +21,27 @@ public interface IndentItemRepository extends JpaRepository<IndentItem, Long> {
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 
     void deleteByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Counts the item lines of many indents in one grouped read.
+     *
+     * <p>The count is all a list of indents needs; reaching it through the mapped {@code items}
+     * collection loads every line, and every line carries a material, so a page of indents pays
+     * for the material graph and its stock aggregate to render a column of numbers.
+     *
+     * <p>An indent with no lines produces no group, so the caller supplies the zero. Pass a
+     * non-empty collection: {@code IN ()} is not valid SQL.
+     *
+     * @param indentIds The indents to count, non-empty.
+     * @return One row per indent that has at least one line.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.indentItem.IndentItemCount(
+                       item.indent.id,
+                       COUNT(item))
+            FROM IndentItem item
+            WHERE item.indent.id IN :indentIds
+            GROUP BY item.indent.id
+            """)
+    List<IndentItemCount> countItemsByIndentIds(@Param("indentIds") Collection<Long> indentIds);
 }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -263,6 +263,34 @@ public class OrganizationService {
     }
 
     /**
+     * The same organizations as {@link #getAllOrganization}, without their contents.
+     *
+     * <p>{@link OrganizationDto} carries every project in the organization, every project carries
+     * its team, its tasks and its attachments, and every task carries its own issues, assignees
+     * and attachments. So the organization picker, which needs a name and a logo, pulls the whole
+     * tenant for each organization the caller belongs to.
+     *
+     * <p>{@link OrganizationSimpleDto} is exactly the scalar half and already exists, so this
+     * reuses it rather than declaring a byte-identical twin under a second name. Its other use is
+     * as the reply to a create or an update, which is a different question about the same shape.
+     *
+     * <p>Offered alongside {@link #getAllOrganization} rather than replacing it: the published
+     * contract is hand-maintained, so moving an endpoint over is a decision per endpoint.
+     *
+     * @return The organizations the caller is a member of, without their contents, empty if none.
+     */
+    @Transactional(readOnly = true)
+    public List<OrganizationSimpleDto> getAllOrganizationsSummary() {
+        User user = userContextService.getCurrentUser();
+        if (user == null) {
+            return List.of();
+        }
+        return repository.findAllByUserEmail(user.getEmail()).stream()
+                .map(org -> organizationMapper.toSimpleDto(org))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Retrieves a list of all organizations created by a specific user.
      * @param creatorId The ID of the user who created the organizations.
      * @return A {@link List} of {@link OrganizationDto}s.

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationWebController.java
@@ -109,6 +109,34 @@ public class OrganizationWebController {
     }
 
     /**
+     * Lists the caller's organizations without their contents.
+     *
+     * <p>The same organizations as {@link #readAllOrganizations}, in the same order, carrying only
+     * the organization's own fields. The full view carries every project in the organization, and
+     * every project carries its team, its tasks and its attachments, so the picker this endpoint
+     * populates was reading the whole tenant to render a name and a logo.
+     *
+     * <p>It is an addition, not a replacement. {@link #readAllOrganizations} is unchanged.
+     *
+     * @return A {@link ResponseEntity} containing the caller's organizations without their contents.
+     */
+    @GetMapping("/summary")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "List the current user's organizations, without their contents",
+            description = "Returns the same organizations as the full listing, carrying only each "
+                    + "organization's own fields: no projects, no employees, no attachments. This "
+                    + "is what an organization picker needs."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of the caller's organizations, empty if they belong to none"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Caller is not authenticated")
+    })
+    public ResponseEntity<List<OrganizationSimpleDto>> readAllOrganizationSummaries() {
+        return ResponseEntity.status(HttpStatus.OK).body(service.getAllOrganizationsSummary());
+    }
+
+    /**
      * Retrieves a single organization by its ID.
      * User must be a member of the organization or a platform admin.
      *

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -27,6 +27,7 @@ import org.tornotron.echno_backend.employee.dto.EmployeeDto;
 import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
 import org.tornotron.echno_backend.project.dto.ProjectDto;
 import org.tornotron.echno_backend.project.dto.ProjectSimpleDto;
+import org.tornotron.echno_backend.project.dto.ProjectSummaryDto;
 
 import java.util.List;
 import java.util.Map;
@@ -152,6 +153,43 @@ public class ProjectControllerWeb {
             @Valid @ParameterObject PageQuery pageQuery,
             @RequestParam(required = false) String search) {
         return ResponseEntity.ok(service.getProjectsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), search));
+    }
+
+    /**
+     * Retrieves a page of projects as summaries, for a list that does not read their contents.
+     *
+     * <p>The same projects, the same order and the same paging as {@link #readAllProjectsPaginated},
+     * with every scalar field of the full project view and none of its collections. Progress means
+     * what it means on the full view: it is read for the whole page in one aggregate rather than by
+     * loading each project's tasks, so a table of project names no longer walks the tenant's tasks,
+     * issues, assignees and attachments to render itself.
+     *
+     * <p>It is an addition, not a replacement. {@link #readAllProjectsPaginated} is unchanged and
+     * still returns the full DTO, so nothing moves until a caller chooses to move.
+     *
+     * @param pageQuery Page index and page size, bounded by {@link PageQuery}.
+     * @param search   Optional case-insensitive match on the project name.
+     * @return A {@link ResponseEntity} containing the page of project summaries.
+     */
+    @GetMapping("/summary")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List projects as summaries, paginated and filtered",
+            description = "Returns a single page of projects carrying every scalar field of the "
+                    + "full project view and none of its collections: no team, no tasks, no "
+                    + "attachments. Progress is the same figure the full view reports. Use this "
+                    + "for lists and tables; use the full listing when the response is read for "
+                    + "its contents. pageSize is clamped to 500."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of project summaries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+    })
+    public ResponseEntity<Page<ProjectSummaryDto>> readAllProjectSummaries(
+            @Valid @ParameterObject PageQuery pageQuery,
+            @RequestParam(required = false) String search) {
+        return ResponseEntity.ok(
+                service.getProjectsSummaryPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), search));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectProgressLookup.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectProgressLookup.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.project;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The average task progress for a whole page of projects, read once and handed to the mapper.
+ *
+ * <p>{@link ProjectDto} reports a project's progress as the mean of its tasks' progress values,
+ * which {@link ProjectProgressCalculator} computes from {@code project.getTasks()}. That is one
+ * {@code Double}, and reaching it costs the project's entire task collection: on a list page,
+ * every task of every project on the page, so that a number can be averaged and the tasks
+ * discarded. The summary projection asks the database for the average instead, once for the whole
+ * page, and passes it down as a MapStruct {@code @Context} in the shape
+ * {@link org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup} established.
+ *
+ * <p>The two agree by construction. {@code AVG} ignores nulls exactly as the calculator filters
+ * them out, and a project with nothing to average is absent from the grouped result, which
+ * {@link #progressOf} reads back as the {@code 0.0} the calculator returns for an empty list.
+ */
+public final class ProjectProgressLookup {
+
+    private static final ProjectProgressLookup EMPTY = new ProjectProgressLookup(Map.of());
+
+    private final Map<Long, Double> byProjectId;
+
+    private ProjectProgressLookup(Map<Long, Double> byProjectId) {
+        this.byProjectId = byProjectId;
+    }
+
+    /**
+     * A lookup holding nothing, so every project reads as no progress.
+     *
+     * <p>For a project that cannot have tasks yet, and for tests. It is not a fallback for a
+     * caller that forgot to read: that would silently report a running project at zero.
+     *
+     * @return The empty lookup.
+     */
+    public static ProjectProgressLookup none() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a lookup from the rows of a grouped read.
+     *
+     * @param totals The per-project averages, at most one row per project.
+     * @return A lookup over those averages.
+     */
+    public static ProjectProgressLookup of(Collection<ProjectProgressTotals> totals) {
+        if (totals == null || totals.isEmpty()) {
+            return EMPTY;
+        }
+        return new ProjectProgressLookup(totals.stream()
+                .filter(row -> row.projectId() != null && row.averageProgress() != null)
+                .collect(Collectors.toMap(ProjectProgressTotals::projectId,
+                        ProjectProgressTotals::averageProgress, (first, second) -> first)));
+    }
+
+    /**
+     * The average task progress for a project.
+     *
+     * @param projectId The project to read, which may be null for an entity not yet persisted.
+     * @return The average, or {@code 0.0} where the project has nothing to average.
+     */
+    public Double progressOf(Long projectId) {
+        return byProjectId.getOrDefault(projectId, 0.0);
+    }
+
+    /**
+     * Whether the lookup holds no rows at all.
+     *
+     * @return {@code true} when every project reads as zero.
+     */
+    public boolean isEmpty() {
+        return byProjectId.isEmpty();
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectProgressTotals.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectProgressTotals.java
@@ -1,0 +1,16 @@
+package org.tornotron.echno_backend.project;
+
+/**
+ * One project's average task progress, as returned by the grouped read in
+ * {@link org.tornotron.echno_backend.task.TaskRepository#averageTaskProgressByProjectIds}.
+ *
+ * <p>A row exists only for a project that has at least one task carrying a progress value, so a
+ * project with no tasks, or with tasks that have never been given one, is absent from the result
+ * rather than present with a zero. {@link ProjectProgressLookup} is what turns that absence back
+ * into the {@code 0.0} the full DTO has always reported.
+ *
+ * @param projectId The project these totals belong to.
+ * @param averageProgress The mean of its tasks' progress values, ignoring tasks with none.
+ */
+public record ProjectProgressTotals(Long projectId, Double averageProgress) {
+}

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,4 +74,33 @@ public interface ProjectRepository extends JpaRepository<Project,Long> {
             """)
     List<Project> findByNormalisedName(@Param("organizationId") Long organizationId,
                                        @Param("name") String name);
+
+    /**
+     * Averages task progress for many projects in one grouped read.
+     *
+     * <p>What a project list needs from a project's tasks is one number. Reaching it through the
+     * mapped {@code project.getTasks()} collection loads every task of every project on the page
+     * so a field can be averaged and the rest thrown away, and the call site shows none of that.
+     * This returns the average itself.
+     *
+     * <p>{@code AVG} ignores tasks whose progress is null, which is what
+     * {@link ProjectProgressCalculator} does in memory. The join is outer, so a project with no
+     * tasks still produces a row, with a null average;
+     * {@link ProjectProgressLookup#of} drops it and reads the project back as the {@code 0.0} the
+     * calculator returns for an empty list. Pass a non-empty collection: {@code IN ()} is not
+     * valid SQL.
+     *
+     * @param projectIds The projects to average, non-empty.
+     * @return One row per project asked for.
+     */
+    @Query("""
+            SELECT new org.tornotron.echno_backend.project.ProjectProgressTotals(
+                       p.id,
+                       AVG(t.progress))
+            FROM Project p LEFT JOIN p.tasks t
+            WHERE p.id IN :projectIds
+            GROUP BY p.id
+            """)
+    List<ProjectProgressTotals> averageTaskProgressByProjectIds(
+            @Param("projectIds") Collection<Long> projectIds);
 }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -40,8 +40,10 @@ import org.tornotron.echno_backend.user.User;
 import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -244,6 +246,54 @@ public class ProjectService {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         return repository.search(searchPattern(search), pageable)
                 .map(project -> projectMapper.toDto(project));
+    }
+
+    /**
+     * Retrieves a page of projects as summaries: every scalar field, none of the collections.
+     *
+     * <p>The list projection of {@link #getProjectsPaginated}. The full DTO carries the team, the
+     * tasks and the attachments of every project on the page, and every task carries its own
+     * issues, assignees and attachments, so rendering a table of project names walks most of the
+     * tenant. The one derived figure a list reads, progress, is the mean of the project's task
+     * progress; this reads that mean for the whole page in a single grouped query rather than by
+     * loading the tasks, so it reports the same number the full view reports.
+     *
+     * <p>Offered alongside {@link #getProjectsPaginated} rather than replacing it. The published
+     * contract is hand-maintained in {@code echno-core} with no code generation, so narrowing an
+     * existing endpoint's response would reach the web app as fields quietly going undefined.
+     * Which endpoints move over is a decision per endpoint.
+     *
+     * @param pageNo   Zero-based page index; a negative value is treated as zero.
+     * @param pageSize Rows per page, clamped to {@link UnpagedResultCap#MAX_ROWS}.
+     * @param search   Optional case-insensitive match on the project name; blank means none.
+     * @return A {@link Page} of project summaries.
+     */
+    @Transactional(readOnly = true)
+    public Page<ProjectSummaryDto> getProjectsSummaryPaginated(int pageNo, int pageSize, String search) {
+        int page = Math.max(pageNo, 0);
+        int size = Math.clamp(pageSize, 1, UnpagedResultCap.MAX_ROWS);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Project> projects = repository.search(searchPattern(search), pageable);
+        ProjectProgressLookup progress = progressFor(projects.getContent());
+        return projects.map(project -> projectMapper.toSummaryDto(project, progress));
+    }
+
+    /**
+     * Reads the average task progress for a whole page of projects, in one query.
+     *
+     * @param projects The projects being converted.
+     * @return Their average task progress, with a project that has nothing to average reading as
+     *         zero.
+     */
+    private ProjectProgressLookup progressFor(Collection<Project> projects) {
+        List<Long> ids = projects.stream()
+                .map(Project::getId)
+                .filter(Objects::nonNull)
+                .toList();
+        if (ids.isEmpty()) {
+            return ProjectProgressLookup.none();
+        }
+        return ProjectProgressLookup.of(repository.averageTaskProgressByProjectIds(ids));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
@@ -1,0 +1,76 @@
+package org.tornotron.echno_backend.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.enums.ProjectType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "A project as it appears in a list: every scalar field of the full project "
+        + "view, without the team, the tasks or the attachments. Progress still means what it "
+        + "means on the full view, the mean of the project's task progress, but it is read for "
+        + "the whole page in one aggregate rather than by loading each project's tasks.")
+@Data
+public class ProjectSummaryDto {
+
+    @Schema(description = "Unique project id.", example = "42")
+    private Long id;
+
+    @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
+    private String projectName;
+
+    @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
+    private String projectAddress;
+
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    private String projectCity;
+
+    @Schema(description = "Indian state or union territory the site is in, used to match statutory "
+            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+    private String projectState;
+
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    private String projectPostalCode;
+
+    @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "Id of the user who created the project. Null on projects created before "
+            + "this was recorded.", example = "17")
+    private Long createdBy;
+
+    @Schema(description = "When the project was last written. Null on projects not written since "
+            + "this was recorded.", example = "2026-08-28T16:41:12")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "Id of the user who last wrote the project.", example = "17")
+    private Long updatedBy;
+
+    @Schema(description = "Current project status.", example = "IN_PROGRESS")
+    private ProjectCreationStatus status;
+
+    @Schema(description = "Construction category of the project.", example = "RESIDENTIAL")
+    private ProjectType projectType;
+
+    @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+    private UUID customerId;
+
+    @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")
+    private Float projectLatitude;
+
+    @Schema(description = "Site longitude in decimal degrees.", example = "80.2707")
+    private Float projectLongitude;
+
+    @Schema(description = "Planned start date of the project.", example = "2026-09-01T00:00:00")
+    private LocalDateTime startDate;
+
+    @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
+    private LocalDateTime endDate;
+
+    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1. The same "
+            + "figure the full project view reports.", example = "0.35")
+    private Double progress;
+}

--- a/src/main/java/org/tornotron/echno_backend/project/mapper/ProjectMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/project/mapper/ProjectMapper.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.project.mapper;
 
 import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -8,8 +9,10 @@ import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
 import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectProgressCalculator;
+import org.tornotron.echno_backend.project.ProjectProgressLookup;
 import org.tornotron.echno_backend.project.dto.ProjectDto;
 import org.tornotron.echno_backend.project.dto.ProjectSimpleDto;
+import org.tornotron.echno_backend.project.dto.ProjectSummaryDto;
 import org.tornotron.echno_backend.task.mapper.TaskMapper;
 
 /**
@@ -17,6 +20,14 @@ import org.tornotron.echno_backend.task.mapper.TaskMapper;
  * {@link TaskMapper}, attachments via {@link AttachmentMapper}. On the full DTO, progress
  * is the average of the tasks' progress (computed in {@link #calcProgress}); on the simple
  * DTO it is the entity's own progress field, mapped by name.
+ *
+ * <p>{@link #toSummaryDto} is the list projection of the full DTO: the same scalar fields, none
+ * of the collections, and a progress figure that means the same thing. It is deliberately not
+ * {@link #toSimpleDto}, which is the shape a create or an update replies with and whose progress
+ * comes from the entity's own {@code progress} column. Nothing in the codebase writes that
+ * column, so on the simple DTO the field is always null; the full DTO derives the number from the
+ * tasks instead, and the summary reads the same derivation out of the
+ * {@link ProjectProgressLookup} the caller fills for the whole page.
  */
 @Mapper(componentModel = "spring",
         uses = {EmployeeMapper.class, TaskMapper.class, AttachmentMapper.class})
@@ -26,6 +37,18 @@ public interface ProjectMapper {
     ProjectDto toDto(Project project);
 
     ProjectSimpleDto toSimpleDto(Project project);
+
+    /**
+     * Converts a project for a list, taking its progress from the supplied lookup.
+     *
+     * @param project The project to convert.
+     * @param progress The average task progress read for the whole page of projects being mapped.
+     *                 A project absent from it reads as zero, which is what
+     *                 {@link ProjectProgressCalculator} returns for a project with no tasks.
+     * @return The project summary.
+     */
+    @Mapping(target = "progress", expression = "java(progress.progressOf(project.getId()))")
+    ProjectSummaryDto toSummaryDto(Project project, @Context ProjectProgressLookup progress);
 
     @AfterMapping
     default void calcProgress(Project project, @MappingTarget ProjectDto dto) {

--- a/src/test/java/org/tornotron/echno_backend/projection/ListProjectionCostIT.java
+++ b/src/test/java/org/tornotron/echno_backend/projection/ListProjectionCostIT.java
@@ -1,0 +1,685 @@
+package org.tornotron.echno_backend.projection;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.category.mapper.CategoryMapper;
+import org.tornotron.echno_backend.category.mapper.CategoryMapperImpl;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapperImpl;
+import org.tornotron.echno_backend.indent.Indent;
+import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.dto.IndentSummaryDto;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
+import org.tornotron.echno_backend.indent.mapper.IndentMapper;
+import org.tornotron.echno_backend.indent.mapper.IndentMapperImpl;
+import org.tornotron.echno_backend.indentItem.IndentItem;
+import org.tornotron.echno_backend.indentItem.IndentItemCountLookup;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapper;
+import org.tornotron.echno_backend.indentItem.mapper.IndentItemMapperImpl;
+import org.tornotron.echno_backend.inventoryTransaction.MaterialStockLookup;
+import org.tornotron.echno_backend.issue.Issue;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.issue.mapper.IssueMapperImpl;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.mapper.MaterialMapper;
+import org.tornotron.echno_backend.material.mapper.MaterialMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.dto.OrganizationDto;
+import org.tornotron.echno_backend.organization.dto.OrganizationSimpleDto;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapperImpl;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectProgressLookup;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.project.dto.ProjectDto;
+import org.tornotron.echno_backend.project.dto.ProjectSummaryDto;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.project.mapper.ProjectMapperImpl;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.enums.TaskStatus;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+import org.tornotron.echno_backend.task.mapper.TaskMapperImpl;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * What a list endpoint costs before and after the projection, in statements and in rows read.
+ *
+ * <p>Issue #522 asked whether the conversion layer was going to scale. Three response shapes carry
+ * an entire object graph on every row of a list: {@code OrganizationDto} carries every project,
+ * each project carries its team, its tasks and its attachments, and each task carries its own
+ * issues, assignees and attachments; {@code ProjectDto} is the middle of that chain; and
+ * {@code IndentDto} carries every line, each line carrying a whole material.
+ *
+ * <p>{@code MaterialMapperCostTest} pinned the equivalent numbers for the {@code @AfterMapping}
+ * problem so that the fix showed up in a diff rather than only in a query log. This does the same
+ * for the graph problem. Both directions are measured on the same fixture and in the same units,
+ * against a real CockroachDB, with Hibernate's own statistics counting.
+ *
+ * <p>Two things are measured, because they answer different questions. Prepared statements say how
+ * many round trips the request makes, and Hibernate's {@code default_batch_fetch_size} of 100 keeps
+ * that number lower than an N+1 would suggest. Entity loads say how many rows were materialised,
+ * and no batch setting reduces that: it is the number that follows the shape of the DTO, and it is
+ * the one that grows without bound as a tenant's history does.
+ *
+ * <p>The strongest of the assertions below is not either absolute number. It is that the full view
+ * costs more when the same page of rows has a deeper graph hanging off it, and the projection costs
+ * exactly the same, so the projection's cost is a function of the page size alone.
+ *
+ * <p>What it measures, on the fixtures below:
+ *
+ * <pre>
+ * a page of 5 projects, 6 tasks each, 3 issues per task
+ *   ProjectDto             14 statements   128 entities   317 collections
+ *   ProjectSummaryDto       3 statements     6 entities     0 collections
+ *
+ * the same 5 projects, shallow (2 tasks, 1 issue) against deep (8 tasks, 4 issues)
+ *   ProjectDto             28 -> 208 entities,  77 -> 497 collections
+ *   ProjectSummaryDto       6 ->   6 entities,   0 ->   0 collections
+ *
+ * one organization holding 4 projects, 4 tasks each, 2 issues per task
+ *   OrganizationDto        16 statements    55 entities   145 collections
+ *   OrganizationSimpleDto   1 statement       1 entity      0 collections
+ *
+ * a page of 5 indents, 10 lines each
+ *   IndentDto               6 statements   109 entities     7 collections
+ *   IndentSummaryDto        4 statements     8 entities     1 collection
+ * </pre>
+ *
+ * <p>The indent figures understate the full view: {@code IndentDto} carries a material on every
+ * line and a material carries its aggregate stock, which the service reads separately and which is
+ * not counted here. And none of the fixtures is large. A tenant with a hundred tasks on a project
+ * and a page of fifty projects multiplies the project row above by ten in the page and again in the
+ * depth; the projection's six stay six.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ListProjectionCostIT extends AbstractIntegrationTest {
+
+    private static final int PAGE = 5;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private IndentItemRepository indentItemRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private ProjectMapper projectMapper;
+    private OrganizationMapper organizationMapper;
+    private IndentMapper indentMapper;
+
+    private int nextSuffix;
+
+    /**
+     * Builds the mappers the way the container does. This is a repository slice, so the MapStruct
+     * beans are not in the context; the generated implementations are what the application runs, so
+     * they are what is measured.
+     */
+    private void wireMappers() {
+        FileStorageService fileStorageService = mock(FileStorageService.class);
+        when(fileStorageService.generateDownloadUrl(anyString(), any(Duration.class)))
+                .thenReturn("https://store.example/signed");
+
+        AttachmentMapper attachmentMapper = new AttachmentMapperImpl();
+        ReflectionTestUtils.setField(attachmentMapper, "fileStorageService", fileStorageService);
+
+        EmployeeMapper employeeMapper = new EmployeeMapperImpl();
+        ReflectionTestUtils.setField(employeeMapper, "attachmentMapper", attachmentMapper);
+        ReflectionTestUtils.setField(employeeMapper, "shiftTimingMapper", mock(ShiftTimingMapper.class));
+
+        IssueMapper issueMapper = new IssueMapperImpl();
+        ReflectionTestUtils.setField(issueMapper, "attachmentMapper", attachmentMapper);
+
+        CategoryMapper categoryMapper = new CategoryMapperImpl();
+
+        TaskMapper taskMapper = new TaskMapperImpl();
+        ReflectionTestUtils.setField(taskMapper, "employeeMapper", employeeMapper);
+        ReflectionTestUtils.setField(taskMapper, "categoryMapper", categoryMapper);
+        ReflectionTestUtils.setField(taskMapper, "issueMapper", issueMapper);
+        ReflectionTestUtils.setField(taskMapper, "attachmentMapper", attachmentMapper);
+
+        projectMapper = new ProjectMapperImpl();
+        ReflectionTestUtils.setField(projectMapper, "employeeMapper", employeeMapper);
+        ReflectionTestUtils.setField(projectMapper, "taskMapper", taskMapper);
+        ReflectionTestUtils.setField(projectMapper, "attachmentMapper", attachmentMapper);
+
+        organizationMapper = new OrganizationMapperImpl();
+        ReflectionTestUtils.setField(organizationMapper, "employeeMapper", employeeMapper);
+        ReflectionTestUtils.setField(organizationMapper, "projectMapper", projectMapper);
+        ReflectionTestUtils.setField(organizationMapper, "attachmentMapper", attachmentMapper);
+
+        MaterialMapper materialMapper = new MaterialMapperImpl();
+        ReflectionTestUtils.setField(materialMapper, "employeeMapper", employeeMapper);
+
+        IndentItemMapper indentItemMapper = new IndentItemMapperImpl();
+        ReflectionTestUtils.setField(indentItemMapper, "materialMapper", materialMapper);
+
+        indentMapper = new IndentMapperImpl();
+        ReflectionTestUtils.setField(indentMapper, "employeeMapper", employeeMapper);
+        ReflectionTestUtils.setField(indentMapper, "indentItemMapper", indentItemMapper);
+    }
+
+    // ------------------------------------------------------------------ projects
+
+    @Test
+    void aPageOfProjectsPaysForEveryTaskAndIssueHangingOffIt() {
+        wireMappers();
+        String tag = fixture(PAGE, 6, 3);
+
+        Cost full = measure(() -> {
+            List<ProjectDto> dtos = page(tag).stream().map(projectMapper::toDto).toList();
+            assertThat(dtos).hasSize(PAGE);
+        });
+
+        Cost summary = measure(() -> {
+            List<Project> projects = page(tag);
+            ProjectProgressLookup progress = progressFor(projects);
+            List<ProjectSummaryDto> dtos = projects.stream()
+                    .map(project -> projectMapper.toSummaryDto(project, progress))
+                    .toList();
+            assertThat(dtos).hasSize(PAGE);
+        });
+
+        System.out.printf("projects, page of %d with 6 tasks and 3 issues each%n"
+                        + "  full  ProjectDto         : %s%n"
+                        + "  summary ProjectSummaryDto: %s%n",
+                PAGE, full, summary);
+
+        // Five projects, thirty tasks, ninety issues, plus the employees on each project and each
+        // task. The full view materialises all of it to render a table of project names.
+        assertThat(full.entitiesLoaded)
+                .as("the full view should load the whole graph: %s", full)
+                .isGreaterThanOrEqualTo(PAGE + PAGE * 6 + PAGE * 6 * 3);
+
+        // The projection loads the page and nothing else. The averages come back as scalars.
+        // The page itself plus the one organization every project on it points at, which is an
+        // eager to-one on the entity and so comes back with the page query.
+        assertThat(summary.entitiesLoaded)
+                .as("the projection should load the page and its own to-one rows, nothing else: %s",
+                        summary)
+                .isEqualTo(PAGE + 1);
+
+        assertThat(summary.statements)
+                .as("the projection should cost fewer round trips: %s against %s", summary, full)
+                .isLessThan(full.statements);
+
+    }
+
+    /**
+     * The claim worth more than either absolute figure: the projection's cost is a function of the
+     * page size alone. Same five projects either way; only the depth of what hangs off them
+     * changes. The full view pays for the difference and the projection does not notice it.
+     */
+    @Test
+    void onlyTheFullProjectViewGetsDearerAsTheGraphDeepens() {
+        wireMappers();
+        String shallow = fixture(PAGE, 2, 1);
+        String deep = fixture(PAGE, 8, 4);
+
+        Cost fullShallow = measure(() -> page(shallow).forEach(projectMapper::toDto));
+        Cost fullDeep = measure(() -> page(deep).forEach(projectMapper::toDto));
+        Cost summaryShallow = measure(() -> summarise(shallow));
+        Cost summaryDeep = measure(() -> summarise(deep));
+
+        assertThat(fullDeep.entitiesLoaded)
+                .as("a deeper graph must cost the full view more: %s against %s", fullDeep, fullShallow)
+                .isGreaterThan(fullShallow.entitiesLoaded);
+
+        assertThat(summaryDeep.entitiesLoaded)
+                .as("the projection must not notice the depth at all: %s against %s",
+                        summaryDeep, summaryShallow)
+                .isEqualTo(summaryShallow.entitiesLoaded);
+        assertThat(summaryDeep.statements)
+                .as("nor in round trips: %s against %s", summaryDeep, summaryShallow)
+                .isEqualTo(summaryShallow.statements);
+
+        System.out.printf("projects, same page of %d, shallow (2 tasks, 1 issue) against deep (8 tasks, 4 issues)%n"
+                        + "  full    : %s -> %s%n"
+                        + "  summary : %s -> %s%n",
+                PAGE, fullShallow, fullDeep, summaryShallow, summaryDeep);
+    }
+
+    /**
+     * The projection is only worth having if it says the same thing. Progress on the full view is
+     * the mean of the project's task progress, computed in memory over the loaded collection; on
+     * the summary it comes out of one {@code AVG} over the page. They have to agree, including for
+     * a project with no tasks, which the calculator reports as zero and the grouped read reports as
+     * no row at all.
+     */
+    @Test
+    void theSummaryReportsTheProgressTheFullViewReports() {
+        wireMappers();
+        String tag = fixture(PAGE, 3, 0);
+        Project childless = persistProject(tag, PAGE);
+        em.flush();
+        em.clear();
+
+        List<Project> projects = page(tag);
+        ProjectProgressLookup progress = progressFor(projects);
+
+        for (Project project : projects) {
+            ProjectDto full = projectMapper.toDto(project);
+            ProjectSummaryDto summary = projectMapper.toSummaryDto(project, progress);
+
+            assertThat(summary.getProgress())
+                    .as("project %d must report the same progress on both views", project.getId())
+                    .isEqualTo(full.getProgress());
+        }
+
+        assertThat(projects).extracting(Project::getId).contains(childless.getId());
+        assertThat(progress.progressOf(childless.getId()))
+                .as("a project with no tasks reports zero, as the calculator does")
+                .isEqualTo(0.0);
+    }
+
+    /**
+     * The projection carries every scalar the full view carries. A list projection that quietly
+     * drops a field is a worse trade than the graph it saves, and nothing else would catch it.
+     */
+    @Test
+    void theSummaryCarriesEveryScalarTheFullViewCarries() {
+        wireMappers();
+        String tag = fixture(1, 2, 1);
+        Project project = page(tag).get(0);
+
+        ProjectDto full = projectMapper.toDto(project);
+        ProjectSummaryDto summary = projectMapper.toSummaryDto(project, progressFor(List.of(project)));
+
+        assertThat(summary.getId()).isEqualTo(full.getId());
+        assertThat(summary.getProjectName()).isEqualTo(full.getProjectName());
+        assertThat(summary.getProjectAddress()).isEqualTo(full.getProjectAddress());
+        assertThat(summary.getProjectCity()).isEqualTo(full.getProjectCity());
+        assertThat(summary.getProjectState()).isEqualTo(full.getProjectState());
+        assertThat(summary.getProjectPostalCode()).isEqualTo(full.getProjectPostalCode());
+        assertThat(summary.getCreatedAt()).isEqualTo(full.getCreatedAt());
+        assertThat(summary.getCreatedBy()).isEqualTo(full.getCreatedBy());
+        assertThat(summary.getUpdatedAt()).isEqualTo(full.getUpdatedAt());
+        assertThat(summary.getUpdatedBy()).isEqualTo(full.getUpdatedBy());
+        assertThat(summary.getStatus()).isEqualTo(full.getStatus());
+        assertThat(summary.getProjectType()).isEqualTo(full.getProjectType());
+        assertThat(summary.getCustomerId()).isEqualTo(full.getCustomerId());
+        assertThat(summary.getProjectLatitude()).isEqualTo(full.getProjectLatitude());
+        assertThat(summary.getProjectLongitude()).isEqualTo(full.getProjectLongitude());
+        assertThat(summary.getStartDate()).isEqualTo(full.getStartDate());
+        assertThat(summary.getEndDate()).isEqualTo(full.getEndDate());
+        assertThat(summary.getProgress()).isEqualTo(full.getProgress());
+    }
+
+    // ------------------------------------------------------------------ organizations
+
+    /**
+     * The organization picker. Its response needs a name and a logo, and the full DTO answers it
+     * with every project in the organization and everything hanging off each one.
+     */
+    @Test
+    void listingAnOrganizationPullsTheWholeTenantAndTheProjectionDoesNot() {
+        wireMappers();
+        String tag = fixture(4, 4, 2);
+        Organization organization = page(tag).get(0).getOrganization();
+        Long organizationId = organization.getId();
+        em.flush();
+        em.clear();
+
+        Cost full = measure(() -> {
+            OrganizationDto dto = organizationMapper.toDto(em.find(Organization.class, organizationId));
+            assertThat(dto.getProjects()).hasSize(4);
+        });
+
+        Cost summary = measure(() -> {
+            OrganizationSimpleDto dto =
+                    organizationMapper.toSimpleDto(em.find(Organization.class, organizationId));
+            assertThat(dto.getOrganizationName()).isNotNull();
+        });
+
+        System.out.printf("organization with 4 projects of 4 tasks and 2 issues each%n"
+                        + "  full  OrganizationDto        : %s%n"
+                        + "  summary OrganizationSimpleDto: %s%n",
+                full, summary);
+
+        assertThat(summary.entitiesLoaded)
+                .as("the picker should read one row: %s", summary)
+                .isEqualTo(1);
+        assertThat(full.entitiesLoaded)
+                .as("the full view reads the tenant: %s", full)
+                .isGreaterThan(summary.entitiesLoaded * 10);
+
+    }
+
+    // ------------------------------------------------------------------ indents
+
+    @Test
+    void aPageOfIndentsPaysForEveryLineAndEveryMaterialOnIt() {
+        wireMappers();
+        String tag = indentFixture(PAGE, 10);
+
+        Cost full = measure(() -> {
+            List<IndentDto> dtos = indents(tag).stream()
+                    .map(indent -> indentMapper.toDto(indent, MaterialStockLookup.none()))
+                    .toList();
+            assertThat(dtos).hasSize(PAGE);
+            assertThat(dtos.get(0).getItems()).hasSize(10);
+        });
+
+        Cost summary = measure(() -> {
+            List<Indent> page = indents(tag);
+            IndentItemCountLookup counts = IndentItemCountLookup.of(
+                    indentItemRepository.countItemsByIndentIds(page.stream().map(Indent::getId).toList()));
+            List<IndentSummaryDto> dtos = page.stream()
+                    .map(indent -> indentMapper.toSummaryDto(indent, counts))
+                    .toList();
+            assertThat(dtos).hasSize(PAGE);
+            assertThat(dtos).allSatisfy(dto -> assertThat(dto.getItemCount()).isEqualTo(10));
+        });
+
+        System.out.printf("indents, page of %d with 10 lines each%n"
+                        + "  full  IndentDto         : %s%n"
+                        + "  summary IndentSummaryDto: %s%n",
+                PAGE, full, summary);
+
+        // Five indents of ten lines: fifty lines, each carrying a material, plus the raiser of each
+        // indent. The stock aggregate the lines then need is on top of this and is not counted here.
+        assertThat(full.entitiesLoaded)
+                .as("the full view should load every line and every material: %s", full)
+                .isGreaterThanOrEqualTo(PAGE + PAGE * 10);
+        // The page, the one employee who raised them all, the one project they are all on, and
+        // that project's organization. Four rows beyond the page however many lines the indents
+        // have, against a hundred and nine.
+        assertThat(summary.entitiesLoaded)
+                .as("the projection should load the page and its own to-one rows, nothing else: %s",
+                        summary)
+                .isEqualTo(PAGE + 3);
+
+    }
+
+    @Test
+    void theIndentSummaryCountsTheLinesTheFullViewLists() {
+        wireMappers();
+        String tag = indentFixture(3, 4);
+        Indent empty = persistIndent(tag, 3, 0);
+        em.flush();
+        em.clear();
+
+        List<Indent> page = indents(tag);
+        IndentItemCountLookup counts = IndentItemCountLookup.of(
+                indentItemRepository.countItemsByIndentIds(page.stream().map(Indent::getId).toList()));
+
+        for (Indent indent : page) {
+            IndentDto full = indentMapper.toDto(indent, MaterialStockLookup.none());
+            IndentSummaryDto summary = indentMapper.toSummaryDto(indent, counts);
+
+            assertThat(summary.getItemCount())
+                    .as("indent %d must count the lines the full view lists", indent.getId())
+                    .isEqualTo(full.getItems().size());
+            assertThat(summary.getIndentNumber()).isEqualTo(full.getIndentNumber());
+            assertThat(summary.getProjectId()).isEqualTo(full.getProjectId());
+            assertThat(summary.getProjectName()).isEqualTo(full.getProjectName());
+            assertThat(summary.getStatus()).isEqualTo(full.getStatus());
+            assertThat(summary.getCreatedById()).isEqualTo(full.getCreatedBy().getId());
+            assertThat(summary.getCreatedByName()).isEqualTo(full.getCreatedBy().getEmployeeName());
+        }
+
+        assertThat(counts.itemCountOf(empty.getId()))
+                .as("an indent with no lines counts zero rather than going missing")
+                .isZero();
+    }
+
+    // ------------------------------------------------------------------ measuring
+
+    /** One reading of what a conversion cost. */
+    private record Cost(long statements, long entitiesLoaded, long collectionsLoaded) {
+        @Override
+        public String toString() {
+            return "%d statements, %d entities, %d collections"
+                    .formatted(statements, entitiesLoaded, collectionsLoaded);
+        }
+    }
+
+    /**
+     * Runs a read and reports what it cost, starting from a cold persistence context so nothing
+     * already in memory makes the second reading look cheaper than the first.
+     *
+     * @param read The read to measure.
+     * @return Its cost.
+     */
+    private Cost measure(Runnable read) {
+        SessionFactory sessionFactory = entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+        Statistics statistics = sessionFactory.getStatistics();
+        boolean wereEnabled = statistics.isStatisticsEnabled();
+        statistics.setStatisticsEnabled(true);
+        try {
+            em.flush();
+            em.clear();
+            statistics.clear();
+
+            read.run();
+
+            return new Cost(statistics.getPrepareStatementCount(),
+                    statistics.getEntityLoadCount(),
+                    statistics.getCollectionLoadCount());
+        } finally {
+            statistics.setStatisticsEnabled(wereEnabled);
+        }
+    }
+
+    private void summarise(String tag) {
+        List<Project> projects = page(tag);
+        ProjectProgressLookup progress = progressFor(projects);
+        projects.forEach(project -> projectMapper.toSummaryDto(project, progress));
+    }
+
+    private List<Project> page(String tag) {
+        return projectRepository.search("%" + tag + "%",
+                PageRequest.of(0, 50, Sort.by(Sort.Direction.ASC, "id"))).getContent();
+    }
+
+    private ProjectProgressLookup progressFor(List<Project> projects) {
+        return ProjectProgressLookup.of(projectRepository.averageTaskProgressByProjectIds(
+                projects.stream().map(Project::getId).toList()));
+    }
+
+    private List<Indent> indents(String tag) {
+        return entityManager.createQuery(
+                        "SELECT i FROM Indent i WHERE i.indentNumber LIKE :tag ORDER BY i.id", Indent.class)
+                .setParameter("tag", "%" + tag + "%")
+                .getResultList();
+    }
+
+    // ------------------------------------------------------------------ fixtures
+
+    /**
+     * Persists one organization holding a number of projects, each with the same number of tasks
+     * and each task the same number of issues.
+     *
+     * @param projects Projects to create.
+     * @param tasksPerProject Tasks on each project.
+     * @param issuesPerTask Issues on each task.
+     * @return The tag every one of those project names carries, for reading them back.
+     */
+    private String fixture(int projects, int tasksPerProject, int issuesPerTask) {
+        String tag = "costfixture" + nextSuffix++;
+        Organization organization = persistOrganization(tag);
+        Employee creator = persistEmployee(organization, tag);
+
+        for (int p = 0; p < projects; p++) {
+            Project project = persistProject(organization, tag, p, creator);
+            for (int t = 0; t < tasksPerProject; t++) {
+                Task task = persistTask(project, creator, organization, tag, p, t);
+                for (int i = 0; i < issuesPerTask; i++) {
+                    persistIssue(task, creator, organization, tag, p, t, i);
+                }
+            }
+        }
+        em.flush();
+        em.clear();
+        return tag;
+    }
+
+    private String indentFixture(int indents, int linesPerIndent) {
+        String tag = "costindent" + nextSuffix++;
+        Organization organization = persistOrganization(tag);
+        Employee creator = persistEmployee(organization, tag);
+        Project project = persistProject(organization, tag, 0, creator);
+
+        for (int n = 0; n < indents; n++) {
+            persistIndent(organization, project, creator, tag, n, linesPerIndent);
+        }
+        em.flush();
+        em.clear();
+        return tag;
+    }
+
+    private Indent persistIndent(String tag, int index, int lines) {
+        Project project = page(tag).get(0);
+        return persistIndent(project.getOrganization(), project,
+                entityManager.createQuery("SELECT e FROM Employee e WHERE e.employeeName = :name", Employee.class)
+                        .setParameter("name", tag).getSingleResult(),
+                tag, index, lines);
+    }
+
+    private Indent persistIndent(Organization organization, Project project, Employee creator,
+                                 String tag, int index, int lines) {
+        Indent indent = new Indent();
+        indent.setIndentNumber(tag + "-" + index);
+        indent.setCreatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        indent.setCreatedBy(creator);
+        indent.setProject(project);
+        indent.setOrganization(organization);
+        indent.setStatus(IndentStatus.PENDING);
+        List<IndentItem> items = new ArrayList<>();
+        indent.setItems(items);
+        em.persist(indent);
+
+        for (int line = 0; line < lines; line++) {
+            Material material = new Material();
+            material.setSku(tag + "-" + index + "-" + line);
+            material.setMaterialName("Material " + index + "-" + line);
+            material.setUnit("bags");
+            material.setOrganization(organization);
+            em.persist(material);
+
+            IndentItem item = new IndentItem();
+            item.setIndent(indent);
+            item.setMaterial(material);
+            item.setRequestedQuantity(5);
+            item.setConvertedToPurchaseOrder(false);
+            item.setOrganization(organization);
+            em.persist(item);
+            items.add(item);
+        }
+        return indent;
+    }
+
+    private Organization persistOrganization(String tag) {
+        Organization organization = new Organization();
+        organization.setOrganizationName("Org " + tag);
+        organization.setOrganizationAddress(tag + " address");
+        organization.setOrganizationEmail(tag + "@example.test");
+        organization.setOrganizationPhone("0000000000");
+        em.persist(organization);
+        return organization;
+    }
+
+    private Employee persistEmployee(Organization organization, String tag) {
+        User user = new User();
+        user.setKeycloakId("kc-" + tag);
+        user.setName(tag);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(organization);
+        employee.setUser(user);
+        employee.setEmployeeName(tag);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress(tag + "@emp.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+        return employee;
+    }
+
+    private Project persistProject(String tag, int index) {
+        List<Project> existing = page(tag);
+        Organization organization = existing.get(0).getOrganization();
+        return persistProject(organization, tag, index, null);
+    }
+
+    private Project persistProject(Organization organization, String tag, int index, Employee member) {
+        Project project = new Project();
+        project.setProjectName("Project " + tag + " " + index);
+        project.setProjectAddress(tag + " site road");
+        project.setProjectCity("Chennai");
+        project.setOrganization(organization);
+        project.setCreatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        if (member != null) {
+            project.setEmployees(List.of(member));
+        }
+        em.persist(project);
+        return project;
+    }
+
+    private Task persistTask(Project project, Employee creator, Organization organization,
+                             String tag, int projectIndex, int taskIndex) {
+        Task task = new Task();
+        task.setTitle("Task %s %d %d".formatted(tag, projectIndex, taskIndex));
+        task.setCreator(creator);
+        task.setProject(project);
+        task.setOrganization(organization);
+        task.setStatus(TaskStatus.onGoing);
+        task.setProgress(0.1 * (taskIndex + 1));
+        task.setCreatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        task.setUpdatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        em.persist(task);
+        return task;
+    }
+
+    private void persistIssue(Task task, Employee creator, Organization organization,
+                              String tag, int projectIndex, int taskIndex, int issueIndex) {
+        Issue issue = new Issue();
+        issue.setTitle("Issue %s %d %d %d".formatted(tag, projectIndex, taskIndex, issueIndex));
+        issue.setDescription("raised by the cost fixture");
+        issue.setType(IssueType.quality);
+        issue.setStatus(IssueStatus.open);
+        issue.setTask(task);
+        issue.setCreatedBy(creator);
+        issue.setOrganization(organization);
+        issue.setCreatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        issue.setUpdatedAt(LocalDateTime.of(2026, 1, 1, 9, 0));
+        em.persist(issue);
+    }
+}


### PR DESCRIPTION
OrganizationDto, ProjectDto and IndentDto each carry an entire object graph on
every row of a list. An organization carries every project, every project its
team, its tasks and its attachments, and every task its own issues, assignees
and attachments; an indent carries every line and every line a whole material,
whose stock is then read from a further aggregate. So the organization picker
reads the tenant to render a name, and a table of project names walks the
tenant's tasks and issues to render itself.

Measured on a real database, with Hibernate's own statistics counting:

  a page of 5 projects, 6 tasks each, 3 issues per task
    ProjectDto             14 statements   128 entities   317 collections
    ProjectSummaryDto       3 statements     6 entities     0 collections

  the same 5 projects, shallow (2 tasks, 1 issue) against deep (8 tasks, 4)
    ProjectDto             28 -> 208 entities,  77 -> 497 collections
    ProjectSummaryDto       6 ->   6 entities,   0 ->   0 collections

  one organization holding 4 projects, 4 tasks each, 2 issues per task
    OrganizationDto        16 statements    55 entities   145 collections
    OrganizationSimpleDto   1 statement       1 entity      0 collections

  a page of 5 indents, 10 lines each
    IndentDto               6 statements   109 entities     7 collections
    IndentSummaryDto        4 statements     8 entities     1 collection

The middle block is the one that matters. The same page of rows costs the full
view seven times as much when the graph under it is deeper, and costs the
projection exactly the same, so the projection's cost is a function of the page
size alone.

Two figures a projection could have got wrong are read for the whole page in one
grouped query and handed to the mapper, which is the shape MaterialMapper
established when the same problem was fixed on the material path, and which
keeps the mappers inside the rule that a mapper asks nobody anything.

  - a project's progress is the mean of its task progress. ProjectSimpleDto,
    which replies to a create or an update, maps it from the entity's own
    progress column, and nothing in the codebase has ever written that column,
    so on that DTO the field is always null. The list projection could not reuse
    it. It reads AVG(task.progress) per project instead and reports the number
    the full view reports.
  - an indent's line count comes from a grouped COUNT rather than from loading
    the lines.

Nothing moves. The existing list endpoints return exactly what they returned,
and three new ones serve the projections beside them: GET /project/web/summary,
GET /indents/web/summary and GET /organization/web/summary, each with the same
authorization as the listing it sits next to. The published contract is
hand-maintained in echno-core with no code generation, so narrowing a live
endpoint would reach the web app as fields quietly going undefined rather than
as a compile error. Which endpoints move over is a decision per endpoint, and a
coordinated one.

docs/openapi.json gains three paths and four schemas and loses nothing: no
existing path or schema changes.

Refs #522

Item B of #522.