### PR TITLE
Derive the progress a project create and update reply with

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13312,8 +13312,8 @@
             "type": "integer"
           },
           "progress": {
-            "description": "Overall completion of the project, as a fraction from 0 to 1.",
-            "example": 0.35,
+            "description": "Overall completion of the project, as a percentage from 0 to 100. The mean of the project's task progress values.",
+            "example": 35.0,
             "format": "double",
             "type": "number"
           },
@@ -13488,8 +13488,8 @@
             "type": "integer"
           },
           "progress": {
-            "description": "Overall completion of the project, as a fraction from 0 to 1.",
-            "example": 0.35,
+            "description": "Overall completion of the project, as a percentage from 0 to 100. The mean of the project's task progress values, the same figure the full project view reports. Zero for a project that has no tasks yet.",
+            "example": 35.0,
             "format": "double",
             "type": "number"
           },
@@ -13602,8 +13602,8 @@
             "type": "integer"
           },
           "progress": {
-            "description": "Overall completion of the project, as a fraction from 0 to 1. The same figure the full project view reports.",
-            "example": 0.35,
+            "description": "Overall completion of the project, as a percentage from 0 to 100. The same figure the full project view reports.",
+            "example": 35.0,
             "format": "double",
             "type": "number"
           },
@@ -16849,8 +16849,8 @@
             "type": "array"
           },
           "progress": {
-            "description": "Completion of the task, as a fraction from 0 to 1.",
-            "example": 0.5,
+            "description": "Completion of the task, as a percentage from 0 to 100.",
+            "example": 50.0,
             "format": "double",
             "type": "number"
           },

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -77,7 +77,8 @@ public class ProjectDto {
     @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
 
-    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1.", example = "0.35")
+    @Schema(description = "Overall completion of the project, as a percentage from 0 to 100. The "
+            + "mean of the project's task progress values.", example = "35.0")
     private Double progress;
 
     @Schema(description = "Tasks that belong to the project.")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -57,6 +57,8 @@ public class ProjectSimpleDto {
     @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
 
-    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1.", example = "0.35")
+    @Schema(description = "Overall completion of the project, as a percentage from 0 to 100. The "
+            + "mean of the project's task progress values, the same figure the full project view "
+            + "reports. Zero for a project that has no tasks yet.", example = "35.0")
     private Double progress;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
@@ -70,7 +70,7 @@ public class ProjectSummaryDto {
     @Schema(description = "Planned completion date of the project.", example = "2027-06-30T00:00:00")
     private LocalDateTime endDate;
 
-    @Schema(description = "Overall completion of the project, as a fraction from 0 to 1. The same "
-            + "figure the full project view reports.", example = "0.35")
+    @Schema(description = "Overall completion of the project, as a percentage from 0 to 100. The "
+            + "same figure the full project view reports.", example = "35.0")
     private Double progress;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/mapper/ProjectMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/project/mapper/ProjectMapper.java
@@ -17,17 +17,20 @@ import org.tornotron.echno_backend.task.mapper.TaskMapper;
 
 /**
  * Maps {@link Project} to its DTOs. employees via {@link EmployeeMapper}, tasks via
- * {@link TaskMapper}, attachments via {@link AttachmentMapper}. On the full DTO, progress
- * is the average of the tasks' progress (computed in {@link #calcProgress}); on the simple
- * DTO it is the entity's own progress field, mapped by name.
+ * {@link TaskMapper}, attachments via {@link AttachmentMapper}. Progress means one thing on
+ * every shape: the average of the project's task progress values. The full DTO and the simple
+ * DTO each compute it through {@link ProjectProgressCalculator} (in {@link #calcProgress} and
+ * {@link #calcSimpleProgress}); the summary reads the same average out of the
+ * {@link ProjectProgressLookup} the caller fills for the whole page.
  *
  * <p>{@link #toSummaryDto} is the list projection of the full DTO: the same scalar fields, none
  * of the collections, and a progress figure that means the same thing. It is deliberately not
- * {@link #toSimpleDto}, which is the shape a create or an update replies with and whose progress
- * comes from the entity's own {@code progress} column. Nothing in the codebase writes that
- * column, so on the simple DTO the field is always null; the full DTO derives the number from the
- * tasks instead, and the summary reads the same derivation out of the
- * {@link ProjectProgressLookup} the caller fills for the whole page.
+ * {@link #toSimpleDto}, which is the shape a create or an update replies with and which carries
+ * no collections at all.
+ *
+ * <p>The entity still declares a {@code progress} column, but nothing writes it and nothing here
+ * reads it. Every mapping above ignores it. It is left in the schema rather than dropped, because
+ * removing a column is a migration with its own risk; treat it as dead until then.
  */
 @Mapper(componentModel = "spring",
         uses = {EmployeeMapper.class, TaskMapper.class, AttachmentMapper.class})
@@ -36,6 +39,7 @@ public interface ProjectMapper {
     @Mapping(target = "progress", ignore = true) // computed in calcProgress
     ProjectDto toDto(Project project);
 
+    @Mapping(target = "progress", ignore = true) // computed in calcSimpleProgress
     ProjectSimpleDto toSimpleDto(Project project);
 
     /**
@@ -52,6 +56,21 @@ public interface ProjectMapper {
 
     @AfterMapping
     default void calcProgress(Project project, @MappingTarget ProjectDto dto) {
+        dto.setProgress(ProjectProgressCalculator.calculate(project.getTasks()));
+    }
+
+    /**
+     * Derives the progress a create or an update replies with, the same way the read shape does.
+     *
+     * <p>Both call sites run inside the service transaction that saved the project, so reaching
+     * the tasks is a lazy association load rather than a detached access. A project being created
+     * has none, and the calculator answers {@code 0.0} for that.
+     *
+     * @param project The project being mapped.
+     * @param dto The simple DTO to fill in.
+     */
+    @AfterMapping
+    default void calcSimpleProgress(Project project, @MappingTarget ProjectSimpleDto dto) {
         dto.setProgress(ProjectProgressCalculator.calculate(project.getTasks()));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskDto.java
@@ -45,7 +45,7 @@ public class TaskDto {
     @Schema(description = "Category the task is filed under.")
     private CategoryDto category;
 
-    @Schema(description = "Completion of the task, as a fraction from 0 to 1.", example = "0.5")
+    @Schema(description = "Completion of the task, as a percentage from 0 to 100.", example = "50.0")
     private Double progress;
 
     @Schema(description = "Free-text tags applied to the task.", example = "[\"concrete\", \"structural\"]")

--- a/src/test/java/org/tornotron/echno_backend/project/mapper/ProjectMapperProgressTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/mapper/ProjectMapperProgressTest.java
@@ -1,0 +1,120 @@
+package org.tornotron.echno_backend.project.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectProgressLookup;
+import org.tornotron.echno_backend.project.ProjectProgressTotals;
+import org.tornotron.echno_backend.project.dto.ProjectSimpleDto;
+import org.tornotron.echno_backend.project.dto.ProjectSummaryDto;
+import org.tornotron.echno_backend.task.Task;
+
+/**
+ * Pins what {@code progress} means on the shape a create and an update reply with.
+ *
+ * <p>{@link ProjectMapper#toSimpleDto} used to map the field by name from the entity's own
+ * {@code progress} column. Nothing in the codebase writes that column, so the field came back
+ * null on every create and every partial update, and a client that reads a number where the
+ * backend sent nothing gets zero: {@code echno-core} parses the response with
+ * {@code progress: Number(raw.progress ?? 0)} and merges the parsed object over the cached
+ * project detail, where {@code progress} is a scalar and is overwritten rather than preserved.
+ * Editing a project therefore dropped the figure on screen to 0% until the refetch landed.
+ *
+ * <p>The mapper derives it now, so the same field name means the same thing on all three project
+ * shapes. These tests are on the simple DTO because that is the one that was wrong, and they check
+ * it against the summary projection, which computes the same average a different way.
+ *
+ * <p>Plain unit tests: {@link ProjectMapper#toSimpleDto} maps no collections, so the generated
+ * mapper needs none of the nested mappers it is wired with in the container.
+ */
+class ProjectMapperProgressTest {
+
+    private final ProjectMapper mapper = new ProjectMapperImpl();
+
+    @Test
+    void progressOfTheSimpleDto_isTheAverageOfTheTasks() {
+        Project project = projectWithTaskProgress(20.0, 40.0, 90.0);
+
+        ProjectSimpleDto dto = mapper.toSimpleDto(project);
+
+        assertThat(dto.getProgress())
+                .as("a create or an update reports the same derived figure the read shape does")
+                .isEqualTo(50.0);
+    }
+
+    @Test
+    void progressOfAProjectWithNoTasks_isZeroRatherThanNull() {
+        Project project = projectWithTaskProgress();
+
+        ProjectSimpleDto dto = mapper.toSimpleDto(project);
+
+        assertThat(dto.getProgress())
+                .as("a project that has just been created has nothing to average, and zero is the "
+                        + "honest answer; null becomes zero in the client anyway, silently")
+                .isEqualTo(0.0);
+    }
+
+    @Test
+    void progressOfAProjectWhoseTasksAreNotLoaded_isZeroRatherThanNull() {
+        Project project = new Project();
+        project.setId(7L);
+        project.setTasks(null);
+
+        ProjectSimpleDto dto = mapper.toSimpleDto(project);
+
+        assertThat(dto.getProgress()).isEqualTo(0.0);
+    }
+
+    @Test
+    void theEntitysOwnProgressColumn_isNotRead() {
+        Project project = projectWithTaskProgress(20.0, 40.0, 90.0);
+        project.setProgress(99.0);
+
+        ProjectSimpleDto dto = mapper.toSimpleDto(project);
+
+        assertThat(dto.getProgress())
+                .as("the column is dead: nothing writes it, so a value left in it must not reach "
+                        + "a response in preference to the derived figure")
+                .isEqualTo(50.0);
+    }
+
+    @Test
+    void tasksCarryingNoProgress_areIgnoredNotCountedAsZero() {
+        Project project = projectWithTaskProgress(60.0, null, 80.0);
+
+        ProjectSimpleDto dto = mapper.toSimpleDto(project);
+
+        assertThat(dto.getProgress()).isEqualTo(70.0);
+    }
+
+    @Test
+    void theSimpleDtoAndTheListProjection_reportTheSameFigure() {
+        Project project = projectWithTaskProgress(20.0, 40.0, 90.0);
+        ProjectProgressLookup lookup =
+                ProjectProgressLookup.of(List.of(new ProjectProgressTotals(project.getId(), 50.0)));
+
+        ProjectSimpleDto simple = mapper.toSimpleDto(project);
+        ProjectSummaryDto summary = mapper.toSummaryDto(project, lookup);
+
+        assertThat(simple.getProgress())
+                .as("the field means one thing across the shapes, whichever endpoint answered")
+                .isEqualTo(summary.getProgress());
+    }
+
+    private Project projectWithTaskProgress(Double... progressValues) {
+        Project project = new Project();
+        project.setId(7L);
+        List<Task> tasks = new ArrayList<>();
+        for (Double value : progressValues) {
+            Task task = new Task();
+            task.setProgress(value);
+            tasks.add(task);
+        }
+        project.setTasks(tasks);
+        return project;
+    }
+}


### PR DESCRIPTION
Closes #617.

`ProjectSimpleDto` is what `POST /api/v1/project`, `POST /api/v1/project/web` and `PATCH /api/v1/project/web/{id}` reply with. Its `progress` was mapped by name from `Project.progress`, the `progress` column on the project table, and nothing in the codebase writes that column: `setProgress` appears only on tasks, WBS elements and issues, and there is no service, seeder or migration that fills the project one. So the field came back null on all three endpoints, and had done since the DTO was introduced.

## Derived, not removed and not stored

`ProjectMapper.toSimpleDto` now ignores the column and computes the figure from `ProjectProgressCalculator.calculate(project.getTasks())`, which is exactly what `toDto` has always done in `calcProgress`. Of the three answers the issue set out, this is the one that leaves the field meaning one thing everywhere: `ProjectDto` derives it, `ProjectSummaryDto` (#615) derives it through `ProjectProgressLookup`, and now the create and update shape does too. Dropping the field would have been a breaking change to the published shape for a field that at least one client already reads; writing the column would have needed an answer for how a stored roll-up stays in step with the tasks, which nothing in the product has today.

## Why a null was worse than it looks

It did not surface as an empty progress bar. `echno-core` parses these responses with `parseProject`, whose progress line is

```ts
progress: Number(raw.progress ?? 0),
```

and `useUpdateProject` / `useUpdateProjectWithFiles` in `src/hooks/project/use-project-mutations.ts` merge that parsed object into the cached project detail with

```ts
mergePreservingNested(old, updatedProject, PROJECT_NESTED_KEYS)
```

where `PROJECT_NESTED_KEYS` is `['attachments', 'members', 'tasks']`. `progress` is a scalar, so it is not in `preserveKeys`, and `{ ...cached, ...partial }` overwrites it. The null therefore landed in the cache as a **0**, and editing a project dropped its displayed progress to 0% until the invalidate refetch came back with the real number. The merge is correct as written; it was being handed a field the backend had no value for.

## The tasks are reachable where this runs

Both `toSimpleDto` call sites, `ProjectService.createProject` (line 212) and `ProjectService.partialUpdateAProject` (line 357), are inside `@Transactional` methods that have just saved the project, so `getTasks()` is a lazy association load in an open session rather than a detached access. A project being created has no tasks at all, and the calculator answers `0.0` for that, which is the same answer the read shape gives it.

The new `@AfterMapping` hook calls a static calculator and no repository, so `MapperDatabaseAccessTest` is satisfied: the rule is about queries issued per row, and an association load is not one.

## The column is dead, and stays

`Project` still declares `@Column(name = "progress")`. Nothing writes it and nothing now reads it. I have not dropped it here, because removing a column is a migration with its own risk and its own rollback story. The mapper javadoc says plainly that it is dead rather than claiming it is read, which is what it used to claim.

## The units were documented wrong

The `@Schema` on `ProjectSimpleDto.progress` said "as a fraction from 0 to 1", example `0.35`. So did `ProjectDto`, `ProjectSummaryDto` and `TaskDto`. The number the calculator averages is `Task.progress`, and the entity's own comment describes it as a percentage. Checked on live staging before changing anything:

```
SELECT count(*), min(progress), max(progress), avg(progress) FROM task;
   9    0    100    28.333333333333332
```

`echno-core` also documents the parsed field as `Completion progress as a number in [0, 100]`. So the description was wrong and the data is right. I fixed the four descriptions and their examples to say percentage 0 to 100. **No number changed**, on either side of the wire.

## Tests

6 new tests in `ProjectMapperProgressTest`, all 6 fail without the mapper change. Verified by reverting the production edit on the build box and re-running.

| Test | Without the fix |
|------|-----------------|
| `progressOfTheSimpleDto_isTheAverageOfTheTasks` | FAILS, `Expecting actual not to be null` |
| `progressOfAProjectWithNoTasks_isZeroRatherThanNull` | FAILS, `Expecting actual not to be null` |
| `progressOfAProjectWhoseTasksAreNotLoaded_isZeroRatherThanNull` | FAILS, `Expecting actual not to be null` |
| `tasksCarryingNoProgress_areIgnoredNotCountedAsZero` | FAILS, `Expecting actual not to be null` |
| `theEntitysOwnProgressColumn_isNotRead` | FAILS, `expected: 50.0 but was: 99.0` |
| `theSimpleDtoAndTheListProjection_reportTheSameFigure` | FAILS, `expected: 50.0 but was: null` |

`theEntitysOwnProgressColumn_isNotRead` is the one that shows the old behaviour rather than just its symptom: a value left in the column reached the response ahead of the derived figure.

`./gradlew build` green on the build box; test heap 568 MB of the 2048 MB cap (28%), 8 contexts cached of 8. `openApiSnapshot -PupdateOpenApiSnapshot` rewrote four description and example pairs, committed here.

## Not done here

Dropping the `progress` column from `project`, and the matching `echno-core` doc line if anyone wants the units restated there. Neither blocks this.
