### PR TITLE
Let the NCR register be asked for a person's own trail

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -74696,7 +74696,7 @@
     },
     "/api/v1/ncrs/web": {
       "get": {
-        "description": "Returns a page of NCRs in the current tenant. Every parameter is an optional filter. Setting open=true returns the punch list: every NCR that has not been closed, whatever stage it has reached.",
+        "description": "Returns a page of NCRs in the current tenant. Every parameter is an optional filter, and they narrow together. Setting open=true returns the punch list: every NCR that has not been closed, whatever stage it has reached. siteEngineerId, raisedById, verifiedById and closedById are employee ids, the same ids the employee directory hands out, and they answer a person's trail through the register: what they were given, what they raised, what they accepted on re-inspection and what they closed.",
         "operationId": "list",
         "parameters": [
           {
@@ -74740,6 +74740,33 @@
           {
             "in": "query",
             "name": "siteEngineerId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "raisedById",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verifiedById",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "closedById",
             "required": false,
             "schema": {
               "format": "int64",

--- a/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/domain/Ncr.java
@@ -44,7 +44,10 @@ import java.util.UUID;
                 @Index(name = "idx_ncr_defect", columnList = "defect_id"),
                 @Index(name = "idx_ncr_status", columnList = "status"),
                 @Index(name = "idx_ncr_type", columnList = "type"),
-                @Index(name = "idx_ncr_site_engineer", columnList = "site_engineer_id")
+                @Index(name = "idx_ncr_site_engineer", columnList = "site_engineer_id"),
+                @Index(name = "idx_ncr_raised_by", columnList = "raised_by_id"),
+                @Index(name = "idx_ncr_verified_by", columnList = "verified_by_id"),
+                @Index(name = "idx_ncr_closed_by", columnList = "closed_by_id")
         })
 @Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter

--- a/src/main/java/org/tornotron/echno_backend/inspection/pdf/NcrReportPdfService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/pdf/NcrReportPdfService.java
@@ -128,7 +128,7 @@ public class NcrReportPdfService {
     public RenderedReport renderPunchList(UUID inspectionId, NcrType type, Long siteEngineerId)
             throws IOException {
         Page<NcrDto> page = ncrService.findAll(
-                inspectionId, type, null, siteEngineerId, Boolean.TRUE,
+                inspectionId, type, null, siteEngineerId, null, null, null, Boolean.TRUE,
                 PageRequest.of(0, UnpagedResultCap.MAX_ROWS,
                         Sort.by(Sort.Direction.DESC, "createdAt")));
 

--- a/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/repositories/NcrSpecifications.java
@@ -24,6 +24,9 @@ public final class NcrSpecifications {
                                                  NcrType type,
                                                  NcrStatus status,
                                                  Long siteEngineerId,
+                                                 Long raisedById,
+                                                 Long verifiedById,
+                                                 Long closedById,
                                                  Boolean open) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
@@ -38,6 +41,20 @@ public final class NcrSpecifications {
             }
             if (siteEngineerId != null) {
                 predicates.add(cb.equal(root.get("siteEngineerId"), siteEngineerId));
+            }
+            // The three people the accountability trail names, each an employee id of
+            // this tenant. They narrow within the tenant and never past it: the org
+            // scope is a separate condition the filter adds to every query, so an id
+            // belonging to somebody in another organization matches no row here rather
+            // than reaching their reports.
+            if (raisedById != null) {
+                predicates.add(cb.equal(root.get("raisedById"), raisedById));
+            }
+            if (verifiedById != null) {
+                predicates.add(cb.equal(root.get("verifiedById"), verifiedById));
+            }
+            if (closedById != null) {
+                predicates.add(cb.equal(root.get("closedById"), closedById));
             }
             if (open != null) {
                 // The punch list: everything still outstanding, which is every NCR that

--- a/src/main/java/org/tornotron/echno_backend/inspection/service/NcrService.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/service/NcrService.java
@@ -67,16 +67,29 @@ public class NcrService {
     /**
      * The NCR register, and with {@code open} the punch list the functional spec
      * asks for: every non-conformance still outstanding, across inspections.
+     *
+     * <p>{@code siteEngineerId}, {@code raisedById}, {@code verifiedById} and
+     * {@code closedById} are all employee ids, not user ids: every one of them is
+     * written from {@link #currentEmployeeId()} or from an assignment that was
+     * checked against this organization's employees. They answer the question a QA
+     * lead actually asks of a person, which is which reports they raised, accepted
+     * or closed, and they narrow the page server-side because narrowing it in the
+     * browser would filter one page of a paged result and quietly drop every match
+     * outside it.
      */
     @Transactional(readOnly = true)
     public Page<NcrDto> findAll(UUID inspectionId,
                                 NcrType type,
                                 NcrStatus status,
                                 Long siteEngineerId,
+                                Long raisedById,
+                                Long verifiedById,
+                                Long closedById,
                                 Boolean open,
                                 Pageable pageable) {
         return ncrRepo.findAll(
-                        NcrSpecifications.withFilters(inspectionId, type, status, siteEngineerId, open),
+                        NcrSpecifications.withFilters(inspectionId, type, status, siteEngineerId,
+                                raisedById, verifiedById, closedById, open),
                         pageable)
                 .map(mapper::toDto);
     }

--- a/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/inspection/web/NcrControllerWeb.java
@@ -85,8 +85,12 @@ public class NcrControllerWeb {
     @Operation(
             summary = "List non-conformance reports",
             description = "Returns a page of NCRs in the current tenant. Every parameter is an "
-                    + "optional filter. Setting open=true returns the punch list: every NCR that has "
-                    + "not been closed, whatever stage it has reached."
+                    + "optional filter, and they narrow together. Setting open=true returns the "
+                    + "punch list: every NCR that has not been closed, whatever stage it has "
+                    + "reached. siteEngineerId, raisedById, verifiedById and closedById are "
+                    + "employee ids, the same ids the employee directory hands out, and they "
+                    + "answer a person's trail through the register: what they were given, what "
+                    + "they raised, what they accepted on re-inspection and what they closed."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of matching NCRs"),
@@ -96,9 +100,13 @@ public class NcrControllerWeb {
                              @RequestParam(required = false) NcrType type,
                              @RequestParam(required = false) NcrStatus status,
                              @RequestParam(required = false) Long siteEngineerId,
+                             @RequestParam(required = false) Long raisedById,
+                             @RequestParam(required = false) Long verifiedById,
+                             @RequestParam(required = false) Long closedById,
                              @RequestParam(required = false) Boolean open,
                              Pageable pageable) {
-        return service.findAll(inspectionId, type, status, siteEngineerId, open, pageable);
+        return service.findAll(inspectionId, type, status, siteEngineerId,
+                raisedById, verifiedById, closedById, open, pageable);
     }
 
     @PostMapping("/{id}/assign")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -370,4 +370,7 @@
     <!-- v4.0 - Materials: lead time consumption, the input the stock levels are derived from -->
     <include file="db/changelog/v4.0/078-add-material-ltc.xml"/>
 
+    <!-- v4.0 - NCRs: index the people columns the listing can now be filtered on -->
+    <include file="db/changelog/v4.0/079-index-ncr-people-columns.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/079-index-ncr-people-columns.xml
+++ b/src/main/resources/db/changelog/v4.0/079-index-ncr-people-columns.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="079-index-ncr-people-columns" author="echno">
+        <comment>
+            The NCR listing can now be narrowed to the person who raised a report, the person who
+            accepted the corrective work on re-inspection and the person who closed it, the same way
+            it could already be narrowed to the site engineer who owns it. Those three columns had no
+            index, because until now nothing selected on them: they were written once and read back
+            on the one report being looked at.
+
+            A filter turns them into a query predicate over the whole register, so each gets the index
+            site_engineer_id already has. Without them the equality filter degrades to a scan of every
+            NCR in the tenant, which is the shape that stops being cheap exactly when a client has
+            enough history to want the filter.
+        </comment>
+
+        <createIndex tableName="ncrs" indexName="idx_ncr_raised_by">
+            <column name="raised_by_id"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_verified_by">
+            <column name="verified_by_id"/>
+        </createIndex>
+        <createIndex tableName="ncrs" indexName="idx_ncr_closed_by">
+            <column name="closed_by_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="ncrs" indexName="idx_ncr_raised_by"/>
+            <dropIndex tableName="ncrs" indexName="idx_ncr_verified_by"/>
+            <dropIndex tableName="ncrs" indexName="idx_ncr_closed_by"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/inspection/NcrReportPdfServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/NcrReportPdfServiceTest.java
@@ -165,7 +165,7 @@ class NcrReportPdfServiceTest {
                     LocalDateTime.of(2026, 8, 21, 10, 0), LocalDateTime.of(2026, 8, 21, 10, 0)));
         }
         Page<NcrDto> page = new PageImpl<>(content, PageRequest.of(0, 500), rows);
-        when(ncrService.findAll(any(), any(), any(), any(), eq(Boolean.TRUE), any()))
+        when(ncrService.findAll(any(), any(), any(), any(), any(), any(), any(), eq(Boolean.TRUE), any()))
                 .thenReturn(page);
     }
 

--- a/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
@@ -10,8 +10,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.test.context.transaction.AfterTransaction;
@@ -86,7 +90,9 @@ class NcrServiceIT extends AbstractIntegrationTest {
     private Long orgAId;
     private Long orgBId;
     private Long projectId;
+    private Long foreignProjectId;
     private Long siteEngineerId;
+    private Long qaLeadId;
     private Long foreignSiteEngineerId;
 
     @BeforeEach
@@ -101,14 +107,31 @@ class NcrServiceIT extends AbstractIntegrationTest {
             project.setOrganization(orgA);
             entityManager.persist(project);
 
+            Project foreignProject = new Project();
+            foreignProject.setProjectName("Tower C");
+            foreignProject.setOrganization(orgB);
+            entityManager.persist(foreignProject);
+
+            // Users with no employee record, seeded first so the two sequences no longer
+            // run in lockstep. Without them a fresh database hands the same number out as
+            // a user id and as an employee id, and a test that mixed the two up would pass
+            // on the coincidence. This is the same confusion that shipped as a real defect
+            // on the web side, so the ids are pushed apart deliberately.
+            persistUser("kc-ncr-spare-1", "Spare One");
+            persistUser("kc-ncr-spare-2", "Spare Two");
+            persistUser("kc-ncr-spare-3", "Spare Three");
+
             Employee siteEngineer = persistEmployee(orgA, "kc-ncr-a", "Site Engineer A");
+            Employee qaLead = persistEmployee(orgA, "kc-ncr-qa", "QA Lead A");
             Employee otherOrgEngineer = persistEmployee(orgB, "kc-ncr-b", "Site Engineer B");
 
             entityManager.flush();
             orgAId = orgA.getId();
             orgBId = orgB.getId();
             projectId = project.getId();
+            foreignProjectId = foreignProject.getId();
             siteEngineerId = siteEngineer.getId();
+            qaLeadId = qaLead.getId();
             foreignSiteEngineerId = otherOrgEngineer.getId();
         });
         TenantContext.setCurrentOrgId(orgAId);
@@ -123,6 +146,7 @@ class NcrServiceIT extends AbstractIntegrationTest {
     void clearTenantState() {
         entityManager.unwrap(Session.class).disableFilter("orgFilter");
         TenantContext.clear();
+        SecurityContextHolder.clearContext();
     }
 
     /**
@@ -157,7 +181,9 @@ class NcrServiceIT extends AbstractIntegrationTest {
             // the users are not org-scoped, so they are named by the ids seeded above.
             deleteForOrgs("DELETE FROM employee WHERE organization_id IN (:a,:b)");
             entityManager.createNativeQuery(
-                            "DELETE FROM users_table WHERE keycloak_id IN ('kc-ncr-a','kc-ncr-b')")
+                            "DELETE FROM users_table WHERE keycloak_id IN "
+                                    + "('kc-ncr-a','kc-ncr-qa','kc-ncr-b',"
+                                    + "'kc-ncr-spare-1','kc-ncr-spare-2','kc-ncr-spare-3')")
                     .executeUpdate();
             deleteForOrgs("DELETE FROM organization WHERE id IN (:a,:b)");
         });
@@ -380,21 +406,208 @@ class NcrServiceIT extends AbstractIntegrationTest {
         entityManager.clear();
         Pageable pageable = PageRequest.of(0, 10);
 
-        assertThat(service.findAll(null, null, null, null, true, pageable).getContent())
+        assertThat(service.findAll(null, null, null, null, null, null, null, true, pageable).getContent())
                 .extracting(NcrDto::id).containsExactly(open);
-        assertThat(service.findAll(null, null, null, null, false, pageable).getContent())
+        assertThat(service.findAll(null, null, null, null, null, null, null, false, pageable).getContent())
                 .extracting(NcrDto::id).containsExactly(done);
-        assertThat(service.findAll(null, NcrType.QUALITY, null, siteEngineerId, null, pageable)
+        assertThat(service.findAll(null, NcrType.QUALITY, null, siteEngineerId, null, null, null, null, pageable)
                 .getTotalElements()).isEqualTo(2);
-        assertThat(service.findAll(null, NcrType.SAFETY, null, null, null, pageable)
+        assertThat(service.findAll(null, NcrType.SAFETY, null, null, null, null, null, null, pageable)
                 .getTotalElements()).isZero();
 
         enableOrgFilter(orgBId);
-        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements())
+        assertThat(service.findAll(null, null, null, null, null, null, null, null, pageable).getTotalElements())
                 .isZero();
         assertThatThrownBy(() -> service.findById(open))
                 .isInstanceOf(ResourceNotFoundException.class);
         disableOrgFilter();
+    }
+
+    /**
+     * The three people on the trail are employee ids, not user ids. The distinction is not
+     * cosmetic: the same mistake was made on the web side and it resolved for a minority of ids
+     * and named the wrong person on a collision. This asserts on the whole chain rather than on
+     * the values matching by luck, so it fails if any of the three is ever written from
+     * {@code getCurrentUserId()} directly.
+     */
+    @Test
+    void theTrailRecordsEmployeeIdsRatherThanUserIds() {
+        Long qaUserId = userIdOf("kc-ncr-qa");
+        authenticateAs("kc-ncr-qa");
+        UUID id = assignedNcr();
+        service.markCorrectiveActionComplete(id, "Re-poured");
+        service.verify(id, "Accepted");
+        service.close(id);
+
+        NcrDto closed = service.findById(id);
+        assertThat(closed.raisedById()).isEqualTo(qaLeadId);
+        assertThat(closed.verifiedById()).isEqualTo(qaLeadId);
+        assertThat(closed.closedById()).isEqualTo(qaLeadId);
+        // and the two are genuinely different numbers here, so none of the three could
+        // have been written from the user id and passed
+        assertThat(qaLeadId).isNotEqualTo(qaUserId);
+    }
+
+    /**
+     * The register can be asked for one person's trail: what they raised, what they accepted on
+     * re-inspection and what they closed. Each assertion names the ids it expects rather than a
+     * count alone, so a filter that was silently ignored returns the whole register and fails
+     * here rather than passing on a coincidence of totals.
+     */
+    @Test
+    void listsByTheThreePeopleOnTheTrail() {
+        Trail trail = seedTrail();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        assertThat(service.findAll(null, null, null, null, qaLeadId, null, null, null, pageable)
+                .getContent()).extracting(NcrDto::id)
+                .containsExactlyInAnyOrder(trail.raisedByQa, trail.alsoRaisedByQa)
+                .doesNotContain(trail.raisedByEngineer);
+        assertThat(service.findAll(null, null, null, null, siteEngineerId, null, null, null, pageable)
+                .getContent()).extracting(NcrDto::id).containsExactly(trail.raisedByEngineer);
+
+        assertThat(service.findAll(null, null, null, null, null, qaLeadId, null, null, pageable)
+                .getContent()).extracting(NcrDto::id).containsExactly(trail.raisedByQa);
+        assertThat(service.findAll(null, null, null, null, null, siteEngineerId, null, null, pageable)
+                .getContent()).extracting(NcrDto::id).containsExactly(trail.alsoRaisedByQa);
+
+        assertThat(service.findAll(null, null, null, null, null, null, qaLeadId, null, pageable)
+                .getContent()).extracting(NcrDto::id).containsExactly(trail.raisedByQa);
+        assertThat(service.findAll(null, null, null, null, null, null, siteEngineerId, null, pageable)
+                .getContent()).extracting(NcrDto::id).containsExactly(trail.alsoRaisedByQa);
+
+        // nobody raised anything as the org B engineer in org A, and an id that matches no row
+        // returns nothing rather than everything
+        assertThat(service.findAll(null, null, null, null, foreignSiteEngineerId, null, null, null,
+                pageable).getTotalElements()).isZero();
+    }
+
+    /**
+     * The new filters narrow with the ones already there rather than replacing them, which is the
+     * whole reason they are predicates on one specification: asking for what a person raised and
+     * somebody else closed has to mean both conditions at once.
+     */
+    @Test
+    void theNewFiltersAndWithTheOnesAlreadyThere() {
+        Trail trail = seedTrail();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        assertThat(service.findAll(null, null, null, null, qaLeadId, siteEngineerId, null, null,
+                pageable).getContent()).extracting(NcrDto::id).containsExactly(trail.alsoRaisedByQa);
+        assertThat(service.findAll(null, NcrType.SAFETY, null, null, qaLeadId, null, null, null,
+                pageable).getTotalElements()).isZero();
+        assertThat(service.findAll(null, null, NcrStatus.CLOSED, null, qaLeadId, null, null, null,
+                pageable).getContent()).extracting(NcrDto::id)
+                .containsExactlyInAnyOrder(trail.raisedByQa, trail.alsoRaisedByQa);
+        // raised by the QA lead and still outstanding: neither of the two closed ones
+        assertThat(service.findAll(null, null, null, null, qaLeadId, null, null, true, pageable)
+                .getTotalElements()).isZero();
+    }
+
+    /**
+     * A filter parameter is a place where the caller supplies an id, so it is the place to check
+     * that it cannot be used to reach across organizations. Org B has its own NCR raised by its
+     * own employee; asking from org A for that employee's reports returns nothing, and asking from
+     * org B for org A's employees returns nothing either, so the leak would be caught whichever
+     * tenant a broken query favoured.
+     *
+     * <p>The count is asserted alongside the rows. {@code getTotalElements} comes from a separate
+     * count query that the specification is applied to independently, so a total that includes
+     * another tenant's rows would say how many reports a rival has against a named person even
+     * when no row of theirs comes back.
+     */
+    @Test
+    void thePeopleFiltersCannotReachAcrossOrganizations() {
+        Trail trail = seedTrail();
+        UUID foreign = seedForeignTrail();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        enableOrgFilter(orgAId);
+        Page<NcrDto> mine = service.findAll(null, null, null, null, qaLeadId, null, null, null, pageable);
+        assertThat(mine.getContent()).extracting(NcrDto::id)
+                .containsExactlyInAnyOrder(trail.raisedByQa, trail.alsoRaisedByQa)
+                .doesNotContain(foreign);
+        assertThat(mine.getTotalElements()).isEqualTo(2);
+        // the org B employee is a real employee, and their reports are still out of reach
+        Page<NcrDto> reachingOut = service.findAll(null, null, null, null, foreignSiteEngineerId,
+                null, null, null, pageable);
+        assertThat(reachingOut.getContent()).isEmpty();
+        assertThat(reachingOut.getTotalElements()).isZero();
+        disableOrgFilter();
+
+        enableOrgFilter(orgBId);
+        Page<NcrDto> theirs = service.findAll(null, null, null, null, foreignSiteEngineerId,
+                null, null, null, pageable);
+        assertThat(theirs.getContent()).extracting(NcrDto::id).containsExactly(foreign);
+        assertThat(theirs.getTotalElements()).isEqualTo(1);
+        // and org A's people are equally out of reach from org B, on all three filters
+        assertThat(service.findAll(null, null, null, null, qaLeadId, null, null, null, pageable)
+                .getTotalElements()).isZero();
+        assertThat(service.findAll(null, null, null, null, null, qaLeadId, null, null, pageable)
+                .getTotalElements()).isZero();
+        assertThat(service.findAll(null, null, null, null, null, null, siteEngineerId, null, pageable)
+                .getTotalElements()).isZero();
+        disableOrgFilter();
+    }
+
+    /** The ids of the three NCRs {@link #seedTrail()} leaves behind. */
+    private record Trail(UUID raisedByQa, UUID alsoRaisedByQa, UUID raisedByEngineer) {}
+
+    /**
+     * Three NCRs in org A with the trail deliberately split between two people: the QA lead raises
+     * two and takes one of them all the way through, the site engineer raises the third and
+     * verifies and closes the other one. Nothing lines up by accident, so a filter on any of the
+     * three columns has a different answer.
+     */
+    private Trail seedTrail() {
+        authenticateAs("kc-ncr-qa");
+        UUID raisedByQa = assignedNcr();
+        UUID alsoRaisedByQa = assignedNcr();
+        service.markCorrectiveActionComplete(raisedByQa, "Re-poured");
+        service.markCorrectiveActionComplete(alsoRaisedByQa, "Re-poured");
+        service.verify(raisedByQa, "Accepted");
+        service.close(raisedByQa);
+
+        authenticateAs("kc-ncr-a");
+        UUID raisedByEngineer = assignedNcr();
+        service.verify(alsoRaisedByQa, "Accepted");
+        service.close(alsoRaisedByQa);
+
+        entityManager.flush();
+        entityManager.clear();
+        return new Trail(raisedByQa, alsoRaisedByQa, raisedByEngineer);
+    }
+
+    /** One NCR in org B, raised by org B's own employee, for the cross-tenant assertions. */
+    private UUID seedForeignTrail() {
+        TenantContext.setCurrentOrgId(orgBId);
+        authenticateAs("kc-ncr-b");
+        InspectionDto inspection = inspectionService.create(new CreateInspectionRequest(
+                "Slab check", InspectionType.QUALITY, null, null, foreignProjectId,
+                "Block A", null, null, LocalDate.of(2026, 8, 20), null,
+                null, null, null, 100L, null, null, null, null, null,
+                null, null));
+        UUID id = service.create(new CreateNcrRequest(inspection.id(), null,
+                "Their non-conformance", "Org B's own report", DefectSeverity.MAJOR,
+                foreignSiteEngineerId, null)).id();
+        entityManager.flush();
+        entityManager.clear();
+        TenantContext.setCurrentOrgId(orgAId);
+        return id;
+    }
+
+    /** Puts the given Keycloak subject in the security context, the way a request would. */
+    private void authenticateAs(String keycloakId) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(keycloakId, "n/a",
+                        AuthorityUtils.NO_AUTHORITIES));
+    }
+
+    private Long userIdOf(String keycloakId) {
+        return ((Number) entityManager
+                .createNativeQuery("SELECT id FROM users_table WHERE keycloak_id = :kc")
+                .setParameter("kc", keycloakId)
+                .getSingleResult()).longValue();
     }
 
     private UUID assignedNcr() {
@@ -446,11 +659,16 @@ class NcrServiceIT extends AbstractIntegrationTest {
         tt.executeWithoutResult(status -> work.run());
     }
 
-    private Employee persistEmployee(Organization org, String keycloakId, String name) {
+    private User persistUser(String keycloakId, String name) {
         User user = new User();
         user.setKeycloakId(keycloakId);
         user.setName(name);
         entityManager.persist(user);
+        return user;
+    }
+
+    private Employee persistEmployee(Organization org, String keycloakId, String name) {
+        User user = persistUser(keycloakId, name);
 
         Employee employee = new Employee();
         employee.setOrganization(org);

--- a/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/inspection/NcrServiceIT.java
@@ -511,41 +511,52 @@ class NcrServiceIT extends AbstractIntegrationTest {
      * org B for org A's employees returns nothing either, so the leak would be caught whichever
      * tenant a broken query favoured.
      *
-     * <p>The count is asserted alongside the rows. {@code getTotalElements} comes from a separate
-     * count query that the specification is applied to independently, so a total that includes
-     * another tenant's rows would say how many reports a rival has against a named person even
-     * when no row of theirs comes back.
+     * <p>The count is asserted alongside the rows, on a page small enough to force it to be
+     * computed. {@code getTotalElements} comes from a count query the specification is applied to
+     * separately, and Spring skips that query altogether when the first page came back short, so
+     * a total read off a roomy page proves nothing about it. Asking for one row at a time when
+     * two match makes the count query actually run under the tenant scope. It matters because a
+     * total that counted another tenant's rows would say how many reports a rival has against a
+     * named person even when no row of theirs came back.
      */
     @Test
     void thePeopleFiltersCannotReachAcrossOrganizations() {
         Trail trail = seedTrail();
         UUID foreign = seedForeignTrail();
         Pageable pageable = PageRequest.of(0, 10);
+        Pageable onePerPage = PageRequest.of(0, 1);
 
         enableOrgFilter(orgAId);
         Page<NcrDto> mine = service.findAll(null, null, null, null, qaLeadId, null, null, null, pageable);
         assertThat(mine.getContent()).extracting(NcrDto::id)
                 .containsExactlyInAnyOrder(trail.raisedByQa, trail.alsoRaisedByQa)
                 .doesNotContain(foreign);
-        assertThat(mine.getTotalElements()).isEqualTo(2);
-        // the org B employee is a real employee, and their reports are still out of reach
+        // a full page, so the count query is issued rather than inferred from the rows
+        Page<NcrDto> counted = service.findAll(null, null, null, null, qaLeadId, null, null, null,
+                onePerPage);
+        assertThat(counted.getContent()).hasSize(1);
+        assertThat(counted.getTotalElements()).isEqualTo(2);
+        assertThat(counted.getTotalPages()).isEqualTo(2);
+        // the org B employee is a real employee, and their reports are still out of reach. Asked
+        // one row at a time, a scope that let them through would fill the page and then count
+        // them, so both assertions here would fail rather than only the first.
         Page<NcrDto> reachingOut = service.findAll(null, null, null, null, foreignSiteEngineerId,
-                null, null, null, pageable);
+                null, null, null, onePerPage);
         assertThat(reachingOut.getContent()).isEmpty();
         assertThat(reachingOut.getTotalElements()).isZero();
         disableOrgFilter();
 
         enableOrgFilter(orgBId);
         Page<NcrDto> theirs = service.findAll(null, null, null, null, foreignSiteEngineerId,
-                null, null, null, pageable);
+                null, null, null, onePerPage);
         assertThat(theirs.getContent()).extracting(NcrDto::id).containsExactly(foreign);
         assertThat(theirs.getTotalElements()).isEqualTo(1);
         // and org A's people are equally out of reach from org B, on all three filters
-        assertThat(service.findAll(null, null, null, null, qaLeadId, null, null, null, pageable)
+        assertThat(service.findAll(null, null, null, null, qaLeadId, null, null, null, onePerPage)
                 .getTotalElements()).isZero();
-        assertThat(service.findAll(null, null, null, null, null, qaLeadId, null, null, pageable)
+        assertThat(service.findAll(null, null, null, null, null, qaLeadId, null, null, onePerPage)
                 .getTotalElements()).isZero();
-        assertThat(service.findAll(null, null, null, null, null, null, siteEngineerId, null, pageable)
+        assertThat(service.findAll(null, null, null, null, null, null, siteEngineerId, null, onePerPage)
                 .getTotalElements()).isZero();
         disableOrgFilter();
     }


### PR DESCRIPTION
Closes #626.

`GET /api/v1/ncrs/web` took `siteEngineerId` and nothing else about a person, so the question a QA lead actually asks of a name on an NCR, which reports did they raise, had no answer. The web app could not answer it client-side either: the endpoint returns a `Page` and the core client unwraps `.content`, so a browser filter would have searched one page and read as the whole register. That is why echno-web#358 wired only the site engineer and left "Raised by" as plain text.

## Contract

`raisedById`, `verifiedById` and `closedById` join `siteEngineerId` on the listing. All optional `Long`, all equality predicates on `NcrSpecifications.withFilters`, all ANDed with the filters already there and with each other.

```
GET /api/v1/ncrs/web
  ?inspectionId=&type=&status=
  &siteEngineerId=&raisedById=&verifiedById=&closedById=
  &open=&page=&size=&sort=
```

No DTO change: `NcrDto` already carries the three fields. Auth is unchanged (`@inspectionSecurity.canRead()`), pagination is the existing `Pageable`, and `docs/openapi.json` is regenerated.

## They are employee ids, not user ids

Confirmed independently for each of the three, not assumed from `siteEngineerId`. `NcrService` writes all three from `currentEmployeeId()`, which resolves the session user through `employeeRepository.findByUserIdAndOrganizationId(...).map(Employee::getId)`. So the values a client already holds from the employee directory are the right ones to send.

The first run of the new test proved why this is worth checking: on a fresh database the user and employee sequences run in lockstep and handed out `26` for both, so a test that had confused the two would have passed on the coincidence. The seed now persists three employee-less users first to push the sequences apart, and the assertion is meaningful.

## Tenant isolation

The org scope is a separate condition the Hibernate `orgFilter` adds to every query, and these predicates only narrow within it. `thePeopleFiltersCannotReachAcrossOrganizations` proves it from both sides: org B holds its own NCR raised by its own employee; from org A, filtering on that employee returns nothing, and from org B, filtering on org A's people returns nothing on all three parameters. Rows and `getTotalElements` are both asserted, because the count is a separate query and a leaked total would say how many reports a rival has against a named person even with no row returned.

## Every filter proven by a failing test

Each predicate was removed in turn and the suite rerun. The scope row stands in for a listing that ignored the tenant scope.

| Mutation | Tests that fail |
|---|---|
| `raisedById` predicate removed | `listsByTheThreePeopleOnTheTrail`, `theNewFiltersAndWithTheOnesAlreadyThere`, `thePeopleFiltersCannotReachAcrossOrganizations` |
| `verifiedById` predicate removed | `listsByTheThreePeopleOnTheTrail`, `theNewFiltersAndWithTheOnesAlreadyThere`, `thePeopleFiltersCannotReachAcrossOrganizations` |
| `closedById` predicate removed | `listsByTheThreePeopleOnTheTrail`, `thePeopleFiltersCannotReachAcrossOrganizations` |
| tenant scope not applied to the listing | `thePeopleFiltersCannotReachAcrossOrganizations`, `listsThePunchListAndScopesEverythingToTheTenant` |

A fourth test, `theTrailRecordsEmployeeIdsRatherThanUserIds`, guards the id-kind question above.

## Also

Changelog `077` indexes `raised_by_id`, `verified_by_id` and `closed_by_id`, which had no index because nothing selected on them until now. `site_engineer_id` already had one for the same reason.

## Follow-on

`echno-core` picks the three parameters up in `NcrListParams`, and the "Raised by", "Verified by" and "Closed by" facts on the NCR detail become links like the site engineer already is. That is item 4 of the six remaining on echno-web#35.