### PR TITLE
Let the annotation processor write the six attendance conversions

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -243,7 +243,7 @@ public class AttendanceService {
             clockEvent.addAttachment(clockEventAttachment);
         }
 
-        return attendanceMapper.toResponseDto(savedAttendance,fileStorageService);
+        return attendanceMapper.toResponseDto(savedAttendance);
     }
 
     private void registerStorageCleanupOnRollback(String storageKey) {
@@ -356,7 +356,7 @@ public class AttendanceService {
             clockEvent.addAttachment(clockEventAttachment);
         }
 
-        return attendanceMapper.toResponseDto(savedAttendance,fileStorageService);
+        return attendanceMapper.toResponseDto(savedAttendance);
     }
 
     /**
@@ -370,7 +370,7 @@ public class AttendanceService {
     public AttendanceResponseDto getAttendanceById(Long id) {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Attendance record with ID " + id + " was not found"));
-        return attendanceMapper.toResponseDto(attendance,fileStorageService);
+        return attendanceMapper.toResponseDto(attendance);
     }
 
     /**
@@ -387,7 +387,7 @@ public class AttendanceService {
                                                                 LocalDate endDate) {
         return attendanceRepository.findByEmployeeIdAndAttendanceDateBetween(employeeId, startDate, endDate)
                 .stream()
-                .map(attendance -> attendanceMapper.toResponseDto(attendance,fileStorageService))
+                .map(attendance -> attendanceMapper.toResponseDto(attendance))
                 .collect(Collectors.toList());
     }
 
@@ -415,7 +415,7 @@ public class AttendanceService {
                 : "%" + search.toLowerCase() + "%";
         return attendanceRepository
                 .findWithFilters(projectId, date, status, searchPattern, pageable)
-                .map(attendance -> attendanceMapper.toResponseDto(attendance,fileStorageService)).getContent();
+                .map(attendance -> attendanceMapper.toResponseDto(attendance)).getContent();
     }
 
     /**
@@ -452,7 +452,7 @@ public class AttendanceService {
             attendance.setRemarks(dto.getRemarks());
         }
 
-        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance),fileStorageService);
+        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance));
     }
 
     /**
@@ -517,7 +517,7 @@ public class AttendanceService {
         attendance.setStatus(AttendanceStatus.ABSENT);
         attendance.setApprovalStatus(ApprovalStatus.APPROVED);
 
-        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance),fileStorageService);
+        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance));
     }
 
     /**
@@ -573,7 +573,7 @@ public class AttendanceService {
         attendance.setLeaveType(leaveType);
         attendance.setApprovalStatus(ApprovalStatus.APPROVED);
 
-        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance),fileStorageService);
+        return attendanceMapper.toResponseDto(attendanceRepository.save(attendance));
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapper.java
@@ -1,73 +1,23 @@
 package org.tornotron.echno_backend.attendance.mapper;
 
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
 import org.tornotron.echno_backend.attendance.Attendance;
 import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
-import org.tornotron.echno_backend.common.service.FileStorageService;
 
-import java.util.stream.Collectors;
+/**
+ * Maps {@link Attendance} to the response DTO. The shift maps through {@link ShiftTimingMapper},
+ * the clock events through {@link ClockEventMapper}, the regularizations through
+ * {@link AttendanceRegularizationMapper} and the movements through {@link MovementRecordMapper};
+ * everything else copies by name.
+ *
+ * <p>The clock events used to need a {@code FileStorageService} threaded in from the service to
+ * sign their attachment URLs. {@link ClockEventMapper} now delegates that to the shared attachment
+ * mapper, which holds the service itself, so the parameter is gone from this signature too.
+ */
+@Mapper(componentModel = "spring",
+        uses = {ShiftTimingMapper.class, ClockEventMapper.class, AttendanceRegularizationMapper.class,
+                MovementRecordMapper.class})
+public interface AttendanceMapper {
 
-@Component
-public class AttendanceMapper {
-
-    private final ShiftTimingMapper shiftTimingMapper;
-    private final ClockEventMapper clockEventMapper;
-    private final MovementRecordMapper movementRecordMapper;
-    private final AttendanceRegularizationMapper regularizationMapper;
-
-    public AttendanceMapper(ShiftTimingMapper shiftTimingMapper,
-                           ClockEventMapper clockEventMapper,
-                           MovementRecordMapper movementRecordMapper,
-                           AttendanceRegularizationMapper regularizationMapper) {
-        this.shiftTimingMapper = shiftTimingMapper;
-        this.clockEventMapper = clockEventMapper;
-        this.movementRecordMapper = movementRecordMapper;
-        this.regularizationMapper = regularizationMapper;
-    }
-
-    public AttendanceResponseDto toResponseDto(Attendance attendance, FileStorageService fileStorageService) {
-        if (attendance == null) return null;
-        return AttendanceResponseDto.builder()
-                .id(attendance.getId())
-                .employeeId(attendance.getEmployeeId())
-                .employeeName(attendance.getEmployeeName())
-                .attendanceDate(attendance.getAttendanceDate())
-                .projectId(attendance.getProjectId())
-                .projectName(attendance.getProjectName())
-                .status(attendance.getStatus())
-                .shiftTiming(shiftTimingMapper.toDto(attendance.getShiftTiming()))
-                .clockEvents(attendance.getClockEvents() != null
-                        ? attendance.getClockEvents().stream()
-                            .map(clockEvent -> ClockEventMapper.toDto(clockEvent,fileStorageService))
-                            .collect(Collectors.toList())
-                        : null)
-                .totalWorkMinutes(attendance.getTotalWorkMinutes())
-                .morningSessionMinutes(attendance.getMorningSessionMinutes())
-                .afternoonSessionMinutes(attendance.getAfternoonSessionMinutes())
-                .overtimeMinutes(attendance.getOvertimeMinutes())
-                .breakDurationMinutes(attendance.getBreakDurationMinutes())
-                .isLateArrival(attendance.getIsLateArrival())
-                .isEarlyCheckout(attendance.getIsEarlyCheckout())
-                .isOvertime(attendance.getIsOvertime())
-                .leaveId(attendance.getLeaveId())
-                .leaveType(attendance.getLeaveType())
-                .regularizations(attendance.getRegularizations() != null
-                        ? attendance.getRegularizations().stream()
-                            .map(regularizationMapper::toDto)
-                            .collect(Collectors.toList())
-                        : null)
-                .movements(attendance.getMovements() != null
-                        ? attendance.getMovements().stream()
-                            .map(movementRecordMapper::toDto)
-                            .collect(Collectors.toList())
-                        : null)
-                .approvalStatus(attendance.getApprovalStatus())
-                .approvedBy(attendance.getApprovedBy())
-                .approvedById(attendance.getApprovedById())
-                .approvedAt(attendance.getApprovedAt())
-                .remarks(attendance.getRemarks())
-                .createdAt(attendance.getCreatedAt())
-                .updatedAt(attendance.getUpdatedAt())
-                .build();
-    }
+    AttendanceResponseDto toResponseDto(Attendance attendance);
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceRegularizationMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceRegularizationMapper.java
@@ -2,7 +2,9 @@ package org.tornotron.echno_backend.attendance.mapper;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.tornotron.echno_backend.attendance.AttendanceRegularization;
 import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
 import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
@@ -10,33 +12,31 @@ import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
 import java.util.Collections;
 import java.util.List;
 
-@Component
-public class AttendanceRegularizationMapper {
+/**
+ * Maps {@link AttendanceRegularization} to its DTO. The parent attendance flattens to its id and
+ * the missing events are held on the row as a JSON string, so they are read back here; everything
+ * else copies by name.
+ *
+ * <p>Abstract class rather than interface because the two JSON pairs are real code: the request
+ * carries a list of missing events and a list of corrected clock events, both stored as JSON on
+ * the row and both read back on the way out.
+ */
+@Mapper(componentModel = "spring")
+public abstract class AttendanceRegularizationMapper {
 
-    private final ObjectMapper objectMapper;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
-    public AttendanceRegularizationMapper(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+    @Mapping(source = "attendance.id", target = "attendanceId")
+    @Mapping(target = "missingEvents", expression = "java(deserializeMissingEvents(entity.getMissingEvents()))")
+    public abstract AttendanceRegularizationDto toDto(AttendanceRegularization entity);
 
-    public AttendanceRegularizationDto toDto(AttendanceRegularization entity) {
-        if (entity == null) return null;
-        return AttendanceRegularizationDto.builder()
-                .id(entity.getId())
-                .attendanceId(entity.getAttendance() != null ? entity.getAttendance().getId() : null)
-                .reason(entity.getReason())
-                .requestedBy(entity.getRequestedBy())
-                .requestedById(entity.getRequestedById())
-                .requestedAt(entity.getRequestedAt())
-                .approvedBy(entity.getApprovedBy())
-                .approvedById(entity.getApprovedById())
-                .approvedAt(entity.getApprovedAt())
-                .status(entity.getStatus())
-                .rejectionReason(entity.getRejectionReason())
-                .missingEvents(deserializeMissingEvents(entity.getMissingEvents()))
-                .build();
-    }
-
+    /**
+     * Renders the named missing events for storage in the row's JSON column.
+     *
+     * @param events The event names to store, possibly null or empty.
+     * @return The JSON array, or null where there is nothing to store or it could not be written.
+     */
     public String serializeMissingEvents(List<String> events) {
         if (events == null || events.isEmpty()) return null;
         try {
@@ -46,6 +46,12 @@ public class AttendanceRegularizationMapper {
         }
     }
 
+    /**
+     * Reads the named missing events back out of the row's JSON column.
+     *
+     * @param json The stored JSON, possibly null, blank or unreadable.
+     * @return The event names, or an empty list where there are none or they could not be read.
+     */
     public List<String> deserializeMissingEvents(String json) {
         if (json == null || json.isBlank()) return Collections.emptyList();
         try {
@@ -61,6 +67,9 @@ public class AttendanceRegularizationMapper {
      * <p>Returns {@code null} for an absent or empty list, matching the nullable column, and also on
      * a serialization failure: a request that cannot carry its corrections is still a valid request
      * for the reason the employee gave, and the manager can enter the times by hand.
+     *
+     * @param events The corrected events submitted with the request.
+     * @return The JSON array, or null where there is nothing to store or it could not be written.
      */
     public String serializeRequestedEvents(List<ClockEventCreationDto> events) {
         if (events == null || events.isEmpty()) return null;
@@ -71,7 +80,12 @@ public class AttendanceRegularizationMapper {
         }
     }
 
-    /** Reads back the corrected clock events stored by {@link #serializeRequestedEvents}. */
+    /**
+     * Reads back the corrected clock events stored by {@link #serializeRequestedEvents}.
+     *
+     * @param json The stored JSON, possibly null, blank or unreadable.
+     * @return The corrected events, or an empty list where there are none or they could not be read.
+     */
     public List<ClockEventCreationDto> deserializeRequestedEvents(String json) {
         if (json == null || json.isBlank()) return Collections.emptyList();
         try {

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceSettingsMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/AttendanceSettingsMapper.java
@@ -1,41 +1,17 @@
 package org.tornotron.echno_backend.attendance.mapper;
 
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.attendance.AttendanceSettings;
 import org.tornotron.echno_backend.attendance.dto.AttendanceSettingsDto;
 
-@Component
-public class AttendanceSettingsMapper {
+/**
+ * Maps {@link AttendanceSettings} to its DTO. The owning organization flattens to its id and the
+ * default shift maps through {@link ShiftTimingMapper}; everything else copies by name.
+ */
+@Mapper(componentModel = "spring", uses = ShiftTimingMapper.class)
+public interface AttendanceSettingsMapper {
 
-    private final ShiftTimingMapper shiftTimingMapper;
-
-    public AttendanceSettingsMapper(ShiftTimingMapper shiftTimingMapper) {
-        this.shiftTimingMapper = shiftTimingMapper;
-    }
-
-    public AttendanceSettingsDto toDto(AttendanceSettings entity) {
-        if (entity == null) return null;
-        return AttendanceSettingsDto.builder()
-                .id(entity.getId())
-                .organizationId(entity.getOrganization() != null ? entity.getOrganization().getId() : null)
-                .projectId(entity.getProjectId())
-                .settingName(entity.getSettingName())
-                .checkInOutCycles(entity.getCheckInOutCycles())
-                .photoRequiredOnCheckIn(entity.getPhotoRequiredOnCheckIn())
-                .photoRequiredOnCheckOut(entity.getPhotoRequiredOnCheckOut())
-                .geolocationRequired(entity.getGeolocationRequired())
-                .geofenceRadiusMeters(entity.getGeofenceRadiusMeters())
-                .movementTrackingEnabled(entity.getMovementTrackingEnabled())
-                .movementPhotoRequired(entity.getMovementPhotoRequired())
-                .movementGeolocationRequired(entity.getMovementGeolocationRequired())
-                .autoMarkAbsentAfterHours(entity.getAutoMarkAbsentAfterHours())
-                .allowSelfRegularization(entity.getAllowSelfRegularization())
-                .regularizationApprovalRequired(entity.getRegularizationApprovalRequired())
-                .maxRegularizationDaysPerMonth(entity.getMaxRegularizationDaysPerMonth())
-                .defaultShiftTiming(shiftTimingMapper.toDto(entity.getDefaultShiftTiming()))
-                .isActive(entity.getIsActive())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
-    }
+    @Mapping(source = "organization.id", target = "organizationId")
+    AttendanceSettingsDto toDto(AttendanceSettings entity);
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/ClockEventMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/ClockEventMapper.java
@@ -1,53 +1,25 @@
 package org.tornotron.echno_backend.attendance.mapper;
 
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.attendance.ClockEvent;
 import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
-import org.tornotron.echno_backend.common.entity.Attachment;
-import org.tornotron.echno_backend.common.entity.AttachmentDto;
-import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
 
-import java.time.Duration;
-import java.util.stream.Collectors;
+/**
+ * Maps {@link ClockEvent} to its DTO. Scalar fields copy by name; the attached photos map
+ * through the shared {@link AttachmentMapper}, which signs their download URLs.
+ *
+ * <p>This class used to sign those URLs itself, from a second copy of the attachment conversion
+ * that took {@code FileStorageService} as a parameter and threaded it down from the service. The
+ * copy filled fewer fields than the shared mapper does, so the same file described one way when
+ * it hung off a clock event and another way everywhere else. Delegating removes both the
+ * duplicate and the parameter.
+ */
+@Mapper(componentModel = "spring", uses = AttachmentMapper.class)
+public interface ClockEventMapper {
 
-@Component
-public class ClockEventMapper {
-
-    public static AttachmentDto convertAttachmentToDto(Attachment attachment, FileStorageService fileStorageService) {
-        AttachmentDto dto = new AttachmentDto();
-        dto.setId(attachment.getId());
-        dto.setUrl(fileStorageService.generateDownloadUrl(attachment.getStorageKey(), Duration.ofHours(1)));
-        dto.setEntityType(attachment.getEntityType());
-        dto.setContentType(attachment.getContentType());
-        dto.setFileSize(attachment.getFileSize());
-        dto.setFileName(attachment.getOriginalFilename());
-        dto.setCreatedAt(attachment.getCreatedAt().toString());
-        dto.setUpdatedAt(attachment.getUpdatedAt().toString());
-        return dto;
-    }
-
-    public static ClockEventDto toDto(ClockEvent entity,FileStorageService fileStorageService) {
-        if (entity == null) return null;
-        return ClockEventDto.builder()
-                .id(entity.getId())
-                .eventType(entity.getEventType())
-                .eventTimestamp(entity.getEventTimestamp())
-                .latitude(entity.getLatitude())
-                .longitude(entity.getLongitude())
-                .gpsAccuracy(entity.getGpsAccuracy())
-                .projectId(entity.getProjectId())
-                .projectName(entity.getProjectName())
-                .devicePlatform(entity.getDevicePlatform())
-                .isWithinGeofence(entity.getIsWithinGeofence())
-                .distanceFromProject(entity.getDistanceFromProject())
-                .remarks(entity.getRemarks())
-                .verifiedBy(entity.getVerifiedBy())
-                .verifiedAt(entity.getVerifiedAt())
-                .isRegularized(entity.getIsRegularized())
-                .regularizationReason(entity.getRegularizationReason())
-                .attachments(entity.getAttachments().stream()
-                        .map(attachment -> convertAttachmentToDto(attachment, fileStorageService))
-                        .collect(Collectors.toList()))
-                .build();
-    }
+    /** The entity has no photo URL of its own; the photos are attachments. */
+    @Mapping(target = "photoUrl", ignore = true)
+    ClockEventDto toDto(ClockEvent entity);
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/MovementRecordMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/MovementRecordMapper.java
@@ -2,51 +2,40 @@ package org.tornotron.echno_backend.attendance.mapper;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.tornotron.echno_backend.attendance.MovementRecord;
 import org.tornotron.echno_backend.attendance.dto.MovementRecordDto;
 
 import java.util.Collections;
 import java.util.List;
 
-@Component
-public class MovementRecordMapper {
+/**
+ * Maps {@link MovementRecord} to its DTO. The parent attendance flattens to its id and the
+ * attachment list is held on the row as a JSON string, so it is read back here; everything else
+ * copies by name.
+ *
+ * <p>Abstract class rather than interface because the JSON pair is real code: the write path
+ * calls {@link #serializeAttachments} on the way in and the read path
+ * {@link #deserializeAttachments} on the way out, and both belong next to each other.
+ */
+@Mapper(componentModel = "spring")
+public abstract class MovementRecordMapper {
 
-    private final ObjectMapper objectMapper;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
-    public MovementRecordMapper(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+    @Mapping(source = "attendance.id", target = "attendanceId")
+    @Mapping(target = "attachments", expression = "java(deserializeAttachments(entity.getAttachments()))")
+    public abstract MovementRecordDto toDto(MovementRecord entity);
 
-    public MovementRecordDto toDto(MovementRecord entity) {
-        if (entity == null) return null;
-        return MovementRecordDto.builder()
-                .id(entity.getId())
-                .attendanceId(entity.getAttendance() != null ? entity.getAttendance().getId() : null)
-                .employeeId(entity.getEmployeeId())
-                .employeeName(entity.getEmployeeName())
-                .movementType(entity.getMovementType())
-                .fromLocation(entity.getFromLocation())
-                .toLocation(entity.getToLocation())
-                .startTime(entity.getStartTime())
-                .endTime(entity.getEndTime())
-                .durationMinutes(entity.getDurationMinutes())
-                .distanceKm(entity.getDistanceKm())
-                .purpose(entity.getPurpose())
-                .remarks(entity.getRemarks())
-                .startLatitude(entity.getStartLatitude())
-                .startLongitude(entity.getStartLongitude())
-                .endLatitude(entity.getEndLatitude())
-                .endLongitude(entity.getEndLongitude())
-                .attachments(deserializeAttachments(entity.getAttachments()))
-                .verifiedBy(entity.getVerifiedBy())
-                .verifiedAt(entity.getVerifiedAt())
-                .isVerified(entity.getIsVerified())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
-    }
-
+    /**
+     * Renders the attachment references for storage in the row's JSON column.
+     *
+     * @param attachments The references to store, possibly null or empty.
+     * @return The JSON array, or null where there is nothing to store or it could not be written.
+     */
     public String serializeAttachments(List<String> attachments) {
         if (attachments == null || attachments.isEmpty()) return null;
         try {
@@ -56,6 +45,12 @@ public class MovementRecordMapper {
         }
     }
 
+    /**
+     * Reads the attachment references back out of the row's JSON column.
+     *
+     * @param json The stored JSON, possibly null, blank or unreadable.
+     * @return The references, or an empty list where there are none or they could not be read.
+     */
     public List<String> deserializeAttachments(String json) {
         if (json == null || json.isBlank()) return Collections.emptyList();
         try {

--- a/src/main/java/org/tornotron/echno_backend/attendance/mapper/ShiftTimingMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/mapper/ShiftTimingMapper.java
@@ -1,27 +1,15 @@
 package org.tornotron.echno_backend.attendance.mapper;
 
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
 import org.tornotron.echno_backend.attendance.ShiftTiming;
 import org.tornotron.echno_backend.attendance.dto.ShiftTimingDto;
 
-@Component
-public class ShiftTimingMapper {
+/**
+ * Maps {@link ShiftTiming} to its DTO. Every field copies by name; the owning organization is
+ * not part of the response.
+ */
+@Mapper(componentModel = "spring")
+public interface ShiftTimingMapper {
 
-    public ShiftTimingDto toDto(ShiftTiming entity) {
-        if (entity == null) return null;
-        return ShiftTimingDto.builder()
-                .id(entity.getId())
-                .shiftName(entity.getShiftName())
-                .startTime(entity.getStartTime())
-                .endTime(entity.getEndTime())
-                .lunchBreakStart(entity.getLunchBreakStart())
-                .lunchBreakEnd(entity.getLunchBreakEnd())
-                .gracePeriodMinutes(entity.getGracePeriodMinutes())
-                .minimumWorkHours(entity.getMinimumWorkHours())
-                .halfDayWorkHours(entity.getHalfDayWorkHours())
-                .overtimeThreshold(entity.getOvertimeThreshold())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
-    }
+    ShiftTimingDto toDto(ShiftTiming entity);
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/MapperConventionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/MapperConventionTest.java
@@ -1,0 +1,121 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ratchet on how a conversion is written: one mechanism for the whole codebase, MapStruct.
+ *
+ * <p>Issue #522 opened on the suspicion that the conversion layer was inconsistent. Counted, it
+ * mostly was not: 52 of 59 mapper classes were already MapStruct, there was no reflective copying
+ * anywhere and no static {@code fromEntity} factories on the DTOs. What was left was seven
+ * hand-written classes, 583 lines, doing by hand what the annotation processor writes. Six of them
+ * were exactly that and are now generated. This test is what keeps the eighth from appearing: it
+ * is easier to add a hand-written mapper than to notice one has been added.
+ *
+ * <p>The value of the rule is not speed. A hand-written mapper is not slower than a generated one,
+ * and none of the seven was on the cost path {@link MapperDatabaseAccessTest} guards. It is that a
+ * generated mapper cannot silently drop a field: add a column to an entity and the DTO, and
+ * MapStruct fills it, while a hand-written builder chain goes on returning null for it until
+ * somebody notices in the browser.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class MapperConventionTest {
+
+    /**
+     * The one hand-written mapper left, and the reason it is still hand-written.
+     *
+     * <p>{@code BillingMapper} is not a field copier. Its job is that there is exactly one route
+     * from persistent state to response state and it goes through an immutable snapshot: every
+     * {@code toXDto(entity)} is one line delegating to {@code toXDto(toXSnapshot(entity))}, so the
+     * value the subscription cache holds and the value the response carries are built from the
+     * same reading of the row. Point MapStruct at {@code Plan -> PlanDto} and it will generate a
+     * direct field-by-field route, and that invariant disappears with nothing failing to say so.
+     *
+     * <p>It also resolves three entitlement flags against one {@code Instant} captured per call.
+     * {@code SubscriptionSnapshot} deliberately stores timestamps rather than booleans, so that a
+     * cached entry answers "expired?" for now rather than for the moment it was cached; as
+     * MapStruct expressions the three would each read the clock separately and two flags on one
+     * response could straddle a period boundary and contradict each other.
+     *
+     * <p>And it is a static utility with a private constructor on purpose. Its callers include
+     * plain unit tests with no Spring context and an integration test standing in for a concurrent
+     * reader, none of which want a bean.
+     *
+     * <p>Converting it is possible and would be worse: an abstract {@code @Mapper} holding
+     * hand-written delegation and an {@code @AfterMapping} that captures the instant is the same
+     * hand-written mapping with an annotation on it.
+     */
+    private static final Set<String> HAND_WRITTEN_BY_DECISION =
+            Set.of("org.tornotron.echno_backend.billing.dto.BillingMapper");
+
+    /**
+     * Every class named {@code *Mapper} converts through MapStruct, bar the recorded exception.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void everyMapperIsGenerated(JavaClasses productionClasses) {
+        List<String> handWritten = productionClasses.stream()
+                .filter(MapperConventionTest::isAMapperOfOurs)
+                .filter(javaClass -> !javaClass.isAnnotatedWith(Mapper.class))
+                .map(JavaClass::getName)
+                .filter(name -> !HAND_WRITTEN_BY_DECISION.contains(name))
+                .sorted()
+                .toList();
+
+        assertThat(handWritten)
+                .as("a conversion is written once, by the annotation processor: a hand-written "
+                        + "mapper copies fields by hand and goes on returning null for the next "
+                        + "one somebody adds. If a mapper genuinely holds behaviour MapStruct "
+                        + "cannot express, add it to HAND_WRITTEN_BY_DECISION with the reason")
+                .isEmpty();
+    }
+
+    /**
+     * The exception list names something real. A recorded exception that has since been deleted or
+     * renamed would otherwise sit there excusing nothing, and the next reader would take it as
+     * evidence that hand-written mappers are ordinary.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void theRecordedExceptionStillExists(JavaClasses productionClasses) {
+        Set<String> present = productionClasses.stream()
+                .map(JavaClass::getName)
+                .filter(HAND_WRITTEN_BY_DECISION::contains)
+                .collect(java.util.stream.Collectors.toSet());
+
+        assertThat(present)
+                .as("HAND_WRITTEN_BY_DECISION should name classes that exist")
+                .isEqualTo(HAND_WRITTEN_BY_DECISION);
+    }
+
+    /**
+     * Whether a class is one of this codebase's mappers.
+     *
+     * <p>Excludes the {@code *MapperImpl} classes MapStruct writes, which sit in the same packages
+     * and carry {@code @Generated} rather than {@code @Mapper}, and anything nested inside a
+     * mapper.
+     *
+     * @param javaClass The class to judge.
+     * @return {@code true} for a mapper written in this repository.
+     */
+    private static boolean isAMapperOfOurs(JavaClass javaClass) {
+        String simpleName = javaClass.getSimpleName();
+        return javaClass.getName().startsWith("org.tornotron.echno_backend.")
+                && simpleName.endsWith("Mapper")
+                && !javaClass.isNestedClass();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapperConversionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/mapper/AttendanceMapperConversionTest.java
@@ -1,0 +1,587 @@
+package org.tornotron.echno_backend.attendance.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRegularization;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.MovementRecord;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceSettingsDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventCreationDto;
+import org.tornotron.echno_backend.attendance.dto.ClockEventDto;
+import org.tornotron.echno_backend.attendance.dto.MovementRecordDto;
+import org.tornotron.echno_backend.attendance.dto.ShiftTimingDto;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.attendance.enums.ClockEventType;
+import org.tornotron.echno_backend.attendance.enums.MovementType;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapper;
+import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins what the attendance conversions produce, field by field.
+ *
+ * <p>Six of the seven hand-written mappers issue #522 counted were in this package: 356 lines of
+ * builder chains doing what the MapStruct processor writes. This test is the safety net the
+ * conversion was done under. It asserts every field of every one of the six DTOs, so it is a
+ * statement of what the response carries rather than of how the mapper is written, and it passes
+ * on either implementation. Written against the hand-written mappers first, it is what says the
+ * generated ones produce the same objects; if a conversion had quietly dropped a field, this is
+ * where it would have shown.
+ *
+ * <p>The one deliberate change it records is on a clock event's attachments. The hand-written
+ * mapper carried a second copy of the attachment conversion, taking {@code FileStorageService} as
+ * a parameter and filling seven of the DTO's twelve fields; the shared {@code AttachmentMapper}
+ * fills all of them. The same file therefore used to describe itself one way hanging off a clock
+ * event and another way everywhere else, and now does not.
+ *
+ * <p>No Spring context: the generated implementations are built directly and their collaborators
+ * set on them, which is what the container does.
+ */
+class AttendanceMapperConversionTest {
+
+    private static final String SIGNED_URL = "https://store.example/echno/signed?sig=abc";
+
+    private ShiftTimingMapper shiftTimingMapper;
+    private AttendanceSettingsMapper attendanceSettingsMapper;
+    private ClockEventMapper clockEventMapper;
+    private MovementRecordMapper movementRecordMapper;
+    private AttendanceRegularizationMapper regularizationMapper;
+    private AttendanceMapper attendanceMapper;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        FileStorageService fileStorageService = mock(FileStorageService.class);
+        when(fileStorageService.generateDownloadUrl(anyString(), any(Duration.class)))
+                .thenReturn(SIGNED_URL);
+        AttachmentMapper attachmentMapper = new AttachmentMapperImpl();
+        ReflectionTestUtils.setField(attachmentMapper, "fileStorageService", fileStorageService);
+
+        shiftTimingMapper = new ShiftTimingMapperImpl();
+
+        attendanceSettingsMapper = new AttendanceSettingsMapperImpl();
+        ReflectionTestUtils.setField(attendanceSettingsMapper, "shiftTimingMapper", shiftTimingMapper);
+
+        clockEventMapper = new ClockEventMapperImpl();
+        ReflectionTestUtils.setField(clockEventMapper, "attachmentMapper", attachmentMapper);
+
+        movementRecordMapper = new MovementRecordMapperImpl();
+        ReflectionTestUtils.setField(movementRecordMapper, "objectMapper", objectMapper);
+
+        regularizationMapper = new AttendanceRegularizationMapperImpl();
+        ReflectionTestUtils.setField(regularizationMapper, "objectMapper", objectMapper);
+
+        attendanceMapper = new AttendanceMapperImpl();
+        ReflectionTestUtils.setField(attendanceMapper, "shiftTimingMapper", shiftTimingMapper);
+        ReflectionTestUtils.setField(attendanceMapper, "clockEventMapper", clockEventMapper);
+        ReflectionTestUtils.setField(attendanceMapper, "attendanceRegularizationMapper", regularizationMapper);
+        ReflectionTestUtils.setField(attendanceMapper, "movementRecordMapper", movementRecordMapper);
+    }
+
+    // ---------------------------------------------------------------- shift timing
+
+    @Test
+    void shiftTiming_mapsEveryField() {
+        ShiftTimingDto dto = shiftTimingMapper.toDto(shiftTiming());
+
+        assertThat(dto.getId()).isEqualTo(4L);
+        assertThat(dto.getShiftName()).isEqualTo("General");
+        assertThat(dto.getStartTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(dto.getEndTime()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(dto.getLunchBreakStart()).isEqualTo(LocalTime.of(13, 0));
+        assertThat(dto.getLunchBreakEnd()).isEqualTo(LocalTime.of(13, 45));
+        assertThat(dto.getGracePeriodMinutes()).isEqualTo(10);
+        assertThat(dto.getMinimumWorkHours()).isEqualByComparingTo("8.00");
+        assertThat(dto.getHalfDayWorkHours()).isEqualByComparingTo("4.00");
+        assertThat(dto.getOvertimeThreshold()).isEqualByComparingTo("9.00");
+        assertThat(dto.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 1, 1, 8, 0));
+        assertThat(dto.getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 1, 8, 0));
+    }
+
+    @Test
+    void shiftTiming_isNullForANullEntity() {
+        assertThat(shiftTimingMapper.toDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- settings
+
+    @Test
+    void settings_mapsEveryFieldAndFlattensTheOrganization() {
+        AttendanceSettingsDto dto = attendanceSettingsMapper.toDto(settings());
+
+        assertThat(dto.getId()).isEqualTo(11L);
+        assertThat(dto.getOrganizationId()).isEqualTo(7L);
+        assertThat(dto.getProjectId()).isEqualTo(3L);
+        assertThat(dto.getSettingName()).isEqualTo("Site default");
+        assertThat(dto.getCheckInOutCycles()).isEqualTo(2);
+        assertThat(dto.getPhotoRequiredOnCheckIn()).isTrue();
+        assertThat(dto.getPhotoRequiredOnCheckOut()).isFalse();
+        assertThat(dto.getGeolocationRequired()).isTrue();
+        assertThat(dto.getGeofenceRadiusMeters()).isEqualTo(150);
+        assertThat(dto.getMovementTrackingEnabled()).isTrue();
+        assertThat(dto.getMovementPhotoRequired()).isFalse();
+        assertThat(dto.getMovementGeolocationRequired()).isTrue();
+        assertThat(dto.getAutoMarkAbsentAfterHours()).isEqualTo(5);
+        assertThat(dto.getAllowSelfRegularization()).isTrue();
+        assertThat(dto.getRegularizationApprovalRequired()).isFalse();
+        assertThat(dto.getMaxRegularizationDaysPerMonth()).isEqualTo(4);
+        assertThat(dto.getDefaultShiftTiming()).isNotNull();
+        assertThat(dto.getDefaultShiftTiming().getShiftName()).isEqualTo("General");
+        assertThat(dto.getIsActive()).isTrue();
+        assertThat(dto.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 1, 2, 8, 0));
+        assertThat(dto.getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 2, 8, 0));
+    }
+
+    @Test
+    void settings_organizationIdIsNullWhenTheSettingHasNoOrganization() {
+        AttendanceSettings settings = settings();
+        settings.setOrganization(null);
+
+        assertThat(attendanceSettingsMapper.toDto(settings).getOrganizationId()).isNull();
+    }
+
+    @Test
+    void settings_isNullForANullEntity() {
+        assertThat(attendanceSettingsMapper.toDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- clock event
+
+    @Test
+    void clockEvent_mapsEveryFieldAndSignsItsAttachments() {
+        ClockEventDto dto = clockEventMapper.toDto(clockEvent());
+
+        assertThat(dto.getId()).isEqualTo(21L);
+        assertThat(dto.getEventType()).isEqualTo(ClockEventType.MORNING_CLOCK_IN);
+        assertThat(dto.getEventTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 4, 9, 5));
+        assertThat(dto.getLatitude()).isEqualTo(13.0827);
+        assertThat(dto.getLongitude()).isEqualTo(80.2707);
+        assertThat(dto.getGpsAccuracy()).isEqualTo(6.5);
+        assertThat(dto.getProjectId()).isEqualTo(3L);
+        assertThat(dto.getProjectName()).isEqualTo("Tower B");
+        assertThat(dto.getDevicePlatform()).isEqualTo("android");
+        assertThat(dto.getIsWithinGeofence()).isTrue();
+        assertThat(dto.getDistanceFromProject()).isEqualTo(12.0);
+        assertThat(dto.getRemarks()).isEqualTo("on time");
+        assertThat(dto.getVerifiedBy()).isEqualTo("Supervisor");
+        assertThat(dto.getVerifiedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 10, 0));
+        assertThat(dto.getIsRegularized()).isFalse();
+        assertThat(dto.getRegularizationReason()).isNull();
+
+        // The entity has no photo URL of its own; the photos are the attachments.
+        assertThat(dto.getPhotoUrl()).isNull();
+
+        assertThat(dto.getAttachments()).hasSize(1);
+        assertThat(dto.getAttachments().get(0).getId()).isEqualTo(88L);
+        assertThat(dto.getAttachments().get(0).getUrl()).isEqualTo(SIGNED_URL);
+        assertThat(dto.getAttachments().get(0).getEntityType()).isEqualTo("CLOCK_EVENT");
+        assertThat(dto.getAttachments().get(0).getContentType()).isEqualTo("image/jpeg");
+        assertThat(dto.getAttachments().get(0).getFileSize()).isEqualTo(2048L);
+        assertThat(dto.getAttachments().get(0).getFileName()).isEqualTo("checkin.jpg");
+        assertThat(dto.getAttachments().get(0).getCreatedAt())
+                .isEqualTo(LocalDateTime.of(2026, 3, 4, 9, 5).toString());
+        assertThat(dto.getAttachments().get(0).getUpdatedAt())
+                .isEqualTo(LocalDateTime.of(2026, 3, 4, 9, 6).toString());
+    }
+
+    @Test
+    void clockEvent_attachmentsNowCarryTheDocumentFieldsEveryOtherAttachmentCarries() {
+        // The hand-written copy of the attachment conversion filled seven of the twelve fields, so
+        // a document hanging off a clock event described itself differently from the same document
+        // hanging off anything else. Delegating to the shared mapper settles that.
+        ClockEventDto dto = clockEventMapper.toDto(clockEvent());
+
+        assertThat(dto.getAttachments().get(0).getDocumentType()).isEqualTo("site-photo");
+        assertThat(dto.getAttachments().get(0).getIssuedOn()).isEqualTo(LocalDate.of(2026, 3, 1));
+        assertThat(dto.getAttachments().get(0).getExpiresOn()).isEqualTo(LocalDate.of(2030, 3, 1));
+        assertThat(dto.getAttachments().get(0).getExpired()).isFalse();
+        assertThat(dto.getAttachments().get(0).getDaysUntilExpiry()).isPositive();
+    }
+
+    @Test
+    void clockEvent_isNullForANullEntity() {
+        assertThat(clockEventMapper.toDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- movement record
+
+    @Test
+    void movementRecord_mapsEveryFieldAndReadsItsAttachmentsBackOutOfJson() {
+        MovementRecordDto dto = movementRecordMapper.toDto(movementRecord());
+
+        assertThat(dto.getId()).isEqualTo(31L);
+        assertThat(dto.getAttendanceId()).isEqualTo(51L);
+        assertThat(dto.getEmployeeId()).isEqualTo(18L);
+        assertThat(dto.getEmployeeName()).isEqualTo("Ramesh Kumar");
+        assertThat(dto.getMovementType()).isEqualTo(MovementType.SITE_TRAVEL);
+        assertThat(dto.getFromLocation()).isEqualTo("Site A");
+        assertThat(dto.getToLocation()).isEqualTo("Site B");
+        assertThat(dto.getStartTime()).isEqualTo(LocalDateTime.of(2026, 3, 4, 11, 0));
+        assertThat(dto.getEndTime()).isEqualTo(LocalDateTime.of(2026, 3, 4, 12, 30));
+        assertThat(dto.getDurationMinutes()).isEqualTo(90);
+        assertThat(dto.getDistanceKm()).isEqualTo(14.2);
+        assertThat(dto.getPurpose()).isEqualTo("material inspection");
+        assertThat(dto.getRemarks()).isEqualTo("took the van");
+        assertThat(dto.getStartLatitude()).isEqualTo(13.01);
+        assertThat(dto.getStartLongitude()).isEqualTo(80.21);
+        assertThat(dto.getEndLatitude()).isEqualTo(13.09);
+        assertThat(dto.getEndLongitude()).isEqualTo(80.29);
+        assertThat(dto.getAttachments()).containsExactly("first.jpg", "second.jpg");
+        assertThat(dto.getVerifiedBy()).isEqualTo("Supervisor");
+        assertThat(dto.getVerifiedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 13, 0));
+        assertThat(dto.getIsVerified()).isTrue();
+        assertThat(dto.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 11, 0));
+        assertThat(dto.getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 13, 0));
+    }
+
+    @Test
+    void movementRecord_readsUnusableAttachmentJsonAsNoAttachments() {
+        // Stored JSON that cannot be read is not worth a 500 on a listing: the movement itself is
+        // still a fact, and this is what the hand-written mapper did.
+        MovementRecord record = movementRecord();
+
+        record.setAttachments(null);
+        assertThat(movementRecordMapper.toDto(record).getAttachments()).isEmpty();
+
+        record.setAttachments("   ");
+        assertThat(movementRecordMapper.toDto(record).getAttachments()).isEmpty();
+
+        record.setAttachments("{not json");
+        assertThat(movementRecordMapper.toDto(record).getAttachments()).isEmpty();
+    }
+
+    @Test
+    void movementRecord_attendanceIdIsNullWhenTheRecordHasNoAttendance() {
+        MovementRecord record = movementRecord();
+        record.setAttendance(null);
+
+        assertThat(movementRecordMapper.toDto(record).getAttendanceId()).isNull();
+    }
+
+    @Test
+    void movementRecord_roundTripsItsAttachmentsThroughJson() {
+        assertThat(movementRecordMapper.serializeAttachments(List.of("a.jpg", "b.jpg")))
+                .isEqualTo("[\"a.jpg\",\"b.jpg\"]");
+        assertThat(movementRecordMapper.serializeAttachments(List.of())).isNull();
+        assertThat(movementRecordMapper.serializeAttachments(null)).isNull();
+        assertThat(movementRecordMapper.deserializeAttachments("[\"a.jpg\"]")).containsExactly("a.jpg");
+    }
+
+    @Test
+    void movementRecord_isNullForANullEntity() {
+        assertThat(movementRecordMapper.toDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- regularization
+
+    @Test
+    void regularization_mapsEveryFieldAndReadsItsMissingEventsBackOutOfJson() {
+        AttendanceRegularizationDto dto = regularizationMapper.toDto(regularization());
+
+        assertThat(dto.getId()).isEqualTo(41L);
+        assertThat(dto.getAttendanceId()).isEqualTo(51L);
+        assertThat(dto.getReason()).isEqualTo("phone battery died");
+        assertThat(dto.getRequestedBy()).isEqualTo("Ramesh Kumar");
+        assertThat(dto.getRequestedById()).isEqualTo(18L);
+        assertThat(dto.getRequestedAt()).isEqualTo(LocalDateTime.of(2026, 3, 5, 9, 0));
+        assertThat(dto.getApprovedBy()).isEqualTo("Supervisor");
+        assertThat(dto.getApprovedById()).isEqualTo(19L);
+        assertThat(dto.getApprovedAt()).isEqualTo(LocalDateTime.of(2026, 3, 5, 10, 0));
+        assertThat(dto.getStatus()).isEqualTo(RegularizationStatus.APPROVED);
+        assertThat(dto.getRejectionReason()).isNull();
+        assertThat(dto.getMissingEvents()).containsExactly("EVENING_CLOCK_OUT");
+    }
+
+    @Test
+    void regularization_readsUnusableMissingEventJsonAsNone() {
+        AttendanceRegularization entity = regularization();
+
+        entity.setMissingEvents(null);
+        assertThat(regularizationMapper.toDto(entity).getMissingEvents()).isEmpty();
+
+        entity.setMissingEvents("{not json");
+        assertThat(regularizationMapper.toDto(entity).getMissingEvents()).isEmpty();
+    }
+
+    @Test
+    void regularization_attendanceIdIsNullWhenTheRequestHasNoAttendance() {
+        AttendanceRegularization entity = regularization();
+        entity.setAttendance(null);
+
+        assertThat(regularizationMapper.toDto(entity).getAttendanceId()).isNull();
+    }
+
+    @Test
+    void regularization_roundTripsTheCorrectedEventsItStoresUntilApproval() {
+        ClockEventCreationDto correction = new ClockEventCreationDto();
+        correction.setEventType(ClockEventType.EVENING_CLOCK_OUT);
+
+        String stored = regularizationMapper.serializeRequestedEvents(List.of(correction));
+        assertThat(stored).isNotNull();
+        assertThat(regularizationMapper.deserializeRequestedEvents(stored))
+                .singleElement()
+                .satisfies(read -> assertThat(read.getEventType()).isEqualTo(ClockEventType.EVENING_CLOCK_OUT));
+
+        assertThat(regularizationMapper.serializeRequestedEvents(List.of())).isNull();
+        assertThat(regularizationMapper.serializeRequestedEvents(null)).isNull();
+        assertThat(regularizationMapper.deserializeRequestedEvents("{not json")).isEmpty();
+    }
+
+    @Test
+    void regularization_isNullForANullEntity() {
+        assertThat(regularizationMapper.toDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- attendance
+
+    @Test
+    void attendance_mapsEveryFieldAndEveryNestedCollection() {
+        AttendanceResponseDto dto = attendanceMapper.toResponseDto(attendance());
+
+        assertThat(dto.getId()).isEqualTo(51L);
+        assertThat(dto.getEmployeeId()).isEqualTo(18L);
+        assertThat(dto.getEmployeeName()).isEqualTo("Ramesh Kumar");
+        assertThat(dto.getAttendanceDate()).isEqualTo(LocalDate.of(2026, 3, 4));
+        assertThat(dto.getProjectId()).isEqualTo(3L);
+        assertThat(dto.getProjectName()).isEqualTo("Tower B");
+        assertThat(dto.getStatus()).isEqualTo(AttendanceStatus.PRESENT);
+        assertThat(dto.getShiftTiming()).isNotNull();
+        assertThat(dto.getShiftTiming().getShiftName()).isEqualTo("General");
+        assertThat(dto.getClockEvents()).hasSize(1);
+        assertThat(dto.getClockEvents().get(0).getId()).isEqualTo(21L);
+        assertThat(dto.getClockEvents().get(0).getAttachments()).hasSize(1);
+        assertThat(dto.getTotalWorkMinutes()).isEqualTo(480);
+        assertThat(dto.getMorningSessionMinutes()).isEqualTo(240);
+        assertThat(dto.getAfternoonSessionMinutes()).isEqualTo(240);
+        assertThat(dto.getOvertimeMinutes()).isEqualTo(30);
+        assertThat(dto.getBreakDurationMinutes()).isEqualTo(45);
+        assertThat(dto.getIsLateArrival()).isFalse();
+        assertThat(dto.getIsEarlyCheckout()).isFalse();
+        assertThat(dto.getIsOvertime()).isTrue();
+        assertThat(dto.getLeaveId()).isEqualTo(61L);
+        assertThat(dto.getLeaveType()).isEqualTo("CASUAL");
+        assertThat(dto.getRegularizations()).hasSize(1);
+        assertThat(dto.getRegularizations().get(0).getId()).isEqualTo(41L);
+        assertThat(dto.getMovements()).hasSize(1);
+        assertThat(dto.getMovements().get(0).getId()).isEqualTo(31L);
+        assertThat(dto.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+        assertThat(dto.getApprovedBy()).isEqualTo("Supervisor");
+        assertThat(dto.getApprovedById()).isEqualTo(19L);
+        assertThat(dto.getApprovedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 19, 0));
+        assertThat(dto.getRemarks()).isEqualTo("full day");
+        assertThat(dto.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 9, 0));
+        assertThat(dto.getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 3, 4, 19, 0));
+    }
+
+    @Test
+    void attendance_leavesANullCollectionNullRatherThanEmpty() {
+        // The hand-written mapper distinguished the two, and a client reading "no clock events"
+        // differently from "clock events not loaded" would notice the change.
+        Attendance attendance = attendance();
+        attendance.setClockEvents(null);
+        attendance.setRegularizations(null);
+        attendance.setMovements(null);
+
+        AttendanceResponseDto dto = attendanceMapper.toResponseDto(attendance);
+
+        assertThat(dto.getClockEvents()).isNull();
+        assertThat(dto.getRegularizations()).isNull();
+        assertThat(dto.getMovements()).isNull();
+    }
+
+    @Test
+    void attendance_isNullForANullEntity() {
+        assertThat(attendanceMapper.toResponseDto(null)).isNull();
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    private static ShiftTiming shiftTiming() {
+        ShiftTiming shift = new ShiftTiming();
+        shift.setId(4L);
+        shift.setShiftName("General");
+        shift.setStartTime(LocalTime.of(9, 0));
+        shift.setEndTime(LocalTime.of(18, 0));
+        shift.setLunchBreakStart(LocalTime.of(13, 0));
+        shift.setLunchBreakEnd(LocalTime.of(13, 45));
+        shift.setGracePeriodMinutes(10);
+        shift.setMinimumWorkHours(new BigDecimal("8.00"));
+        shift.setHalfDayWorkHours(new BigDecimal("4.00"));
+        shift.setOvertimeThreshold(new BigDecimal("9.00"));
+        shift.setCreatedAt(LocalDateTime.of(2026, 1, 1, 8, 0));
+        shift.setUpdatedAt(LocalDateTime.of(2026, 2, 1, 8, 0));
+        return shift;
+    }
+
+    private static AttendanceSettings settings() {
+        Organization organization = new Organization();
+        organization.setId(7L);
+
+        AttendanceSettings settings = new AttendanceSettings();
+        settings.setId(11L);
+        settings.setOrganization(organization);
+        settings.setProjectId(3L);
+        settings.setSettingName("Site default");
+        settings.setCheckInOutCycles(2);
+        settings.setPhotoRequiredOnCheckIn(true);
+        settings.setPhotoRequiredOnCheckOut(false);
+        settings.setGeolocationRequired(true);
+        settings.setGeofenceRadiusMeters(150);
+        settings.setMovementTrackingEnabled(true);
+        settings.setMovementPhotoRequired(false);
+        settings.setMovementGeolocationRequired(true);
+        settings.setAutoMarkAbsentAfterHours(5);
+        settings.setAllowSelfRegularization(true);
+        settings.setRegularizationApprovalRequired(false);
+        settings.setMaxRegularizationDaysPerMonth(4);
+        settings.setDefaultShiftTiming(shiftTiming());
+        settings.setIsActive(true);
+        settings.setCreatedAt(LocalDateTime.of(2026, 1, 2, 8, 0));
+        settings.setUpdatedAt(LocalDateTime.of(2026, 2, 2, 8, 0));
+        return settings;
+    }
+
+    private static Attachment attachment() {
+        Attachment attachment = new Attachment();
+        attachment.setId(88L);
+        attachment.setStorageKey("clock-events/88/checkin.jpg");
+        attachment.setEntityType("CLOCK_EVENT");
+        attachment.setContentType("image/jpeg");
+        attachment.setFileSize(2048L);
+        attachment.setOriginalFilename("checkin.jpg");
+        attachment.setCreatedAt(LocalDateTime.of(2026, 3, 4, 9, 5));
+        attachment.setUpdatedAt(LocalDateTime.of(2026, 3, 4, 9, 6));
+        attachment.setDocumentType("site-photo");
+        attachment.setIssuedOn(LocalDate.of(2026, 3, 1));
+        attachment.setExpiresOn(LocalDate.of(2030, 3, 1));
+        return attachment;
+    }
+
+    private static ClockEvent clockEvent() {
+        ClockEvent event = new ClockEvent();
+        event.setId(21L);
+        event.setEventType(ClockEventType.MORNING_CLOCK_IN);
+        event.setEventTimestamp(LocalDateTime.of(2026, 3, 4, 9, 5));
+        event.setLatitude(13.0827);
+        event.setLongitude(80.2707);
+        event.setGpsAccuracy(6.5);
+        event.setProjectId(3L);
+        event.setProjectName("Tower B");
+        event.setDevicePlatform("android");
+        event.setIsWithinGeofence(true);
+        event.setDistanceFromProject(12.0);
+        event.setRemarks("on time");
+        event.setVerifiedBy("Supervisor");
+        event.setVerifiedAt(LocalDateTime.of(2026, 3, 4, 10, 0));
+        event.setIsRegularized(false);
+        event.setAttachments(List.of(attachment()));
+        return event;
+    }
+
+    private static MovementRecord movementRecord() {
+        MovementRecord record = new MovementRecord();
+        record.setId(31L);
+        record.setAttendance(bareAttendance());
+        record.setEmployeeId(18L);
+        record.setEmployeeName("Ramesh Kumar");
+        record.setMovementType(MovementType.SITE_TRAVEL);
+        record.setFromLocation("Site A");
+        record.setToLocation("Site B");
+        record.setStartTime(LocalDateTime.of(2026, 3, 4, 11, 0));
+        record.setEndTime(LocalDateTime.of(2026, 3, 4, 12, 30));
+        record.setDurationMinutes(90);
+        record.setDistanceKm(14.2);
+        record.setPurpose("material inspection");
+        record.setRemarks("took the van");
+        record.setStartLatitude(13.01);
+        record.setStartLongitude(80.21);
+        record.setEndLatitude(13.09);
+        record.setEndLongitude(80.29);
+        record.setAttachments("[\"first.jpg\",\"second.jpg\"]");
+        record.setVerifiedBy("Supervisor");
+        record.setVerifiedAt(LocalDateTime.of(2026, 3, 4, 13, 0));
+        record.setIsVerified(true);
+        record.setCreatedAt(LocalDateTime.of(2026, 3, 4, 11, 0));
+        record.setUpdatedAt(LocalDateTime.of(2026, 3, 4, 13, 0));
+        return record;
+    }
+
+    private static AttendanceRegularization regularization() {
+        AttendanceRegularization entity = new AttendanceRegularization();
+        entity.setId(41L);
+        entity.setAttendance(bareAttendance());
+        entity.setReason("phone battery died");
+        entity.setRequestedBy("Ramesh Kumar");
+        entity.setRequestedById(18L);
+        entity.setRequestedAt(LocalDateTime.of(2026, 3, 5, 9, 0));
+        entity.setApprovedBy("Supervisor");
+        entity.setApprovedById(19L);
+        entity.setApprovedAt(LocalDateTime.of(2026, 3, 5, 10, 0));
+        entity.setStatus(RegularizationStatus.APPROVED);
+        entity.setMissingEvents("[\"EVENING_CLOCK_OUT\"]");
+        return entity;
+    }
+
+    private static Attendance bareAttendance() {
+        Attendance attendance = new Attendance();
+        attendance.setId(51L);
+        return attendance;
+    }
+
+    private static Attendance attendance() {
+        Attendance attendance = bareAttendance();
+        attendance.setEmployeeId(18L);
+        attendance.setEmployeeName("Ramesh Kumar");
+        attendance.setAttendanceDate(LocalDate.of(2026, 3, 4));
+        attendance.setProjectId(3L);
+        attendance.setProjectName("Tower B");
+        attendance.setStatus(AttendanceStatus.PRESENT);
+        attendance.setShiftTiming(shiftTiming());
+        attendance.setClockEvents(List.of(clockEvent()));
+        attendance.setTotalWorkMinutes(480);
+        attendance.setMorningSessionMinutes(240);
+        attendance.setAfternoonSessionMinutes(240);
+        attendance.setOvertimeMinutes(30);
+        attendance.setBreakDurationMinutes(45);
+        attendance.setIsLateArrival(false);
+        attendance.setIsEarlyCheckout(false);
+        attendance.setIsOvertime(true);
+        attendance.setLeaveId(61L);
+        attendance.setLeaveType("CASUAL");
+        attendance.setRegularizations(List.of(regularization()));
+        attendance.setMovements(List.of(movementRecord()));
+        attendance.setApprovalStatus(ApprovalStatus.APPROVED);
+        attendance.setApprovedBy("Supervisor");
+        attendance.setApprovedById(19L);
+        attendance.setApprovedAt(LocalDateTime.of(2026, 3, 4, 19, 0));
+        attendance.setRemarks("full day");
+        attendance.setCreatedAt(LocalDateTime.of(2026, 3, 4, 9, 0));
+        attendance.setUpdatedAt(LocalDateTime.of(2026, 3, 4, 19, 0));
+        return attendance;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -101,7 +101,7 @@ class AttendanceServiceApprovalTest {
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
         when(employeeRepository.findByUserIdAndOrganizationId(USER_ID, ORG)).thenReturn(Optional.of(approver()));
         when(attendanceRepository.save(any(Attendance.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(attendanceMapper.toResponseDto(any(Attendance.class), any(FileStorageService.class)))
+        when(attendanceMapper.toResponseDto(any(Attendance.class)))
                 .thenReturn(AttendanceResponseDto.builder().build());
 
         service.approveAttendance(ATT_ID, approvalDto());
@@ -122,7 +122,7 @@ class AttendanceServiceApprovalTest {
         when(attendanceRepository.findByIdAndOrganization_Id(ATT_ID, ORG)).thenReturn(Optional.of(record));
         when(userContextService.getCurrentUserId()).thenReturn(null);
         when(attendanceRepository.save(any(Attendance.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(attendanceMapper.toResponseDto(any(Attendance.class), any(FileStorageService.class)))
+        when(attendanceMapper.toResponseDto(any(Attendance.class)))
                 .thenReturn(AttendanceResponseDto.builder().build());
 
         service.approveAttendance(ATT_ID, approvalDto());

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeManagerListingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeManagerListingIT.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapperImpl;
 import org.tornotron.echno_backend.common.enums.OrgRole;
 import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
 import org.tornotron.echno_backend.common.service.FileStorageService;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({EmployeeHierarchyService.class, EmployeeMapperImpl.class,
-        AttachmentMapperImpl.class, ShiftTimingMapper.class})
+        AttachmentMapperImpl.class, ShiftTimingMapperImpl.class})
 class EmployeeManagerListingIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/employee/EmployeeShiftUnificationIT.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.tornotron.echno_backend.attendance.ShiftTiming;
-import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper;
+import org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapperImpl;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.mapper.AttachmentMapperImpl;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({EmployeeService.class, EmployeeHierarchyService.class, EmployeeMapperImpl.class,
-        AttachmentMapperImpl.class, ShiftTimingMapper.class})
+        AttachmentMapperImpl.class, ShiftTimingMapperImpl.class})
 class EmployeeShiftUnificationIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableCreationIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableCreationIT.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({PayableService.class, PayableMapperImpl.class, EmployeeMapperImpl.class,
         AttachmentMapperImpl.class, TenantEntityHelper.class,
-        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper.class})
+        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapperImpl.class})
 class PayableCreationIT extends AbstractIntegrationTest {
 
     private static final String SHARED_NUMBER = "PAY-2026-000001";

--- a/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/payable/PayableServiceIT.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({PayableService.class, PayableMapperImpl.class, EmployeeMapperImpl.class,
         AttachmentMapperImpl.class, TenantEntityHelper.class,
-        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapper.class})
+        org.tornotron.echno_backend.attendance.mapper.ShiftTimingMapperImpl.class})
 class PayableServiceIT extends AbstractIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
Issue #522 opened on the suspicion that the conversion layer was inconsistent.
Counted, it mostly was not: 52 of 59 mapper classes were already MapStruct,
there was no reflective copying anywhere and no static fromEntity factories on
the DTOs. What was left was seven hand-written classes, 583 lines, doing by hand
what the processor writes. Six of them were exactly that and are generated now.

They are the six in the attendance package, 344 lines of builder chains reduced
to 44 lines of interface and two small abstract classes. The behaviour is
unchanged and AttendanceMapperConversionTest says so field by field: it asserts
every field of all six DTOs, including the edge cases the hand-written code
carried on purpose, and it was written against the old implementations before
any of them moved.

  - a null entity maps to null
  - a null clock-event, regularization or movement collection stays null rather
    than becoming empty, which a client can tell apart
  - a movement's attachments and a regularization's missing events live in the
    row as JSON, and unreadable JSON reads back as no attachments rather than as
    a 500 on a listing
  - a parent that is absent flattens to a null id

Two things did change, both deliberate.

ClockEventMapper carried a second copy of the attachment conversion, taking a
FileStorageService as a parameter and threading it down from the service through
AttendanceMapper. It filled seven of AttachmentDto's twelve fields, so the same
file described itself one way hanging off a clock event and another way
everywhere else: no document type, no issue date, no expiry, no expired flag.
It now delegates to the shared AttachmentMapper, which fills all of them and
holds the storage service itself. That removes the parameter from
AttendanceMapper.toResponseDto as well.

Four integration tests imported ShiftTimingMapper into their context by its
concrete class, which is a thing only a hand-written mapper allows; they now
import the generated implementation, as they already did for every other mapper
in the same @Import list.

BillingMapper, the seventh, stays hand-written, and MapperConventionTest records
it as the one exception with the reason. It is not a field copier. Its job is
that there is exactly one route from persistent state to response state and it
goes through an immutable snapshot: every toXDto(entity) is one line delegating
to toXDto(toXSnapshot(entity)), so the value the subscription cache holds and
the value the response carries are built from the same reading of the row. Point
MapStruct at Plan -> PlanDto and it generates a direct field-by-field route, and
that invariant is gone with nothing failing to say so. It also resolves three
entitlement flags against one Instant captured per call, which is why
SubscriptionSnapshot stores timestamps rather than booleans; as MapStruct
expressions the three would each read the clock separately and two flags on one
response could straddle a period boundary and contradict each other. And it is a
static utility on purpose, called from plain unit tests with no Spring context
and from an integration test standing in for a concurrent reader.

MapperConventionTest is what keeps an eighth from appearing. It fails on the
seven as they were. The value of the rule is not speed, since a hand-written
mapper is no slower and none of the seven was on the cost path
MapperDatabaseAccessTest guards. It is that a generated mapper cannot silently
drop a field: add a column to an entity and its DTO and MapStruct fills it,
while a builder chain goes on returning null for it until somebody notices in
the browser.

No API shape changes, so docs/openapi.json is untouched.

Refs #522

Item C of #522.