### PR TITLE
Name the verifier on a payment voucher, the last stamp still rendering as an id

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3591,6 +3591,11 @@
             "example": 2,
             "format": "int64",
             "type": "integer"
+          },
+          "verifiedByName": {
+            "description": "Name of the user that verified the voucher, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the voucher was never verified.",
+            "example": "Aneesh Johny",
+            "type": "string"
           }
         },
         "type": "object"

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -87,6 +87,12 @@ public record ConstructionPaymentDto(
         @Schema(description = "User id that verified the voucher.", example = "2")
         Long verifiedBy,
 
+        @Schema(description = "Name of the user that verified the voucher, or their email where the "
+                + "account carries no name. Reads \"User #<id>\" when the account has since been "
+                + "deleted; null only when the voucher was never verified.",
+                example = "Aneesh Johny")
+        String verifiedByName,
+
         @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
         Instant verifiedAt,
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
@@ -1,11 +1,35 @@
 package org.tornotron.echno_backend.finance.construction.mapper;
 
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
+/**
+ * Maps {@link ConstructionPayment} to its DTO.
+ *
+ * <p>The voucher records who verified it as a user id and nothing else, so the name comes from the
+ * {@link UserNameLookup} the caller hands in rather than from the payment. That is the shape
+ * {@code ConstructionInvoiceMapper} and {@code StockAdjustmentMapper} already use, and
+ * {@code MapperDatabaseAccessTest} enforces: whatever a mapper cannot reach from the object it was
+ * given, the caller reads once for the whole page and passes in.
+ *
+ * <p>{@code employeeId} stays a bare id. It is the payee on a salary or advance voucher, an
+ * employee id from a different sequence, and resolving it through the user directory is the
+ * wrong-person bug echno-web#346 removed.
+ */
 @Mapper(componentModel = "spring")
 public interface ConstructionPaymentMapper {
 
-    ConstructionPaymentDto toDto(ConstructionPayment payment);
+    /**
+     * Converts a payment voucher, taking its verifier name from the supplied lookup.
+     *
+     * @param payment The payment to convert.
+     * @param names The names read for every user id on the set of payments being mapped.
+     * @return The payment DTO.
+     */
+    @Mapping(target = "verifiedByName", expression = "java(names.nameOf(payment.getVerifiedBy()))")
+    ConstructionPaymentDto toDto(ConstructionPayment payment, @Context UserNameLookup names);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -21,7 +21,11 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionP
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentSpecifications;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -42,10 +46,11 @@ public class ConstructionPaymentService {
     private final EntryNumberGenerator numberGen;
     private final ConstructionPaymentMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
+    private final UserNameDirectory userNameDirectory;
 
     @Transactional(readOnly = true)
     public ConstructionPaymentDto findById(UUID id) {
-        return mapper.toDto(paymentRepo.findByIdScoped(id)
+        return toDto(paymentRepo.findByIdScoped(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Construction payment with ID " + id + " was not found")));
     }
@@ -57,10 +62,11 @@ public class ConstructionPaymentService {
                                                 ConstructionPaymentType type,
                                                 ConstructionPayeeType payeeType,
                                                 Pageable pageable) {
-        return paymentRepo.findAll(
-                        ConstructionPaymentSpecifications.withFilters(projectId, vendorId, status, type, payeeType),
-                        pageable)
-                .map(mapper::toDto);
+        Page<ConstructionPayment> payments = paymentRepo.findAll(
+                ConstructionPaymentSpecifications.withFilters(projectId, vendorId, status, type, payeeType),
+                pageable);
+        UserNameLookup names = namesFor(payments.getContent());
+        return payments.map(payment -> mapper.toDto(payment, names));
     }
 
     @Transactional
@@ -96,7 +102,7 @@ public class ConstructionPaymentService {
 
         ConstructionPayment saved = paymentRepo.save(payment);
         log.info("Created construction payment {}", saved.getPaymentNumber());
-        return mapper.toDto(saved);
+        return toDto(saved);
     }
 
     @Transactional
@@ -138,10 +144,37 @@ public class ConstructionPaymentService {
         payment.setNotes(req.notes());
 
         log.info("Updated construction payment {}", payment.getPaymentNumber());
-        return mapper.toDto(payment);
+        return toDto(payment);
     }
 
     private String resolveCurrency(String currency) {
         return (currency == null || currency.isBlank()) ? DEFAULT_CURRENCY : currency;
+    }
+
+    /**
+     * Converts one voucher, resolving its verifier name first.
+     *
+     * @param payment The payment to convert.
+     * @return The payment DTO, with the verifier named.
+     */
+    private ConstructionPaymentDto toDto(ConstructionPayment payment) {
+        return mapper.toDto(payment, namesFor(List.of(payment)));
+    }
+
+    /**
+     * Reads the display name for every verifier stamp on the vouchers about to be mapped.
+     *
+     * <p>One call covers a whole page, so the query count does not follow the row count. The
+     * mapper cannot do this for itself: the voucher holds only the user id, and a lookup inside
+     * the conversion would cost a round trip per row with nothing at the call site to show it,
+     * which is what {@code MapperDatabaseAccessTest} exists to prevent.
+     *
+     * @param payments The payments being converted.
+     * @return Their verifier names, with an id that no longer resolves reading as a placeholder.
+     */
+    private UserNameLookup namesFor(Collection<ConstructionPayment> payments) {
+        return userNameDirectory.namesFor(payments.stream()
+                .map(ConstructionPayment::getVerifiedBy)
+                .toList());
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -44,7 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ConstructionPaymentService.class, ConstructionPaymentMapperImpl.class,
-        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class})
+        TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
+        org.tornotron.echno_backend.user.UserNameDirectory.class})
 class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
@@ -1,0 +1,150 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.user.UserDisplayName;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins that a payment voucher comes back naming who verified it, and that a page costs one
+ * directory read whatever its size.
+ *
+ * <p>The counterpart to {@code ConstructionInvoiceStampNameTest} and
+ * {@code StockAdjustmentStampNameTest}: the same stamp, the same fix, and the same reason the
+ * mapper cannot resolve it for itself. The real mapper is used so the test would catch a name that
+ * came from a query inside the conversion rather than from the lookup the caller passed in.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionPaymentStampNameTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long VERIFIER = 41L;
+    private static final long NAMELESS_VERIFIER = 42L;
+    private static final long DELETED_USER = 43L;
+
+    @Mock private ConstructionPaymentRepository paymentRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private UserNameDirectory userNameDirectory;
+
+    private final ConstructionPaymentMapper mapper = new ConstructionPaymentMapperImpl();
+
+    private ConstructionPaymentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionPaymentService(paymentRepo, numberGen, mapper, tenantEntityHelper,
+                userNameDirectory);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void readingOneVoucher_namesTheVerifier() {
+        UUID id = UUID.randomUUID();
+        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment(id, VERIFIER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(VERIFIER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        ConstructionPaymentDto dto = service.findById(id);
+
+        assertThat(dto.verifiedBy()).isEqualTo(VERIFIER);
+        assertThat(dto.verifiedByName()).isEqualTo("Aneesh Johny");
+    }
+
+    @Test
+    void anUnverifiedVoucherHasNoVerifierNameRatherThanAPlaceholder() {
+        UUID id = UUID.randomUUID();
+        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment(id, null)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.none());
+
+        ConstructionPaymentDto dto = service.findById(id);
+
+        assertThat(dto.verifiedByName()).isNull();
+    }
+
+    @Test
+    void aVerifierWhoseAccountIsGone_stillRendersOnTheVoucher() {
+        UUID id = UUID.randomUUID();
+        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment(id, DELETED_USER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.none());
+
+        ConstructionPaymentDto dto = service.findById(id);
+
+        assertThat(dto.verifiedByName()).isEqualTo("User #" + DELETED_USER);
+    }
+
+    @Test
+    void aVerifierWithNoNameFallsBackToTheirEmail() {
+        UUID id = UUID.randomUUID();
+        when(paymentRepo.findByIdScoped(id))
+                .thenReturn(Optional.of(payment(id, NAMELESS_VERIFIER)));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(NAMELESS_VERIFIER, "  ", "hrishi@echno.test"))));
+
+        ConstructionPaymentDto dto = service.findById(id);
+
+        assertThat(dto.verifiedByName()).isEqualTo("hrishi@echno.test");
+    }
+
+    @Test
+    void listingAPage_readsTheDirectoryOnceForEveryStampOnIt() {
+        List<ConstructionPayment> page = List.of(
+                payment(UUID.randomUUID(), VERIFIER),
+                payment(UUID.randomUUID(), null),
+                payment(UUID.randomUUID(), DELETED_USER));
+        when(paymentRepo.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(page));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(VERIFIER, "Aneesh Johny", "aneesh@echno.test"))));
+
+        List<ConstructionPaymentDto> dtos = service
+                .findAll(null, null, null, null, null, Pageable.unpaged()).getContent();
+
+        ArgumentCaptor<Collection<Long>> asked = ArgumentCaptor.captor();
+        verify(userNameDirectory, times(1)).namesFor(asked.capture());
+        assertThat(asked.getValue()).contains(VERIFIER, DELETED_USER);
+        assertThat(dtos).extracting(ConstructionPaymentDto::verifiedByName)
+                .containsExactly("Aneesh Johny", null, "User #" + DELETED_USER);
+    }
+
+    private ConstructionPayment payment(UUID id, Long verifiedBy) {
+        ConstructionPayment payment = new ConstructionPayment();
+        payment.setId(id);
+        payment.setVerifiedBy(verifiedBy);
+        return payment;
+    }
+}


### PR DESCRIPTION
Closes #621. Follows #596 / PR #610, which named the stamps on `StockAdjustmentDto` and `ConstructionInvoiceDto` and missed this one.

## Is `verifiedBy` a user id?

Yes. #610 deliberately left `physicalCountBy` alone because it holds an **employee** id, so this was checked before anything was written:

- `ConstructionPaymentDto.verifiedBy` and `CreateConstructionPaymentRequest.verifiedBy` both document it as "User id that verified the voucher". `StockAdjustmentDto.physicalCountBy` documents itself as "Id of the employee who performed the physical count", which is the distinction #610 turned on.
- `ConstructionInvoice` says so from the other side. The comment over its own stamps reads: *"ids are core-domain user ids (no cross-module FK), matching the verifiedBy/verifiedAt convention on ConstructionPayment"*. The invoice stamps #610 named were modelled on this field.
- Nothing in the backend treats it as an employee id. `employeeId` on the same voucher is the payee on a salary or advance and stays a bare id, for exactly the reason `physicalCountBy` did.

Two things worth knowing, since neither changes the answer but both are true: `verified_by` is a plain `BIGINT` with no foreign key (v4.0/024), and the value is taken straight from the request body rather than from the session, so nothing on the server enforces the contract the schema states. No web screen writes it today. Making the stamp session-derived is the same conversation as #598 and belongs in its own issue, not here.

## What this adds

`ConstructionPaymentDto.verifiedByName`, resolved by the mechanism #610 built rather than a second one:

- `UserNameDirectory.namesFor` reads every stamped id on the page in one projection query.
- `ConstructionPaymentMapper.toDto` receives a plain `UserNameLookup` through a MapStruct `@Context`, so the mapper does no I/O. That is required, not stylistic: `architecture/MapperDatabaseAccessTest` forbids it, and a lookup per stamp per row is what item A of #522 removed.
- `findAll` resolves once for the page; `findById`, `create` and `update` go through a private `toDto` that resolves for the single voucher.

The three things #610 settled are preserved, and each has a test:

- an account with **no employee record** resolves normally, because `findDisplayNamesByIdIn` reads the `users` row and joins nothing
- an empty name column falls back to the **email**
- a **deleted** account renders the literal `User #<id>`, so `nameOf` returning null still means "never verified" and stays distinguishable from "the account is gone"

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`; the diff is the five lines for the new field.

## Tests

New `ConstructionPaymentStampNameTest`, the counterpart to `ConstructionInvoiceStampNameTest`, using the real `ConstructionPaymentMapperImpl` so a name that came from a query inside the conversion would be caught.

Removing the mapper's `@Mapping` for `verifiedByName` and leaving everything else in place:

| Test | Without the fix |
|---|---|
| `readingOneVoucher_namesTheVerifier` | FAILED, `verifiedByName` null |
| `aVerifierWhoseAccountIsGone_stillRendersOnTheVoucher` | FAILED, no `User #43` placeholder |
| `aVerifierWithNoNameFallsBackToTheirEmail` | FAILED, no email fallback |
| `listingAPage_readsTheDirectoryOnceForEveryStampOnIt` | FAILED, every row unnamed |
| `anUnverifiedVoucherHasNoVerifierNameRatherThanAPlaceholder` | passes, since null is null either way |

Reverting the DTO field and the service wiring as well does not compile the test at all, which is the same statement in a blunter form.

Green on the lab box (`10.24.6.116`) with the mapper restored: `ConstructionPaymentStampNameTest`, `ConstructionPaymentServiceIT` (Testcontainers against CockroachDB) and the whole `architecture` suite including `MapperDatabaseAccessTest`, plus `openApiSnapshot`.

## Client side

`echno-core` needs `verifiedByName` on `ConstructionPayment` and its parser, then `echno-web` swaps `userReferenceLabel(payment.verifiedBy)` for `userStampLabel(payment.verifiedByName, payment.verifiedBy)`, the shape the invoice and stock-adjustment screens already use. Tracked on echno-web#353.
