### PR TITLE
Scope labour contacts and category names to the organization, drop the issue title constraint

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/category/Category.java
+++ b/src/main/java/org/tornotron/echno_backend/category/Category.java
@@ -30,7 +30,13 @@ public class Category implements TenantScopedEntity {
     @Column(name = "category_name", nullable = false)
     private String name;
 
-    @Column(name = "normalized_name", unique = true)
+    /**
+     * The name with case, punctuation and spacing folded away, used to decide whether a category
+     * already exists. Unique per organization rather than globally: the constraint that enforces
+     * it is {@code uk_category_org_normalized_name} in the schema, and it is composite, so it
+     * cannot be declared here as a column-level unique.
+     */
+    @Column(name = "normalized_name")
     private String normalizedName;
 
     /** A brief description of the category. */

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryRepository.java
@@ -22,7 +22,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndOrganization_Id(Long id, Long organizationId);
 
-    boolean existsByNormalizedName(String normalizedName);
+    /**
+     * Whether this organization already holds a category whose name normalizes to the given
+     * string. Scoped to the organization because the constraint behind it,
+     * {@code uk_category_org_normalized_name}, is: two tenants may both have a "Civil Works".
+     */
+    boolean existsByNormalizedNameAndOrganization_Id(String normalizedName, Long organizationId);
 
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
+++ b/src/main/java/org/tornotron/echno_backend/category/CategoryService.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.common.exception.DatabaseOperationException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.organization.Organization;
 
 
 /**
@@ -47,12 +48,13 @@ public class CategoryService {
      */
     @Transactional
     public CategorySimpleDto addCategory(CategoryCreationDto categoryCreationDto) {
+        Organization organization = tenantEntityHelper.resolveCurrentOrganization();
         String normalized = CategoryNormalizer.normalize(categoryCreationDto.getName());
-        if(categoryRepository.existsByNormalizedName(normalized)) {
+        if(categoryRepository.existsByNormalizedNameAndOrganization_Id(normalized, organization.getId())) {
             throw new IllegalArgumentException("Category with name " + normalized + " already exists.");
         }
         Category category = new Category();
-        category.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
+        category.setOrganization(organization);
         category.setName(categoryCreationDto.getName());
         category.setNormalizedName(normalized);
         category.setDescription(categoryCreationDto.getDescription());

--- a/src/main/java/org/tornotron/echno_backend/issue/Issue.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/Issue.java
@@ -36,7 +36,13 @@ public class Issue implements TenantScopedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "title", nullable = false, unique = true)
+    /**
+     * What was found on site, as a sentence. Deliberately not unique, in any scope: it is a
+     * description rather than a reference, nothing looks an issue up by it, and one project can
+     * genuinely raise the same finding on many tasks. It used to be unique across every
+     * organization at once; migration 076 removed that.
+     */
+    @Column(name = "title", nullable = false)
     private String title;
 
     @Column(name = "description", nullable = true)

--- a/src/main/java/org/tornotron/echno_backend/labour/Labour.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/Labour.java
@@ -40,13 +40,20 @@ public class Labour extends BaseEntity implements TenantScopedEntity {
     @Column(name = "full_name", nullable = false)
     private String fullName;
 
-    @Column(name = "email", nullable = true,unique = true)
+    /**
+     * Unique per organization rather than globally, so the same worker can be on two
+     * contractors' books. The constraint is {@code uk_labour_org_email} in the schema, and it is
+     * composite, so it cannot be declared here as a column-level unique. Nullable, and NULLs are
+     * distinct, so any number of workers may have no email recorded.
+     */
+    @Column(name = "email", nullable = true)
     private String email;
 
     @Column(name = "address", nullable = true)
     private String address;
 
-    @Column(name = "phone_number", nullable = false,unique = true)
+    /** Unique per organization; see {@link #email}. The constraint is {@code uk_labour_org_phone_number}. */
+    @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
     @Column(name = "emergency_contact_name", nullable = true)
@@ -86,7 +93,8 @@ public class Labour extends BaseEntity implements TenantScopedEntity {
     @Column(name = "over_time_rate")
     private BigDecimal overTimeRate;
 
-    @Column(name = "bank_account_number",unique = true)
+    /** Unique per organization; see {@link #email}. The constraint is {@code uk_labour_org_bank_account_number}. */
+    @Column(name = "bank_account_number")
     private String bankAccountNumber;
 
     @Column(name = "bank_name")

--- a/src/main/java/org/tornotron/echno_backend/labour/LabourRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/LabourRepository.java
@@ -7,4 +7,19 @@ import java.util.Optional;
 public interface LabourRepository extends JpaRepository<Labour,Long> {
 
     Optional<Labour> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Whether another worker in this organization already holds the given email. The id is
+     * excluded so an update that resends a worker's own address does not clash with itself.
+     *
+     * <p>Scoped to the organization because the constraint behind it, {@code uk_labour_org_email},
+     * is: the same person may be on two contractors' books.
+     */
+    boolean existsByEmailAndOrganization_IdAndIdNot(String email, Long organizationId, Long id);
+
+    /** As {@link #existsByEmailAndOrganization_IdAndIdNot}, for {@code uk_labour_org_phone_number}. */
+    boolean existsByPhoneNumberAndOrganization_IdAndIdNot(String phoneNumber, Long organizationId, Long id);
+
+    /** As {@link #existsByEmailAndOrganization_IdAndIdNot}, for {@code uk_labour_org_bank_account_number}. */
+    boolean existsByBankAccountNumberAndOrganization_IdAndIdNot(String bankAccountNumber, Long organizationId, Long id);
 }

--- a/src/main/java/org/tornotron/echno_backend/labour/LabourService.java
+++ b/src/main/java/org/tornotron/echno_backend/labour/LabourService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.labour.mapper.LabourMapper;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
@@ -30,6 +31,13 @@ import org.tornotron.echno_backend.project.ProjectRepository;
 @Service
 public class LabourService {
 
+    /**
+     * Stands in for "this worker does not exist yet" in the duplicate checks below, which all
+     * exclude one id so an update that resends a worker's own details does not clash with
+     * itself. On a create there is no id to exclude, and no row can carry a negative one.
+     */
+    private static final long NO_EXISTING_WORKER = -1L;
+
     private final LabourRepository labourRepository;
     private final TenantEntityHelper tenantEntityHelper;
     private final ProjectRepository projectRepository;
@@ -46,12 +54,22 @@ public class LabourService {
      * Creates a labour record and assigns it to the given current project.
      *
      * @param labourCreationDto The worker's identity, contact, employment, and pay details, plus the current project ID.
+     * <p>The worker's email, phone number and bank account number are each checked against the
+     * rest of this organization first, which is the scope the constraints behind them enforce.
+     * The same person on another contractor's books is not a clash and is accepted.
+     *
      * @return The created labour as a simple DTO.
      * @throws ResourceNotFoundException if the referenced current project cannot be found in the organization.
+     * @throws DuplicateResourceException if another worker in this organization already holds one
+     *         of those three details.
      */
     @Transactional
     public LabourSimpleDto createLabour(LabourCreationDto labourCreationDto) {
         Organization org = tenantEntityHelper.resolveCurrentOrganization();
+        requireContactDetailsFree(org.getId(), NO_EXISTING_WORKER,
+                labourCreationDto.getEmail(),
+                labourCreationDto.getPhoneNumber(),
+                labourCreationDto.getBankAccountNumber());
         Labour labour = new Labour();
         labour.setLabourID(labourCreationDto.getLabourID());
         labour.setOrganization(org);
@@ -126,6 +144,8 @@ public class LabourService {
     }
 
     private void applyUpdates(LabourUpdateDto updates, Labour labour, Organization org) {
+        requireContactDetailsFree(org.getId(), labour.getId(),
+                updates.getEmail(), updates.getPhoneNumber(), updates.getBankAccountNumber());
         if (updates.getLabourID() != null) labour.setLabourID(updates.getLabourID());
         if (updates.getFullName() != null) labour.setFullName(updates.getFullName());
         if (updates.getEmail() != null) labour.setEmail(updates.getEmail());
@@ -149,6 +169,45 @@ public class LabourService {
             labour.setCurrentProject(projectRepository.findByIdAndOrganization_Id(projectId, org.getId())
                     .orElseThrow(() -> new ResourceNotFoundException("Project with ID " + projectId + " was not found in this organization")));
         }
+    }
+
+    /**
+     * Refuses a worker whose email, phone number or bank account number is already held by
+     * another worker in the same organization.
+     *
+     * <p>Until migration 076 these three were reserved across every organization at once, and
+     * nothing here checked them, so a contractor registering a worker another contractor had
+     * already registered was turned away by a constraint over rows they cannot see. The
+     * constraints are now per organization, and this says so before the insert reaches them, so
+     * the caller is told which detail clashed rather than being handed a bare integrity
+     * violation. Both answer 409, so no caller sees a different status than before.
+     *
+     * <p>A null or blank value is not a duplicate of anything: all three columns are free to be
+     * absent, and on an update a null means the field was not supplied at all.
+     *
+     * @param organizationId The organization to look within.
+     * @param excludedId     The worker being updated, so their own details do not clash with
+     *                       themselves, or {@link #NO_EXISTING_WORKER} on a create.
+     */
+    private void requireContactDetailsFree(Long organizationId, Long excludedId,
+                                           String email, String phoneNumber, String bankAccountNumber) {
+        long selfId = (excludedId == null) ? NO_EXISTING_WORKER : excludedId;
+        if (isPresent(email)
+                && labourRepository.existsByEmailAndOrganization_IdAndIdNot(email, organizationId, selfId)) {
+            throw new DuplicateResourceException("A worker with email " + email + " is already registered in this organization");
+        }
+        if (isPresent(phoneNumber)
+                && labourRepository.existsByPhoneNumberAndOrganization_IdAndIdNot(phoneNumber, organizationId, selfId)) {
+            throw new DuplicateResourceException("A worker with phone number " + phoneNumber + " is already registered in this organization");
+        }
+        if (isPresent(bankAccountNumber)
+                && labourRepository.existsByBankAccountNumberAndOrganization_IdAndIdNot(bankAccountNumber, organizationId, selfId)) {
+            throw new DuplicateResourceException("A worker with bank account number " + bankAccountNumber + " is already registered in this organization");
+        }
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isBlank();
     }
 
     /**

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -361,4 +361,7 @@
     <!-- v4.0 - Payables: the number is the tenant's own series, so scope it to the organization -->
     <include file="db/changelog/v4.0/075-payable-number-per-org-uniqueness.xml"/>
 
+    <!-- v4.0 - Labour contacts and category names: scope them to the organization; drop the issue title constraint -->
+    <include file="db/changelog/v4.0/076-tenant-scoped-uniqueness.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/076-tenant-scoped-uniqueness.xml
+++ b/src/main/resources/db/changelog/v4.0/076-tenant-scoped-uniqueness.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="076-add-per-org-labour-uniqueness" author="echno">
+        <comment>
+            Finishes the sweep 061 started and 075 continued. A labour record is tenant scoped
+            (it implements TenantScopedEntity and carries the orgFilter), but its email, phone
+            number and bank account number were reserved across every organization at once, so
+            the first contractor to register a worker took that worker's contact details away
+            from every other contractor on the platform. A labourer on two contractors' books is
+            an ordinary arrangement on a construction site rather than an unlucky one, and the
+            second contractor had no way to record them and no explanation for why: nothing in
+            the service checks for a duplicate, so the rejection arrived as a constraint
+            violation over rows they cannot see.
+
+            The three constraints are composite on organization_id, which is what the tenant
+            filter has always meant. All three columns stay nullable and CockroachDB treats NULLs
+            as distinct, so a worker with no email or no bank account is unaffected, as before.
+
+            They are added before the global ones are dropped, so the columns are never
+            unconstrained in between.
+        </comment>
+
+        <addUniqueConstraint tableName="labour"
+                             columnNames="organization_id, email"
+                             constraintName="uk_labour_org_email"/>
+
+        <addUniqueConstraint tableName="labour"
+                             columnNames="organization_id, phone_number"
+                             constraintName="uk_labour_org_phone_number"/>
+
+        <addUniqueConstraint tableName="labour"
+                             columnNames="organization_id, bank_account_number"
+                             constraintName="uk_labour_org_bank_account_number"/>
+
+        <rollback>
+            <dropUniqueConstraint tableName="labour" constraintName="uk_labour_org_email"/>
+            <dropUniqueConstraint tableName="labour" constraintName="uk_labour_org_phone_number"/>
+            <dropUniqueConstraint tableName="labour" constraintName="uk_labour_org_bank_account_number"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="076-add-per-org-category-normalized-name-uniqueness" author="echno">
+        <comment>
+            Same shape on the category's normalized name. This one also contradicted the
+            constraint sitting beside it: uk_category_name_org already scopes the raw
+            category_name to the organization, while uq_category_normalized_name reserved the
+            normalized form globally. Two tenants could therefore not both have a "Civil Works"
+            category, even though the per-organization constraint on the same table says they
+            may. The service check agreed with the global constraint rather than the scoped one,
+            so the refusal at least arrived as a message rather than a constraint violation, but
+            the message named a category the caller cannot see.
+
+            uk_category_name_org is left in place. It is not redundant: normalized_name is
+            nullable, and two different raw names can normalize to the same string, so neither
+            constraint implies the other.
+        </comment>
+
+        <addUniqueConstraint tableName="category"
+                             columnNames="organization_id, normalized_name"
+                             constraintName="uk_category_org_normalized_name"/>
+
+        <rollback>
+            <dropUniqueConstraint tableName="category" constraintName="uk_category_org_normalized_name"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="076-drop-global-labour-and-category-uniqueness" author="echno">
+        <comment>
+            Removes the cross-tenant constraints now that the per-tenant ones above stand in
+            their place. DROP INDEX rather than DROP CONSTRAINT because CockroachDB backs a
+            UNIQUE column constraint with an index of the same name and that is how it is
+            removed. This follows 061's fourth changeset and 075's second.
+        </comment>
+
+        <sql>
+            DROP INDEX IF EXISTS labour@uq_labour_email CASCADE;
+            DROP INDEX IF EXISTS labour@uq_labour_phone_number CASCADE;
+            DROP INDEX IF EXISTS labour@uq_labour_bank_account_number CASCADE;
+            DROP INDEX IF EXISTS category@uq_category_normalized_name CASCADE;
+        </sql>
+
+        <rollback>
+            <comment>
+                Restoring a global unique constraint would fail on any data that has since made
+                use of the per-tenant scope, so the rollback does not pretend it can.
+            </comment>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="076-drop-global-issue-title-uniqueness" author="echno">
+        <comment>
+            The issue title is dropped outright rather than rescoped to the organization, which
+            is where it differs from every other column in this sweep.
+
+            An issue title is a sentence describing something found on site, not a reference
+            series. The two comparable free-text names in this schema, task.title and
+            project.project_name, carry no unique constraint at all, and nothing looks an issue
+            up by title: the only read of the column is a LIKE in IssueRepository.search, which
+            a unique index does not serve. Repetition within one organization is the expected
+            case rather than the unlucky one, because an issue is raised against a task and a
+            project of forty identical flats genuinely raises "Tiles not level" on forty of
+            them.
+
+            So a per-organization constraint would not be restoring an invariant, it would be
+            inventing one, and it would start refusing creates that succeed today. That is the
+            other difference from 061 and 075: those aligned the schema to a check the service
+            had always made, and IssueService makes no such check. Making the schema agree with
+            the code here means removing the constraint, not narrowing it.
+
+            uk_issue_title is the name on databases built from the v1, v2, v3 and v4 baselines
+            alike, so one statement covers all of them.
+        </comment>
+
+        <sql>
+            DROP INDEX IF EXISTS issue@uk_issue_title CASCADE;
+        </sql>
+
+        <rollback>
+            <comment>
+                Restoring it would fail on any organization that has since raised two issues
+                with the same title, which is the whole point of removing it.
+            </comment>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/category/CategoryUniquenessIT.java
+++ b/src/test/java/org/tornotron/echno_backend/category/CategoryUniquenessIT.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.category;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.category.dto.CategoryCreationDto;
+import org.tornotron.echno_backend.category.mapper.CategoryMapperImpl;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for the scope of a category name against a real CockroachDB, so the schema's
+ * own constraints are part of what is under test (issue #614).
+ *
+ * <p>The category table carried two constraints that disagreed: {@code uk_category_name_org}
+ * scoped the raw name to the organization, while {@code uq_category_normalized_name} reserved
+ * the normalized form across every organization at once. The service check agreed with the
+ * global one, so the first tenant to create a "Civil Works" category took the name away from
+ * everyone else, and the refusal named a category the caller cannot see.
+ *
+ * <p>Migration 076 makes the normalized name per organization too, and the service check follows
+ * it. A clash within one tenant is still refused, including one that differs only in the case,
+ * punctuation or spacing the normalizer folds away.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({CategoryService.class, CategoryMapperImpl.class, TenantEntityHelper.class})
+class CategoryUniquenessIT extends AbstractIntegrationTest {
+
+    private static final String SHARED_NAME = "Civil Works";
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long firstOrgId;
+    private Long secondOrgId;
+
+    @BeforeEach
+    void seed() {
+        firstOrgId = persistOrganization("first");
+        secondOrgId = persistOrganization("second");
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private Long persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName("Category Uniqueness Org " + name);
+        org.setOrganizationAddress("addr");
+        org.setOrganizationEmail("category-uniqueness-" + name + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        entityManager.flush();
+        return org.getId();
+    }
+
+    private void createAs(Long orgId, String name) {
+        TenantContext.setCurrentOrgId(orgId);
+        CategoryCreationDto dto = new CategoryCreationDto();
+        dto.setName(name);
+        dto.setDescription(name + " description");
+        categoryService.addCategory(dto);
+        entityManager.flush();
+    }
+
+    @Test
+    void sameNameInAnotherOrganization_isAccepted() {
+        createAs(firstOrgId, SHARED_NAME);
+
+        assertThatNoException().isThrownBy(() -> createAs(secondOrgId, SHARED_NAME));
+    }
+
+    @Test
+    void aNameAnotherOrganizationHoldsOnlyAfterNormalizing_isAccepted() {
+        createAs(firstOrgId, "Steel & Rebar");
+
+        assertThatNoException().isThrownBy(() -> createAs(secondOrgId, "steel and rebar"));
+    }
+
+    @Test
+    void sameNameTwiceInOneOrganization_isRejected() {
+        createAs(firstOrgId, SHARED_NAME);
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                createAs(firstOrgId, SHARED_NAME));
+    }
+
+    @Test
+    void aNameThatOnlyNormalizesToAnExistingOneInTheSameOrganization_isRejected() {
+        createAs(firstOrgId, "Steel & Rebar");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                createAs(firstOrgId, "  steel and   rebar "));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueTitleUniquenessIT.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueTitleUniquenessIT.java
@@ -1,0 +1,112 @@
+package org.tornotron.echno_backend.issue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.User;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for the issue title against a real CockroachDB, so the schema's own
+ * constraints are what is under test (issue #614).
+ *
+ * <p>An issue title used to be unique across every organization at once, under
+ * {@code uk_issue_title}. Two tenants could therefore not both raise "Leak in basement", and
+ * because nothing in {@link IssueService} checks for a duplicate first, the second tenant's
+ * create came back as a constraint violation over rows they cannot see.
+ *
+ * <p>Migration 076 removes the constraint rather than rescoping it to the organization. A title
+ * is a description rather than a reference, nothing looks an issue up by it, and one project
+ * genuinely raises the same finding against many tasks, so both of the cases pinned here have
+ * to be accepted: the same title in another organization, and the same title twice in one.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class IssueTitleUniquenessIT extends AbstractIntegrationTest {
+
+    private static final String SHARED_TITLE = "Leak in basement";
+
+    @Autowired
+    private IssueRepository issueRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void sameTitleInAnotherOrganization_isAccepted() {
+        Organization first = persistOrganization("Issue Title Org One");
+        Organization second = persistOrganization("Issue Title Org Two");
+        persistIssue(first, SHARED_TITLE, persistEmployee(first, "raiser-one"));
+
+        assertThatNoException().isThrownBy(() -> {
+            persistIssue(second, SHARED_TITLE, persistEmployee(second, "raiser-two"));
+            em.flush();
+        });
+
+        assertThat(issueRepository.findAll())
+                .filteredOn(issue -> SHARED_TITLE.equals(issue.getTitle()))
+                .hasSize(2);
+    }
+
+    @Test
+    void sameTitleTwiceInOneOrganization_isAccepted() {
+        Organization org = persistOrganization("Issue Title Org Three");
+        Employee raiser = persistEmployee(org, "raiser-three");
+        persistIssue(org, "Tiles not level", raiser);
+
+        assertThatNoException().isThrownBy(() -> {
+            persistIssue(org, "Tiles not level", raiser);
+            em.flush();
+        });
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "-").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Employee persistEmployee(Organization org, String handle) {
+        User user = new User();
+        user.setKeycloakId("kc-issue-title-" + handle);
+        user.setName(handle);
+        em.persist(user);
+
+        Employee employee = new Employee();
+        employee.setOrganization(org);
+        employee.setUser(user);
+        employee.setEmployeeName(handle);
+        employee.setGender("U");
+        employee.setPhoneNumber("0000000000");
+        employee.setEmailAddress("issue-title-" + handle + "@example.test");
+        employee.setDateOfBirth(LocalDateTime.of(1990, 1, 1, 0, 0));
+        em.persist(employee);
+        return employee;
+    }
+
+    private void persistIssue(Organization org, String title, Employee createdBy) {
+        Issue issue = new Issue();
+        issue.setTitle(title);
+        issue.setDescription(title + " description");
+        issue.setType(IssueType.safety);
+        issue.setStatus(IssueStatus.open);
+        issue.setOrganization(org);
+        issue.setCreatedBy(createdBy);
+        em.persist(issue);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/labour/LabourUniquenessIT.java
+++ b/src/test/java/org/tornotron/echno_backend/labour/LabourUniquenessIT.java
@@ -1,0 +1,208 @@
+package org.tornotron.echno_backend.labour;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tornotron.echno_backend.common.exception.DuplicateResourceException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.labour.dto.LabourCreationDto;
+import org.tornotron.echno_backend.labour.dto.LabourUpdateDto;
+import org.tornotron.echno_backend.labour.mapper.LabourMapperImpl;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for the scope of a worker's contact details against a real CockroachDB, so
+ * the schema's own constraints are part of what is under test (issue #614).
+ *
+ * <p>A worker's email, phone number and bank account number used to be reserved across every
+ * organization at once, under {@code uq_labour_email}, {@code uq_labour_phone_number} and
+ * {@code uq_labour_bank_account_number}. A labourer on two contractors' books is an ordinary
+ * arrangement on a construction site, and the second contractor could not register them at all:
+ * nothing in {@link LabourService} checked for a duplicate, so the create came back as a
+ * constraint violation over rows they cannot see.
+ *
+ * <p>Migration 076 makes all three per organization, and the service now says so before the
+ * insert reaches them, so a genuine clash within one tenant names the detail that clashed.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({LabourService.class, LabourMapperImpl.class, TenantEntityHelper.class})
+class LabourUniquenessIT extends AbstractIntegrationTest {
+
+    private static final String SHARED_EMAIL = "suresh.pillai@example.test";
+    private static final String SHARED_PHONE = "9847098470";
+    private static final String SHARED_ACCOUNT = "50100234567890";
+
+    @Autowired
+    private LabourService labourService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Tenant first;
+    private Tenant second;
+
+    /** One organization with the project a labour record has to reference. */
+    private record Tenant(Long orgId, Long projectId) {
+    }
+
+    @BeforeEach
+    void seed() {
+        first = persistTenant("first");
+        second = persistTenant("second");
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private Tenant persistTenant(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName("Labour Uniqueness Org " + name);
+        org.setOrganizationAddress("addr");
+        org.setOrganizationEmail("labour-uniqueness-" + name + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+
+        Project project = new Project();
+        project.setProjectName("Project " + name);
+        project.setOrganization(org);
+        entityManager.persist(project);
+
+        entityManager.flush();
+        return new Tenant(org.getId(), project.getId());
+    }
+
+    private LabourCreationDto dtoFor(Tenant tenant, String labourId, String email,
+                                     String phone, String account) {
+        LabourCreationDto dto = new LabourCreationDto();
+        dto.setLabourID(labourId);
+        dto.setFullName("Suresh Pillai");
+        dto.setEmail(email);
+        dto.setPhoneNumber(phone);
+        dto.setEmploymentType("DAILY_WAGE");
+        dto.setSkillLevel("SKILLED");
+        dto.setStatus("ACTIVE");
+        dto.setJoiningDate(LocalDate.of(2026, 1, 15));
+        dto.setCurrentProjectId(tenant.projectId());
+        dto.setBankAccountNumber(account);
+        return dto;
+    }
+
+    private Long createAs(Tenant tenant, String labourId, String email, String phone, String account) {
+        TenantContext.setCurrentOrgId(tenant.orgId());
+        labourService.createLabour(dtoFor(tenant, labourId, email, phone, account));
+        entityManager.flush();
+        return entityManager
+                .createQuery("SELECT l.id FROM Labour l WHERE l.labourID = :code", Long.class)
+                .setParameter("code", labourId)
+                .getSingleResult();
+    }
+
+    // --- The same worker on two contractors' books ------------------------
+
+    @Test
+    void sameEmailInAnotherOrganization_isAccepted() {
+        createAs(first, "LAB-0001", SHARED_EMAIL, "9000000001", null);
+
+        assertThatNoException().isThrownBy(() ->
+                createAs(second, "LAB-0002", SHARED_EMAIL, "9000000002", null));
+    }
+
+    @Test
+    void samePhoneNumberInAnotherOrganization_isAccepted() {
+        createAs(first, "LAB-0003", null, SHARED_PHONE, null);
+
+        assertThatNoException().isThrownBy(() ->
+                createAs(second, "LAB-0004", null, SHARED_PHONE, null));
+    }
+
+    @Test
+    void sameBankAccountNumberInAnotherOrganization_isAccepted() {
+        createAs(first, "LAB-0005", null, "9000000005", SHARED_ACCOUNT);
+
+        assertThatNoException().isThrownBy(() ->
+                createAs(second, "LAB-0006", null, "9000000006", SHARED_ACCOUNT));
+    }
+
+    // --- A genuine clash within one organization --------------------------
+
+    @Test
+    void sameEmailTwiceInOneOrganization_isRejectedAsADuplicate() {
+        createAs(first, "LAB-0007", SHARED_EMAIL, "9000000007", null);
+
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(() ->
+                createAs(first, "LAB-0008", SHARED_EMAIL, "9000000008", null));
+    }
+
+    @Test
+    void samePhoneNumberTwiceInOneOrganization_isRejectedAsADuplicate() {
+        createAs(first, "LAB-0009", null, SHARED_PHONE, null);
+
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(() ->
+                createAs(first, "LAB-0010", null, SHARED_PHONE, null));
+    }
+
+    @Test
+    void sameBankAccountNumberTwiceInOneOrganization_isRejectedAsADuplicate() {
+        createAs(first, "LAB-0011", null, "9000000011", SHARED_ACCOUNT);
+
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(() ->
+                createAs(first, "LAB-0012", null, "9000000012", SHARED_ACCOUNT));
+    }
+
+    // --- Absent details are not duplicates of one another -----------------
+
+    @Test
+    void twoWorkersWithNoEmailOrBankAccount_areBothAccepted() {
+        createAs(first, "LAB-0013", null, "9000000013", null);
+
+        assertThatNoException().isThrownBy(() ->
+                createAs(first, "LAB-0014", null, "9000000014", null));
+    }
+
+    // --- Updating a worker with their own details -------------------------
+
+    @Test
+    void updatingAWorkerWithTheirOwnDetails_isAccepted() {
+        Long id = createAs(first, "LAB-0015", SHARED_EMAIL, SHARED_PHONE, SHARED_ACCOUNT);
+
+        LabourUpdateDto updates = new LabourUpdateDto();
+        updates.setEmail(SHARED_EMAIL);
+        updates.setPhoneNumber(SHARED_PHONE);
+        updates.setBankAccountNumber(SHARED_ACCOUNT);
+        updates.setFullName("Suresh K Pillai");
+
+        assertThatNoException().isThrownBy(() -> {
+            labourService.partialUpdateALabour(updates, id);
+            entityManager.flush();
+        });
+    }
+
+    @Test
+    void updatingAWorkerOntoAnotherWorkersEmail_isRejectedAsADuplicate() {
+        createAs(first, "LAB-0016", SHARED_EMAIL, "9000000016", null);
+        Long id = createAs(first, "LAB-0017", "other@example.test", "9000000017", null);
+
+        LabourUpdateDto updates = new LabourUpdateDto();
+        updates.setEmail(SHARED_EMAIL);
+
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(() ->
+                labourService.partialUpdateALabour(updates, id));
+    }
+}


### PR DESCRIPTION
Closes #614.

Finishes the sweep migration **061** started and **075** (#613) continued. Four columns on tenant-scoped entities were still unique across the whole estate. Three are rescoped to the organization; one is removed, and that difference is the part worth reading.

## Checked against live staging first

Read-only, on `echno.in`, before writing the migration. The point was to know whether the new constraints can fail at deploy time.

| Table | Rows | Organizations | Cross-tenant duplicates | Within-org duplicates | Null `organization_id` |
|-------|-----:|--------------:|------------------------:|----------------------:|-----------------------:|
| `issue` | 3 | 1 | 0 | 0 | 0 |
| `labour` | 2 | 1 | 0 | 0 | 0 |
| `category` | 24 | 2 | 0 | 0 | 0 |

Zero everywhere, which is what the current global constraints guarantee: a set of rows that satisfies a global unique also satisfies the composite one, so `076` cannot fail on existing data and needs no deduplication step. One `labour` row has a null `bank_account_number`, which stays legal because CockroachDB treats NULLs as distinct.

Worth saying plainly: `category` already shows the fault. 24 rows across 2 organizations with no overlapping normalized name at all, on a table whose 24 names are the seeded defaults. The second tenant's category list is not the first's because it could not be.

## `labour.email`, `phone_number`, `bank_account_number` — rescoped

A labourer on two contractors' books is an ordinary arrangement on a construction site rather than an unlucky one, and the second contractor could not register them at all. Nothing in `LabourService` checked for a duplicate, so the create came back as a `DataIntegrityViolationException` raised by a constraint over rows they cannot see.

`LabourService` now checks all three within the organization, on create and on update, excluding the worker being updated so their own details do not clash with themselves. Both paths already answered **409** (the integrity violation handler and `DuplicateResourceException` map to the same status), so no caller sees a different status than before, only a message naming the detail that clashed instead of a bare integrity error.

## `category.normalized_name` — rescoped

This one contradicted the constraint sitting beside it. `uk_category_name_org` already scoped the raw `category_name` to the organization while `uq_category_normalized_name` reserved the normalized form globally, so the table said both things at once. `CategoryService.existsByNormalizedName` followed the global constraint rather than the scoped one, so it was at least self-consistent, but it meant the first tenant to create a "Civil Works" category took the name from every tenant after them, and the refusal named a category the caller cannot see.

The check is now `existsByNormalizedNameAndOrganization_Id`. `uk_category_name_org` stays: `normalized_name` is nullable and two different raw names can normalize to the same string, so neither constraint implies the other.

The exception type is deliberately left as `IllegalArgumentException` (400). It is the wrong status for a duplicate, but changing it would change what an existing caller sees for a reason that has nothing to do with tenant scope. Separate change.

## `issue.title` — removed, not rescoped

The issue asked for this to be argued rather than assumed, so:

1. **It is not an identifier.** Nothing looks an issue up by title. `IssueRepository` has no `findByTitle` or `existsByTitle`; the only read of the column is a `LIKE` in `search`, which a unique index does not serve. The constraint was carrying no query.
2. **The comparable columns in this schema are not unique.** `task.title` has no unique constraint and `project.project_name` has only a plain index. An issue title is the same kind of value as both, a sentence describing something found on site.
3. **Repetition within one organization is the expected case.** An issue is raised against a task, and a project of forty identical flats genuinely raises "Tiles not level" on forty of them. A per-organization constraint would refuse the second one.
4. **There is no invariant to restore.** This is the real difference from 061 and 075. Those aligned the schema to a check the service had always made: the service said "within this organization" and the schema said "everywhere", and the migration made the schema agree with the code. `IssueService` makes no such check, so a composite constraint would not restore an invariant, it would invent one, and it would start refusing creates that succeed today, as a raw constraint violation rather than a 409, since there is no check to produce the nicer error.

So making the schema agree with the code here means removing the constraint, not narrowing it. `uk_issue_title` is dropped with no replacement.

## Not touched

`users_table` keycloak_id / email / phone, `project.invite_code`, `feature.code` and `plan.code` are all deliberately global and stay that way, as the issue records.

## Tests

16 new tests across three integration classes, all against a real CockroachDB so the schema's own constraints are what is under test. **12 of the 16 fail without this change.** Verified by running the same three test files against a clean checkout of `development` on the build box.

| Test | Without the fix |
|------|-----------------|
| `IssueTitleUniquenessIT.sameTitleInAnotherOrganization_isAccepted` | FAILS — `violates unique constraint "uk_issue_title"  Detail: Key (title)=('Leak in basement') already exists` |
| `IssueTitleUniquenessIT.sameTitleTwiceInOneOrganization_isAccepted` | FAILS — same, on `('Tiles not level')` |
| `LabourUniquenessIT.sameEmailInAnotherOrganization_isAccepted` | FAILS — `violates unique constraint "uq_labour_email"` |
| `LabourUniquenessIT.samePhoneNumberInAnotherOrganization_isAccepted` | FAILS — `violates unique constraint "uq_labour_phone_number"` |
| `LabourUniquenessIT.sameBankAccountNumberInAnotherOrganization_isAccepted` | FAILS — `violates unique constraint "uq_labour_bank_account_number"` |
| `LabourUniquenessIT.sameEmailTwiceInOneOrganization_isRejectedAsADuplicate` | FAILS — `DataIntegrityViolationException` where a `DuplicateResourceException` is expected |
| `LabourUniquenessIT.samePhoneNumberTwiceInOneOrganization_isRejectedAsADuplicate` | FAILS — same |
| `LabourUniquenessIT.sameBankAccountNumberTwiceInOneOrganization_isRejectedAsADuplicate` | FAILS — same |
| `LabourUniquenessIT.updatingAWorkerOntoAnotherWorkersEmail_isRejectedAsADuplicate` | FAILS — same |
| `CategoryUniquenessIT.sameNameInAnotherOrganization_isAccepted` | FAILS — `Category with name civil works already exists` |
| `CategoryUniquenessIT.aNameAnotherOrganizationHoldsOnlyAfterNormalizing_isAccepted` | FAILS — `Category with name steel and rebar already exists` |

The other four pin behaviour that has to survive the change: two workers with no email and no bank account are both accepted, updating a worker with their own details is accepted, a duplicate name within one organization is still refused, and so is one that only clashes after the normalizer folds away case, punctuation and spacing.

`./gradlew build` green on the build box; test heap **554 MB of the 2048 MB cap (27%)**, 8 contexts cached of a maximum 8. `openApiSnapshot -PupdateOpenApiSnapshot` produces no diff, and would not: no controller or DTO surface changes here.

Changelog re-checked against `development` immediately before committing; the maximum was still 075, so this takes **076**.
