### PR TITLE
Make a payment voucher's verification a session-stamped action, not a payload field

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3532,6 +3532,17 @@
             "format": "int64",
             "type": "integer"
           },
+          "raisedBy": {
+            "description": "User id that raised the voucher, taken from the session that created it. Null on vouchers raised before the voucher recorded this.",
+            "example": 8,
+            "format": "int64",
+            "type": "integer"
+          },
+          "raisedByName": {
+            "description": "Name of the user that raised the voucher, on the same fallbacks as the verifier name. Null only where the voucher does not record who raised it.",
+            "example": "Hrishi",
+            "type": "string"
+          },
           "referenceNumber": {
             "description": "Cheque or reference number for the payment.",
             "example": "CHQ-000123",
@@ -3547,7 +3558,7 @@
               "CANCELLED",
               "REFUNDED"
             ],
-            "example": "VERIFIED",
+            "example": "COMPLETED",
             "type": "string"
           },
           "subContractId": {
@@ -3587,7 +3598,7 @@
             "type": "string"
           },
           "verifiedBy": {
-            "description": "User id that verified the voucher.",
+            "description": "User id that verified the voucher, taken from the session that verified it.",
             "example": 2,
             "format": "int64",
             "type": "integer"
@@ -3893,7 +3904,7 @@
         "type": "object"
       },
       "CreateConstructionPaymentRequest": {
-        "description": "Payload to create a construction payment voucher. The status is not accepted here: a new voucher always starts pending, and the payment number is generated server side.",
+        "description": "Payload to create a construction payment voucher. The status is not accepted here: a new voucher always starts pending, and the payment number is generated server side. Nor is the verification stamp, which is written only by the verify action, from the session and the clock.",
         "properties": {
           "accountNumber": {
             "description": "Bank account number used for the payment.",
@@ -4063,18 +4074,6 @@
           "vendorId": {
             "description": "Vendor being paid, when the payee is a vendor.",
             "example": 17,
-            "format": "int64",
-            "type": "integer"
-          },
-          "verifiedAt": {
-            "description": "Timestamp the voucher was verified, if already verified.",
-            "example": "2026-08-06T10:20:00Z",
-            "format": "date-time",
-            "type": "string"
-          },
-          "verifiedBy": {
-            "description": "User id that verified the voucher, if already verified.",
-            "example": 2,
             "format": "int64",
             "type": "integer"
           }
@@ -17429,7 +17428,7 @@
         "type": "object"
       },
       "UpdateConstructionPaymentRequest": {
-        "description": "Payload to fully replace an editable construction payment voucher. The status is set directly, and no ledger journal entry is created on any status transition.",
+        "description": "Payload to fully replace an editable construction payment voucher. The status is set directly, and no ledger journal entry is created on any status transition. The verification stamp is not replaced here: only the verify action writes it, from the session and the clock.",
         "properties": {
           "accountNumber": {
             "description": "Bank account number used for the payment.",
@@ -17580,7 +17579,7 @@
               "CANCELLED",
               "REFUNDED"
             ],
-            "example": "VERIFIED",
+            "example": "COMPLETED",
             "type": "string"
           },
           "subContractId": {
@@ -17612,18 +17611,6 @@
           "vendorId": {
             "description": "Vendor being paid, when the payee is a vendor.",
             "example": 17,
-            "format": "int64",
-            "type": "integer"
-          },
-          "verifiedAt": {
-            "description": "Timestamp the voucher was verified.",
-            "example": "2026-08-06T10:20:00Z",
-            "format": "date-time",
-            "type": "string"
-          },
-          "verifiedBy": {
-            "description": "User id that verified the voucher.",
-            "example": 2,
             "format": "int64",
             "type": "integer"
           }
@@ -38346,6 +38333,119 @@
           }
         },
         "summary": "Update a construction payment voucher",
+        "tags": [
+          "Construction Payments"
+        ]
+      }
+    },
+    "/api/v1/finance/construction-payments/web/{id}/verify": {
+      "post": {
+        "description": "Records that the voucher has been checked. The verifier is the signed-in user and the time is the server clock; neither can be supplied, so a voucher cannot be recorded as verified by somebody who did not verify it. Whoever raised the voucher cannot verify it, and a verification already recorded is not replaced.",
+        "operationId": "verify_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConstructionPaymentDto"
+                }
+              }
+            },
+            "description": "Voucher verified, and returned naming the verifier"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "The voucher is cancelled, already verified, or is being verified by whoever raised it"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No voucher with the given id in the current tenant"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Verify a construction payment voucher",
         "tags": [
           "Construction Payments"
         ]
@@ -105324,7 +105424,7 @@
       "name": "Construction Invoices"
     },
     {
-      "description": "Payment vouchers recording money paid out on construction projects to vendors, subcontractors, labour and employees. A voucher captures the amount, method and payee details and moves through a pending and verified lifecycle. This increment does not post ledger journal entries. All endpoints are tenant scoped and limited to system administrators and project managers.",
+      "description": "Payment vouchers recording money paid out on construction projects to vendors, subcontractors, labour and employees. A voucher captures the amount, method and payee details and moves through a pending and verified lifecycle. Verification is its own action, stamped from the session, and is not part of the update payload. This increment does not post ledger journal entries. All endpoints are tenant scoped and limited to system administrators and project managers.",
       "name": "Construction Payments"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
@@ -119,6 +119,16 @@ public class ConstructionPayment extends BaseEntity implements TenantScopedEntit
     @Column(name = "ifsc_code", length = 20)
     private String ifscCode;
 
+    // Who raised the voucher and who verified it, both platform user ids stamped from the
+    // session by the service (no cross-module FK, matching the submittedBy/approvedBy
+    // convention on ConstructionInvoice). raisedBy exists so the verification has a raiser
+    // to be compared against: without it the segregation-of-duties rule has nothing to read,
+    // and created_by holds an auditing string rather than an id. Vouchers written before this
+    // column carry a null and are verified without the comparison, which SelfApprovalPolicy
+    // logs.
+    @Column(name = "raised_by")
+    private Long raisedBy;
+
     @Column(name = "verified_by")
     private Long verifiedBy;
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -23,7 +23,7 @@ public record ConstructionPaymentDto(
         @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         ConstructionPaymentType type,
 
-        @Schema(description = "Lifecycle status of the voucher.", example = "VERIFIED")
+        @Schema(description = "Lifecycle status of the voucher.", example = "COMPLETED")
         ConstructionPaymentVoucherStatus status,
 
         @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
@@ -84,7 +84,17 @@ public record ConstructionPaymentDto(
         @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         String ifscCode,
 
-        @Schema(description = "User id that verified the voucher.", example = "2")
+        @Schema(description = "User id that raised the voucher, taken from the session that created "
+                + "it. Null on vouchers raised before the voucher recorded this.", example = "8")
+        Long raisedBy,
+
+        @Schema(description = "Name of the user that raised the voucher, on the same fallbacks as "
+                + "the verifier name. Null only where the voucher does not record who raised it.",
+                example = "Hrishi")
+        String raisedByName,
+
+        @Schema(description = "User id that verified the voucher, taken from the session that "
+                + "verified it.", example = "2")
         Long verifiedBy,
 
         @Schema(description = "Name of the user that verified the voucher, or their email where the "

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CreateConstructionPaymentRequest.java
@@ -7,7 +7,6 @@ import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMetho
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -15,9 +14,15 @@ import java.util.UUID;
  * Creates a construction payment voucher. The status is not accepted here: a new
  * voucher always starts PENDING (no ledger posting in this increment). The payment
  * number is generated server-side with the CPMT sequence.
+ *
+ * <p>Neither is the verification stamp. A voucher is verified through the verify action,
+ * which takes the verifier from the session and the time from the clock; a payload that
+ * could name the verifier would let whoever raised the voucher record somebody else as
+ * having checked it.
  */
 @Schema(description = "Payload to create a construction payment voucher. The status is not accepted here: "
-        + "a new voucher always starts pending, and the payment number is generated server side.")
+        + "a new voucher always starts pending, and the payment number is generated server side. Nor is the "
+        + "verification stamp, which is written only by the verify action, from the session and the clock.")
 public record CreateConstructionPaymentRequest(
         @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         @NotNull ConstructionPaymentType type,
@@ -79,12 +84,6 @@ public record CreateConstructionPaymentRequest(
 
         @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         @Size(max = 20) String ifscCode,
-
-        @Schema(description = "User id that verified the voucher, if already verified.", example = "2")
-        Long verifiedBy,
-
-        @Schema(description = "Timestamp the voucher was verified, if already verified.", example = "2026-08-06T10:20:00Z")
-        Instant verifiedAt,
 
         @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         @Size(max = 1000) String description,

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/UpdateConstructionPaymentRequest.java
@@ -8,7 +8,6 @@ import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -16,14 +15,19 @@ import java.util.UUID;
  * Full replacement of an editable construction payment voucher. The status is set
  * directly (no ledger posting in this increment); no JournalEntry is created on any
  * status transition.
+ *
+ * <p>The verification stamp is not part of the replacement. It is written only by the verify
+ * action, which reads the verifier from the session, so an edit can neither name a verifier
+ * nor clear one that a verification actually recorded.
  */
 @Schema(description = "Payload to fully replace an editable construction payment voucher. The status is "
-        + "set directly, and no ledger journal entry is created on any status transition.")
+        + "set directly, and no ledger journal entry is created on any status transition. The verification "
+        + "stamp is not replaced here: only the verify action writes it, from the session and the clock.")
 public record UpdateConstructionPaymentRequest(
         @Schema(description = "Kind of payment.", example = "VENDOR_PAYMENT")
         @NotNull ConstructionPaymentType type,
 
-        @Schema(description = "Lifecycle status to set on the voucher.", example = "VERIFIED")
+        @Schema(description = "Lifecycle status to set on the voucher.", example = "COMPLETED")
         @NotNull ConstructionPaymentVoucherStatus status,
 
         @Schema(description = "Method used to settle the payment.", example = "BANK_TRANSFER")
@@ -83,12 +87,6 @@ public record UpdateConstructionPaymentRequest(
 
         @Schema(description = "IFSC code of the paying bank branch.", example = "HDFC0001234")
         @Size(max = 20) String ifscCode,
-
-        @Schema(description = "User id that verified the voucher.", example = "2")
-        Long verifiedBy,
-
-        @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
-        Instant verifiedAt,
 
         @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         @Size(max = 1000) String description,

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/mapper/ConstructionPaymentMapper.java
@@ -10,8 +10,8 @@ import org.tornotron.echno_backend.user.UserNameLookup;
 /**
  * Maps {@link ConstructionPayment} to its DTO.
  *
- * <p>The voucher records who verified it as a user id and nothing else, so the name comes from the
- * {@link UserNameLookup} the caller hands in rather than from the payment. That is the shape
+ * <p>The voucher records who raised and who verified it as user ids and nothing else, so both names
+ * come from the {@link UserNameLookup} the caller hands in rather than from the payment. That is the shape
  * {@code ConstructionInvoiceMapper} and {@code StockAdjustmentMapper} already use, and
  * {@code MapperDatabaseAccessTest} enforces: whatever a mapper cannot reach from the object it was
  * given, the caller reads once for the whole page and passes in.
@@ -24,12 +24,13 @@ import org.tornotron.echno_backend.user.UserNameLookup;
 public interface ConstructionPaymentMapper {
 
     /**
-     * Converts a payment voucher, taking its verifier name from the supplied lookup.
+     * Converts a payment voucher, taking its raiser and verifier names from the supplied lookup.
      *
      * @param payment The payment to convert.
      * @param names The names read for every user id on the set of payments being mapped.
      * @return The payment DTO.
      */
+    @Mapping(target = "raisedByName", expression = "java(names.nameOf(payment.getRaisedBy()))")
     @Mapping(target = "verifiedByName", expression = "java(names.nameOf(payment.getVerifiedBy()))")
     ConstructionPaymentDto toDto(ConstructionPayment payment, @Context UserNameLookup names);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.configuration.MoneyUtils;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
@@ -21,18 +23,25 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionP
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentSpecifications;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 import org.tornotron.echno_backend.user.UserNameLookup;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
- * CRUD + list for construction payment vouchers. This increment deliberately does
- * NO ledger or journal posting: the status is set directly and no JournalEntry is
+ * CRUD + list + verification for construction payment vouchers. This increment deliberately
+ * does NO ledger or journal posting: the status is set directly and no JournalEntry is
  * created. A later increment will add the ledger-posting hooks (post the cash/bank
  * and payable movement on completion, reverse on cancel/refund).
+ *
+ * <p>Who raised a voucher and who verified it are both read from the session, never from a
+ * payload. {@link #verify} is the only writer of the verification stamp, and {@link #update}
+ * cannot reach it.
  */
 @Slf4j
 @Service
@@ -47,6 +56,8 @@ public class ConstructionPaymentService {
     private final ConstructionPaymentMapper mapper;
     private final TenantEntityHelper tenantEntityHelper;
     private final UserNameDirectory userNameDirectory;
+    private final UserContextService userContextService;
+    private final SelfApprovalPolicy selfApprovalPolicy;
 
     @Transactional(readOnly = true)
     public ConstructionPaymentDto findById(UUID id) {
@@ -94,8 +105,7 @@ public class ConstructionPaymentService {
         payment.setBankName(req.bankName());
         payment.setAccountNumber(req.accountNumber());
         payment.setIfscCode(req.ifscCode());
-        payment.setVerifiedBy(req.verifiedBy());
-        payment.setVerifiedAt(req.verifiedAt());
+        payment.setRaisedBy(userContextService.getCurrentUserId());
         payment.setDescription(req.description());
         payment.setNotes(req.notes());
         payment.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
@@ -138,12 +148,64 @@ public class ConstructionPaymentService {
         payment.setBankName(req.bankName());
         payment.setAccountNumber(req.accountNumber());
         payment.setIfscCode(req.ifscCode());
-        payment.setVerifiedBy(req.verifiedBy());
-        payment.setVerifiedAt(req.verifiedAt());
         payment.setDescription(req.description());
         payment.setNotes(req.notes());
 
         log.info("Updated construction payment {}", payment.getPaymentNumber());
+        return toDto(payment);
+    }
+
+    /**
+     * Records that the voucher has been verified, stamping the verifier from the session and the
+     * time from the clock.
+     *
+     * <p>This is an action rather than a pair of editable fields for the reason every attribution
+     * stamp on this codebase became session-derived: a stamp a caller can write is a statement
+     * about someone else that nobody made. On a payment voucher it is wrong twice over, because
+     * the record would name a person who never checked the payment and would say so silently.
+     * {@link #update} therefore cannot reach these two columns at all.
+     *
+     * <p>Verification is refused where there is nothing left to verify: a cancelled voucher, and a
+     * voucher already verified. Re-verifying is not an idempotent no-op, it would overwrite a
+     * stamp somebody else's check produced, so it is refused and the existing stamp stands. There
+     * is deliberately no action to clear a verification: an unverify would be the same silent
+     * rewrite of the audit trail from the other direction, and nothing has asked for one.
+     *
+     * <p>Whoever raised the voucher cannot verify it, on the rule every other second-pair-of-eyes
+     * check here follows: see {@link SelfApprovalPolicy}. A voucher raised before the raiser was
+     * stamped carries no id to compare, and the policy allows that verification through at WARN
+     * rather than stranding it.
+     *
+     * @param id The voucher to verify.
+     * @return The verified voucher, naming the verifier.
+     */
+    @Transactional
+    public ConstructionPaymentDto verify(UUID id) {
+        ConstructionPayment payment = paymentRepo.findByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction payment with ID " + id + " was not found"));
+
+        if (payment.getStatus() == ConstructionPaymentVoucherStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber()
+                            + " is cancelled and cannot be verified");
+        }
+        if (payment.getVerifiedAt() != null) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber()
+                            + " has already been verified, and a verification cannot be replaced");
+        }
+
+        Long verifier = userContextService.getCurrentUserId();
+        selfApprovalPolicy.checkSelfApproval(
+                ApprovalParty.ofUser(payment.getRaisedBy()),
+                ApprovalParty.ofUser(verifier),
+                "Construction payment " + payment.getPaymentNumber());
+
+        payment.setVerifiedBy(verifier);
+        payment.setVerifiedAt(Instant.now());
+
+        log.info("Verified construction payment {}", payment.getPaymentNumber());
         return toDto(payment);
     }
 
@@ -162,19 +224,21 @@ public class ConstructionPaymentService {
     }
 
     /**
-     * Reads the display name for every verifier stamp on the vouchers about to be mapped.
+     * Reads the display name for every raiser and verifier stamp on the vouchers about to be mapped.
      *
-     * <p>One call covers a whole page, so the query count does not follow the row count. The
-     * mapper cannot do this for itself: the voucher holds only the user id, and a lookup inside
-     * the conversion would cost a round trip per row with nothing at the call site to show it,
-     * which is what {@code MapperDatabaseAccessTest} exists to prevent.
+     * <p>One call covers a whole page and both stamps, so the query count follows neither the row
+     * count nor the number of stamps per row. The mapper cannot do this for itself: the voucher
+     * holds only the user ids, and a lookup inside the conversion would cost a round trip per row
+     * with nothing at the call site to show it, which is what {@code MapperDatabaseAccessTest}
+     * exists to prevent.
      *
      * @param payments The payments being converted.
-     * @return Their verifier names, with an id that no longer resolves reading as a placeholder.
+     * @return Their raiser and verifier names, with an id that no longer resolves reading as a
+     *         placeholder.
      */
     private UserNameLookup namesFor(Collection<ConstructionPayment> payments) {
         return userNameDirectory.namesFor(payments.stream()
-                .map(ConstructionPayment::getVerifiedBy)
+                .flatMap(payment -> Stream.of(payment.getRaisedBy(), payment.getVerifiedBy()))
                 .toList());
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -159,11 +159,14 @@ public class ConstructionPaymentService {
      * Records that the voucher has been verified, stamping the verifier from the session and the
      * time from the clock.
      *
-     * <p>This is an action rather than a pair of editable fields for the reason every attribution
-     * stamp on this codebase became session-derived: a stamp a caller can write is a statement
-     * about someone else that nobody made. On a payment voucher it is wrong twice over, because
-     * the record would name a person who never checked the payment and would say so silently.
-     * {@link #update} therefore cannot reach these two columns at all.
+     * <p>This is an action rather than a pair of editable fields for the reason the attribution
+     * stamps in this module are session-derived: a stamp a caller can write is a statement about
+     * someone else that nobody made. On a payment voucher it is wrong twice over, because the
+     * record would name a person who never checked the payment and would say so silently.
+     * {@link #update} therefore cannot reach these two columns at all. The one instance of the
+     * same shape still outstanding is
+     * {@code MovementRecordService.verifyMovement}, which takes its verifier from a request
+     * parameter.
      *
      * <p>Verification is refused where there is nothing left to verify: a cancelled voucher, and a
      * voucher already verified. Re-verifying is not an idempotent no-op, it would overwrite a

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -29,9 +29,10 @@ import java.util.UUID;
         name = "Construction Payments",
         description = "Payment vouchers recording money paid out on construction projects to vendors, "
                 + "subcontractors, labour and employees. A voucher captures the amount, method and payee "
-                + "details and moves through a pending and verified lifecycle. This increment does not post "
-                + "ledger journal entries. All endpoints are tenant scoped and limited to system "
-                + "administrators and project managers."
+                + "details and moves through a pending and verified lifecycle. Verification is its own "
+                + "action, stamped from the session, and is not part of the update payload. This increment "
+                + "does not post ledger journal entries. All endpoints are tenant scoped and limited to "
+                + "system administrators and project managers."
 )
 public class ConstructionPaymentControllerWeb {
 
@@ -105,5 +106,25 @@ public class ConstructionPaymentControllerWeb {
     public ConstructionPaymentDto update(@PathVariable UUID id,
                                          @Valid @RequestBody UpdateConstructionPaymentRequest req) {
         return service.update(id, req);
+    }
+
+    @PostMapping("/{id}/verify")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Verify a construction payment voucher",
+            description = "Records that the voucher has been checked. The verifier is the signed-in user "
+                    + "and the time is the server clock; neither can be supplied, so a voucher cannot be "
+                    + "recorded as verified by somebody who did not verify it. Whoever raised the voucher "
+                    + "cannot verify it, and a verification already recorded is not replaced."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Voucher verified, and returned naming the verifier"),
+            @ApiResponse(responseCode = "400", description = "The voucher is cancelled, already verified, "
+                    + "or is being verified by whoever raised it"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No voucher with the given id in the current tenant")
+    })
+    public ConstructionPaymentDto verify(@PathVariable UUID id) {
+        return service.verify(id);
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -373,4 +373,7 @@
     <!-- v4.0 - NCRs: index the people columns the listing can now be filtered on -->
     <include file="db/changelog/v4.0/079-index-ncr-people-columns.xml"/>
 
+    <!-- v4.0 - Payment vouchers: record the raiser, so a verification has someone to be compared against -->
+    <include file="db/changelog/v4.0/080-add-construction-payment-raised-by.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/080-add-construction-payment-raised-by.xml
+++ b/src/main/resources/db/changelog/v4.0/080-add-construction-payment-raised-by.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="080-add-construction-payment-raised-by" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="construction_payments" columnName="raised_by"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Record the platform user id of whoever raised a payment voucher, next to the verified_by
+            id the voucher already stores. Verification is the second pair of eyes on money paid out,
+            so it has to come from someone other than whoever raised the voucher, and until now there
+            was nothing on the row to compare a verifier against: created_by holds the auditing
+            string, not a user id, and the two cannot be matched. Vouchers written before this column
+            exists keep a null here and are verified without the comparison, which the self-approval
+            rule logs rather than passing silently.
+        </comment>
+
+        <addColumn tableName="construction_payments">
+            <column name="raised_by" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -12,10 +12,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.configuration.JpaAuditingConfig;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -25,26 +28,36 @@ import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionP
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
 import org.tornotron.echno_backend.finance.construction.service.ConstructionPaymentService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
 
 /**
  * End-to-end exercise of the construction payment CRUD path against a real
  * CockroachDB: create stores the voucher and generates a CPMT number, get and list
  * return it, update replaces its fields and sets the status directly, and the org
  * filter keeps one tenant's payments invisible to another.
+ *
+ * <p>The verification stamp is exercised here as well as in the unit tests, because it is the
+ * half that depends on the schema: the raiser id the self-approval comparison reads is a column
+ * added by changelog 080, and a migration that had not run would leave the rule with nothing to
+ * compare while every mocked test still passed.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({ConstructionPaymentService.class, ConstructionPaymentMapperImpl.class,
         TenantEntityHelper.class, EntryNumberGenerator.class, JpaAuditingConfig.class,
+        SelfApprovalPolicy.class,
         org.tornotron.echno_backend.user.UserNameDirectory.class})
 class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
 
@@ -54,11 +67,20 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
     @Autowired
     private ConstructionPaymentRepository paymentRepo;
 
+    @MockitoBean
+    private UserContextService userContextService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
     @PersistenceContext
     private EntityManager entityManager;
 
     @Autowired
     private PlatformTransactionManager txManager;
+
+    private static final long RAISER = 7L;
+    private static final long VERIFIER = 8L;
 
     private Long orgAId;
     private Long orgBId;
@@ -121,6 +143,7 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
 
     @Test
     void create_get_list_update_persistsVoucherAndScopesByTenant() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
         CreateConstructionPaymentRequest createReq = new CreateConstructionPaymentRequest(
                 ConstructionPaymentType.INVOICE,
                 ConstructionPaymentMethod.BANK_TRANSFER,
@@ -134,7 +157,6 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
                 "INR",
                 LocalDate.of(2026, 8, 1),
                 "TXN-0001", "REF-0001", "State Bank", "0001112223", "SBIN0000001",
-                7L, null,
                 "First running payment", "Approved by PM"
         );
 
@@ -192,7 +214,6 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
                 "INR",
                 LocalDate.of(2026, 8, 2),
                 "TXN-0002", "REF-0002", "State Bank", "0001112223", "SBIN0000001",
-                7L, null,
                 "Revised running payment", "Settled"
         );
 
@@ -201,6 +222,67 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
         assertThat(updated.method()).isEqualTo(ConstructionPaymentMethod.UPI);
         assertThat(updated.amount()).isEqualByComparingTo(bd("16000"));
         assertThat(updated.paymentDate()).isEqualTo(LocalDate.of(2026, 8, 2));
+    }
+
+    @Test
+    void verify_stampsTheSessionAgainstThePersistedRaiser_andRefusesASecondVerification() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        ConstructionPaymentDto created = service.create(minimalCreateRequest());
+        assertThat(created.raisedBy()).isEqualTo(RAISER);
+        assertThat(created.verifiedBy()).isNull();
+        assertThat(created.verifiedAt()).isNull();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // The raiser is read back from the column, not from the object create left behind.
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+        ConstructionPaymentDto verified = service.verify(created.id());
+        assertThat(verified.verifiedBy()).isEqualTo(VERIFIER);
+        assertThat(verified.verifiedAt()).isNotNull();
+        assertThat(verified.raisedBy()).isEqualTo(RAISER);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(created.id()))
+                .withMessageContaining("already been verified");
+    }
+
+    @Test
+    void verify_refusesTheRaiserOfTheVoucher() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+        ConstructionPaymentDto created = service.create(minimalCreateRequest());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(created.id()))
+                .withMessageContaining("raised by the same person");
+
+        assertThat(service.findById(created.id()).verifiedAt()).isNull();
+    }
+
+    private CreateConstructionPaymentRequest minimalCreateRequest() {
+        return new CreateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                ConstructionPaymentMethod.BANK_TRANSFER,
+                ConstructionPayeeType.VENDOR,
+                projectId,
+                null, null,
+                42L,
+                null, null, null,
+                "Acme Supplies", null,
+                bd("1000"),
+                "INR",
+                LocalDate.of(2026, 8, 1),
+                null, null, null, null, null,
+                "Running payment", null
+        );
     }
 
     private void enableOrgFilter(Long orgId) {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
@@ -18,6 +19,7 @@ import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPayment
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
 import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
 import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserDisplayName;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 import org.tornotron.echno_backend.user.UserNameLookup;
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.when;
 class ConstructionPaymentStampNameTest {
 
     private static final long ORG_ID = 9L;
+    private static final long RAISER = 40L;
     private static final long VERIFIER = 41L;
     private static final long NAMELESS_VERIFIER = 42L;
     private static final long DELETED_USER = 43L;
@@ -55,6 +58,8 @@ class ConstructionPaymentStampNameTest {
     @Mock private EntryNumberGenerator numberGen;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private UserContextService userContextService;
+    @Mock private SelfApprovalPolicy selfApprovalPolicy;
 
     private final ConstructionPaymentMapper mapper = new ConstructionPaymentMapperImpl();
 
@@ -64,7 +69,7 @@ class ConstructionPaymentStampNameTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG_ID);
         service = new ConstructionPaymentService(paymentRepo, numberGen, mapper, tenantEntityHelper,
-                userNameDirectory);
+                userNameDirectory, userContextService, selfApprovalPolicy);
     }
 
     @AfterEach
@@ -139,6 +144,25 @@ class ConstructionPaymentStampNameTest {
         assertThat(asked.getValue()).contains(VERIFIER, DELETED_USER);
         assertThat(dtos).extracting(ConstructionPaymentDto::verifiedByName)
                 .containsExactly("Aneesh Johny", null, "User #" + DELETED_USER);
+    }
+
+    @Test
+    void aVoucherAlsoNamesWhoRaisedIt_fromTheSameSingleRead() {
+        UUID id = UUID.randomUUID();
+        ConstructionPayment payment = payment(id, VERIFIER);
+        payment.setRaisedBy(RAISER);
+        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment));
+        when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.of(List.of(
+                new UserDisplayName(VERIFIER, "Aneesh Johny", "aneesh@echno.test"),
+                new UserDisplayName(RAISER, "Hrishi", "hrishi@echno.test"))));
+
+        ConstructionPaymentDto dto = service.findById(id);
+
+        ArgumentCaptor<Collection<Long>> asked = ArgumentCaptor.captor();
+        verify(userNameDirectory, times(1)).namesFor(asked.capture());
+        assertThat(asked.getValue()).contains(RAISER, VERIFIER);
+        assertThat(dto.raisedByName()).isEqualTo("Hrishi");
+        assertThat(dto.verifiedByName()).isEqualTo("Aneesh Johny");
     }
 
     private ConstructionPayment payment(UUID id, Long verifiedBy) {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentVerifyActionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentVerifyActionTest.java
@@ -1,0 +1,216 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * The verify action: who a verification records, and when it is refused.
+ *
+ * <p>Verification of a payment voucher is a transition, not an attribute, which is why it is an
+ * action rather than a pair of fields on the update payload. The stamp it writes names the session
+ * and nothing else, so a caller cannot record a colleague as having checked a payment they never
+ * saw, and cannot backdate the check either.
+ *
+ * <p>The self-approval rule is the real policy rather than a mock, because what is being pinned is
+ * the outcome of the comparison, not that a call was made. Segregation of duties applies here for
+ * the reason it applies to an approval: the verification is the second pair of eyes on money that
+ * has gone out, and the role gate does not supply it, since whoever may verify may also raise.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionPaymentVerifyActionTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long RAISER = 51L;
+    private static final long VERIFIER = 52L;
+
+    @Mock private ConstructionPaymentRepository paymentRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private UserNameDirectory userNameDirectory;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private final ConstructionPaymentMapper mapper = new ConstructionPaymentMapperImpl();
+
+    private ConstructionPaymentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionPaymentService(paymentRepo, numberGen, mapper, tenantEntityHelper,
+                userNameDirectory, userContextService, new SelfApprovalPolicy(orgSecurity));
+        lenient().when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.none());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void verifying_stampsTheSessionUserAndTheClock() {
+        ConstructionPayment payment = pending();
+        Instant before = Instant.now();
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+
+        service.verify(payment.getId());
+
+        assertThat(payment.getVerifiedBy()).isEqualTo(VERIFIER);
+        assertThat(payment.getVerifiedAt()).isNotNull().isAfterOrEqualTo(before);
+    }
+
+    @Test
+    void anUpdateCannotWriteTheStamp_soAVerifiedVoucherSurvivesAnEdit() {
+        ConstructionPayment payment = pending();
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+        service.verify(payment.getId());
+
+        Long stampedBy = payment.getVerifiedBy();
+        Instant stampedAt = payment.getVerifiedAt();
+
+        service.update(payment.getId(), anEdit());
+
+        assertThat(payment.getVerifiedBy()).isEqualTo(stampedBy);
+        assertThat(payment.getVerifiedAt()).isEqualTo(stampedAt);
+    }
+
+    @Test
+    void theRaiserCannotVerifyTheirOwnVoucher() {
+        ConstructionPayment payment = pending();
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(payment.getId()))
+                .withMessageContaining("raised by the same person");
+
+        assertThat(payment.getVerifiedBy()).isNull();
+        assertThat(payment.getVerifiedAt()).isNull();
+    }
+
+    @Test
+    void aSystemAdministratorMayVerifyTheirOwnVoucher_asTheRecordedException() {
+        ConstructionPayment payment = pending();
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+
+        service.verify(payment.getId());
+
+        assertThat(payment.getVerifiedBy()).isEqualTo(RAISER);
+    }
+
+    @Test
+    void aSessionThatResolvesToNoUser_isRefusedRatherThanStampingNobody() {
+        ConstructionPayment payment = pending();
+        when(userContextService.getCurrentUserId()).thenReturn(null);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(payment.getId()))
+                .withMessageContaining("resolves to no user");
+
+        assertThat(payment.getVerifiedBy()).isNull();
+    }
+
+    @Test
+    void aVoucherRaisedBeforeTheRaiserWasRecorded_isStillVerifiable() {
+        ConstructionPayment payment = pending();
+        payment.setRaisedBy(null);
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+
+        service.verify(payment.getId());
+
+        assertThat(payment.getVerifiedBy()).isEqualTo(VERIFIER);
+    }
+
+    @Test
+    void aVerificationAlreadyRecorded_isNotReplaced() {
+        ConstructionPayment payment = pending();
+        Instant original = Instant.parse("2026-08-06T10:20:00Z");
+        payment.setVerifiedBy(VERIFIER);
+        payment.setVerifiedAt(original);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(payment.getId()))
+                .withMessageContaining("already been verified");
+
+        assertThat(payment.getVerifiedBy()).isEqualTo(VERIFIER);
+        assertThat(payment.getVerifiedAt()).isEqualTo(original);
+    }
+
+    @Test
+    void aCancelledVoucherCannotBeVerified() {
+        ConstructionPayment payment = pending();
+        payment.setStatus(ConstructionPaymentVoucherStatus.CANCELLED);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.verify(payment.getId()))
+                .withMessageContaining("cancelled");
+
+        assertThat(payment.getVerifiedAt()).isNull();
+    }
+
+    /** An ordinary edit of the voucher: every field the update payload still carries. */
+    private UpdateConstructionPaymentRequest anEdit() {
+        return new UpdateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                ConstructionPaymentVoucherStatus.COMPLETED,
+                ConstructionPaymentMethod.UPI,
+                ConstructionPayeeType.VENDOR,
+                42L,
+                null, null, 17L, null, null, null,
+                "Acme Supplies", null,
+                new BigDecimal("16000"),
+                "INR",
+                LocalDate.of(2026, 8, 2),
+                null, null, null, null, null,
+                "Revised running payment", "Settled");
+    }
+
+    /** A pending voucher raised by {@link #RAISER}, already registered with the repository stub. */
+    private ConstructionPayment pending() {
+        UUID id = UUID.randomUUID();
+        ConstructionPayment payment = new ConstructionPayment();
+        payment.setId(id);
+        payment.setPaymentNumber("CPMT-2026-0031");
+        payment.setStatus(ConstructionPaymentVoucherStatus.PENDING);
+        payment.setRaisedBy(RAISER);
+        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment));
+        return payment;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentVerificationStampTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentVerificationStampTest.java
@@ -1,0 +1,169 @@
+package org.tornotron.echno_backend.finance.construction.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionPaymentService;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pins that the verification stamp cannot be written from a request body.
+ *
+ * <p>The bug this covers was not that the stamp was validated loosely, it was that it was bound at
+ * all: {@code verifiedBy} and {@code verifiedAt} were fields on the create and update payloads and
+ * were copied onto the voucher as sent, so any caller who could edit a voucher could record that a
+ * named colleague had checked a payment, at a time of their choosing. The test therefore posts the
+ * two fields on the wire, the way the defect was reachable, and asserts that nothing the controller
+ * hands the service carries them. Reading the bound request as JSON rather than calling an accessor
+ * is deliberate: an accessor would only compile against the payload that no longer has the field,
+ * so the test would pass by not existing rather than by the fix.
+ *
+ * <p>The counterpart to {@code ConstructionPaymentVerifyActionTest}, which covers the action that
+ * replaced the fields.
+ */
+@WebMvcTest(ConstructionPaymentControllerWeb.class)
+@Import(ConstructionPaymentVerificationStampTest.TestSecurityConfig.class)
+class ConstructionPaymentVerificationStampTest {
+
+    private static final String CREATE_BODY = """
+            {
+              "type": "INVOICE",
+              "method": "BANK_TRANSFER",
+              "projectId": 42,
+              "amount": 15000.50,
+              "paymentDate": "2026-08-05",
+              "verifiedBy": 999,
+              "verifiedAt": "2020-01-01T00:00:00Z"
+            }
+            """;
+
+    private static final String UPDATE_BODY = """
+            {
+              "type": "INVOICE",
+              "status": "COMPLETED",
+              "method": "BANK_TRANSFER",
+              "projectId": 42,
+              "amount": 15000.50,
+              "paymentDate": "2026-08-05",
+              "verifiedBy": 999,
+              "verifiedAt": "2020-01-01T00:00:00Z"
+            }
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ConstructionPaymentService service;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @Test
+    void aCreateBodyNamingAVerifier_reachesTheServiceCarryingNoVerificationStamp() throws Exception {
+        allowElevatedRole();
+
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<CreateConstructionPaymentRequest> bound = ArgumentCaptor.captor();
+        verify(service).create(bound.capture());
+        assertThat(fieldsOf(bound.getValue()))
+                .doesNotContainKeys("verifiedBy", "verifiedAt")
+                .containsKeys("projectId", "amount", "paymentDate");
+    }
+
+    @Test
+    void anUpdateBodyNamingAVerifier_reachesTheServiceCarryingNoVerificationStamp() throws Exception {
+        allowElevatedRole();
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(put("/api/v1/finance/construction-payments/web/{id}", id)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<UpdateConstructionPaymentRequest> bound = ArgumentCaptor.captor();
+        verify(service).update(eq(id), bound.capture());
+        assertThat(fieldsOf(bound.getValue()))
+                .doesNotContainKeys("verifiedBy", "verifiedAt")
+                .containsEntry("status", "COMPLETED");
+    }
+
+    @Test
+    void verify_isTheActionThatWritesTheStamp_andIsRoleGated() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
+                .thenReturn(false);
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web/{id}/verify", id).with(jwt()))
+                .andExpect(status().isForbidden());
+
+        allowElevatedRole();
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web/{id}/verify", id).with(jwt()))
+                .andExpect(status().isOk());
+        verify(service).verify(id);
+    }
+
+    private void allowElevatedRole() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
+                .thenReturn(true);
+    }
+
+    /** The request as it reached the service, read as plain JSON so no accessor is named. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> fieldsOf(Object boundRequest) {
+        return objectMapper.convertValue(boundRequest, Map.class);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #631.

## What was wrong

`ConstructionPaymentService.create` and `update` copied the stamp straight off the payload:

```java
payment.setVerifiedBy(req.verifiedBy());
payment.setVerifiedAt(req.verifiedAt());
```

Nothing checked that the id was the caller, a user in the caller's organization, or a user at all. So anyone who could edit a voucher could record that a named colleague had verified it, at a time of their choosing, or clear a verification that did happen. Not reachable through the product, because no screen writes those fields. That is containment, not a fix.

## Is verify-on-behalf-of a real requirement?

No, and the evidence is the same shape #598 found for the attribution fields:

- `echno-web`'s `PaymentFormData` (the create and edit form model) has no verification fields at all, and neither `payments/new` nor `payments/[id]/edit` sets one.
- `echno-core` carries them on both request interfaces, but `appendConstructionPaymentOptionalFields` writes them only `if (dto.verifiedBy !== undefined)`, and no call site defines one.
- There is no verify screen anywhere, so there is no flow in which a person records somebody else's check.

So the fields are removed rather than validated, which is the #598 answer rather than the #589 one.

## What replaced them

A verify action, because a verification is a transition with meaning rather than an attribute someone edits, and because `verifiedAt` has the same problem and the pair only ever moves together:

- `POST /finance/construction-payments/web/{id}/verify`, stamping the verifier from the session subject and the time from the clock, behind the same `@PreAuthorize` the rest of the module carries.
- `verifiedBy` and `verifiedAt` dropped from `CreateConstructionPaymentRequest` and `UpdateConstructionPaymentRequest`, so `update()` cannot touch either column.
- Verification is refused on a cancelled voucher and on one already verified. Re-verifying is not an idempotent no-op, it would overwrite a stamp somebody else's check produced, so the existing stamp stands. There is deliberately no unverify: that would be the same silent rewrite from the other direction, and nothing has asked for one.

## Does `SelfApprovalPolicy` apply?

Yes, for the reason it applies to an approval: the verification is the second pair of eyes on money that has already gone out, and the role gate does not supply it, since every verifier may also raise a voucher.

The voucher had nothing to compare a verifier against, though. `created_by` on `BaseEntity` holds the auditing string, not a user id, and comparing across those is exactly what `ApprovalParty` rejects. So changelog **080** adds `raised_by`, stamped from the session on create, which is the move changelog 072 made for regularizations when the same rule had nothing to read. The policy then refuses the raiser, admits a `system-admin` as the recorded exception, and refuses a session that resolves to no user rather than stamping nobody. A voucher raised before the column existed carries a null and is verified without the comparison, which the policy logs at WARN rather than stranding it.

`raisedBy` and `raisedByName` join the response DTO, resolved through the same single `UserNameDirectory` read PR #630 built for `verifiedByName` (one query per page, both stamps), so the break-glass case is visible on the document where the policy's own comment says the raiser and the approver should both be readable.

## Deploy safety

**This side ships alone.** Spring discards unrecognised properties, and every value a client sends for these two fields today is already ignored, so removing them breaks no caller. Refusing a value would have needed the client first; removing one does not. `echno-core` can drop the two optional properties whenever it next changes.

## Tests

| Test | Without the fix |
|---|---|
| `ConstructionPaymentVerificationStampTest.aCreateBodyNamingAVerifier_reachesTheServiceCarryingNoVerificationStamp` | **FAILED** |
| `ConstructionPaymentVerificationStampTest.anUpdateBodyNamingAVerifier_reachesTheServiceCarryingNoVerificationStamp` | **FAILED** |
| `ConstructionPaymentVerificationStampTest.verify_isTheActionThatWritesTheStamp_andIsRoleGated` | passed |

The two red cases post `verifiedBy` and `verifiedAt` on the wire, the way the defect was reachable, and read the request the controller handed the service back as JSON rather than through an accessor. That is deliberate: an accessor would only compile against the payload that no longer has the field, so the test would pass by not existing rather than by the fix. Verified by reinstating the two fields and the two `set` calls on the build machine, leaving everything else in place.

Also added:

- `ConstructionPaymentVerifyActionTest` (real `SelfApprovalPolicy`, not a mock): the session user and the clock are what get stamped; an edit cannot move a stamp already written; the raiser is refused; a `system-admin` is admitted as the recorded exception; a session resolving to no user is refused; a voucher with no raiser recorded is still verifiable; an existing verification is not replaced; a cancelled voucher is refused.
- `ConstructionPaymentServiceIT`: create stamps the raiser, verify stamps a different session against the raiser read back from the column, a second verify is refused, and the raiser is refused. This half runs against a real CockroachDB on purpose, because the comparison depends on changelog 080 having run.
- `ConstructionPaymentStampNameTest`: the raiser name comes from the same single directory read as the verifier's.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.

Full suite green on the build machine: heap 574 MB live of the 2048 MB cap, 28% used.