### PR TITLE
Take a movement record's verifier from the session, not from the request

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10407,9 +10407,15 @@
             "type": "string"
           },
           "verifiedBy": {
-            "description": "Name or id of the person who verified the movement.",
+            "description": "Name of the person who verified the movement, taken from their session.",
             "example": "Anand Rajashekar",
             "type": "string"
+          },
+          "verifiedById": {
+            "description": "Employee id of the person who verified the movement, null where the verifier has no employee record in this organization.",
+            "example": 17,
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -74447,7 +74453,7 @@
     },
     "/api/v1/movement-records/web/{id}/verify": {
       "post": {
-        "description": "Marks a movement record as verified by the given approver, for example after checking the reported distance and purpose.",
+        "description": "Records that the movement has been checked, for example against the reported distance and purpose. The verifier is taken from the authenticated session, not from the request: the caller does not choose whose name the record carries. The employee the movement belongs to cannot verify their own movement, and a movement already verified is not verified again.",
         "operationId": "verify_2",
         "parameters": [
           {
@@ -74457,14 +74463,6 @@
             "schema": {
               "format": "int64",
               "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "verifiedBy",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -74487,7 +74485,7 @@
                 }
               }
             },
-            "description": "Bad Request"
+            "description": "Already verified, verified by the employee it belongs to, or the session resolves to no user of this organization"
           },
           "402": {
             "content": {
@@ -74681,7 +74679,7 @@
     },
     "/api/v1/movement-records/{id}/verify": {
       "post": {
-        "description": "Marks a movement record as verified by the given approver, for example after checking the reported distance and purpose.",
+        "description": "Records that the movement has been checked, for example against the reported distance and purpose. The verifier is taken from the authenticated session, not from the request: the caller does not choose whose name the record carries. The employee the movement belongs to cannot verify their own movement, and a movement already verified is not verified again.",
         "operationId": "verify_1",
         "parameters": [
           {
@@ -74691,14 +74689,6 @@
             "schema": {
               "format": "int64",
               "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "verifiedBy",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -74721,7 +74711,7 @@
                 }
               }
             },
-            "description": "Bad Request"
+            "description": "Already verified, verified by the employee it belongs to, or the session resolves to no user of this organization"
           },
           "402": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecord.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecord.java
@@ -83,6 +83,15 @@ public class MovementRecord implements TenantScopedEntity {
     @Column(name = "verified_by")
     private String verifiedBy;
 
+    /**
+     * The verifier's employee id, next to the name in {@code verified_by}. Stamped from the
+     * session, and null for a verifier who holds a record-management role without an employee
+     * record in this tenant, the same way {@code Attendance.approvedById} is. Names are not
+     * identities: two people can share one and a person can change theirs.
+     */
+    @Column(name = "verified_by_id")
+    private Long verifiedById;
+
     @Column(name = "verified_at")
     private LocalDateTime verifiedAt;
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordController.java
@@ -91,16 +91,19 @@ public class MovementRecordController {
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
     @Operation(
             summary = "Verify a movement record",
-            description = "Marks a movement record as verified by the given approver, for example after "
-                    + "checking the reported distance and purpose."
+            description = "Records that the movement has been checked, for example against the reported "
+                    + "distance and purpose. The verifier is taken from the authenticated session, not "
+                    + "from the request: the caller does not choose whose name the record carries. The "
+                    + "employee the movement belongs to cannot verify their own movement, and a movement "
+                    + "already verified is not verified again."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement record verified"),
+            @ApiResponse(responseCode = "400", description = "Already verified, verified by the employee it belongs to, or the session resolves to no user of this organization"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
             @ApiResponse(responseCode = "404", description = "No movement record with the given id")
     })
-    public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
-                                                     @RequestParam String verifiedBy) {
-        return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));
+    public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id) {
+        return ResponseEntity.ok(movementRecordService.verifyMovement(id));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordControllerWeb.java
@@ -92,16 +92,19 @@ public class MovementRecordControllerWeb {
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
     @Operation(
             summary = "Verify a movement record",
-            description = "Marks a movement record as verified by the given approver, for example after "
-                    + "checking the reported distance and purpose."
+            description = "Records that the movement has been checked, for example against the reported "
+                    + "distance and purpose. The verifier is taken from the authenticated session, not "
+                    + "from the request: the caller does not choose whose name the record carries. The "
+                    + "employee the movement belongs to cannot verify their own movement, and a movement "
+                    + "already verified is not verified again."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Movement record verified"),
+            @ApiResponse(responseCode = "400", description = "Already verified, verified by the employee it belongs to, or the session resolves to no user of this organization"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
             @ApiResponse(responseCode = "404", description = "No movement record with the given id")
     })
-    public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id,
-                                                     @RequestParam String verifiedBy) {
-        return ResponseEntity.ok(movementRecordService.verifyMovement(id, verifiedBy));
+    public ResponseEntity<MovementRecordDto> verify(@PathVariable Long id) {
+        return ResponseEntity.ok(movementRecordService.verifyMovement(id));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/MovementRecordRepository.java
@@ -1,6 +1,10 @@
 package org.tornotron.echno_backend.attendance;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,6 +13,22 @@ import java.util.Optional;
 public interface MovementRecordRepository extends JpaRepository<MovementRecord, Long> {
 
     Optional<MovementRecord> findByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * Reads one movement record for verification, holding the row until the transaction ends.
+     *
+     * <p>Verification reads whether the record is already verified and then stamps it. Two
+     * verifications running at once on the same row would each read it as unverified, both pass
+     * the guard, and both stamp, so the second would replace a verification the first had already
+     * recorded, which is the one thing the guard exists to prevent. With the lock the second
+     * caller waits, reads the stamp the first committed, and is refused.
+     *
+     * <p>The same lock the stock-adjustment, leave-approval and payable paths take for the same
+     * reason. Reads that only display a movement keep the unlocked lookup above.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM MovementRecord m WHERE m.id = :id AND m.organization.id = :orgId")
+    Optional<MovementRecord> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
     List<MovementRecord> findByAttendanceIdOrderByStartTimeAsc(Long attendanceId);
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
@@ -71,8 +71,11 @@ public class MovementRecordDto {
     @Schema(description = "URLs of supporting attachments, for example a delivery receipt.", example = "[\"https://storage.echno.xyz/movements/220-receipt.jpg\"]")
     private List<String> attachments;
 
-    @Schema(description = "Name or id of the person who verified the movement.", example = "Anand Rajashekar")
+    @Schema(description = "Name of the person who verified the movement, taken from their session.", example = "Anand Rajashekar")
     private String verifiedBy;
+
+    @Schema(description = "Employee id of the person who verified the movement, null where the verifier has no employee record in this organization.", example = "17")
+    private Long verifiedById;
 
     @Schema(description = "Timestamp the movement was verified.", example = "2026-01-16T09:00:00")
     private LocalDateTime verifiedAt;

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceActorResolver.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceActorResolver.java
@@ -1,0 +1,79 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+/**
+ * Resolves the authenticated caller into the identity the attendance module records on a
+ * document: a display name, the platform user id, and the employee id where the caller has an
+ * employee record in the current tenant.
+ *
+ * <p>It exists because every stamp in this module has to come from the session rather than from
+ * the request. A regularization records who raised it and who decided it, and a movement record
+ * records who verified it; all three used to be, or still could be, a value the caller supplied,
+ * and a name a caller chooses is not evidence of who acted. Keeping the resolution in one bean
+ * means the fallbacks below are the same wherever a stamp is written, and the self-approval rule
+ * compares like with like.
+ */
+@Component
+public class AttendanceActorResolver {
+
+    /** The name recorded when the caller resolves to no identity at all. */
+    public static final String SYSTEM_ACTOR = "system";
+
+    private final UserContextService userContextService;
+    private final EmployeeRepository employeeRepository;
+
+    public AttendanceActorResolver(UserContextService userContextService,
+                                    EmployeeRepository employeeRepository) {
+        this.userContextService = userContextService;
+        this.employeeRepository = employeeRepository;
+    }
+
+    /**
+     * Who the authenticated caller is, as recorded on an attendance document: a display name,
+     * their platform user id, and, when the caller has an employee record in this tenant, that
+     * employee's id.
+     *
+     * @param name The name to store and show on the document.
+     * @param userId The platform user id, null where the caller resolves to no user row.
+     * @param employeeId The employee id in the current tenant, null where the caller has none.
+     */
+    public record Actor(String name, Long userId, Long employeeId) {
+
+        /** The same identity as the self-approval rule compares parties by. */
+        public ApprovalParty party() {
+            return new ApprovalParty(userId, employeeId);
+        }
+    }
+
+    /**
+     * Resolves the authenticated caller into what gets recorded on a document.
+     *
+     * <p>The caller's employee record in the current organization is preferred, because the
+     * employee id is what the attendance record carries and what the web client links a person
+     * by. A caller with no employee record in this tenant, for instance a bootstrap administrator,
+     * still gets a stable identity: their authenticated username to display, and their platform
+     * user id to be compared by, which is the identity the self-approval rule falls back to when
+     * there is no employee on one side. Only a caller with no identity at all falls back to
+     * {@value #SYSTEM_ACTOR}, which the endpoints' authorization rules already rule out and which
+     * the self-approval rule refuses to decide on rather than assuming it cannot happen.
+     *
+     * @return The caller's identity, never null.
+     */
+    public Actor resolveCurrentActor() {
+        Long userId = userContextService.getCurrentUserId();
+        Employee employee = userId == null ? null
+                : employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
+                        .orElse(null);
+        if (employee != null) {
+            return new Actor(employee.getEmployeeName(), userId, employee.getId());
+        }
+        String username = userContextService.getCurrentUsername();
+        return new Actor(username == null || username.isBlank() ? SYSTEM_ACTOR : username, userId, null);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -9,16 +9,14 @@ import org.tornotron.echno_backend.attendance.dto.*;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceRegularizationMapper;
+import org.tornotron.echno_backend.attendance.service.AttendanceActorResolver.Actor;
 import org.tornotron.echno_backend.common.approval.ApprovalParty;
 import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
-import org.tornotron.echno_backend.employee.Employee;
-import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
-import org.tornotron.echno_backend.user.UserContextService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,9 +40,6 @@ import java.util.stream.Collectors;
 @Service
 public class AttendanceRegularizationService {
 
-    /** Recorded when the caller cannot be resolved to any identity at all. */
-    private static final String SYSTEM_ACTOR = "system";
-
     /** Note carried by the corrected clock events of a request approved under the break-glass role. */
     private static final String SELF_APPROVAL_NOTE =
             " (self-approved: raised and approved by the same person)";
@@ -52,44 +47,31 @@ public class AttendanceRegularizationService {
     private final AttendanceRegularizationRepository regularizationRepository;
     private final AttendanceRepository attendanceRepository;
     private final OrganizationRepository organizationRepository;
-    private final EmployeeRepository employeeRepository;
     private final AttendanceSettingsService settingsService;
     private final AttendanceCalculationService calculationService;
     private final AttendanceRegularizationMapper regularizationMapper;
-    private final UserContextService userContextService;
+    private final AttendanceActorResolver actorResolver;
     private final SelfApprovalPolicy selfApprovalPolicy;
     private final AttendanceSecurityService attendanceSecurity;
 
     public AttendanceRegularizationService(AttendanceRegularizationRepository regularizationRepository,
                                             AttendanceRepository attendanceRepository,
                                             OrganizationRepository organizationRepository,
-                                            EmployeeRepository employeeRepository,
                                             AttendanceSettingsService settingsService,
                                             AttendanceCalculationService calculationService,
                                             AttendanceRegularizationMapper regularizationMapper,
-                                            UserContextService userContextService,
+                                            AttendanceActorResolver actorResolver,
                                             SelfApprovalPolicy selfApprovalPolicy,
                                             AttendanceSecurityService attendanceSecurity) {
         this.regularizationRepository = regularizationRepository;
         this.attendanceRepository = attendanceRepository;
         this.organizationRepository = organizationRepository;
-        this.employeeRepository = employeeRepository;
         this.settingsService = settingsService;
         this.calculationService = calculationService;
         this.regularizationMapper = regularizationMapper;
-        this.userContextService = userContextService;
+        this.actorResolver = actorResolver;
         this.selfApprovalPolicy = selfApprovalPolicy;
         this.attendanceSecurity = attendanceSecurity;
-    }
-
-    /** Who the authenticated caller is, as recorded on a request: a display name, their platform
-     *  user id, and, when the caller has an employee record in this tenant, that employee's id. */
-    private record Actor(String name, Long userId, Long employeeId) {
-
-        /** The same identity as the self-approval rule compares parties by. */
-        ApprovalParty party() {
-            return new ApprovalParty(userId, employeeId);
-        }
     }
 
     /**
@@ -109,7 +91,7 @@ public class AttendanceRegularizationService {
      */
     @Transactional
     public AttendanceRegularizationDto submitRequest(RegularizationRequestDto dto) {
-        Actor requester = resolveCurrentActor();
+        Actor requester = actorResolver.resolveCurrentActor();
         String requestedBy = requester.name();
         Long orgId = TenantContext.getCurrentOrgId();
         Organization org = organizationRepository.findById(orgId)
@@ -233,7 +215,7 @@ public class AttendanceRegularizationService {
                             + " and can no longer be actioned");
         }
 
-        Actor approver = resolveCurrentActor();
+        Actor approver = actorResolver.resolveCurrentActor();
         boolean selfApproved = dto.getStatus() == RegularizationStatus.APPROVED
                 && selfApprovalPolicy.checkSelfApproval(
                         new ApprovalParty(regularization.getRequestedByUserId(),
@@ -335,27 +317,4 @@ public class AttendanceRegularizationService {
         }
     }
 
-    /**
-     * Resolves the authenticated caller into what gets recorded on a request.
-     *
-     * <p>The caller's employee record in the current organization is preferred, because the
-     * employee id is what the attendance record carries and what the web client links a requester
-     * by. A caller with no employee record in this tenant, for instance a bootstrap administrator,
-     * still gets a stable identity: their authenticated username to display, and their platform
-     * user id to be compared by, which is the identity the self-approval rule falls back to when
-     * there is no employee on one side. Only a caller with no identity at all falls back to
-     * {@value #SYSTEM_ACTOR}, which the endpoint's authorization rules already rule out and which
-     * the self-approval rule now refuses to approve on rather than assuming it cannot happen.
-     */
-    private Actor resolveCurrentActor() {
-        Long userId = userContextService.getCurrentUserId();
-        Employee employee = userId == null ? null
-                : employeeRepository.findByUserIdAndOrganizationId(userId, TenantContext.getCurrentOrgId())
-                        .orElse(null);
-        if (employee != null) {
-            return new Actor(employee.getEmployeeName(), userId, employee.getId());
-        }
-        String username = userContextService.getCurrentUsername();
-        return new Actor(username == null || username.isBlank() ? SYSTEM_ACTOR : username, userId, null);
-    }
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance.service;
 
 import jakarta.validation.ValidationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,10 @@ import org.tornotron.echno_backend.attendance.*;
 import org.tornotron.echno_backend.attendance.dto.MovementRecordCreationDto;
 import org.tornotron.echno_backend.attendance.dto.MovementRecordDto;
 import org.tornotron.echno_backend.attendance.mapper.MovementRecordMapper;
+import org.tornotron.echno_backend.attendance.service.AttendanceActorResolver.Actor;
+import org.tornotron.echno_backend.common.approval.ApprovalParty;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
@@ -21,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class MovementRecordService {
 
@@ -31,6 +37,8 @@ public class MovementRecordService {
     private final AttendanceSettingsService settingsService;
     private final MovementRecordMapper movementRecordMapper;
     private final AttendanceSecurityService attendanceSecurity;
+    private final AttendanceActorResolver actorResolver;
+    private final SelfApprovalPolicy selfApprovalPolicy;
 
     public MovementRecordService(MovementRecordRepository movementRecordRepository,
                                   AttendanceRepository attendanceRepository,
@@ -38,7 +46,9 @@ public class MovementRecordService {
                                   OrganizationRepository organizationRepository,
                                   AttendanceSettingsService settingsService,
                                   MovementRecordMapper movementRecordMapper,
-                                  AttendanceSecurityService attendanceSecurity) {
+                                  AttendanceSecurityService attendanceSecurity,
+                                  AttendanceActorResolver actorResolver,
+                                  SelfApprovalPolicy selfApprovalPolicy) {
         this.movementRecordRepository = movementRecordRepository;
         this.attendanceRepository = attendanceRepository;
         this.employeeRepository = employeeRepository;
@@ -46,6 +56,8 @@ public class MovementRecordService {
         this.settingsService = settingsService;
         this.movementRecordMapper = movementRecordMapper;
         this.attendanceSecurity = attendanceSecurity;
+        this.actorResolver = actorResolver;
+        this.selfApprovalPolicy = selfApprovalPolicy;
     }
 
     /**
@@ -132,15 +144,60 @@ public class MovementRecordService {
         return movementRecordMapper.toDto(movementRecordRepository.save(record));
     }
 
+    /**
+     * Records that a movement has been checked, stamping the checker from the session.
+     *
+     * <p>The verifier used to arrive as a request parameter, and the web client sent whatever
+     * name it had to hand, so the person a movement record named as its verifier was a value the
+     * caller chose. A verification is a statement that somebody looked at the reported distance,
+     * times and purpose; a name typed by the person asking for the stamp is not evidence that
+     * anyone did. It is read from the authenticated session here instead, which is the shape
+     * {@code ConstructionPaymentService.verify} and
+     * {@link AttendanceRegularizationService#processRegularization} both settled on.
+     *
+     * <p>The employee the movement belongs to cannot verify it, on the rule every other
+     * second-pair-of-eyes check here follows: see {@link SelfApprovalPolicy}. A movement record is
+     * the employee's own account of where they went during a work day, so the check on it has to
+     * come from somebody else. The record already carries the employee id to compare against, so
+     * unlike the payment voucher this needed no new column. A verifier who holds a
+     * record-management role without having an employee record in the tenant shares no identity
+     * with the employee, and the policy allows that verification through at WARN rather than
+     * stranding it.
+     *
+     * <p>A movement already verified is not verified again. Re-verifying is not an idempotent
+     * no-op, it would overwrite a stamp somebody else's check produced, so the existing stamp
+     * stands. There is deliberately no action to clear one.
+     *
+     * @param movementId The movement record to verify.
+     * @return The verified movement, naming the verifier.
+     * @throws ResourceNotFoundException if no such movement exists in this organization.
+     * @throws InvalidRequestException if the movement is already verified, if the verifier is the
+     *         employee the movement belongs to and does not hold the break-glass role, or if the
+     *         session resolves to no user of this organization.
+     */
     @Transactional
-    public MovementRecordDto verifyMovement(Long movementId, String verifiedBy) {
+    public MovementRecordDto verifyMovement(Long movementId) {
         MovementRecord record = movementRecordRepository.findByIdAndOrganization_Id(movementId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Movement record with ID " + movementId + " was not found"));
 
+        if (Boolean.TRUE.equals(record.getIsVerified())) {
+            throw new InvalidRequestException(
+                    "Movement record with ID " + movementId + " has already been verified, and a "
+                            + "verification cannot be replaced");
+        }
+
+        Actor verifier = actorResolver.resolveCurrentActor();
+        selfApprovalPolicy.checkSelfApproval(
+                new ApprovalParty(null, record.getEmployeeId()),
+                verifier.party(),
+                "Movement record with ID " + movementId);
+
         record.setIsVerified(true);
-        record.setVerifiedBy(verifiedBy);
+        record.setVerifiedBy(verifier.name());
+        record.setVerifiedById(verifier.employeeId());
         record.setVerifiedAt(LocalDateTime.now());
 
+        log.info("Verified movement record {}", movementId);
         return movementRecordMapper.toDto(movementRecordRepository.save(record));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/MovementRecordService.java
@@ -166,7 +166,9 @@ public class MovementRecordService {
      *
      * <p>A movement already verified is not verified again. Re-verifying is not an idempotent
      * no-op, it would overwrite a stamp somebody else's check produced, so the existing stamp
-     * stands. There is deliberately no action to clear one.
+     * stands. There is deliberately no action to clear one. The row is read under a write lock so
+     * that two verifications arriving at once cannot each read it as unverified and both stamp,
+     * which would replace a verification through the very guard meant to prevent it.
      *
      * @param movementId The movement record to verify.
      * @return The verified movement, naming the verifier.
@@ -177,7 +179,8 @@ public class MovementRecordService {
      */
     @Transactional
     public MovementRecordDto verifyMovement(Long movementId) {
-        MovementRecord record = movementRecordRepository.findByIdAndOrganization_Id(movementId,TenantContext.getCurrentOrgId())
+        MovementRecord record = movementRecordRepository
+                .lockByIdAndOrganizationId(movementId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Movement record with ID " + movementId + " was not found"));
 
         if (Boolean.TRUE.equals(record.getIsVerified())) {

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -376,4 +376,7 @@
     <!-- v4.0 - Payment vouchers: record the raiser, so a verification has someone to be compared against -->
     <include file="db/changelog/v4.0/080-add-construction-payment-raised-by.xml"/>
 
+    <!-- v4.0 - Movement records: record the verifier's employee id, not just the name they were stamped with -->
+    <include file="db/changelog/v4.0/081-add-movement-record-verified-by-id.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/081-add-movement-record-verified-by-id.xml
+++ b/src/main/resources/db/changelog/v4.0/081-add-movement-record-verified-by-id.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="081-add-movement-record-verified-by-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="movement_record" columnName="verified_by_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Record the verifier's employee id next to the name in verified_by, the way attendance
+            and regularization records already store approved_by alongside approved_by_id. The name
+            used to arrive as a request parameter and was the only thing kept, so a movement record
+            named whoever the caller typed and there was no identity on the row at all. The name is
+            now stamped from the session, and the id makes it an identity rather than a label: two
+            people can share a name and a person can change theirs. Rows verified before this column
+            exists keep a null here and still show the name they were stamped with.
+        </comment>
+
+        <addColumn tableName="movement_record">
+            <column name="verified_by_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/MovementVerifierIsNotTakenFromTheRequestTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/MovementVerifierIsNotTakenFromTheRequestTest.java
@@ -1,0 +1,145 @@
+package org.tornotron.echno_backend.attendance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.attendance.service.MovementRecordService;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pins that nothing a caller sends can name the verifier of a movement record.
+ *
+ * <p>The defect was not a loose check on the value, it was that the value was bound at all:
+ * {@code verifiedBy} was a required {@code @RequestParam} on both verify handlers and was written
+ * onto the row as sent, so the person a movement record named as its verifier was whatever the
+ * client typed. Unlike the payment voucher this was reachable through the product, because the web
+ * client did send it.
+ *
+ * <p>The requests below therefore carry {@code ?verifiedBy=Mallory Cheatham} on the wire, the way
+ * the defect was reachable, and the assertion reads the arguments the controller handed the
+ * service off the Mockito invocation rather than naming a method signature. That is deliberate: an
+ * assertion written against the one-argument signature would only compile after the fix, so the
+ * test would pass by not existing rather than by the fix. Read this way it is red on the old code,
+ * where the arguments are {@code [7, "Mallory Cheatham"]}.
+ *
+ * <p>The status assertions are the deploy-safety evidence. A query parameter the handler no longer
+ * declares is not a validation failure in Spring MVC, it is simply not bound, so the deployed
+ * client's request still succeeds and its name is discarded; and a request that omits the
+ * parameter, which the old code rejected outright because the parameter was required, succeeds
+ * too. The backend can therefore ship before the client changes.
+ *
+ * <p>The counterpart to {@code MovementVerifyActionTest}, which covers what the action stamps.
+ */
+@WebMvcTest({MovementRecordControllerWeb.class, MovementRecordController.class})
+@Import(MovementVerifierIsNotTakenFromTheRequestTest.TestSecurityConfig.class)
+class MovementVerifierIsNotTakenFromTheRequestTest {
+
+    private static final long MOVEMENT_ID = 7L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MovementRecordService service;
+
+    @MockitoBean(name = "attendanceSecurity")
+    private AttendanceSecurityService attendanceSecurity;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @Test
+    void aVerifyNamingSomebodyElse_isAcceptedAndTheNameNeverReachesTheService() throws Exception {
+        when(attendanceSecurity.canManageRecords()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/movement-records/web/{id}/verify", MOVEMENT_ID)
+                        .with(jwt())
+                        .param("verifiedBy", "Mallory Cheatham"))
+                .andExpect(status().isOk());
+
+        assertThat(argumentsOfTheVerifyCall()).containsExactly(MOVEMENT_ID);
+    }
+
+    @Test
+    void theSameHoldsOnTheNonWebController() throws Exception {
+        when(attendanceSecurity.canManageRecords()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/movement-records/{id}/verify", MOVEMENT_ID)
+                        .with(jwt())
+                        .param("verifiedBy", "Mallory Cheatham"))
+                .andExpect(status().isOk());
+
+        assertThat(argumentsOfTheVerifyCall()).containsExactly(MOVEMENT_ID);
+    }
+
+    @Test
+    void aVerifyThatNamesNobodyIsAcceptedToo_soAClientCanStopSendingTheParameter() throws Exception {
+        when(attendanceSecurity.canManageRecords()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/movement-records/web/{id}/verify", MOVEMENT_ID).with(jwt()))
+                .andExpect(status().isOk());
+
+        assertThat(argumentsOfTheVerifyCall()).containsExactly(MOVEMENT_ID);
+    }
+
+    @Test
+    void verifyStaysGatedOnTheRecordManagementRole() throws Exception {
+        when(attendanceSecurity.canManageRecords()).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/movement-records/web/{id}/verify", MOVEMENT_ID)
+                        .with(jwt())
+                        .param("verifiedBy", "Mallory Cheatham"))
+                .andExpect(status().isForbidden());
+
+        assertThat(mockingDetails(service).getInvocations()).isEmpty();
+    }
+
+    /**
+     * What the controller passed the service, read off the recorded invocation rather than
+     * through a typed verification, so the assertion compiles against either signature.
+     */
+    private List<Object> argumentsOfTheVerifyCall() {
+        return mockingDetails(service).getInvocations().stream()
+                .filter(invocation -> "verifyMovement".equals(invocation.getMethod().getName()))
+                .findFirst()
+                .map(invocation -> List.of(invocation.getArguments()))
+                .orElseThrow(() -> new AssertionError("the controller never called verifyMovement"));
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
@@ -112,7 +112,8 @@ class AttendanceActorAuthorizationTest {
     private MovementRecordService movementRecordService() {
         return new MovementRecordService(movementRecordRepository, attendanceRepository,
                 employeeRepository, organizationRepository, settingsService, movementRecordMapper,
-                attendanceSecurity);
+                attendanceSecurity, new AttendanceActorResolver(userContextService, employeeRepository),
+                org.mockito.Mockito.mock(SelfApprovalPolicy.class));
     }
 
     private Organization organization() {
@@ -262,8 +263,9 @@ class AttendanceActorAuthorizationTest {
         SelfApprovalPolicy selfApprovalPolicy = org.mockito.Mockito.mock(SelfApprovalPolicy.class);
         AttendanceRegularizationService regularizationService = new AttendanceRegularizationService(
                 regularizationRepository, attendanceRepository, organizationRepository,
-                employeeRepository, settingsService, calculationService, regularizationMapper,
-                userContextService, selfApprovalPolicy, attendanceSecurity);
+                settingsService, calculationService, regularizationMapper,
+                new AttendanceActorResolver(userContextService, employeeRepository),
+                selfApprovalPolicy, attendanceSecurity);
         when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
         when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
                 .thenReturn(Optional.of(colleaguesAttendance()));

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationSelfApprovalTest.java
@@ -93,9 +93,9 @@ class AttendanceRegularizationSelfApprovalTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
-                organizationRepository, employeeRepository, settingsService, calculationService,
-                regularizationMapper, userContextService, new SelfApprovalPolicy(orgSecurity),
-                attendanceSecurity);
+                organizationRepository, settingsService, calculationService,
+                regularizationMapper, new AttendanceActorResolver(userContextService, employeeRepository),
+                new SelfApprovalPolicy(orgSecurity), attendanceSecurity);
         // Not the concern here: these tests exercise the self-approval rule, not who may raise.
         org.mockito.Mockito.lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     }

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationServiceTest.java
@@ -89,8 +89,9 @@ class AttendanceRegularizationServiceTest {
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
         service = new AttendanceRegularizationService(regularizationRepository, attendanceRepository,
-                organizationRepository, employeeRepository, settingsService, calculationService,
-                regularizationMapper, userContextService, selfApprovalPolicy, attendanceSecurity);
+                organizationRepository, settingsService, calculationService, regularizationMapper,
+                new AttendanceActorResolver(userContextService, employeeRepository),
+                selfApprovalPolicy, attendanceSecurity);
         // Not the concern here: these tests exercise the lifecycle, not who may raise a request.
         lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
         // The session is the requesting employee unless a test says otherwise.

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/MovementVerifyActionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/MovementVerifyActionTest.java
@@ -1,0 +1,214 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.MovementRecord;
+import org.tornotron.echno_backend.attendance.MovementRecordRepository;
+import org.tornotron.echno_backend.attendance.mapper.MovementRecordMapper;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the verify action stamps, now that it stamps it from the session.
+ *
+ * <p>The counterpart to {@code MovementVerifierIsNotTakenFromTheRequestTest}, which covers the
+ * wire. These cases run the real {@link SelfApprovalPolicy} and the real
+ * {@link AttendanceActorResolver} rather than mocks, because the behaviour being pinned is the
+ * decision those two make together and a stubbed policy would only pin the stubbing.
+ *
+ * <p>The self-approval half is new behaviour rather than a stamp being moved: a movement record is
+ * the employee's own account of where they went during a work day, so the check on it has to come
+ * from somebody else. The record already carries the employee id, so unlike the payment voucher in
+ * #631 there was nothing to add to the row before the rule could be applied.
+ */
+@ExtendWith(MockitoExtension.class)
+class MovementVerifyActionTest {
+
+    private static final Long ORG = 1L;
+    private static final Long MOVEMENT_ID = 7L;
+
+    private static final Long TRAVELLER_USER_ID = 100L;
+    private static final Long TRAVELLER_EMP_ID = 10L;
+    private static final Long CHECKER_USER_ID = 200L;
+    private static final Long CHECKER_EMP_ID = 20L;
+
+    @Mock private MovementRecordRepository movementRecordRepository;
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private MovementRecordMapper movementRecordMapper;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private MovementRecordService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new MovementRecordService(movementRecordRepository, attendanceRepository,
+                employeeRepository, organizationRepository, settingsService, movementRecordMapper,
+                attendanceSecurity,
+                new AttendanceActorResolver(userContextService, employeeRepository),
+                new SelfApprovalPolicy(orgSecurity));
+        lenient().when(movementRecordRepository.save(any(MovementRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("stamps the signed-in checker's name and employee id, and the clock")
+    void stampsTheSessionCheckerAndTheClock() {
+        storedMovement(unverified());
+        signedInAs(CHECKER_USER_ID, CHECKER_EMP_ID, "Anand Rajashekar");
+        LocalDateTime before = LocalDateTime.now();
+
+        service.verifyMovement(MOVEMENT_ID);
+
+        MovementRecord saved = savedRecord();
+        assertThat(saved.getIsVerified()).isTrue();
+        assertThat(saved.getVerifiedBy()).isEqualTo("Anand Rajashekar");
+        assertThat(saved.getVerifiedById()).isEqualTo(CHECKER_EMP_ID);
+        assertThat(saved.getVerifiedAt()).isBetween(before, LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("refuses the employee whose movement it is, so the check is somebody else's")
+    void refusesTheEmployeeTheMovementBelongsTo() {
+        storedMovement(unverified());
+        signedInAs(TRAVELLER_USER_ID, TRAVELLER_EMP_ID, "Aneesh Johny");
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> service.verifyMovement(MOVEMENT_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("second pair of eyes");
+
+        verify(movementRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("admits a system administrator verifying their own movement, as the recorded exception")
+    void admitsTheBreakGlassRole() {
+        storedMovement(unverified());
+        signedInAs(TRAVELLER_USER_ID, TRAVELLER_EMP_ID, "Aneesh Johny");
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE))
+                .thenReturn(true);
+
+        service.verifyMovement(MOVEMENT_ID);
+
+        // Verifying that the role was consulted, not only that the stamp landed: without it this
+        // case would still pass with the self-approval rule deleted altogether.
+        verify(orgSecurity).hasAnyOrgRoleForCurrentTenant(SelfApprovalPolicy.BREAK_GLASS_ROLE);
+        assertThat(savedRecord().getVerifiedById()).isEqualTo(TRAVELLER_EMP_ID);
+    }
+
+    @Test
+    @DisplayName("verifies where the checker has no employee record, and records their username")
+    void verifiesWhereTheCheckerHasNoEmployeeRecord() {
+        storedMovement(unverified());
+        when(userContextService.getCurrentUserId()).thenReturn(CHECKER_USER_ID);
+        when(employeeRepository.findByUserIdAndOrganizationId(CHECKER_USER_ID, ORG))
+                .thenReturn(Optional.empty());
+        when(userContextService.getCurrentUsername()).thenReturn("admin@echno.com");
+
+        service.verifyMovement(MOVEMENT_ID);
+
+        MovementRecord saved = savedRecord();
+        assertThat(saved.getVerifiedBy()).isEqualTo("admin@echno.com");
+        assertThat(saved.getVerifiedById()).isNull();
+    }
+
+    @Test
+    @DisplayName("refuses a session that resolves to no user, rather than stamping nobody")
+    void refusesASessionThatResolvesToNobody() {
+        storedMovement(unverified());
+        when(userContextService.getCurrentUserId()).thenReturn(null);
+        when(userContextService.getCurrentUsername()).thenReturn(null);
+
+        assertThatThrownBy(() -> service.verifyMovement(MOVEMENT_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("resolves to no user");
+
+        verify(movementRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("does not replace a verification somebody else's check produced")
+    void doesNotReplaceAnExistingVerification() {
+        MovementRecord alreadyVerified = unverified();
+        alreadyVerified.setIsVerified(true);
+        alreadyVerified.setVerifiedBy("Anand Rajashekar");
+        alreadyVerified.setVerifiedById(CHECKER_EMP_ID);
+        alreadyVerified.setVerifiedAt(LocalDateTime.of(2026, 8, 30, 9, 0));
+        storedMovement(alreadyVerified);
+
+        assertThatThrownBy(() -> service.verifyMovement(MOVEMENT_ID))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("already been verified");
+
+        verify(movementRecordRepository, never()).save(any());
+        assertThat(alreadyVerified.getVerifiedBy()).isEqualTo("Anand Rajashekar");
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    private MovementRecord unverified() {
+        MovementRecord record = new MovementRecord();
+        record.setId(MOVEMENT_ID);
+        record.setEmployeeId(TRAVELLER_EMP_ID);
+        record.setEmployeeName("Aneesh Johny");
+        record.setIsVerified(false);
+        return record;
+    }
+
+    private void storedMovement(MovementRecord record) {
+        when(movementRecordRepository.findByIdAndOrganization_Id(MOVEMENT_ID, ORG))
+                .thenReturn(Optional.of(record));
+    }
+
+    private void signedInAs(Long userId, Long employeeId, String name) {
+        Employee employee = new Employee();
+        employee.setId(employeeId);
+        employee.setEmployeeName(name);
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+        when(employeeRepository.findByUserIdAndOrganizationId(userId, ORG))
+                .thenReturn(Optional.of(employee));
+    }
+
+    private MovementRecord savedRecord() {
+        ArgumentCaptor<MovementRecord> saved = ArgumentCaptor.captor();
+        verify(movementRecordRepository).save(saved.capture());
+        return saved.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/MovementVerifyActionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/MovementVerifyActionTest.java
@@ -164,6 +164,21 @@ class MovementVerifyActionTest {
     }
 
     @Test
+    @DisplayName("reads the row under a write lock, so two verifications cannot both stamp it")
+    void readsTheRowUnderAWriteLock() {
+        storedMovement(unverified());
+        signedInAs(CHECKER_USER_ID, CHECKER_EMP_ID, "Anand Rajashekar");
+
+        service.verifyMovement(MOVEMENT_ID);
+
+        // The guard above reads the stamp and then writes it, so the two have to be one step.
+        // This pins that the locking finder is the one verification reads through; it cannot
+        // demonstrate the database behaviour, which the lock annotation is responsible for.
+        verify(movementRecordRepository).lockByIdAndOrganizationId(MOVEMENT_ID, ORG);
+        verify(movementRecordRepository, never()).findByIdAndOrganization_Id(any(), any());
+    }
+
+    @Test
     @DisplayName("does not replace a verification somebody else's check produced")
     void doesNotReplaceAnExistingVerification() {
         MovementRecord alreadyVerified = unverified();
@@ -193,7 +208,7 @@ class MovementVerifyActionTest {
     }
 
     private void storedMovement(MovementRecord record) {
-        when(movementRecordRepository.findByIdAndOrganization_Id(MOVEMENT_ID, ORG))
+        when(movementRecordRepository.lockByIdAndOrganizationId(MOVEMENT_ID, ORG))
                 .thenReturn(Optional.of(record));
     }
 


### PR DESCRIPTION
Closes #635.

## What was wrong

`MovementRecordService.verifyMovement` wrote the stamp from its argument, and the argument was a required `@RequestParam String verifiedBy` on both `MovementRecordController` and `MovementRecordControllerWeb`. Nothing checked that the value was the caller, named anyone in the caller's organization, or named a person at all.

This is the fifth instance of the shape, and the first one the client actually reaches. `echno-web`'s `MovementManagement` calls `useVerifyMovement` with a `verifiedBy` it builds itself, so the exposure is not confined to the API the way #631's was.

## Is verify-on-behalf-of a real requirement?

No, and the client itself is the evidence. There is exactly one call site in either client repo:

```ts
const verifierId = currentEmployee?.name ?? currentEmployee?.employeeId ?? '';
...
verifyMutation.mutate({ id: movement.id, verifiedBy: verifierId })
```

`echno-web/features/attendance/components/movement-management.tsx`. `currentEmployee` comes from `useCurrentUserEmployee()`, which is the signed-in person. So the client already sends only the caller, badly: it sends a display name where it has one and an employee code where it does not, and it sends nothing at all if the profile has not loaded, which the component has to guard against with a toast. No screen offers a verifier field, and there is no second call site in `echno-core` or `echno-web`.

Nothing verifies on anyone's behalf, so this is the #598 / #631 answer rather than the #589 one: the parameter is removed, not validated.

## What replaced it

`verifyMovement(Long movementId)`, stamping from the session. Unlike #631 no new action was needed, because `POST /{id}/verify` was already a dedicated verify action rather than an attribute on an update payload. What it stamps changes:

- The verifier's name and employee id come from the session, through the same resolution the regularization service uses.
- The employee the movement belongs to cannot verify it, through `SelfApprovalPolicy`.
- A movement already verified is not verified again. Re-verifying is not an idempotent no-op, it would overwrite a stamp somebody else's check produced. As in #631 there is deliberately no unverify.

## Does `SelfApprovalPolicy` apply, and did it need a column first?

It applies, and **no**, it needed nothing added. This is the one place this instance is easier than #631.

The voucher had nothing to compare a verifier against, because `created_by` on `BaseEntity` holds the auditing string rather than a user id, which is why changelog 080 had to add `raised_by`. A movement record already carries `employee_id`, a real id, and that is the right counterparty: the record is the employee's own account of where they went during a work day, and the verification is the independent check on it, so the person the record is about is exactly who must not sign it off. `new ApprovalParty(null, record.getEmployeeId())` against the verifier's party, and the rule works on rows written years ago.

A verifier holding a record-management role without an employee record in the tenant shares no identity with the employee, so the policy allows that verification through at WARN rather than stranding it, which is the documented behaviour. A session that resolves to no user at all is refused.

## Does the deployed client break?

**No, and this ships alone.** The reasoning in the issue was the cautious one, and the distinction it drew is real but lands the other way here.

A `@RequestParam` is not a JSON property, so the "Jackson ignores unknown fields" argument does not apply. What does apply is that Spring MVC binds the parameters a handler declares and ignores the rest of the query string: an undeclared parameter is not a validation failure, there is no strict mode to trip. Both directions are pinned in `MovementVerifierIsNotTakenFromTheRequestTest` rather than argued:

- a request carrying `?verifiedBy=Mallory Cheatham`, which is what the deployed client sends, returns 200 and hands the service `[7]`;
- a request omitting the parameter, which is what the updated client will send, also returns 200. On the old code that one is rejected outright, because the parameter was required.

So the deploy order is free. What does change for a user is that the name on the record is now the session's, which is the point of the issue.

## `verified_by_id`, and the timestamp

Changelog **081** adds `verified_by_id` next to the name, the way `Attendance` and `AttendanceRegularization` already store `approved_by` alongside `approved_by_id`. Storing only a name repeats in a smaller way the objection `ApprovalParty` documents against comparing names: two people can share one and a person can change theirs. The column is additive and nullable, so old rows keep the name they were stamped with, and it is additive on the wire, which `echno-core` parses for free.

`verifiedAt` stays a naive `LocalDateTime`. The issue asked whether it should become an `Instant`; it should not. `MovementTimestampContractTest` pins this record's times as local wall clock deliberately, and `approvedAt` on both siblings is the same type, so converting one field would break the client's parse and leave the entity internally inconsistent for no gain.

## Also here

`AttendanceRegularizationService`'s private `Actor` and `resolveCurrentActor` move to `AttendanceActorResolver`, because a third stamp now needs the same fallbacks and they have to agree for the policy to compare like with like. That drops two now-unused dependencies from the regularization service; the three tests that construct it pass the resolver instead, with their existing stubs unchanged.

## Tests

Every case below was proved red by deleting exactly the code it pins, one deletion at a time, on the build machine.

| Test | Reddened by deleting |
|---|---|
| `MovementVerifierIsNotTakenFromTheRequestTest.aVerifyNamingSomebodyElse_isAcceptedAndTheNameNeverReachesTheService` | the parameter removal (args become `[7, "Mallory Cheatham"]`) |
| `...theSameHoldsOnTheNonWebController` | the same, on the twin |
| `...aVerifyThatNamesNobodyIsAcceptedToo_soAClientCanStopSendingTheParameter` | the same (a request with no parameter is rejected) |
| `...verifyStaysGatedOnTheRecordManagementRole` | the handler's `@PreAuthorize` |
| `MovementVerifyActionTest.stampsTheSessionCheckerAndTheClock` | `setVerifiedById`, and the session stamp itself |
| `...refusesTheEmployeeTheMovementBelongsTo` | the `checkSelfApproval` call |
| `...admitsTheBreakGlassRole` | the `checkSelfApproval` call |
| `...refusesASessionThatResolvesToNobody` | the `checkSelfApproval` call |
| `...verifiesWhereTheCheckerHasNoEmployeeRecord` | the resolver's username fallback |
| `...doesNotReplaceAnExistingVerification` | the already-verified guard |

The wire test reads the arguments the controller handed the service off the Mockito invocation rather than through a typed verification. That is deliberate, and the same reason #634 read its bound request as JSON: an assertion written against the one-argument signature would only compile after the fix, so it would pass by not existing rather than by the fix.

The break-glass case additionally verifies that the role was consulted. Without that it would still pass with the self-approval rule deleted altogether, which is the failure mode of asserting only on the happy path.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.

Full suite green on the build machine: 557 MB live of the 2048 MB cap, 27% used, 8 contexts cached of 8.

## Client work

Filed rather than built, per the split #631 used: `echno-core` for the service and hook signatures, `echno-web` for the component that supplies the name. Neither is blocking, because the parameter is discarded either way. `echno-core` #74 already tracks the payment-side client work from #631.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movement verification now identifies the verifier from the authenticated session.
  * Verification records include the verifier’s name and employee ID when available.
* **Bug Fixes**
  * Prevented self-verification and re-verification of already verified movements.
  * Requests can no longer supply or override the verifier identity.
* **Documentation**
  * Updated API descriptions, response fields, and error details for the revised verification rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->