### PR TITLE
Print the indent status badge in words, in colour, and inside the page

### DIFF
--- a/src/main/java/org/tornotron/echno_backend/indent/enums/IndentStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/enums/IndentStatus.java
@@ -1,9 +1,28 @@
 package org.tornotron.echno_backend.indent.enums;
 
+/**
+ * Where an indent has got to.
+ *
+ * <p>Each constant carries the words a person should see. The constant name is the wire format
+ * and the storage format, and it stays that way: {@link #getLabel()} exists for documents the
+ * client reads, where "ON_SITE" is the internal name leaking onto a page rather than a status.
+ * Nothing serializes the label, so the API and the database are unaffected.
+ */
 public enum IndentStatus {
-    ON_SITE,
-    DELAYED,
-    PENDING,
-    ORDERED,
-    CANCELLED
+    ON_SITE("On site"),
+    DELAYED("Delayed"),
+    PENDING("Pending"),
+    ORDERED("Ordered"),
+    CANCELLED("Cancelled");
+
+    private final String label;
+
+    IndentStatus(String label) {
+        this.label = label;
+    }
+
+    /** The status as it should be printed for a reader, for example "On site". */
+    public String getLabel() {
+        return label;
+    }
 }

--- a/src/main/resources/static/css/report.css
+++ b/src/main/resources/static/css/report.css
@@ -38,6 +38,7 @@ body { font-family: Inter, sans-serif; font-size: 12px; color: #2b2b2b; }
 
 .valbox { margin-bottom:6px }
 .valbox .label { font-size:11px; color:#666 }
+.valbox .label .progress-value { float: right; font-weight: 600; color: #2b2b2b; }
 .valbox .value { font-size:13px; font-weight:600 }
 
 .category-span {
@@ -97,7 +98,48 @@ body { font-family: Inter, sans-serif; font-size: 12px; color: #2b2b2b; }
     border-left-color: #60A5FA; /* Tailwind blue-400 */
 }
 
-.container { width: 100%; margin-left: auto; margin-right: auto; padding-left: 1rem; padding-right: 1rem; }
+/* Status: Cancelled (Grey) */
+.status-cancelled {
+    border-left-width: 4px;
+    border-left-color: #9CA3AF; /* Tailwind gray-400 */
+}
+
+/*
+ * The status badge. The cell keeps it on one line and hard against the right edge of the
+ * indent header; without the nowrap the pill broke across two lines as soon as the label
+ * carried a space, which "On site" does and "ORDERED" did not.
+ */
+.status-cell {
+    text-align: right;
+    vertical-align: top;
+    white-space: nowrap;
+}
+
+.status-badge {
+    white-space: nowrap;
+}
+
+/* Badge fill and text, one pair per status, keyed off the enum constant. */
+.badge-on-site { color: #059669; background-color: #D1FAE5; }
+.badge-delayed { color: #DC2626; background-color: #FEE2E2; }
+.badge-pending { color: #D97706; background-color: #FEF3C7; }
+.badge-ordered { color: #2563EB; background-color: #DBEAFE; }
+.badge-cancelled { color: #4B5563; background-color: #F3F4F6; }
+
+.dot-on-site { background-color: #10B981; }
+.dot-delayed { background-color: #EF4444; }
+.dot-pending { background-color: #F59E0B; }
+.dot-ordered { background-color: #3B82F6; }
+.dot-cancelled { background-color: #6B7280; }
+
+/*
+ * No width here on purpose. A block-level div already fills its parent, and stating
+ * width:100% alongside the padding made the box 100% *plus* the padding: the element carries
+ * both this rule's 1rem and .md\:p-8's 2rem, so the indent section ran 4rem past the right
+ * page margin and the status badge, being the rightmost thing in it, was the part the page
+ * edge cut off. The task section never showed the fault because it does not use .container.
+ */
+.container { margin-left: auto; margin-right: auto; padding-left: 1rem; padding-right: 1rem; }
 .p-4 { padding: 1rem; }
 .md\:p-8 { padding: 2rem; }
 .p-6 { padding: 1.5rem; }

--- a/src/main/resources/templates/report/report.html
+++ b/src/main/resources/templates/report/report.html
@@ -69,9 +69,16 @@
                 </td>
                 <td class="task-right">
                     <div class="valbox">
-                        <div class="label">Progress Till Date</div>
+                        <!--
+                          The percentage is printed beside the caption rather than inside the bar.
+                          Inside, a task at 0% drew its "0%" in a bar of zero width, so the label
+                          spilled over the empty track and read as though it belonged to it. Widening
+                          the bar to fit the label would have been worse: it would show a task that
+                          has not started as though it had.
+                        -->
+                        <div class="label">Progress Till Date<span class="progress-value" th:text="${task.getProgress()} + '%'">0%</span></div>
                         <div class="progress-bar-container">
-                            <div class="progress-bar" th:classappend="${task.getProgress() == 100 ? 'completed' : ''}" th:style="'width: ' + ${task.getProgress()} + '%;'" th:text="${task.getProgress()} + '%'"></div>
+                            <div class="progress-bar" th:classappend="${task.getProgress() == 100 ? 'completed' : ''}" th:style="'width: ' + ${task.getProgress()} + '%;'"></div>
                         </div>
                     </div>
                     <!--                    <div class="valbox"><div class="label">Today's Update</div><div class="value" th:text="${task.progressPercent} + '%'">0%</div></div>-->
@@ -91,11 +98,19 @@
     <main>
         <section id="active-requests">
             <h2 class="text-2xl font-semibold mb-4">Active Resource Requests</h2>
+                <!--
+                  The status decides three classes, and all three are derived from the constant
+                  name rather than matched against a list of spellings. Every one of these used to
+                  compare #strings.toLowerCase(indent.status) against 'on-site', which the enum
+                  never equals: it lowercases to on_site, with an underscore. ON_SITE therefore got
+                  no border, no pill and no dot, while the four constants with no underscore in
+                  them happened to match, which is why the fault looked intermittent. Deriving the
+                  suffix removes the whole class of it, and it covers CANCELLED, which none of the
+                  branches named at all.
+                -->
                 <div th:each="indent : ${indents}" class="bg-white rounded-xl shadow-md overflow-hidden mb-6"
-                     th:classappend="${#strings.toLowerCase(indent.status) == 'on-site' ? 'status-on-site' :
-                                       (#strings.toLowerCase(indent.status) == 'delayed' ? 'status-delaayed' :
-                                       (#strings.toLowerCase(indent.status) == 'pending' ? 'status-pending' :
-                                       (#strings.toLowerCase(indent.status) == 'ordered' ? 'status-ordered' : '')))}">
+                     th:with="statusKey=${#strings.replace(#strings.toLowerCase(indent.status), '_', '-')}"
+                     th:classappend="${'status-' + statusKey}">
                     <div class="indent-header">
                         <table style="width: 100%;">
                             <tr>
@@ -103,18 +118,11 @@
                                     <p class="text-sm text-gray-500">Indent Number</p>
                                     <h3 class="text-lg font-semibold text-gray-900" th:text="${indent.indentNumber}">INT-0000</h3>
                                 </td>
-                                <td style="text-align: right; vertical-align: top;">
-                                    <span class="text-sm font-semibold px-3 py-1 rounded-full"
-                                          th:classappend="${#strings.toLowerCase(indent.status) == 'on-site' ? 'text-green-600 bg-green-100' :
-                                                           (#strings.toLowerCase(indent.status) == 'delayed' ? 'text-red-600 bg-red-100' :
-                                                           (#strings.toLowerCase(indent.status) == 'pending' ? 'text-yellow-600 bg-yellow-100' :
-                                                           (#strings.toLowerCase(indent.status) == 'ordered' ? 'text-blue-600 bg-blue-100' : '')))}">
-                                        <span class="status-dot"
-                                              th:classappend="${#strings.toLowerCase(indent.status) == 'on-site' ? 'bg-green-500' :
-                                                               (#strings.toLowerCase(indent.status) == 'delayed' ? 'bg-red-500' :
-                                                               (#strings.toLowerCase(indent.status) == 'pending' ? 'bg-yellow-500' :
-                                                               (#strings.toLowerCase(indent.status) == 'ordered' ? 'bg-blue-500' : '')))}"></span>
-                                        <span th:text="${indent.status}">Status</span>
+                                <td class="status-cell">
+                                    <span class="status-badge text-sm font-semibold px-3 py-1 rounded-full"
+                                          th:classappend="${'badge-' + statusKey}">
+                                        <span class="status-dot" th:classappend="${'dot-' + statusKey}"></span>
+                                        <span th:text="${indent.status.label}">Status</span>
                                     </span>
                                 </td>
                             </tr>

--- a/src/test/java/org/tornotron/echno_backend/pdfGeneration/ReportIndentBadgeRenderTest.java
+++ b/src/test/java/org/tornotron/echno_backend/pdfGeneration/ReportIndentBadgeRenderTest.java
@@ -1,0 +1,288 @@
+package org.tornotron.echno_backend.pdfGeneration;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingColor;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingColorN;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingColorSpace;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingDeviceCMYKColor;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingDeviceGrayColor;
+import org.apache.pdfbox.contentstream.operator.color.SetNonStrokingDeviceRGBColor;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.text.TextPosition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.tornotron.echno_backend.common.configuration.ThymeleafConfig;
+import org.tornotron.echno_backend.common.conversions.DateConversion;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
+import org.tornotron.echno_backend.employee.dto.EmployeeDto;
+import org.tornotron.echno_backend.indent.IndentService;
+import org.tornotron.echno_backend.indent.dto.IndentDto;
+import org.tornotron.echno_backend.indent.enums.IndentStatus;
+import org.tornotron.echno_backend.organization.OrganizationService;
+import org.tornotron.echno_backend.project.ProjectService;
+import org.tornotron.echno_backend.task.TaskService;
+import org.tornotron.echno_backend.task.dto.TaskDto;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * How the indent status badge comes out of the renderer, measured on the page rather than
+ * asserted about the template (issue #612).
+ *
+ * <p>Until #605 the report answered 500 for any tenant holding an indent, so nobody had seen a
+ * rendered copy with indent rows in it. The first look found three faults in the badge, and all
+ * three are pinned here: it was cut off by the right page edge, it printed the constant name
+ * rather than words, and its colour never applied to {@code ON_SITE}.
+ *
+ * <p>The clipping is checked by position, not by looking for a truncated string. {@code .container}
+ * declared {@code width: 100%} next to its own padding and inherited more from {@code .md:p-8}, so
+ * the indent section ran 4rem past the right page margin and the badge, the rightmost thing in it,
+ * was what the page edge took. Reading every glyph's right edge out of the content stream catches
+ * that whatever the label happens to say.
+ *
+ * <p>No Spring context, following {@link ReportPdfRenderTest} and the other PDF tests.
+ */
+class ReportIndentBadgeRenderTest {
+
+    /** The {@code @page} margin in report.css, 15mm, in PDF points. */
+    private static final float PAGE_MARGIN_PT = 15f / 25.4f * 72f;
+
+    /** Rounding room, so a box that lands exactly on the margin is not read as overflowing it. */
+    private static final float TOLERANCE_PT = 1f;
+
+    private final TaskService taskService = mock(TaskService.class);
+    private final PdfReportService pdfReportService = mock(PdfReportService.class);
+    private final ProjectService projectService = mock(ProjectService.class);
+    private final OrganizationService organizationService = mock(OrganizationService.class);
+    private final IndentService indentService = mock(IndentService.class);
+
+    private final ReportController controller = new ReportController(
+            taskService, pdfReportService, new DateConversion(),
+            new ThymeleafConfig().pdfTemplateEngine(), new PdfRenderer(),
+            projectService, organizationService, indentService);
+
+    @Test
+    void theStatusBadgeIsPrintedInWordsRatherThanAsTheConstantName() throws Exception {
+        given(IndentStatus.ON_SITE);
+
+        String text = textOf(render());
+
+        assertThat(text).contains("On site");
+        assertThat(text).doesNotContain("ON_SITE");
+    }
+
+    @ParameterizedTest
+    @EnumSource(IndentStatus.class)
+    void everyStatusPrintsItsOwnLabel(IndentStatus status) throws Exception {
+        given(status);
+
+        String text = textOf(render());
+
+        assertThat(text).contains(status.getLabel());
+        assertThat(text).doesNotContain(status.name());
+    }
+
+    @Test
+    void nothingInTheReportRunsPastTheRightMargin() throws Exception {
+        given(IndentStatus.ON_SITE);
+
+        for (Chunk chunk : chunksOf(render())) {
+            assertThat(chunk.right())
+                    .describedAs("'%s' on page %d ends at %.1fpt, past the %.1fpt right margin",
+                            chunk.text(), chunk.pageNumber(), chunk.right(), chunk.rightLimit())
+                    .isLessThanOrEqualTo(chunk.rightLimit() + TOLERANCE_PT);
+        }
+    }
+
+    /**
+     * The badge specifically, so a regression that moves only the badge off the page is named as
+     * such rather than arriving as a general overflow.
+     */
+    @Test
+    void theStatusBadgeSitsInsideTheRightMargin() throws Exception {
+        given(IndentStatus.ON_SITE);
+
+        List<Chunk> badge = chunksOf(render()).stream()
+                .filter(chunk -> chunk.text().contains("On site"))
+                .toList();
+
+        assertThat(badge).isNotEmpty();
+        for (Chunk chunk : badge) {
+            assertThat(chunk.right())
+                    .describedAs("the badge ends at %.1fpt, past the %.1fpt right margin",
+                            chunk.right(), chunk.rightLimit())
+                    .isLessThanOrEqualTo(chunk.rightLimit() + TOLERANCE_PT);
+        }
+    }
+
+    /**
+     * The colour half of the fault. The template decided the badge colour by comparing
+     * {@code #strings.toLowerCase(indent.status)} to {@code 'on-site'}, which an enum that
+     * lowercases to {@code on_site} never equals, so an ON_SITE badge was drawn in the body's
+     * default grey while the four constants with no underscore in them came out coloured.
+     */
+    @Test
+    void theOnSiteBadgeIsPrintedInItsOwnColour() throws Exception {
+        given(IndentStatus.ON_SITE);
+
+        List<Chunk> badge = chunksOf(render()).stream()
+                .filter(chunk -> chunk.text().contains("On site"))
+                .toList();
+
+        assertThat(badge).isNotEmpty();
+        assertThat(badge).allSatisfy(chunk ->
+                assertThat(chunk.rgb() & 0xFFFFFF)
+                        .describedAs("the badge label's fill colour")
+                        .isEqualTo(0x059669));
+    }
+
+    private byte[] render() throws Exception {
+        ResponseEntity<byte[]> response = controller.pdfReport();
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private void given(IndentStatus status) {
+        Page<TaskDto> taskPage = page(List.of(task(1L, "Slab shuttering, block C", 0.0)));
+        Page<IndentDto> indentPage = page(List.of(indent(status)));
+        when(taskService.getAllTasks(0, UnpagedResultCap.MAX_ROWS)).thenReturn(taskPage);
+        when(indentService.getAllIndents(0, UnpagedResultCap.MAX_ROWS)).thenReturn(indentPage);
+        when(pdfReportService.statusCount())
+                .thenReturn(Map.of("COMPLETED", 2L, "IN_PROGRESS", 5L, "NOT_STARTED", 1L));
+    }
+
+    private <T> Page<T> page(List<T> content) {
+        return new PageImpl<>(content, PageRequest.of(0, UnpagedResultCap.MAX_ROWS), content.size());
+    }
+
+    private String textOf(byte[] pdf) throws Exception {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            return new PDFTextStripper().getText(document);
+        }
+    }
+
+    /**
+     * One drawn character: what it says, where its right edge is, how far right that page allows,
+     * and the fill colour in force when it was drawn.
+     */
+    private record Glyph(String text, float right, float rightLimit, int pageNumber, int rgb) {
+    }
+
+    /** A run of glyphs drawn one after another, reassembled into a word. */
+    private record Chunk(String text, float right, float rightLimit, int pageNumber, int rgb) {
+    }
+
+    /**
+     * Every character the renderer actually drew, with its right edge, the page's own right
+     * margin, and its colour. Read from the content stream rather than from the extracted string,
+     * because a character drawn past the edge of the paper is still in the stream: the fault is
+     * where it was put, not whether it survived extraction.
+     *
+     * <p>Collected in {@code processTextPosition}, which runs while the stream is being walked,
+     * rather than in {@code writeString}, which PDFBox calls only once the whole page has been
+     * processed. By then the graphics state holds whatever colour the page happened to end on, so
+     * reading the fill colour there reports the last one for every character on the page.
+     *
+     * <p>The colour operators have to be registered by hand: a plain {@link PDFTextStripper}
+     * installs the text operators only, so without these the fill colour never moves off its
+     * initial black and every glyph reads as {@code 000000}.
+     */
+    private List<Glyph> glyphsOf(byte[] pdf) throws IOException {
+        List<Glyph> glyphs = new ArrayList<>();
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            PDFTextStripper stripper = new PDFTextStripper() {
+                @Override
+                protected void processTextPosition(TextPosition text) {
+                    PDPage page = getCurrentPage();
+                    float limit = page.getMediaBox().getUpperRightX() - PAGE_MARGIN_PT;
+                    int rgb;
+                    try {
+                        rgb = getGraphicsState().getNonStrokingColor().toRGB();
+                    } catch (IOException e) {
+                        throw new IllegalStateException("Could not read the fill colour of a glyph", e);
+                    }
+                    glyphs.add(new Glyph(text.getUnicode(),
+                            text.getXDirAdj() + text.getWidthDirAdj(),
+                            limit, getCurrentPageNo(), rgb));
+                    super.processTextPosition(text);
+                }
+            };
+            stripper.addOperator(new SetNonStrokingColorSpace(stripper));
+            stripper.addOperator(new SetNonStrokingDeviceRGBColor(stripper));
+            stripper.addOperator(new SetNonStrokingDeviceGrayColor(stripper));
+            stripper.addOperator(new SetNonStrokingDeviceCMYKColor(stripper));
+            stripper.addOperator(new SetNonStrokingColor(stripper));
+            stripper.addOperator(new SetNonStrokingColorN(stripper));
+            stripper.getText(document);
+        }
+        return glyphs;
+    }
+
+    /**
+     * Groups the glyphs into runs that share a page and a colour, so a test can talk about "the
+     * badge" rather than about individual letters. A run's right edge is its rightmost glyph's.
+     */
+    private List<Chunk> chunksOf(byte[] pdf) throws IOException {
+        List<Chunk> chunks = new ArrayList<>();
+        StringBuilder text = new StringBuilder();
+        Glyph first = null;
+        float right = 0f;
+        for (Glyph glyph : glyphsOf(pdf)) {
+            boolean sameRun = first != null && first.pageNumber() == glyph.pageNumber()
+                    && first.rgb() == glyph.rgb();
+            if (!sameRun && first != null) {
+                chunks.add(new Chunk(text.toString(), right, first.rightLimit(), first.pageNumber(), first.rgb()));
+                text.setLength(0);
+                right = 0f;
+            }
+            if (!sameRun) {
+                first = glyph;
+            }
+            text.append(glyph.text());
+            right = Math.max(right, glyph.right());
+        }
+        if (first != null) {
+            chunks.add(new Chunk(text.toString(), right, first.rightLimit(), first.pageNumber(), first.rgb()));
+        }
+        return chunks;
+    }
+
+    private TaskDto task(Long id, String title, Double progress) {
+        TaskDto task = new TaskDto();
+        task.setId(id);
+        task.setTitle(title);
+        task.setProgress(progress);
+        task.setUpdatedAt(LocalDateTime.of(2026, 8, 20, 9, 30));
+        return task;
+    }
+
+    private IndentDto indent(IndentStatus status) {
+        EmployeeDto createdBy = new EmployeeDto();
+        createdBy.setId(4L);
+        createdBy.setEmployeeName("Echno Admin");
+
+        IndentDto indent = new IndentDto();
+        indent.setId(1L);
+        indent.setIndentNumber("IND-2026-000001");
+        indent.setStatus(status);
+        indent.setCreatedBy(createdBy);
+        indent.setProjectId(5L);
+        indent.setCreatedAt(LocalDateTime.of(2026, 8, 18, 11, 0));
+        return indent;
+    }
+}


### PR DESCRIPTION
Closes #612.

Three presentation faults in the report's indent section. None of them had been seen before #605 made the report render at all for a tenant holding indents, so this is the first pass over a section that has never been looked at.

## 1. The badge ran off the right edge of the page

`.container` declared `width: 100%` next to padding it sets itself, and the element carries more from `.md:p-8`, so with `content-box` its box came out **100% plus 4rem**. The indent section therefore ran past the right page margin, and the badge, being the rightmost thing in it, was the part the page edge took. The task section never showed the fault because it does not use `.container`.

Dropping the `width` is the whole fix. A block-level div already fills its parent, so the padding now sits inside the page rather than being added to it. The badge also gained `white-space: nowrap` on its cell and its pill, because the new label carries a space and would otherwise have broken across two lines where "ORDERED" did not.

## 2. The colour never applied to `ON_SITE`

The template decided all three classes by comparing `#strings.toLowerCase(indent.status)` to `'on-site'`. `indent.status` is an `IndentStatus`, so `#strings.toLowerCase` gives the constant lowercased, `on_site`, with an underscore. It never matched, so an `ON_SITE` indent got no border, no pill and no dot, while `ORDERED`, `DELAYED` and `PENDING` matched because those constants have no underscore in them. That is why the fault read as intermittent rather than broken.

Rather than fix the three spellings, all three decisions now **derive** the class suffix from the constant name:

```html
th:with="statusKey=${#strings.replace(#strings.toLowerCase(indent.status), '_', '-')}"
```

That removes the whole class of the fault instead of one instance of it, drops twelve ternary branches, and picks up two things the branches had missed:

- `CANCELLED` was named by none of them, so a cancelled indent had no styling at all. It now has a grey border, pill and dot.
- The `DELAYED` branch appended `status-delaayed` while the stylesheet defines `.status-delayed`, so `DELAYED` had been quietly missing its left border too.

## 3. The badge printed the constant name

The report is a document a client reads, so "ON_SITE" is an internal name leaking onto a page. `IndentStatus` now carries the words a person should see and the template asks for those.

The constant name stays the wire format and the storage format. Only the report reads `getLabel()`; Jackson still serializes the enum by `name()`, and `openApiSnapshot -PupdateOpenApiSnapshot` produces no diff, so the API and the database are untouched by this.

## Also, the 0% progress bar

The issue raised it as worth deciding while in this file. At 0% the label was drawn inside a bar of zero width and spilled over the empty track. The percentage now sits beside the "Progress Till Date" caption, which reads correctly at every value.

Widening the bar to fit its label would have been the smaller edit and the wrong one: it would draw a task that has not started as though it had, in a document a client reads.

## Tests

`ReportIndentBadgeRenderTest`, 9 tests, all of them **failing without this change**. Verified by running the same test file against a clean checkout of `development` on the build box, with only the (inert) `getLabel()` accessor added so it compiles.

| Test | Without the fix |
|------|-----------------|
| `nothingInTheReportRunsPastTheRightMargin` | FAILS — text ends at 559.5pt, past the 552.8pt right margin |
| `theStatusBadgeSitsInsideTheRightMargin` | FAILS — no badge found reading "On site" |
| `theOnSiteBadgeIsPrintedInItsOwnColour` | FAILS — same |
| `theStatusBadgeIsPrintedInWordsRatherThanAsTheConstantName` | FAILS — the page says `ON_SITE` |
| `everyStatusPrintsItsOwnLabel`, 5 cases | FAILS — one per constant |

The faults are measured on the rendered page rather than asserted about the template, which is the point: the clipping is read as a coordinate out of the content stream, and the colour is read as the fill colour in force when the glyph was drawn. Two things about that were worth a comment in the file and are worth one here, because both fail silently rather than loudly:

- The colour has to be captured in `processTextPosition`, which runs while the stream is being walked. `writeString` is called only after the whole page has been processed, so reading the graphics state there reports the page's last colour for every character on it.
- A plain `PDFTextStripper` installs the text operators only. Without registering the six non-stroking colour operators by hand, the fill colour never moves off its initial black and every glyph reads as `000000`, which looks exactly like a stylesheet that failed to load.

`./gradlew build` green on the build box; test heap 564 MB of the 2048 MB cap (28%), 8 contexts cached of 8.
