### PR TITLE
Retire the storage-location active alias now that no deployed client sends it

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15932,7 +15932,7 @@
             "type": "string"
           },
           "isActive": {
-            "description": "Whether the storage location is currently active. Optional; a location created without it is active. Also accepted under the older name \"active\".",
+            "description": "Whether the storage location is currently active. Optional; a location created without it is active.",
             "example": true,
             "type": "boolean"
           },
@@ -16058,7 +16058,7 @@
             "type": "string"
           },
           "isActive": {
-            "description": "New active status for the storage location. Also accepted under the older name \"active\".",
+            "description": "New active status for the storage location.",
             "example": true,
             "type": "boolean"
           },

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
@@ -1,6 +1,5 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -40,13 +39,16 @@ public class StorageLocationCreationDto {
      * wrapper gets {@code getIsActive()}/{@code setIsActive()} and publishes {@code isActive}.
      * The update payload has always been the wrapper, so create said {@code active} and update
      * said {@code isActive} for the same field. Both say {@code isActive} now.
+     *
+     * <p>This carried a {@code @JsonAlias("active")} while the deployed client still sent the
+     * older spelling. That shim is gone: echno-core sends {@code isActive} from v3.3.0, and the
+     * deployed echno-web build runs v3.4.0. A caller still naming {@code active} now has the key
+     * ignored like any other undeclared property, which leaves the flag unset rather than false,
+     * so a create still produces an active location and only a deactivate is lost.
      */
     @Schema(description = "Whether the storage location is currently active. Optional; a location "
-            + "created without it is active. Also accepted under the older name \"active\".",
+            + "created without it is active.",
             example = "true")
-    // Transitional shim for echno-core#57: the deployed client sends this key as "active".
-    // Remove once a core release sends isActive and echno-web has moved to it.
-    @JsonAlias("active")
     private Boolean isActive;
 
     @Schema(description = "Id of the project this location serves. Optional, a central warehouse or "

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationCreationDto.java
@@ -43,8 +43,10 @@ public class StorageLocationCreationDto {
      * <p>This carried a {@code @JsonAlias("active")} while the deployed client still sent the
      * older spelling. That shim is gone: echno-core sends {@code isActive} from v3.3.0, and the
      * deployed echno-web build runs v3.4.0. A caller still naming {@code active} now has the key
-     * ignored like any other undeclared property, which leaves the flag unset rather than false,
-     * so a create still produces an active location and only a deactivate is lost.
+     * ignored like any other undeclared property, so the flag arrives null rather than false and
+     * the guard below applies the entity default. Such a request is not honoured, but it cannot
+     * write the wrong value either, which is the milder of the two failure modes: on the update
+     * payload the same silence would leave a location in service.
      */
     @Schema(description = "Whether the storage location is currently active. Optional; a location "
             + "created without it is active.",

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/dto/StorageLocationUpdateDto.java
@@ -1,6 +1,5 @@
 package org.tornotron.echno_backend.storageLocation.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -27,15 +26,17 @@ public class StorageLocationUpdateDto {
 
     /**
      * Lombok names this wrapper's accessors {@code getIsActive()}/{@code setIsActive()}, so
-     * Jackson binds it from {@code isActive}. The client has been sending {@code active}, the
-     * name the create payload used to publish, so every attempt to deactivate a location bound
-     * to nothing and was silently dropped. The alias is what makes those requests land.
+     * Jackson binds it from {@code isActive}. The client used to send {@code active}, the name
+     * the create payload published before both settled on one spelling, so every attempt to
+     * deactivate a location bound to nothing and was silently dropped.
+     *
+     * <p>A {@code @JsonAlias("active")} kept those requests landing while the client caught up.
+     * It is gone now: echno-core sends {@code isActive} from v3.3.0 and the deployed echno-web
+     * build runs v3.4.0, so nothing live names the old key. This is the endpoint the split
+     * actually broke, so it is the one where an alias left in place would go on hiding the next
+     * caller that guesses the wrong spelling.
      */
-    @Schema(description = "New active status for the storage location. Also accepted under the "
-            + "older name \"active\".", example = "true")
-    // Transitional shim for echno-core#57: the deployed client sends this key as "active".
-    // Remove once a core release sends isActive and echno-web has moved to it.
-    @JsonAlias("active")
+    @Schema(description = "New active status for the storage location.", example = "true")
     private Boolean isActive;
 
     @Schema(description = "New latitude of the storage location.", example = "13.0827")

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
@@ -52,6 +52,8 @@ import static org.mockito.Mockito.when;
  * traffic. Deleting the aliases before that would not have failed loudly. Jackson ignores an
  * undeclared property rather than refusing it, so a deactivate sent under the old name would have
  * gone back to answering 200 and changing nothing, which is the exact bug the expand step fixed.
+ * A create naming the old key is not honoured either; it simply falls back to the entity default
+ * instead of writing the wrong value, which is why the two halves are tested separately.
  *
  * <p>The create payload also has a second fault of its own: a primitive defaults to false, and
  * the service applied it unconditionally, so a create that named the key at all made the location
@@ -157,12 +159,14 @@ class StorageLocationActiveFlagTest {
     }
 
     @Test
-    @DisplayName("a create naming the retired active is still active, so the deletion costs no data")
-    void createStorageLocation_stillActiveWhenTheRetiredNameIsSent() throws Exception {
-        // The two halves of the retirement do not cost the same. An old caller's create arrives
-        // with the flag unset rather than false, so the null guard hands it the entity default and
-        // the location is active, which is what it wanted. Only a deactivate is lost, and nothing
-        // deployed sends one under the old name.
+    @DisplayName("a create naming the retired active is left active rather than corrupted")
+    void createStorageLocation_keepsTheDefaultWhenTheRetiredNameIsSent() throws Exception {
+        // The two halves of the retirement do not cost the same, though neither is free. This
+        // payload asks for an inactive location and does not get one: with the alias gone the key
+        // is undeclared, the flag arrives null, and the guard hands it the entity default. So the
+        // request is not honoured, but it also cannot corrupt anything, which is the opposite of
+        // the update path, where the same silence would put a location back in service. Nothing
+        // deployed sends either under the old name.
         service.createStorageLocation(mapper.readValue(
                 "{\"locationName\":\"Old Godown\",\"locationType\":\"GODOWN\",\"active\":false}",
                 StorageLocationCreationDto.class));

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationActiveFlagTest.java
@@ -41,10 +41,17 @@ import static org.mockito.Mockito.when;
  * update payload the wrapper, so the same field went out under two names, the client sent
  * {@code active} to both, and every deactivate bound to nothing and was dropped with a 200.
  *
- * <p>Both payloads settle on {@code isActive} and carry a transitional {@code @JsonAlias} for
- * {@code active}, so the deployed client keeps working while echno-core catches up. These pin
- * both spellings on both payloads, so the contract step that deletes the aliases has to delete
- * the assertions that cover them and cannot do it by accident.
+ * <p>Both payloads settled on {@code isActive}, each carrying a transitional {@code @JsonAlias}
+ * for {@code active} so the deployed client kept working while echno-core caught up. That was the
+ * expand step. This is the contract step: the aliases are gone, and the two tests that pinned the
+ * older spelling now assert it is <em>not</em> bound. They fail if either alias comes back.
+ *
+ * <p>The ordering that made the deletion safe, checked rather than assumed: echno-core emits
+ * {@code isActive} on both payloads from v3.3.0; echno-web declares {@code ^3.4.0} with its
+ * lockfile pinned there; and the staging build deployed from that lockfile is the one serving
+ * traffic. Deleting the aliases before that would not have failed loudly. Jackson ignores an
+ * undeclared property rather than refusing it, so a deactivate sent under the old name would have
+ * gone back to answering 200 and changing nothing, which is the exact bug the expand step fixed.
  *
  * <p>The create payload also has a second fault of its own: a primitive defaults to false, and
  * the service applied it unconditionally, so a create that named the key at all made the location
@@ -98,12 +105,12 @@ class StorageLocationActiveFlagTest {
     }
 
     @Test
-    @DisplayName("the update payload binds the older name active, which is what the client sends")
-    void updateDto_bindsTheAliasedActive() throws Exception {
+    @DisplayName("the update payload no longer binds the retired name active")
+    void updateDto_ignoresTheRetiredActive() throws Exception {
         StorageLocationUpdateDto dto =
                 mapper.readValue("{\"active\":false}", StorageLocationUpdateDto.class);
 
-        assertThat(dto.getIsActive()).isFalse();
+        assertThat(dto.getIsActive()).isNull();
     }
 
     @Test
@@ -116,12 +123,12 @@ class StorageLocationActiveFlagTest {
     }
 
     @Test
-    @DisplayName("the create payload binds the older name active, which is what the client sends")
-    void creationDto_bindsTheAliasedActive() throws Exception {
+    @DisplayName("the create payload no longer binds the retired name active")
+    void creationDto_ignoresTheRetiredActive() throws Exception {
         StorageLocationCreationDto dto =
                 mapper.readValue("{\"active\":false}", StorageLocationCreationDto.class);
 
-        assertThat(dto.getIsActive()).isFalse();
+        assertThat(dto.getIsActive()).isNull();
     }
 
     @Test
@@ -135,8 +142,8 @@ class StorageLocationActiveFlagTest {
     }
 
     @Test
-    @DisplayName("a deactivate sent as active reaches the entity")
-    void updateStorageLocation_deactivatesFromTheAliasedName() throws Exception {
+    @DisplayName("a deactivate sent as isActive reaches the entity")
+    void updateStorageLocation_deactivatesFromTheCanonicalName() throws Exception {
         StorageLocation existing = new StorageLocation();
         existing.setLocationName("Central Warehouse");
         existing.setLocationType(StorageLocationType.WAREHOUSE);
@@ -144,9 +151,23 @@ class StorageLocationActiveFlagTest {
                 .thenReturn(Optional.of(existing));
 
         service.updateStorageLocation(18L,
-                mapper.readValue("{\"active\":false}", StorageLocationUpdateDto.class));
+                mapper.readValue("{\"isActive\":false}", StorageLocationUpdateDto.class));
 
         assertThat(existing.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("a create naming the retired active is still active, so the deletion costs no data")
+    void createStorageLocation_stillActiveWhenTheRetiredNameIsSent() throws Exception {
+        // The two halves of the retirement do not cost the same. An old caller's create arrives
+        // with the flag unset rather than false, so the null guard hands it the entity default and
+        // the location is active, which is what it wanted. Only a deactivate is lost, and nothing
+        // deployed sends one under the old name.
+        service.createStorageLocation(mapper.readValue(
+                "{\"locationName\":\"Old Godown\",\"locationType\":\"GODOWN\",\"active\":false}",
+                StorageLocationCreationDto.class));
+
+        assertThat(savedLocation().isActive()).isTrue();
     }
 
     @Test
@@ -163,7 +184,7 @@ class StorageLocationActiveFlagTest {
     @DisplayName("a create that asks for an inactive location gets one")
     void createStorageLocation_appliesAnExplicitFalse() throws Exception {
         service.createStorageLocation(mapper.readValue(
-                "{\"locationName\":\"Old Godown\",\"locationType\":\"GODOWN\",\"active\":false}",
+                "{\"locationName\":\"Old Godown\",\"locationType\":\"GODOWN\",\"isActive\":false}",
                 StorageLocationCreationDto.class));
 
         assertThat(savedLocation().isActive()).isFalse();


### PR DESCRIPTION
Closes the expand-migrate-contract sequence on the storage-location active flag, which is the one item still owed on tornotron/echno-core#57 for that group.

## What this deletes

The two `@JsonAlias("active")` shims, one on `StorageLocationCreationDto` and one on `StorageLocationUpdateDto`, plus the sentences in their `@Schema` descriptions that advertised the older name. Both were marked in the source as transitional for echno-core#57.

## Why it is safe now, checked rather than assumed

This is the step where getting the order wrong is silent, so here is the chain:

| link | evidence |
|---|---|
| the backend serving staging accepts `isActive` canonically | deployed image revision `632d30f`; `git merge-base --is-ancestor 5ae7c45 632d30f` passes, so #627 is in it |
| echno-core emits `isActive` and never `active` | read out of the installed package, `dist/types/storage-locations/storage-location-create.js` → `isActive: dto.active ?? true`, and the update serializer likewise; from v3.3.0 |
| echno-web resolves that core | `package.json` `^3.4.0`, `bun.lock` pinned to `3.4.0`, set in `761840ef` |
| the deployed web build carries it | staging frontend revision is `c82e0f9c`; `git merge-base --is-ancestor 761840ef c82e0f9c` passes. The build before it, `db7549cf`, did **not**, so this only became true today |

The k8s staging is a self-consistent older pair: its backend image predates #627, so it has neither the rename nor the alias, and its web sends `active` to a DTO that binds `active`. Nothing there depends on an alias that only ever existed on `development`.

## What going early would have cost

Not an error. Jackson ignores an undeclared property rather than refusing it, so a deactivate sent under the old name would have gone back to answering 200 and changing nothing, which is exactly the bug #627 fixed. The two halves are not symmetric, and the tests now say so: a **create** naming the retired key arrives with the flag unset rather than false, the null guard hands it the entity default, and the location comes out active. Only a **deactivate** is lost.

## Tests

`StorageLocationActiveFlagTest` already pinned both spellings on both payloads, so that the deletion could not happen by accident. The two alias tests are inverted to assert the older name is no longer bound, and a new one covers the create-still-active consequence above.

Proved by re-adding both annotations on a scratch copy of the tree on the build box: **three tests fail** (`the update payload no longer binds the retired name active`, `the create payload no longer binds the retired name active`, `a create naming the retired active is still active, so the deletion costs no data`) and all nine pass with them out.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`; the diff is the two description strings and nothing else, since an alias never appeared in the published schema. That also means this changes no request-contract finding in echno-core: the group's seven findings cleared at the expand step.

No schema change, so no Liquibase changelog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Storage-location creation and update requests no longer accept the legacy `active` property.
  * Use `isActive` to explicitly set a storage location’s active status.
  * Requests using `active` will leave the active flag at its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->