### PR TITLE
Accept the three project, material and storage-location fields the web forms already send

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9582,6 +9582,12 @@
             "example": 2523,
             "type": "string"
           },
+          "ltc": {
+            "description": "Lead time consumption: quantity expected to be consumed over the supplier's lead time. The planning input the stock levels are derived from.",
+            "example": 250,
+            "format": "double",
+            "type": "number"
+          },
           "materialName": {
             "description": "Name of the material.",
             "example": "OPC 53 Grade Cement",
@@ -9695,6 +9701,12 @@
             "example": 12,
             "format": "int64",
             "type": "integer"
+          },
+          "ltc": {
+            "description": "Lead time consumption: quantity expected to be consumed over the supplier's lead time. The planning input the stock levels are derived from.",
+            "example": 250,
+            "format": "double",
+            "type": "number"
           },
           "materialName": {
             "description": "Name of the material.",
@@ -10004,6 +10016,12 @@
             "description": "HSN code for the material, used on GST invoices.",
             "example": 2523,
             "type": "string"
+          },
+          "ltc": {
+            "description": "Lead time consumption: quantity expected to be consumed over the supplier's lead time. The planning input the stock levels are derived from.",
+            "example": 250,
+            "format": "double",
+            "type": "number"
           },
           "materialName": {
             "description": "Name of the material.",
@@ -13177,6 +13195,13 @@
             "format": "uuid",
             "type": "string"
           },
+          "description": {
+            "description": "Optional free-text description of the project.",
+            "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
+            "maxLength": 2000,
+            "minLength": 0,
+            "type": "string"
+          },
           "endDate": {
             "description": "Planned completion date of the project.",
             "example": "2027-06-30T00:00:00",
@@ -13290,6 +13315,11 @@
             "description": "Finance customer the project is billed to. Null when no client is set.",
             "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
             "format": "uuid",
+            "type": "string"
+          },
+          "description": {
+            "description": "Free-text description of the project. Null when not recorded.",
+            "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
             "type": "string"
           },
           "employees": {
@@ -13701,6 +13731,11 @@
             "description": "Id of the finance customer the project bills to, as a UUID string. The customer must belong to the caller's organization; null or blank clears the link.",
             "example": "3f2a1c64-7b21-4d1e-9c8f-0a2b3c4d5e6f",
             "format": "uuid",
+            "type": "string"
+          },
+          "description": {
+            "description": "Free-text description of the project. At most 2000 characters.",
+            "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
             "type": "string"
           },
           "endDate": {
@@ -15879,9 +15914,6 @@
       "StorageLocationCreationDto": {
         "description": "Payload to create a storage location where inventory is held, such as a site store, a central warehouse or a godown.",
         "properties": {
-          "active": {
-            "type": "boolean"
-          },
           "address": {
             "description": "Postal address of the storage location.",
             "example": "Plot 14, Ambattur Industrial Estate, Chennai",
@@ -15893,6 +15925,11 @@
             "description": "Storage capacity, free text since units vary by material.",
             "example": 5000,
             "type": "string"
+          },
+          "isActive": {
+            "description": "Whether the storage location is currently active. Optional; a location created without it is active. Also accepted under the older name \"active\".",
+            "example": true,
+            "type": "boolean"
           },
           "latitude": {
             "description": "Latitude of the storage location.",
@@ -16016,7 +16053,7 @@
             "type": "string"
           },
           "isActive": {
-            "description": "New active status for the storage location.",
+            "description": "New active status for the storage location. Also accepted under the older name \"active\".",
             "example": true,
             "type": "boolean"
           },

--- a/src/main/java/org/tornotron/echno_backend/material/Material.java
+++ b/src/main/java/org/tornotron/echno_backend/material/Material.java
@@ -73,6 +73,15 @@ public class Material implements TenantScopedEntity {
     @Column(name = "reorder_level")
     private Double reorderLevel;
 
+    /**
+     * Lead time consumption: how much of this material is expected to be consumed over the
+     * supplier's lead time. It is the planning input the reorder level, minimum stock and
+     * maximum stock are derived from, so it is stored in the same unit and the same type as
+     * they are.
+     */
+    @Column(name = "ltc")
+    private Double ltc;
+
     @OneToMany(mappedBy = "material")
     private List<IndentItem> indentItems;
 

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialService.java
@@ -108,6 +108,7 @@ public class MaterialService {
         material.setMaxStock(creationDto.getMaxStock());
         material.setSafetyStock(creationDto.getSafetyStock());
         material.setReorderLevel(creationDto.getReorderLevel());
+        material.setLtc(creationDto.getLtc());
 
         material = materialRepository.save(material);
 
@@ -264,6 +265,10 @@ public class MaterialService {
 
         if (updateDto.getReorderLevel() != null) {
             material.setReorderLevel(updateDto.getReorderLevel());
+        }
+
+        if (updateDto.getLtc() != null) {
+            material.setLtc(updateDto.getLtc());
         }
 
         material = materialRepository.save(material);

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialCreationDto.java
@@ -66,6 +66,11 @@ public class MaterialCreationDto {
     @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
 
+    @Schema(description = "Lead time consumption: quantity expected to be consumed over the "
+            + "supplier's lead time. The planning input the stock levels are derived from.",
+            example = "250")
+    private Double ltc;
+
     @Schema(description = "Cost per unit of the material.", example = "410.50")
     private BigDecimal unitCost;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialDto.java
@@ -38,6 +38,10 @@ public class MaterialDto {
     private Double safetyStock;
     @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
+    @Schema(description = "Lead time consumption: quantity expected to be consumed over the "
+            + "supplier's lead time. The planning input the stock levels are derived from.",
+            example = "250")
+    private Double ltc;
     @Schema(description = "Current stock valued at unit cost.", example = "139570.00")
     private BigDecimal stockValue;
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialUpdateDto.java
@@ -44,4 +44,9 @@ public class MaterialUpdateDto {
 
     @Schema(description = "Stock level at which a reorder should be triggered.", example = "300")
     private Double reorderLevel;
+
+    @Schema(description = "Lead time consumption: quantity expected to be consumed over the "
+            + "supplier's lead time. The planning input the stock levels are derived from.",
+            example = "250")
+    private Double ltc;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/Project.java
+++ b/src/main/java/org/tornotron/echno_backend/project/Project.java
@@ -40,6 +40,15 @@ public class Project implements TenantScopedEntity {
     @Column(name = "project_name",nullable = true)
     private String projectName;
 
+    /**
+     * Free-text description of the project: scope, client brief, anything the name and the
+     * address do not say. Optional, and held as TEXT because it is a paragraph typed into a
+     * textarea and any character bound picked here would be arbitrary. The length the API
+     * accepts is bounded on the payloads instead, where it can be changed without a migration.
+     */
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
     /** The street address of the site, as one line. */
     @Column(name = "project_address", nullable = true)
     private String projectAddress;

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -70,9 +70,9 @@ public class ProjectService {
      * <p>{@code organizationId} is deliberately not here even though the client sends it on every
      * update, because it is the one key worth a warning every time. The organization comes from
      * {@code TenantContext}, and honouring a value from the payload would be a tenant-isolation
-     * hole. {@code description} and {@code employees} are warned about too: both are on the list
-     * in echno-core#57, description as a form field that writes to a concept no layer has, members
-     * as something the project-employee routes already do properly.
+     * hole. {@code employees} is warned about too, as something the project-employee routes
+     * already do properly. {@code description} used to be warned about alongside it, as a form
+     * field writing to a concept no layer had; it is a real column now, so the switch applies it.
      */
     private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments");
 
@@ -171,6 +171,7 @@ public class ProjectService {
 
             Project project = new Project();
             project.setProjectName(projectDto.getProjectName());
+            project.setDescription(trimToNull(projectDto.getDescription()));
             project.setProjectAddress(projectDto.getProjectAddress());
             project.setProjectCity(trimToNull(projectDto.getProjectCity()));
             project.setProjectState(canonicalState(projectDto.getProjectState()));
@@ -364,6 +365,9 @@ public class ProjectService {
             switch (key) {
                 case "projectName":
                     project.setProjectName((String) value);
+                    break;
+                case "description":
+                    project.setDescription(trimToNull((String) value));
                     break;
                 case "projectAddress":
                     project.setProjectAddress((String) value);

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -23,6 +23,11 @@ public class ProjectCreationDto {
     @Size(min = 3,max = 50,message = "projectName must be between 3 and 50 characters")
     private String projectName;
 
+    @Schema(description = "Optional free-text description of the project.",
+            example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
+    @Size(max = 2000, message = "description must be at most 2000 characters")
+    private String description;
+
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     @NotBlank(message = "projectAddress is required")
     @Size(min = 3,max = 255,message = "projectAddress must be between 3 and 255 characters")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -22,6 +22,10 @@ public class ProjectDto {
     @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     private String projectName;
 
+    @Schema(description = "Free-text description of the project. Null when not recorded.",
+            example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
+    private String description;
+
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
 

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
@@ -25,6 +25,10 @@ public class ProjectUpdateFieldsDto {
     @Schema(description = "Name of the project.", example = "Marina Heights, phase 2")
     private String projectName;
 
+    @Schema(description = "Free-text description of the project. At most 2000 characters.",
+            example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
+    private String description;
+
     @Schema(description = "Street address of the site.", example = "12 Kamaraj Salai")
     private String projectAddress;
 

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationService.java
@@ -59,7 +59,11 @@ public class StorageLocationService {
         storageLocation.setAddress(creationDto.getAddress());
         storageLocation.setLatitude(creationDto.getLatitude());
         storageLocation.setLongitude(creationDto.getLongitude());
-        storageLocation.setActive(creationDto.isActive());
+        // Left to the entity's own default of true when the payload says nothing. Applying it
+        // unconditionally off a primitive made every create that omitted the key inactive.
+        if (creationDto.getIsActive() != null) {
+            storageLocation.setActive(creationDto.getIsActive());
+        }
         storageLocation.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         // Project is optional - central warehouses/godowns may serve multiple projects

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -28,8 +29,25 @@ public class StorageLocationCreationDto {
     @Schema(description = "Storage capacity, free text since units vary by material.", example = "5000 sq ft")
     private String capacity;
 
-    @Schema(description = "Whether the storage location is currently active.", example = "true")
-    private boolean isActive;
+    /**
+     * Wrapper rather than a primitive, so "not sent" is distinguishable from "sent as false".
+     * As a primitive it defaulted to false and the service applied it unconditionally, which
+     * turned every create that omitted the key into an inactive location and defeated the
+     * entity's own default of true.
+     *
+     * <p>The wrapper also settles the wire name. Lombok names a primitive's accessors
+     * {@code isActive()}/{@code setActive()}, which Jackson publishes as {@code active}, while a
+     * wrapper gets {@code getIsActive()}/{@code setIsActive()} and publishes {@code isActive}.
+     * The update payload has always been the wrapper, so create said {@code active} and update
+     * said {@code isActive} for the same field. Both say {@code isActive} now.
+     */
+    @Schema(description = "Whether the storage location is currently active. Optional; a location "
+            + "created without it is active. Also accepted under the older name \"active\".",
+            example = "true")
+    // Transitional shim for echno-core#57: the deployed client sends this key as "active".
+    // Remove once a core release sends isActive and echno-web has moved to it.
+    @JsonAlias("active")
+    private Boolean isActive;
 
     @Schema(description = "Id of the project this location serves. Optional, a central warehouse or "
             + "godown may serve more than one project.", example = "12")

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -24,7 +25,17 @@ public class StorageLocationUpdateDto {
     @Schema(description = "New storage capacity, free text since units vary by material.", example = "6000 sq ft")
     private String capacity;
 
-    @Schema(description = "New active status for the storage location.", example = "true")
+    /**
+     * Lombok names this wrapper's accessors {@code getIsActive()}/{@code setIsActive()}, so
+     * Jackson binds it from {@code isActive}. The client has been sending {@code active}, the
+     * name the create payload used to publish, so every attempt to deactivate a location bound
+     * to nothing and was silently dropped. The alias is what makes those requests land.
+     */
+    @Schema(description = "New active status for the storage location. Also accepted under the "
+            + "older name \"active\".", example = "true")
+    // Transitional shim for echno-core#57: the deployed client sends this key as "active".
+    // Remove once a core release sends isActive and echno-web has moved to it.
+    @JsonAlias("active")
     private Boolean isActive;
 
     @Schema(description = "New latitude of the storage location.", example = "13.0827")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -364,4 +364,10 @@
     <!-- v4.0 - Labour contacts and category names: scope them to the organization; drop the issue title constraint -->
     <include file="db/changelog/v4.0/076-tenant-scoped-uniqueness.xml"/>
 
+    <!-- v4.0 - Projects: the description the create and edit forms have always submitted -->
+    <include file="db/changelog/v4.0/077-add-project-description.xml"/>
+
+    <!-- v4.0 - Materials: lead time consumption, the input the stock levels are derived from -->
+    <include file="db/changelog/v4.0/078-add-material-ltc.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/077-add-project-description.xml
+++ b/src/main/resources/db/changelog/v4.0/077-add-project-description.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="077-add-project-description" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="project" columnName="description"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Give a project somewhere to keep its description. The create and edit forms have both
+            rendered a labelled description textarea and submitted what was typed in it, but no
+            layer of the backend had the field, so the value was dropped on the way in and the box
+            came back empty when the project was reopened. TEXT because it is a paragraph and any
+            character bound chosen here would be arbitrary; the API bounds the accepted length on
+            the payload instead, where raising it costs no migration. Nullable, since every
+            existing project has no description and none is required.
+        </comment>
+
+        <addColumn tableName="project">
+            <column name="description" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/078-add-material-ltc.xml
+++ b/src/main/resources/db/changelog/v4.0/078-add-material-ltc.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="078-add-material-ltc" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="material" columnName="ltc"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Store lead time consumption on a material: the quantity expected to be consumed over
+            the supplier's lead time. The material create and edit forms take it as a labelled
+            input and the client uses it to recompute the minimum stock, reorder level and maximum
+            stock, so the derived numbers were persisted while the input behind them was not.
+            Reopening the form therefore recomputed from a blank field. DOUBLE and
+            nullable, matching min_stock, max_stock, safety_stock, reorder_level, moq and
+            opening_stock, which are the levels it is derived into and are held in the same unit.
+        </comment>
+
+        <addColumn tableName="material">
+            <column name="ltc" type="DOUBLE"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/material/MaterialLtcTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/MaterialLtcTest.java
@@ -1,0 +1,160 @@
+package org.tornotron.echno_backend.material;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
+import org.tornotron.echno_backend.material.dto.MaterialUpdateDto;
+import org.tornotron.echno_backend.material.mapper.MaterialMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Lead time consumption on a material, on the way in.
+ *
+ * <p>LTC is a labelled input on the material create and edit forms and is sent on both. Nothing
+ * in the backend had it under that or any other name, and the client uses it to recompute the
+ * minimum stock, reorder level and maximum stock, so the derived numbers were stored while the
+ * input behind them was thrown away. Reopening the form then recomputed from a blank field.
+ *
+ * <p>The update is a bound DTO, a run of {@code if (field != null)} blocks rather than a map and
+ * a switch, so no schema contract test can notice a field the run forgets. That is what the last
+ * two of these are for.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MaterialLtcTest {
+
+    @Mock private MaterialRepository materialRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private MaterialMapper materialMapper;
+    @Mock private UserContextService userContextService;
+
+    private MaterialService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MaterialService(materialRepository, inventoryService,
+                inventoryTransactionRepository, tenantEntityHelper, employeeRepository,
+                projectRepository, storageLocationRepository, materialMapper, userContextService);
+
+        TenantContext.setCurrentOrgId(1L);
+
+        Organization organization = new Organization();
+        organization.setId(1L);
+        Employee createdBy = new Employee();
+        createdBy.setId(7L);
+
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(organization);
+        when(employeeRepository.findByIdAndOrganizationId(any(), any()))
+                .thenReturn(Optional.of(createdBy));
+        when(materialRepository.existsBySkuAndOrganization_Id(anyString(), any())).thenReturn(false);
+        when(materialRepository.save(any(Material.class))).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private MaterialCreationDto creationDto() {
+        MaterialCreationDto dto = new MaterialCreationDto();
+        dto.setMaterialName("TMT Bar 12mm");
+        dto.setUnit("kg");
+        dto.setCreatedBy(7L);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("create stores the lead time consumption the form submitted")
+    void createMaterial_storesLtc() {
+        MaterialCreationDto dto = creationDto();
+        dto.setLtc(250.0);
+
+        service.createMaterial(dto);
+
+        assertThat(savedMaterial().getLtc()).isEqualTo(250.0);
+    }
+
+    @Test
+    @DisplayName("create leaves the lead time consumption null when the payload omits it")
+    void createMaterial_leavesLtcNullWhenAbsent() {
+        service.createMaterial(creationDto());
+
+        assertThat(savedMaterial().getLtc()).isNull();
+    }
+
+    @Test
+    @DisplayName("update applies the lead time consumption")
+    void updateMaterial_appliesLtc() {
+        Material existing = existingMaterial(250.0);
+
+        MaterialUpdateDto update = new MaterialUpdateDto();
+        update.setLtc(400.0);
+        service.updateMaterial(12L, update);
+
+        assertThat(existing.getLtc()).isEqualTo(400.0);
+    }
+
+    @Test
+    @DisplayName("update leaves the stored lead time consumption alone when the payload omits it")
+    void updateMaterial_leavesLtcAloneWhenAbsent() {
+        // The contract every field on a bound update DTO has to keep: a null means "not sent",
+        // never "set it to null". Nothing but a test enforces it on this endpoint.
+        Material existing = existingMaterial(250.0);
+
+        MaterialUpdateDto update = new MaterialUpdateDto();
+        update.setMaterialName("TMT Bar 16mm");
+        service.updateMaterial(12L, update);
+
+        assertThat(existing.getLtc()).isEqualTo(250.0);
+        assertThat(existing.getMaterialName()).isEqualTo("TMT Bar 16mm");
+    }
+
+    private Material existingMaterial(Double ltc) {
+        Material material = new Material();
+        material.setId(12L);
+        material.setMaterialName("TMT Bar 12mm");
+        material.setUnit("kg");
+        material.setLtc(ltc);
+        when(materialRepository.findByIdAndOrganization_Id(any(), any()))
+                .thenReturn(Optional.of(material));
+        return material;
+    }
+
+    private Material savedMaterial() {
+        ArgumentCaptor<Material> captor = ArgumentCaptor.forClass(Material.class);
+        verify(materialRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectDescriptionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectDescriptionTest.java
@@ -1,0 +1,204 @@
+package org.tornotron.echno_backend.project;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.dto.ProjectCreationDto;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A project's description, on the way in.
+ *
+ * <p>The create and edit forms have both rendered a labelled description textarea and submitted
+ * what was typed in it, while the backend had the field at no layer: not on the entity, not on
+ * any payload, not as a case in the update switch and not as a column. The write was accepted
+ * with a 200 and the text went nowhere, so reopening the project showed an empty box. These pin
+ * both write paths.
+ *
+ * <p>Plain Mockito with a real validator and no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectDescriptionTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock private ProjectRepository repository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private AttachmentService attachmentService;
+    @Mock private ProjectMapper projectMapper;
+    @Mock private EmployeeMapper employeeMapper;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
+
+    private Validator validator;
+    private ProjectService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        service = new ProjectService(repository, organizationRepository, employeeRepository,
+                attachmentService, projectMapper, employeeMapper, eventPublisher,
+                customerRepository, new PayloadValidator(validator), userContextService,
+                statusTransitionRecorder, statusTransitionRepository, statusTransitionMapper);
+
+        TenantContext.setCurrentOrgId(1L);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(organization));
+        when(repository.existsProjectByProjectName(anyString())).thenReturn(false);
+        when(repository.save(any(Project.class))).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private ProjectCreationDto validDto() {
+        ProjectCreationDto dto = new ProjectCreationDto();
+        dto.setProjectName("Riverside Tower");
+        dto.setProjectAddress("12 Mount Road, Mylapore, Tamil Nadu");
+        return dto;
+    }
+
+    @Test
+    @DisplayName("create stores the description the form submitted")
+    void addProject_storesTheDescription() {
+        ProjectCreationDto dto = validDto();
+        dto.setDescription("Twelve-storey residential tower, two basement levels.");
+
+        service.addProject(dto, null);
+
+        assertThat(savedProject().getDescription())
+                .isEqualTo("Twelve-storey residential tower, two basement levels.");
+    }
+
+    @Test
+    @DisplayName("create treats a blank textarea as no description rather than an empty string")
+    void addProject_treatsABlankDescriptionAsAbsent() {
+        ProjectCreationDto dto = validDto();
+        dto.setDescription("   ");
+
+        service.addProject(dto, null);
+
+        assertThat(savedProject().getDescription()).isNull();
+    }
+
+    @Test
+    @DisplayName("create refuses a description past the payload's bound")
+    void creationPayload_boundsTheDescriptionLength() {
+        ProjectCreationDto dto = validDto();
+        dto.setDescription("x".repeat(2001));
+
+        Set<ConstraintViolation<ProjectCreationDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("description must be at most 2000 characters");
+    }
+
+    @Test
+    @DisplayName("partial update applies the description, which the switch used to drop")
+    void partialUpdate_appliesTheDescription() {
+        Project project = updateWith(Map.of("description", "Revised scope: two towers, one podium."));
+
+        assertThat(project.getDescription()).isEqualTo("Revised scope: two towers, one podium.");
+    }
+
+    @Test
+    @DisplayName("partial update clears the description when the textarea is emptied")
+    void partialUpdate_clearsTheDescriptionWhenBlank() {
+        Project existing = new Project();
+        existing.setDescription("Something written earlier.");
+
+        Project project = updateWith(existing, singletonUpdate("description", ""));
+
+        assertThat(project.getDescription()).isNull();
+    }
+
+    @Test
+    @DisplayName("partial update leaves the description alone when the payload omits it")
+    void partialUpdate_leavesTheDescriptionAloneWhenAbsent() {
+        Project existing = new Project();
+        existing.setDescription("Something written earlier.");
+
+        Project project = updateWith(existing, Map.of("projectName", "Marina Towers"));
+
+        assertThat(project.getDescription()).isEqualTo("Something written earlier.");
+        assertThat(project.getProjectName()).isEqualTo("Marina Towers");
+    }
+
+    /** {@link Map#of} refuses a null value, and a blank one is what an emptied textarea sends. */
+    private Map<String, Object> singletonUpdate(String key, Object value) {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put(key, value);
+        return Collections.unmodifiableMap(updates);
+    }
+
+    private Project updateWith(Map<String, Object> updates) {
+        return updateWith(new Project(), updates);
+    }
+
+    private Project updateWith(Project project, Map<String, Object> updates) {
+        when(repository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(project));
+        service.partialUpdateAProject(updates, 12L, null, "PROJECT");
+        return project;
+    }
+
+    private Project savedProject() {
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        verify(repository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
@@ -1,0 +1,177 @@
+package org.tornotron.echno_backend.storageLocation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.dto.StorageLocationCreationDto;
+import org.tornotron.echno_backend.storageLocation.dto.StorageLocationUpdateDto;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.storageLocation.mapper.StorageLocationMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The active flag on a storage location, on both write paths.
+ *
+ * <p>A storage location could not be deactivated at all, and the cause was a naming split inside
+ * the backend rather than anything the client did. Lombok names a primitive {@code boolean
+ * isActive}'s accessors {@code isActive()}/{@code setActive()}, which Jackson publishes as
+ * {@code active}; a wrapper {@code Boolean isActive} gets {@code getIsActive()}/{@code
+ * setIsActive()} and publishes {@code isActive}. The create payload was the primitive and the
+ * update payload the wrapper, so the same field went out under two names, the client sent
+ * {@code active} to both, and every deactivate bound to nothing and was dropped with a 200.
+ *
+ * <p>Both payloads settle on {@code isActive} and carry a transitional {@code @JsonAlias} for
+ * {@code active}, so the deployed client keeps working while echno-core catches up. These pin
+ * both spellings on both payloads, so the contract step that deletes the aliases has to delete
+ * the assertions that cover them and cannot do it by accident.
+ *
+ * <p>The create payload also has a second fault of its own: a primitive defaults to false, and
+ * the service applied it unconditionally, so a create that named the key at all made the location
+ * inactive and the entity's own default of true never stood. That is the last test here.
+ *
+ * <p>Binding goes through {@link Jackson2ObjectMapperBuilder}, which is what Spring Boot's
+ * Jackson auto-configuration builds the injected mapper from, so what binds here is what binds
+ * on the endpoint.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StorageLocationActiveFlagTest {
+
+    private final ObjectMapper mapper = Jackson2ObjectMapperBuilder.json().build();
+
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private StorageLocationMapper storageLocationMapper;
+    @Mock private InventoryService inventoryService;
+
+    private StorageLocationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new StorageLocationService(storageLocationRepository, projectRepository,
+                tenantEntityHelper, storageLocationMapper, inventoryService);
+
+        TenantContext.setCurrentOrgId(1L);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(organization);
+        when(storageLocationRepository.existsByLocationNameAndOrganization_Id(anyString(), any()))
+                .thenReturn(false);
+        when(storageLocationRepository.save(any(StorageLocation.class)))
+                .thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("the update payload binds the canonical isActive")
+    void updateDto_bindsIsActive() throws Exception {
+        StorageLocationUpdateDto dto =
+                mapper.readValue("{\"isActive\":false}", StorageLocationUpdateDto.class);
+
+        assertThat(dto.getIsActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("the update payload binds the older name active, which is what the client sends")
+    void updateDto_bindsTheAliasedActive() throws Exception {
+        StorageLocationUpdateDto dto =
+                mapper.readValue("{\"active\":false}", StorageLocationUpdateDto.class);
+
+        assertThat(dto.getIsActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("the create payload binds the canonical isActive")
+    void creationDto_bindsIsActive() throws Exception {
+        StorageLocationCreationDto dto =
+                mapper.readValue("{\"isActive\":false}", StorageLocationCreationDto.class);
+
+        assertThat(dto.getIsActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("the create payload binds the older name active, which is what the client sends")
+    void creationDto_bindsTheAliasedActive() throws Exception {
+        StorageLocationCreationDto dto =
+                mapper.readValue("{\"active\":false}", StorageLocationCreationDto.class);
+
+        assertThat(dto.getIsActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("a create payload naming neither spelling leaves the flag unset")
+    void creationDto_leavesTheFlagUnsetWhenNeitherNameIsSent() throws Exception {
+        StorageLocationCreationDto dto = mapper.readValue(
+                "{\"locationName\":\"Central Warehouse\",\"locationType\":\"WAREHOUSE\"}",
+                StorageLocationCreationDto.class);
+
+        assertThat(dto.getIsActive()).isNull();
+    }
+
+    @Test
+    @DisplayName("a deactivate sent as active reaches the entity")
+    void updateStorageLocation_deactivatesFromTheAliasedName() throws Exception {
+        StorageLocation existing = new StorageLocation();
+        existing.setLocationName("Central Warehouse");
+        existing.setLocationType(StorageLocationType.WAREHOUSE);
+        when(storageLocationRepository.findByIdAndOrganization_Id(any(), any()))
+                .thenReturn(Optional.of(existing));
+
+        service.updateStorageLocation(18L,
+                mapper.readValue("{\"active\":false}", StorageLocationUpdateDto.class));
+
+        assertThat(existing.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("a create naming neither spelling leaves the location active")
+    void createStorageLocation_keepsTheEntityDefaultWhenThePayloadIsSilent() throws Exception {
+        service.createStorageLocation(mapper.readValue(
+                "{\"locationName\":\"Central Warehouse\",\"locationType\":\"WAREHOUSE\"}",
+                StorageLocationCreationDto.class));
+
+        assertThat(savedLocation().isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a create that asks for an inactive location gets one")
+    void createStorageLocation_appliesAnExplicitFalse() throws Exception {
+        service.createStorageLocation(mapper.readValue(
+                "{\"locationName\":\"Old Godown\",\"locationType\":\"GODOWN\",\"active\":false}",
+                StorageLocationCreationDto.class));
+
+        assertThat(savedLocation().isActive()).isFalse();
+    }
+
+    private StorageLocation savedLocation() {
+        ArgumentCaptor<StorageLocation> captor = ArgumentCaptor.forClass(StorageLocation.class);
+        verify(storageLocationRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Three fields the web client already puts on the wire are dropped by the backend, because they exist at no layer or under a different name. This is the **server half**: the API accepts the new shape before any `echno-core` release ships the client that depends on it, following the sequence backend #583 used.

## What each item was, and what I checked

**1. Project `description` (new column).** Confirmed it exists nowhere: not on `Project`, not on `ProjectCreationDto`, `ProjectUpdateFieldsDto` or `ProjectDto`, not as a case in `ProjectService.partialUpdateAProject`, and no column in any changelog. The one trace of it in the codebase was the javadoc on `DELIBERATELY_DROPPED_UPDATE_KEYS`, which named `description` as "a form field that writes to a concept no layer has"; that comment is now updated. The forms submit it, so the write took a 200 and the text went nowhere.

Added end to end: entity column, changelog, all three payloads, the create path, and `case "description"` in the switch. `ProjectUpdateFieldsDto` and the switch move together, which is what `PartialUpdateSchemaContractTest` enforces in both directions; the method signature string it matches on is untouched.

*Column type:* `TEXT`. It is a paragraph typed into a textarea, and every other free-text description on this schema is `TEXT` (`WbsElement`, `Asset`, `ChatRoom`, `Expense`, `Receipt`, `ComplianceRule`, `ContractMilestone`). A `VARCHAR(n)` here would put an arbitrary number in the schema where changing it later costs a migration. The accepted length is bounded on the payload instead, at `@Size(max = 2000)`, matching the longest free-text bound already in the codebase (`termsAndConditions` on the construction invoice payloads) and written in the same message style the other `ProjectCreationDto` string bounds use. Raising it is then a one-line change with no DDL. Blank input is trimmed to null on both write paths, the way `projectCity` and `projectPostalCode` already are, so an emptied textarea clears the column rather than storing an empty string.

**2. Material `ltc` (new column).** Confirmed nothing named `ltc`, `leadTime` or `lead_time` exists anywhere in the backend. Added to `Material`, a changelog, `MaterialCreationDto`, `MaterialUpdateDto`, `MaterialDto`, the create path and the update path. `MaterialDto` picks it up through MapStruct by name.

*Numeric type:* `Double` on the entity, `DOUBLE` in the changelog. LTC is a consumption quantity in the material's own unit, and the client derives `minStock`, `reorderLevel` and `maxStock` from it. Those, plus `safetyStock`, `moq` and `openingStock`, are all `Double` / `DOUBLE` already (v3.0 `008-add-stock-levels-to-material`, v4.0 `045`). An input and the levels derived from it should not be held in different types, so this matches them. Nullable, since every existing material has no LTC.

The update here is a **bound DTO**, a run of `if (updateDto.getX() != null)` blocks with no map and no switch, and `Material` is not in `PartialUpdateSurfaces`, so nothing would have caught a missing `if`. `MaterialLtcTest` covers that gap explicitly.

**3. StorageLocation `isActive` (the expand).** Verified the whole chain before changing anything:

- `StorageLocationCreationDto` declared primitive `boolean isActive`, so Lombok generated `isActive()`/`setActive()` and Jackson published the wire key **`active`**. Confirmed in the committed `docs/openapi.json`.
- `StorageLocationUpdateDto` declared wrapper `Boolean isActive`, so Lombok generated `getIsActive()`/`setIsActive()` and Jackson published **`isActive`**. Also confirmed in the snapshot.
- The entity has primitive `boolean isActive = true`, and `StorageLocationDto` serialises as `active`.
- Both endpoints bind through `@Valid @RequestBody`, so `StorageLocation` is correctly absent from `PartialUpdateSurfaces`.

So the same field went out under two names, the client sent `active` to both, create worked and update silently did not: a storage location could not be deactivated at all.

**The expand.** Both payloads settle on the canonical `isActive`, and each carries `@JsonAlias("active")` so no deployed client breaks. On the update payload the alias is what fixes the live bug **today**, before any core release. On the create payload the `Boolean` change moves the wire key from `active` to `isActive`, and the alias keeps the deployed client's creates working across that move. Each alias carries a comment naming echno-core#57 so the contract step knows exactly what to delete. The idiom follows `AssetCreationDto`'s `@JsonAlias("condition")` and the chat DTOs' `@JsonProperty("isArchived")` / `("isEdited")` / `("isDeleted")`.

**The second bug in the same place, also fixed.** `createStorageLocation` did `setActive(creationDto.isActive())` unconditionally off a primitive that defaults to `false`, so a create that omitted the key set the location inactive and the entity's own `= true` default never stood. The field is a `Boolean` now and the assignment is null-guarded, so silence on the payload leaves the entity default alone.

*Out of scope, worth doing next:* `StorageLocationDto` still serialises the flag as `active`, because primitive `boolean isActive` reads the same way on the way out. That is a read-side rename with its own client-side blast radius, so it is not in this PR. I think it should follow, as its own expand step (add `isActive` alongside, let the client move, then drop `active`), so that one field is not called two different things depending on direction of travel.

## Expand, migrate, contract

This is the **expand** step.

- **Now (this PR):** the server accepts `isActive` and `active` on both storage-location payloads.
- **Migrate:** an `echno-core` release that sends `isActive` on storage-location create and update, then `echno-web` moving its `@tornotron/echno-core` dependency to that release and deploying.
- **Contract (a later PR):** delete the two `@JsonAlias("active")` shims, their comments, and the four test cases that pin the aliased spelling. Nothing else comes out.

Project `description` and material `ltc` are **not** shims. They are new columns under their canonical names on payloads that had no such field at all, so they need no contract step and nothing about them is ever deleted.

## Tests

Every assertion below was confirmed to fail with the change reverted. I built a copy of the tree with the behaviour removed (create assignments, the switch case, the `@Size` bound, the update `if` block, both aliases, and the unconditional primitive-defaulting create) while keeping the field declarations so the tests still compiled, and ran the three classes against it: **10 of 22 failed**, and each is named below. The remaining cases are the guards that are trivially true when a field is absent (leaves-null, leaves-alone) plus the canonical-name bindings.

`ProjectDescriptionTest` (plain Mockito, no Spring context, in the style of `ProjectCreateStatusTest` and `ProjectPartialUpdateDateTest`):

- create stores the description the form submitted &mdash; **fails without the change**
- create treats a blank textarea as no description rather than an empty string
- create refuses a description past the payload's bound &mdash; **fails without the change**
- partial update applies the description, which the switch used to drop &mdash; **fails without the change**
- partial update clears the description when the textarea is emptied &mdash; **fails without the change**
- partial update leaves the description alone when the payload omits it

`MaterialLtcTest`:

- create stores the lead time consumption the form submitted &mdash; **fails without the change**
- create leaves the lead time consumption null when the payload omits it
- update applies the lead time consumption &mdash; **fails without the change**
- update leaves the stored lead time consumption alone when the payload omits it (the `if (x != null)` contract, which nothing but this test enforces on a bound-DTO update)

`StorageLocationActiveFlagTest` (binding through `Jackson2ObjectMapperBuilder.json().build()`, the configuration Spring Boot auto-configures, following `IssueCreationDtoTest`):

- the update payload binds the canonical `isActive`
- the update payload binds the older name `active`, which is what the client sends &mdash; **fails without the change**
- the create payload binds the canonical `isActive` &mdash; on `development` this does not merely fail, it does not compile: the primitive field has no `getIsActive()`
- the create payload binds the older name `active`, which is what the client sends &mdash; **fails without the change**
- a create payload naming neither spelling leaves the flag unset
- a deactivate sent as `active` reaches the entity, end to end from JSON through the service &mdash; **fails without the change**
- a create naming neither spelling leaves the location active &mdash; **fails without the change**, coming back `false` on today's code
- a create that asks for an inactive location gets one

`PartialUpdateSchemaContractTest` still passes, which is the check that `ProjectUpdateFieldsDto` and the update switch stayed in step.

The full `./gradlew test` is green on the lab box after the rebase onto current `development`: 555 MB live of the 2048 MB cap (27%), 8 contexts cached of a maximum 8, so this adds no Spring context.

## Liquibase and OpenAPI

- `v4.0/077-add-project-description.xml` and `v4.0/078-add-material-ltc.xml`, both included at the bottom of `db.changelog-master.xml`. Both guarded with a `columnExists` precondition on `MARK_RAN`, no context, matching the surrounding files. The numbers moved during this work: they were 076/077 when first written, and were renumbered on the rebase after `076-tenant-scoped-uniqueness.xml` landed.
- `docs/openapi.json` regenerated with `./gradlew openApiSnapshot -PupdateOpenApiSnapshot` after the rebase and verified with a plain `./gradlew openApiSnapshot`. The snapshot now shows `description` on the three project schemas, `ltc` on the three material schemas, and `isActive` on both storage-location payload schemas where the create one used to say `active`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lead-time consumption (LTC) for materials, available when creating, updating, and viewing materials.
  * Added optional project descriptions, up to 2,000 characters, with support for updates.
  * Added database support for the new material and project fields.

* **Bug Fixes**
  * Storage locations now remain active by default when no status is provided.
  * Both `isActive` and legacy `active` request fields are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->