### PR TITLE
Hold a patched project description to the same length a created one is held to

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13739,8 +13739,9 @@
             "type": "string"
           },
           "description": {
-            "description": "Free-text description of the project. At most 2000 characters.",
+            "description": "Free-text description of the project.",
             "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
+            "maxLength": 2000,
             "type": "string"
           },
           "endDate": {

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -367,7 +367,7 @@ public class ProjectService {
                     project.setProjectName((String) value);
                     break;
                 case "description":
-                    project.setDescription(trimToNull((String) value));
+                    project.setDescription(requireDescriptionWithinBound(trimToNull((String) value)));
                     break;
                 case "projectAddress":
                     project.setProjectAddress((String) value);
@@ -588,6 +588,27 @@ public class ProjectService {
                             + "one. Set the project's state (for example Tamil Nadu) and approve it "
                             + "again.");
         }
+    }
+
+    /**
+     * Holds a patched description to the same length the create payload is validated against.
+     *
+     * <p>The patch endpoint keeps its payload as a map, so no bean validation runs on it and the
+     * bound the create payload publishes would otherwise apply to creates alone: a project could
+     * be created with at most 2000 characters and then patched to any length at all. The column
+     * is TEXT and would take it, which is what makes this worth checking rather than leaving to
+     * the database. The two bounds are the same constant, so they cannot drift apart.
+     *
+     * @param description The description as patched, already trimmed, possibly null.
+     * @return The same value, when it is within the bound.
+     * @throws IllegalArgumentException if it is longer than the payload accepts.
+     */
+    private String requireDescriptionWithinBound(String description) {
+        if (description != null && description.length() > ProjectCreationDto.MAX_DESCRIPTION_LENGTH) {
+            throw new IllegalArgumentException("description must be at most "
+                    + ProjectCreationDto.MAX_DESCRIPTION_LENGTH + " characters");
+        }
+        return description;
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectCreationDto.java
@@ -18,6 +18,14 @@ import java.util.UUID;
 @Data
 public class ProjectCreationDto {
 
+    /**
+     * The longest description the API accepts. The column behind it is TEXT, so this is a policy
+     * bound rather than a storage one and can be raised without a migration. Read by
+     * {@code ProjectService} so the partial-update path holds the same line, and named on
+     * {@code ProjectUpdateFieldsDto} so the published schema says so.
+     */
+    public static final int MAX_DESCRIPTION_LENGTH = 2000;
+
     @Schema(description = "Project name.", example = "Tower B, Riverside Residences")
     @NotBlank(message = "projectName is required")
     @Size(min = 3,max = 50,message = "projectName must be between 3 and 50 characters")
@@ -25,7 +33,7 @@ public class ProjectCreationDto {
 
     @Schema(description = "Optional free-text description of the project.",
             example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
-    @Size(max = 2000, message = "description must be at most 2000 characters")
+    @Size(max = MAX_DESCRIPTION_LENGTH, message = "description must be at most 2000 characters")
     private String description;
 
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
@@ -25,7 +25,8 @@ public class ProjectUpdateFieldsDto {
     @Schema(description = "Name of the project.", example = "Marina Heights, phase 2")
     private String projectName;
 
-    @Schema(description = "Free-text description of the project. At most 2000 characters.",
+    @Schema(description = "Free-text description of the project.",
+            maxLength = ProjectCreationDto.MAX_DESCRIPTION_LENGTH,
             example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
     private String description;
 

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectDescriptionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectDescriptionTest.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -165,6 +166,24 @@ class ProjectDescriptionTest {
         Project project = updateWith(existing, singletonUpdate("description", ""));
 
         assertThat(project.getDescription()).isNull();
+    }
+
+    @Test
+    @DisplayName("partial update refuses a description past the same bound the create payload uses")
+    void partialUpdate_boundsTheDescriptionLength() {
+        // No bean validation runs on the map the patch endpoint keeps, so without this the bound
+        // would apply to creates alone and a project could be patched to any length at all.
+        assertThatThrownBy(() -> updateWith(Map.of("description", "x".repeat(2001))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("description must be at most 2000 characters");
+    }
+
+    @Test
+    @DisplayName("partial update accepts a description exactly at the bound")
+    void partialUpdate_acceptsADescriptionAtTheBound() {
+        Project project = updateWith(Map.of("description", "x".repeat(2000)));
+
+        assertThat(project.getDescription()).hasSize(2000);
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #627, which added project `description` end to end. #627 was merged while its CodeRabbit review was still open; this is the one finding from that review worth acting on, plus the enforcement gap behind it.

## What was wrong

`ProjectCreationDto` validates the description at 2000 characters. `ProjectUpdateFieldsDto` did not publish that bound, which is what the review flagged, and the reason it did not is the more interesting half: **the patch endpoint keeps its payload as a `Map`**, so no bean validation runs on it at all. The bound therefore applied to creates alone. A project could be created within 2000 characters and then patched to any length whatever, and the column is `TEXT`, so nothing downstream would have objected.

That is an asymmetry a client cannot see and cannot work around: the published schema said 2000 on one endpoint and nothing on the other, and the server enforced 2000 on one endpoint and nothing on the other.

## What this does

- The bound moves to `ProjectCreationDto.MAX_DESCRIPTION_LENGTH`, read by the payload's own `@Size` and by the service, so the create and patch limits are literally the same constant and cannot drift apart.
- `case "description"` in `ProjectService.partialUpdateAProject` now checks the length and throws `IllegalArgumentException` past it, the way the `projectLongitude` and `projectLatitude` cases already range-check their values. The case label is untouched, so `PartialUpdateSchemaContractTest` still passes.
- `ProjectUpdateFieldsDto` declares `@Schema(maxLength = ...)`, so the published schema now says 2000 on both endpoints. A `@Schema` attribute rather than `@Size`, because nothing deserializes into that class: it is the endpoint's published schema, not a binding target, and a validation annotation there would suggest an enforcement that does not live in it.

## Tests

Two new cases in `ProjectDescriptionTest`, both confirmed to fail without the service change:

- partial update refuses a description past the same bound the create payload uses &mdash; fails without the change, the over-long value being stored happily
- partial update accepts a description exactly at the bound &mdash; guards the off-by-one in the other direction

Full `./gradlew test` is green on the lab box after the rebase onto current `development` (590 MB live of the 2048 MB cap, 8 contexts cached of a maximum 8, no new context). `docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot` and verified with a plain `./gradlew openApiSnapshot`; the only change in it is `maxLength: 2000` appearing on the update schema's `description`.

## Not done, and why

The review's other finding asked for `nullable: true` on `ltc` and the two `description` fields. Declined here, for consistency rather than disagreement: the committed snapshot is OpenAPI 3.1.0 and contains **zero** occurrences of `nullable` across the whole document, so every optional field in this API is declared exactly the way these are, `minStock`, `maxStock`, `safetyStock`, `reorderLevel` and `moq` included. Annotating three fields alone would make `ltc` the odd one out among its own siblings on the same schema without changing what a generated client does with the rest. How the snapshot declares optionality is a repo-wide convention question and belongs in its own change across all schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project descriptions in partial updates are now limited to 2,000 characters.
  * Descriptions at the 2,000-character limit are accepted, while longer values are rejected with a clear validation message.

* **Documentation**
  * API documentation now displays the 2,000-character maximum for project descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->