### PR TITLE
Deploy staging by dispatch only, now that the staging branch is retired

### DIFF
--- a/.github/workflows/deploy-staging-iitm.yml
+++ b/.github/workflows/deploy-staging-iitm.yml
@@ -14,14 +14,19 @@ name: Staging (IITM)
 #   * it authenticates to the fereydon account with a key and a become password
 #     rather than as deploy over Tailscale SSH.
 #
-# IITM is now the staging environment: a merge into `staging` deploys here (the
-# DO staging box was retired to save cost). workflow_dispatch stays for manual
-# runs.
+# IITM is the staging environment (the DO staging box was retired to save cost).
+#
+# The trigger is workflow_dispatch on `development`, and nothing else. It used to
+# also fire on a pull request merging into `staging`, but that branch was retired:
+# it had gone 240 commits stale while every real deploy ran by hand, so the merge
+# would have promoted months of in-flight work from several people in one go
+# rather than the change the operator meant to ship. See echno-deployment#38.
+#
+# The cost of dispatch-only is that a staging deploy carries no review gate. That
+# is acceptable here because staging is where things are meant to break, and it
+# would not be acceptable for production, which keeps its own gated workflow.
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [staging]
   workflow_dispatch:
 
 concurrency:
@@ -37,8 +42,6 @@ env:
 
 jobs:
   build:
-    # workflow_dispatch carries no pull request, so let it through explicitly.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,10 +1,6 @@
 name: Staging
 
-# Promotion to staging.
-#
-# Triggered by a pull request merging into `staging`, not by a push. Previously
-# a bare `git push` reached a live server with nothing in between, so a mistake
-# went straight to a running environment.
+# Deploy to the DigitalOcean staging box.
 #
 # The image is published to the GitHub Container Registry, private, and the
 # server pulls it by digest. Deployment runs the Ansible playbook from
@@ -12,10 +8,11 @@ name: Staging
 # path serves CI, an operator's laptop, and the IIT Madras host.
 
 on:
-  # The DO staging box was destroyed to save cost, so this no longer fires on a
-  # merge; the merge-to-staging deploy now targets IITM (deploy-staging-iitm.yml).
-  # It remains here, dispatch-only, to rebuild and redeploy the DO box from the
-  # IaC if it is ever brought back.
+  # Dispatch-only, and dormant. The DO staging box was destroyed to save cost and
+  # IITM took over staging (deploy-staging-iitm.yml), so this exists to rebuild
+  # and redeploy the DO box from the IaC if it is ever brought back. It once ran
+  # on a merge into `staging`; that branch has since been retired
+  # (echno-deployment#38).
   workflow_dispatch:
 
 concurrency:
@@ -31,8 +28,6 @@ env:
 
 jobs:
   build:
-    # workflow_dispatch carries no pull request, so let it through explicitly.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
The `staging` branch is being deleted across `echno-backend` and `echno-web`, and this brings the workflows into line with that.

## Why

The documented deploy trigger and the one in use had diverged. `staging` was **240 commits stale** here (last merge 25 Jul, PR #318) while every real deploy to `echno.in` ran as `workflow_dispatch` on `development`. A merge trigger on a branch nobody merges into is worse than no trigger: a well-meant merge would have promoted months of several people’s in-flight work in one go. That very nearly happened this week.

Nothing was stranded on `staging`. I compared content rather than hashes before proposing the deletion: all 36 files present on `staging` but absent from `development` had existed on `development` and were deliberately removed or refactored there, and all ten of Hrishi’s finance multi-tenancy commits reached `development` by rebase (verified via `021-add-org-scope-to-finance.xml` plus org scoping on `Account`, `Customer`, `Invoice`, `JournalEntry`, `Payment`, `CompanyBankAccount`, `DocumentSequence`, `EntryNumberGenerator` and the report layer).

## What changed

- `deploy-staging-iitm.yml`: drops the `pull_request: {types: [closed], branches: [staging]}` trigger, keeps `workflow_dispatch`, which is what has actually been deploying. The `if` guard on the build job goes with it, as there is no longer a pull request event to distinguish.
- `staging.yml`: behaviour unchanged, it was already dispatch-only and dormant after the DO box was destroyed. Only the comment is corrected, since it still described a merge trigger it had not carried for weeks.

## The cost, stated rather than implied

A staging deploy is now a manual act with **no review gate**. That is the right trade for staging and would be the wrong one for production, which keeps its own gated `deploy-prod.yml` with a typed per-client confirmation. This is recorded in the workflow comments and in the `echno-deployment` docs.

Closes part of tornotron/echno-deployment#38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment Updates**
  * Staging deployments are now initiated manually rather than automatically after pull requests are merged.
  * IITM is now the active staging environment.
  * The previous DigitalOcean staging deployment is dormant and no longer used for routine staging validation.
  * The retired `staging` branch is no longer part of the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->