### PR TITLE
Make the billing surface reachable and the organization gate configured

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -25870,7 +25870,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -25980,7 +25980,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26085,7 +26085,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26197,7 +26197,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26310,7 +26310,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26421,7 +26421,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26542,7 +26542,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26655,7 +26655,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26760,7 +26760,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26870,7 +26870,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -26982,7 +26982,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller is not authenticated"
           },
           "404": {
             "content": {
@@ -27087,7 +27087,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller is not authenticated"
           },
           "404": {
             "content": {
@@ -27200,7 +27200,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -27311,7 +27311,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller is not authenticated"
           },
           "404": {
             "content": {
@@ -27432,7 +27432,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -27545,7 +27545,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -27668,7 +27668,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -27789,7 +27789,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -28688,7 +28688,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -28809,7 +28809,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -28931,7 +28931,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -29054,7 +29054,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -29170,7 +29170,7 @@
                 }
               }
             },
-            "description": "Caller lacks the billing admin authority"
+            "description": "Caller lacks the platform-admin role"
           },
           "404": {
             "content": {
@@ -105375,11 +105375,11 @@
       "name": "Auth"
     },
     {
-      "description": "Individually toggleable capabilities that a plan can grant, such as report exports or a device quota. A feature has a type (boolean, quota or metered) and, once deactivated, is no longer offered on new plans. All endpoints are restricted to the billing admin authority.",
+      "description": "Individually toggleable capabilities that a plan can grant, such as report exports or a device quota. A feature has a type (boolean, quota or metered) and, once deactivated, is no longer offered on new plans. The feature catalogue is platform-wide rather than per-customer, so every endpoint here is restricted to the platform-admin role.",
       "name": "Billing Features"
     },
     {
-      "description": "Subscription plans such as Starter, Professional or Enterprise, each carrying a price per billing period and a set of assigned features. Endpoints cover listing public plans, full plan administration, and attaching or detaching features on a plan. All administrative endpoints require the billing admin authority.",
+      "description": "Subscription plans such as Starter, Professional or Enterprise, each carrying a price per billing period and a set of assigned features. Endpoints cover listing public plans, full plan administration, and attaching or detaching features on a plan. All administrative endpoints require the platform-admin role.",
       "name": "Billing Plans"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/FeatureController.java
@@ -27,8 +27,8 @@ import java.util.List;
         name = "Billing Features",
         description = "Individually toggleable capabilities that a plan can grant, such as report exports "
                 + "or a device quota. A feature has a type (boolean, quota or metered) and, once deactivated, "
-                + "is no longer offered on new plans. All endpoints are restricted to the billing admin "
-                + "authority."
+                + "is no longer offered on new plans. The feature catalogue is platform-wide rather than "
+                + "per-customer, so every endpoint here is restricted to the platform-admin role."
 )
 public class FeatureController {
 
@@ -40,9 +40,8 @@ public class FeatureController {
      *
      * @return List of active features
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping
-//    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     @Operation(
             summary = "List active features",
             description = "Returns the features that are currently active and available for assignment to "
@@ -50,7 +49,7 @@ public class FeatureController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of active features"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<List<FeatureDto>> getActiveFeatures() {
         List<Feature> features = featureService.getAllActiveFeatures();
@@ -63,16 +62,15 @@ public class FeatureController {
      *
      * @return List of all features
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping("/all")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "List all features",
             description = "Returns every feature, including deactivated ones, for administration."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of all features"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<List<FeatureDto>> getAllFeatures() {
         List<Feature> features = featureService.getAllFeatures();
@@ -85,16 +83,15 @@ public class FeatureController {
      * @param id Feature ID
      * @return Feature details
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a feature by id",
             description = "Returns a single feature by its numeric id."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
     })
     public ResponseEntity<FeatureDto> getFeatureById(@PathVariable Long id) {
@@ -108,16 +105,15 @@ public class FeatureController {
      * @param code Feature code
      * @return Feature details
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping("/code/{code}")
-//    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a feature by code",
             description = "Returns a single feature by its unique code, such as report-export."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given code")
     })
     public ResponseEntity<FeatureDto> getFeatureByCode(@PathVariable String code) {
@@ -132,9 +128,8 @@ public class FeatureController {
      * @param dto Feature creation data
      * @return Created feature
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Create a feature",
             description = "Creates a new feature that can subsequently be assigned to plans."
@@ -142,7 +137,7 @@ public class FeatureController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Feature created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<FeatureDto> createFeature(@Valid @RequestBody FeatureCreateDto dto) {
         Feature feature = featureService.createFeature(dto);
@@ -157,9 +152,8 @@ public class FeatureController {
      * @param dto Feature update data
      * @return Updated feature
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PutMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Update a feature",
             description = "Updates the details of an existing feature identified by id."
@@ -167,7 +161,7 @@ public class FeatureController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
     })
     public ResponseEntity<FeatureDto> updateFeature(@PathVariable Long id, @Valid @RequestBody FeatureCreateDto dto) {
@@ -182,9 +176,8 @@ public class FeatureController {
      * @param id Feature ID
      * @return Success message
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @DeleteMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Deactivate a feature",
             description = "Soft-deletes a feature so it can no longer be assigned to new plans. Plans that "
@@ -192,7 +185,7 @@ public class FeatureController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature deactivated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
     })
     public ResponseEntity<ApiResponse> deactivateFeature(@PathVariable Long id) {
@@ -207,16 +200,15 @@ public class FeatureController {
      * @param id Feature ID
      * @return Success message
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping("/{id}/activate")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Reactivate a feature",
             description = "Reactivates a previously deactivated feature so it can be assigned to plans again."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature activated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No feature with the given id")
     })
     public ResponseEntity<ApiResponse> activateFeature(@PathVariable Long id) {

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/PlanController.java
@@ -16,6 +16,32 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 
 import java.util.List;
 
+/**
+ * Two different bars here, because these are two different kinds of endpoint.
+ *
+ * <p>The catalogue reads are ordinary authenticated reads. A signed-in user, including one who
+ * belongs to no organization yet, has to be able to see what plans exist before they can buy one,
+ * which is what a pricing page needs. {@code GET /public} in particular is named for that and was
+ * previously gated on a platform-admin authority, which is wrong on its own terms.
+ *
+ * <p>The catalogue writes are platform-staff operations. The plan catalogue is global, so it must
+ * not fall to a customer's own {@code system-admin}: that role is held by the administrator of
+ * every tenant, and letting it edit plans would let any customer rewrite what every other customer
+ * is sold.
+ *
+ * <p>All of these used to ask for {@code hasAuthority('billing:admin')}. {@code JwtAuthConverter}
+ * mints a bare {@code resource:scope} authority in exactly one place, from the {@code authorization}
+ * claim of an RPT, so that string needed a Keycloak Authorization Services resource named
+ * {@code billing} carrying an {@code admin} scope. The multi-tenancy audit of 2026-08-18 checked
+ * the live realm for the identical case of {@code organization:admin} and found zero authorization
+ * scopes realm-wide, one scopeless {@code Default Resource} and one scopeless
+ * {@code Default Permission}. A scopeless permission yields no {@code resource:scope} authority, so
+ * {@code billing:admin} was issued to nobody and could not be issued to anybody. It is now a
+ * Keycloak client role, delivered through {@code resource_access} as {@code ROLE_platform-admin},
+ * which is the grant mechanism this realm actually has. Until the realm carries that role these
+ * endpoints still refuse, but they refuse deliberately and the grant is a realm change rather than
+ * an impossibility. See #641.
+ */
 @RestController
 @RequestMapping("/api/v1/billing/plans/web")
 @RequiredArgsConstructor
@@ -25,7 +51,7 @@ import java.util.List;
         description = "Subscription plans such as Starter, Professional or Enterprise, each carrying a "
                 + "price per billing period and a set of assigned features. Endpoints cover listing public "
                 + "plans, full plan administration, and attaching or detaching features on a plan. All "
-                + "administrative endpoints require the billing admin authority."
+                + "administrative endpoints require the platform-admin role."
 )
 public class PlanController {
 
@@ -37,7 +63,7 @@ public class PlanController {
      *
      * @return List of public plans
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/public")
     @Operation(
             summary = "List public plans",
@@ -45,7 +71,7 @@ public class PlanController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of public plans"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated")
     })
     public ResponseEntity<List<PlanDto>> getPublicPlans() {
         return ResponseEntity.ok(planService.getAllPublicPlans());
@@ -57,16 +83,15 @@ public class PlanController {
      *
      * @return List of all plans
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "List all plans",
             description = "Returns every plan, including private and inactive ones, for administration."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of all plans"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<List<PlanDto>> getAllPlans() {
         return ResponseEntity.ok(planService.getAllPlans());
@@ -78,16 +103,15 @@ public class PlanController {
      * @param id Plan ID
      * @return Plan details
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a plan by id",
             description = "Returns a single plan by its numeric id, including its assigned features."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<PlanDto> getPlanById(@PathVariable Long id) {
@@ -100,16 +124,15 @@ public class PlanController {
      * @param code Plan code
      * @return Plan details
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/code/{code}")
-//    @PreAuthorize("hasAuthority('billing:read') or hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a plan by code",
             description = "Returns a single plan by its unique code, such as professional-monthly."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not authenticated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code")
     })
     public ResponseEntity<PlanDto> getPlanByCode(@PathVariable String code) {
@@ -123,9 +146,8 @@ public class PlanController {
      * @param dto Plan creation data
      * @return Created plan
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Create a plan",
             description = "Creates a new plan with the given price and billing period. Features are attached "
@@ -134,7 +156,7 @@ public class PlanController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Plan created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<PlanDto> createPlan(@Valid @RequestBody PlanCreateDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(dto));
@@ -148,9 +170,8 @@ public class PlanController {
      * @param dto Plan update data
      * @return Updated plan
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PutMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Update a plan",
             description = "Updates the price, period or visibility of an existing plan identified by id."
@@ -158,7 +179,7 @@ public class PlanController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<PlanDto> updatePlan(@PathVariable Long id, @Valid @RequestBody PlanCreateDto dto) {
@@ -172,9 +193,8 @@ public class PlanController {
      * @param id Plan ID
      * @return Success message
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @DeleteMapping("/{id}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Deactivate a plan",
             description = "Soft-deletes a plan so it can no longer be subscribed to. Existing subscriptions "
@@ -182,7 +202,7 @@ public class PlanController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan deactivated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<ApiResponse> deactivatePlan(@PathVariable Long id) {
@@ -197,16 +217,15 @@ public class PlanController {
      * @param id Plan ID
      * @return Success message
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping("/{id}/activate")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Reactivate a plan",
             description = "Reactivates a previously deactivated plan so it can be subscribed to again."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Plan activated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id")
     })
     public ResponseEntity<ApiResponse> activatePlan(@PathVariable Long id) {
@@ -222,9 +241,8 @@ public class PlanController {
      * @param dto    Feature assignment data
      * @return Updated plan
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping("/{planId}/features")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Assign a feature to a plan",
             description = "Attaches a feature to a plan, optionally with a quota or limit value carried in "
@@ -233,7 +251,7 @@ public class PlanController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature assigned, plan returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id, or no feature with the given code")
     })
     public ResponseEntity<PlanDto> assignFeatureToPlan(
@@ -250,9 +268,8 @@ public class PlanController {
      * @param featureCode Feature code to remove
      * @return Updated plan
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @DeleteMapping("/{planId}/features/{featureCode}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Remove a feature from a plan",
             description = "Detaches a feature from a plan. Subscribers to the plan lose access to the "
@@ -260,7 +277,7 @@ public class PlanController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Feature removed, plan returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given id, or the feature is not assigned to it")
     })
     public ResponseEntity<PlanDto> removeFeatureFromPlan(

--- a/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/controllers/SubscriptionController.java
@@ -219,9 +219,8 @@ public class SubscriptionController {
      * @param userId User ID
      * @return Active subscription or empty
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping("/user/{userId}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a user's subscription",
             description = "Returns the active subscription for the given user id. An empty body with 204 "
@@ -230,7 +229,7 @@ public class SubscriptionController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Active subscription returned"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "User has no active subscription"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<SubscriptionDto> getUserSubscription(@PathVariable Long userId) {
         return subscriptionService.getActiveSubscription(userId)
@@ -245,9 +244,8 @@ public class SubscriptionController {
      * @param userId User ID
      * @return List of subscriptions
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @GetMapping("/user/{userId}/history")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Get a user's subscription history",
             description = "Returns every subscription the given user has ever held, most recently created "
@@ -255,7 +253,7 @@ public class SubscriptionController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription history returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role")
     })
     public ResponseEntity<List<SubscriptionDto>> getUserSubscriptionHistory(@PathVariable Long userId) {
         return ResponseEntity.ok(subscriptionService.getSubscriptionHistory(userId));
@@ -269,9 +267,8 @@ public class SubscriptionController {
      * @param dto    Subscription creation data
      * @return Created subscription
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping("/user/{userId}")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Create a subscription for a user",
             description = "Subscribes the given user to the plan identified by planCode, for the given "
@@ -280,7 +277,7 @@ public class SubscriptionController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Subscription created"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No plan with the given code"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "User already has an active subscription")
     })
@@ -299,9 +296,8 @@ public class SubscriptionController {
      * @param dto    Plan change data
      * @return Updated subscription
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PutMapping("/user/{userId}/change-plan")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Change a user's plan",
             description = "Moves the given user's active subscription to a different plan, identified by "
@@ -310,7 +306,7 @@ public class SubscriptionController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription moved to the new plan"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User has no active subscription, or no plan with the given code")
     })
     public ResponseEntity<SubscriptionDto> changeSubscriptionForUser(
@@ -327,9 +323,8 @@ public class SubscriptionController {
      * @param dto    Cancellation options
      * @return Success message
      */
-    @PreAuthorize("hasAuthority('billing:admin')")
+    @PreAuthorize("hasRole('platform-admin')")
     @PostMapping("/user/{userId}/cancel")
-//    @PreAuthorize("hasAuthority('billing:admin')")
     @Operation(
             summary = "Cancel a user's subscription",
             description = "Cancels the given user's active subscription. By default it stays active until "
@@ -338,7 +333,7 @@ public class SubscriptionController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscription canceled"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the billing admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the platform-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User has no active subscription")
     })
     public ResponseEntity<ApiResponse> cancelSubscriptionForUser(

--- a/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/services/SubscriptionService.java
@@ -23,7 +23,7 @@ import org.tornotron.echno_backend.common.exception.NoActiveSubscriptionExceptio
 import org.tornotron.echno_backend.common.exception.PlanNotFoundException;
 
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -209,9 +209,24 @@ public class SubscriptionService {
         return FeatureAccessResultDto.allowed(currentUsage, quotaLimit);
     }
 
+    /**
+     * The start and end of the quota window a usage record falls in, for a given period.
+     *
+     * <p>Computed in UTC, deliberately. These bounds are both the window
+     * {@link #checkQuotaAccess} sums existing usage over and the {@code periodStart} and
+     * {@code periodEnd} {@link #recordUsage} stamps on every {@link UsageRecord} it writes, so
+     * the two only line up while every process computing them agrees on where a period begins.
+     * They were derived from {@code ZoneId.systemDefault()}, which made that agreement a
+     * property of the container's timezone: a month or year boundary moves by a whole day
+     * between two zones, which moves a user between quota periods and can allow or refuse them
+     * against a window that does not match the rows being counted.
+     *
+     * @param period The quota period to compute the current window for.
+     * @return The window start and end, in that order.
+     */
     private Instant[] calculatePeriodBounds(QuotaPeriod period) {
         Instant now = Instant.now();
-        ZonedDateTime zdt = now.atZone(ZoneId.systemDefault());
+        ZonedDateTime zdt = now.atZone(ZoneOffset.UTC);
 
         switch (period) {
             case HOURLY:

--- a/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/multitenancy/TenantFilter.java
@@ -152,6 +152,20 @@ public class TenantFilter extends OncePerRequestFilter {
      * {@code /users/profile}, never matched the real singular paths and were removed to avoid the
      * false impression that those endpoints are unfiltered.)
      *
+     * <p>{@code /billing} used to be listed here too, with the reason "Billing is keyed on the
+     * user rather than the organization". That was a description of how {@code Subscription} is
+     * stored, not a reason for the surface to sit outside tenant isolation, and it had a cost
+     * that was not obvious from reading it: an unscoped declaration leaves
+     * {@code TenantContext.getCurrentOrgId()} null, and every billing endpoint is guarded by
+     * {@code @orgSecurity.hasAnyOrgRoleForCurrentTenant} or {@code isMemberOfCurrentTenant},
+     * both of which refuse a null organization. The declaration was therefore refusing the whole
+     * self-service billing surface to everyone, in every environment. Billing now runs inside
+     * tenant isolation like any other authenticated surface. Nothing it reaches is a
+     * {@code TenantScopedEntity}, so the Hibernate org filter has nothing to act on and no query
+     * changes; what changes is that the organization id the guards were written against is
+     * present. The genuinely cross-organization admin reads belong on a method-level declaration,
+     * not on a path prefix that also catches the self-service ones.
+     *
      * @return the reason to record, or null if this request is an ordinary tenant-scoped one
      */
     private String preTenantReason(HttpServletRequest request) {
@@ -163,9 +177,6 @@ public class TenantFilter extends OncePerRequestFilter {
         }
         if (path.equals(apiRoot + "/user/web")) {
             return "The current-user lookup answers across every organization the caller belongs to";
-        }
-        if (path.startsWith(apiRoot + "/billing")) {
-            return "Billing is keyed on the user rather than the organization";
         }
         return null;
     }

--- a/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/OrganizationService.java
@@ -126,9 +126,38 @@ public class OrganizationService {
 
         FeatureAccessResultDto access = subscriptionService.checkFeatureAccess(currentUser.getId(), CREATE_ORGANIZATION_FEATURE);
         if (!access.isAllowed()) {
-            String message = access.getMessage() != null ? access.getMessage() : access.getReason();
-            throw new SubscriptionAccessDeniedException(message, CREATE_ORGANIZATION_FEATURE, access);
+            throw new SubscriptionAccessDeniedException(
+                    explainOrganizationDenial(access), CREATE_ORGANIZATION_FEATURE, access);
         }
+    }
+
+    /**
+     * Turns a refused entitlement into something the person who hit it can act on.
+     *
+     * <p>The generic result carries a {@code reason} written for a log reader, and for the case
+     * that matters most here it reads "No active subscription": true, and useless to someone who
+     * has never been asked to subscribe to anything and is looking at a button that stopped
+     * working. What a caller needs is the limit, what they have used against it, and the fact that
+     * a plan governs it.
+     *
+     * <p>Two shapes reach this. A quota result knows the numbers, so the message quotes them. A
+     * refusal for any other reason, including the account having no plan at all, does not, so it
+     * says what governs the decision without inventing a figure.
+     *
+     * @param access The refused access result.
+     * @return A message naming what was exceeded, or what governs the decision when no limit is known.
+     */
+    private String explainOrganizationDenial(FeatureAccessResultDto access) {
+        Long limit = access.getQuotaLimit();
+        if (limit != null) {
+            Long used = access.getCurrentUsage();
+            return "Your plan covers " + limit + (limit == 1L ? " organization" : " organizations")
+                    + " and you have already created " + (used == null ? limit : used)
+                    + ". Moving to a plan with a higher organization limit will let you create another.";
+        }
+        return "Creating more than one organization needs a plan that covers additional "
+                + "organizations, and this account is not on one. The first organization is always "
+                + "free and does not need a plan.";
     }
 
     /**

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -379,4 +379,7 @@
     <!-- v4.0 - Movement records: record the verifier's employee id, not just the name they were stamped with -->
     <include file="db/changelog/v4.0/081-add-movement-record-verified-by-id.xml"/>
 
+    <!-- v4.0 - Billing: seed the plan catalogue the organization-creation gate reads -->
+    <include file="db/changelog/v4.0/082-seed-billing-plans.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/082-seed-billing-plans.xml
+++ b/src/main/resources/db/changelog/v4.0/082-seed-billing-plans.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Seeds the plan catalogue the entitlement gate reads.
+
+        OrganizationService.requireCreateOrganizationEntitlement exempts a caller's first
+        organization and puts every one after it through checkFeatureAccess on the
+        CREATE_ORGANIZATION feature. That gate is deliberate (b6e2f63, closes #521), but
+        nothing has ever configured what it reads: no changelog inserts a plan, a feature or
+        a plan_feature. The rows on the IITM staging box were put there by hand in May 2026
+        and exist in no other environment, so every environment built from this changelog
+        comes up with an empty catalogue and no plan can be granted to anyone. See #642.
+
+        Each changeSet is guarded on its table being empty and marked as run otherwise, so an
+        environment that was already seeded by hand keeps exactly the rows it has. That is
+        what makes this safe to apply to staging, where it is a no-op.
+
+        Two things are deliberately NOT decided here, because they are business decisions and
+        are open questions on the payment-gateway ticket (ClickUp 86d456frt):
+
+          - Price. Staging carries figures somebody typed in May; they were never signed off,
+            and the RBI e-mandate threshold makes the monthly figure a decision with product
+            consequences rather than a number to copy forward. Prices are left null.
+          - Public visibility. is_public is false on every row, so an unpriced catalogue
+            cannot appear on a pricing page by accident. PlanService.getAllPublicPlans filters
+            on it. Flip it per tier when the price list is agreed.
+
+        What this does give is a catalogue that exists, so a plan can be granted by hand and
+        the first customers can be invoiced, which is the whole of what the gate needs to stop
+        being an accidental hard block.
+
+        The per-tier organization limits below reproduce the two that are actually in use on
+        staging (FREE 1, PRO 5). STARTER and ENTERPRISE had no grant of this feature there at
+        all, which would leave a paying customer worse off than a free one, so they are given
+        the monotonic reading: STARTER sits between the two, ENTERPRISE is unmetered. Those
+        two numbers are provisional and want confirming with the tier matrix.
+    -->
+
+    <changeSet id="082-seed-billing-features" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM feature</sqlCheck>
+        </preConditions>
+
+        <insert tableName="feature">
+            <column name="code" value="CREATE_ORGANIZATION"/>
+            <column name="name" value="Organization Limit"/>
+            <column name="description"
+                    value="How many organizations an account may create. The first is always free and is part of signing up; this limit governs every one after it."/>
+            <column name="feature_type" value="QUOTA"/>
+            <column name="category" value="PLATFORM"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="082-seed-billing-plans" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM plan</sqlCheck>
+        </preConditions>
+
+        <insert tableName="plan">
+            <column name="code" value="FREE"/>
+            <column name="name" value="Free Plan"/>
+            <column name="description" value="Basic access for small teams to explore the platform."/>
+            <column name="version" valueNumeric="1"/>
+            <column name="currency" value="INR"/>
+            <column name="is_active" valueBoolean="true"/>
+            <column name="is_public" valueBoolean="false"/>
+            <column name="trial_days" valueNumeric="0"/>
+            <column name="max_users" valueNumeric="3"/>
+            <column name="sort_order" valueNumeric="1"/>
+        </insert>
+
+        <insert tableName="plan">
+            <column name="code" value="STARTER"/>
+            <column name="name" value="Starter Plan"/>
+            <column name="description" value="For small teams needing essential features and basic support."/>
+            <column name="version" valueNumeric="1"/>
+            <column name="currency" value="INR"/>
+            <column name="is_active" valueBoolean="true"/>
+            <column name="is_public" valueBoolean="false"/>
+            <column name="trial_days" valueNumeric="14"/>
+            <column name="max_users" valueNumeric="10"/>
+            <column name="sort_order" valueNumeric="2"/>
+        </insert>
+
+        <insert tableName="plan">
+            <column name="code" value="PRO"/>
+            <column name="name" value="Professional Plan"/>
+            <column name="description" value="For growing teams with higher usage limits and priority support."/>
+            <column name="version" valueNumeric="1"/>
+            <column name="currency" value="INR"/>
+            <column name="is_active" valueBoolean="true"/>
+            <column name="is_public" valueBoolean="false"/>
+            <column name="trial_days" valueNumeric="14"/>
+            <column name="max_users" valueNumeric="50"/>
+            <column name="sort_order" valueNumeric="3"/>
+        </insert>
+
+        <insert tableName="plan">
+            <column name="code" value="ENTERPRISE"/>
+            <column name="name" value="Enterprise Plan"/>
+            <column name="description" value="For large organizations with unlimited users and dedicated support."/>
+            <column name="version" valueNumeric="1"/>
+            <column name="currency" value="INR"/>
+            <column name="is_active" valueBoolean="true"/>
+            <column name="is_public" valueBoolean="false"/>
+            <column name="trial_days" valueNumeric="30"/>
+            <column name="sort_order" valueNumeric="4"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="082-seed-billing-plan-features" author="abhijith">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM plan_feature</sqlCheck>
+        </preConditions>
+
+        <!--
+            The ids are looked up by code rather than written literally: both parent tables
+            are auto-increment, so an environment that seeded them in a different order would
+            otherwise get the limits attached to the wrong tiers.
+
+            A null quota_limit is how "unmetered" is expressed. PlanFeatureSnapshot.hasQuota
+            requires a limit above zero, so ENTERPRISE falls through to allowed outright
+            rather than being compared against a number.
+        -->
+        <insert tableName="plan_feature">
+            <column name="plan_id" valueComputed="(SELECT id FROM plan WHERE code = 'FREE')"/>
+            <column name="feature_id" valueComputed="(SELECT id FROM feature WHERE code = 'CREATE_ORGANIZATION')"/>
+            <column name="enabled" valueBoolean="true"/>
+            <column name="quota_limit" valueNumeric="1"/>
+            <column name="quota_period" value="TOTAL"/>
+        </insert>
+
+        <insert tableName="plan_feature">
+            <column name="plan_id" valueComputed="(SELECT id FROM plan WHERE code = 'STARTER')"/>
+            <column name="feature_id" valueComputed="(SELECT id FROM feature WHERE code = 'CREATE_ORGANIZATION')"/>
+            <column name="enabled" valueBoolean="true"/>
+            <column name="quota_limit" valueNumeric="3"/>
+            <column name="quota_period" value="TOTAL"/>
+        </insert>
+
+        <insert tableName="plan_feature">
+            <column name="plan_id" valueComputed="(SELECT id FROM plan WHERE code = 'PRO')"/>
+            <column name="feature_id" valueComputed="(SELECT id FROM feature WHERE code = 'CREATE_ORGANIZATION')"/>
+            <column name="enabled" valueBoolean="true"/>
+            <column name="quota_limit" valueNumeric="5"/>
+            <column name="quota_period" value="TOTAL"/>
+        </insert>
+
+        <insert tableName="plan_feature">
+            <column name="plan_id" valueComputed="(SELECT id FROM plan WHERE code = 'ENTERPRISE')"/>
+            <column name="feature_id" valueComputed="(SELECT id FROM feature WHERE code = 'CREATE_ORGANIZATION')"/>
+            <column name="enabled" valueBoolean="true"/>
+            <column name="quota_period" value="TOTAL"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PublicEndpointTenantExposureTest.java
@@ -78,9 +78,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * from.
  *
  * <p>Nor does it cover the authenticated-but-unscoped paths that {@code TenantFilter} enumerates
- * ({@code /user/web}, {@code /billing/**}, and the no-membership state). Those already read
- * tenant-scoped rows knowingly, scoped by the caller's own user id rather than by the tenant
- * layer, so a rule over them would be an allowlist of its own contents and would say nothing.
+ * ({@code /user/web} and the no-membership state). Those already read tenant-scoped rows
+ * knowingly, scoped by the caller's own user id rather than by the tenant layer, so a rule over
+ * them would be an allowlist of its own contents and would say nothing. {@code /billing/**} was
+ * a third entry here and is no longer unscoped: the declaration left the tenant id null, which
+ * refused every billing endpoint outright, and billing now runs inside tenant isolation like any
+ * other authenticated surface. See #640.
  *
  * <h2>What the walk follows</h2>
  *

--- a/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/BillingMappingIT.java
@@ -448,6 +448,66 @@ class BillingMappingIT extends AbstractIntegrationTest {
         return plan;
     }
 
+    /**
+     * The plan catalogue the organization-creation gate reads is seeded by the changelog.
+     *
+     * <p>{@code requireCreateOrganizationEntitlement} exempts a caller's first organization and
+     * puts every one after it through {@code checkFeatureAccess} on {@code CREATE_ORGANIZATION}.
+     * Nothing had ever configured what that reads: no changelog inserted a plan, a feature or a
+     * plan_feature, and the rows on staging were typed in by hand and existed nowhere else. So a
+     * gate that was working as designed refused everybody, in every environment built from this
+     * changelog, for want of a catalogue to read.
+     *
+     * <p>Running against a database the migrations have actually been applied to is the point.
+     * The changesets are guarded on their tables being empty, and the plan_feature rows resolve
+     * their parent ids through subqueries on the code rather than literal ids, so a version of
+     * this that only parsed the XML would miss both a precondition that skips when it should not
+     * and a subquery that resolves to the wrong tier. See #642.
+     */
+    @Test
+    void theChangelogSeedsThePlanCatalogueTheOrganizationGateReads() {
+        PlanDto free = planService.getPlanByCode("FREE");
+
+        assertThat(free.getFeatures())
+                .as("the free tier grants the organization limit the gate checks")
+                .anySatisfy(feature -> {
+                    assertThat(feature.getFeatureCode()).isEqualTo("CREATE_ORGANIZATION");
+                    assertThat(feature.getQuotaLimit()).isEqualTo(1L);
+                    assertThat(feature.getQuotaPeriod().name()).isEqualTo("TOTAL");
+                });
+
+        // Every tier grants it, and they ascend. A paid tier that granted less than free, or did
+        // not grant it at all, is the shape the hand-seeded staging box was actually in.
+        assertThat(planService.getPlanByCode("STARTER").getFeatures())
+                .anySatisfy(f -> assertThat(f.getQuotaLimit()).isEqualTo(3L));
+        assertThat(planService.getPlanByCode("PRO").getFeatures())
+                .anySatisfy(f -> assertThat(f.getQuotaLimit()).isEqualTo(5L));
+
+        // A null limit is how "unmetered" is expressed: hasQuota needs a limit above zero, so
+        // enterprise falls through to allowed rather than being compared against a number.
+        assertThat(planService.getPlanByCode("ENTERPRISE").getFeatures())
+                .anySatisfy(f -> {
+                    assertThat(f.getFeatureCode()).isEqualTo("CREATE_ORGANIZATION");
+                    assertThat(f.getQuotaLimit()).isNull();
+                });
+    }
+
+    /**
+     * The price list is a business decision that has not been made, so the seed does not invent
+     * one, and it keeps the unpriced catalogue off the pricing page until it has. Staging carries
+     * figures somebody typed in May 2026 that were never signed off; promoting those into every
+     * environment would have made them look decided.
+     */
+    @Test
+    void theSeededCatalogueIsNeitherPricedNorPublic() {
+        for (String code : List.of("FREE", "STARTER", "PRO", "ENTERPRISE")) {
+            PlanDto plan = planService.getPlanByCode(code);
+            assertThat(plan.getMonthlyPrice()).as("%s monthly price", code).isNull();
+            assertThat(plan.getAnnualPrice()).as("%s annual price", code).isNull();
+            assertThat(plan.getIsPublic()).as("%s is not on the pricing page yet", code).isFalse();
+        }
+    }
+
     private void executeUpdate(String sql) {
         entityManager.createNativeQuery(sql).executeUpdate();
     }

--- a/src/test/java/org/tornotron/echno_backend/billing/controllers/BillingEndpointAuthorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/controllers/BillingEndpointAuthorityTest.java
@@ -1,0 +1,117 @@
+package org.tornotron.echno_backend.billing.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The billing surface may not be guarded by an authority this realm has no way to issue.
+ *
+ * <p>Every endpoint on all three billing controllers used to ask for
+ * {@code hasAuthority('billing:admin')}. That string occurred 45 times in the source and every
+ * one of them was the annotation itself: nothing granted it, and nothing could.
+ * {@code JwtAuthConverter} mints a bare {@code resource:scope} authority in exactly one place,
+ * {@code extractPermissions}, which reads the {@code authorization} claim of an RPT, so the
+ * string required a Keycloak Authorization Services resource named {@code billing} carrying an
+ * {@code admin} scope. The multi-tenancy audit of 2026-08-18 checked the live realm for the
+ * identical case of {@code organization:admin} and found zero authorization scopes realm-wide,
+ * one scopeless {@code Default Resource} and one scopeless {@code Default Permission}. A
+ * scopeless permission yields no {@code resource:scope} authority at all.
+ *
+ * <p>So the whole administrative billing surface was permanently refused, and it looked guarded
+ * rather than dead. This test is what stops that from being reintroduced by copying a neighbouring
+ * annotation. See #641.
+ *
+ * <p>The rule is deliberately scoped to the billing package. The same phantom shape exists
+ * elsewhere in the codebase, notably {@code organization:admin}, and is worth the same treatment,
+ * but widening this test is a change to endpoints outside the package it was written for.
+ */
+class BillingEndpointAuthorityTest {
+
+    /** The three controllers that make up the billing HTTP surface. */
+    private static final List<Class<?>> BILLING_CONTROLLERS =
+            List.of(SubscriptionController.class, PlanController.class, FeatureController.class);
+
+    /**
+     * A bare {@code resource:scope} grant inside a hasAuthority call, which is the form that
+     * needs an authorization scope the realm does not define. Org-scoped authorities built at
+     * runtime, such as {@code ORG_MEMBER_7}, do not match and are not the subject here.
+     */
+    private static final Pattern UNGRANTABLE_SCOPE_AUTHORITY =
+            Pattern.compile("hasAuthority\\(\\s*'([a-z]+:[a-z]+)'\\s*\\)");
+
+    private record Guarded(String endpoint, String expression) {}
+
+    private List<Guarded> guardedEndpoints() {
+        List<Guarded> guarded = new ArrayList<>();
+        for (Class<?> controller : BILLING_CONTROLLERS) {
+            for (Method method : controller.getDeclaredMethods()) {
+                PreAuthorize preAuthorize = method.getAnnotation(PreAuthorize.class);
+                if (preAuthorize != null) {
+                    guarded.add(new Guarded(
+                            controller.getSimpleName() + "." + method.getName(),
+                            preAuthorize.value()));
+                }
+            }
+        }
+        return guarded;
+    }
+
+    @Test
+    void noBillingEndpointIsGuardedByAnAuthorityTheRealmCannotIssue() {
+        List<String> offenders = guardedEndpoints().stream()
+                .filter(g -> {
+                    Matcher m = UNGRANTABLE_SCOPE_AUTHORITY.matcher(g.expression());
+                    return m.find();
+                })
+                .map(g -> g.endpoint() + " asks for " + g.expression())
+                .toList();
+
+        assertThat(offenders)
+                .as("billing endpoints guarded by a resource:scope authority that nothing in the "
+                        + "realm grants, so they refuse every caller forever")
+                .isEmpty();
+    }
+
+    @Test
+    void everyBillingEndpointIsStillGuardedBySomething() {
+        // Without this, the rule above passes for the worst possible reason: an endpoint whose
+        // guard was deleted rather than corrected is not an offender, and neither is a deleted
+        // controller. Pinning the count is what makes the absence of offenders mean something.
+        List<Guarded> guarded = guardedEndpoints();
+
+        long endpoints = BILLING_CONTROLLERS.stream()
+                .flatMap(c -> Arrays.stream(c.getDeclaredMethods()))
+                .filter(m -> m.getAnnotations().length > 0)
+                .filter(m -> java.lang.reflect.Modifier.isPublic(m.getModifiers()))
+                .count();
+
+        assertThat(guarded)
+                .as("every public billing endpoint carries a @PreAuthorize")
+                .hasSize((int) endpoints);
+        assertThat(guarded)
+                .as("the three billing controllers still expose their endpoints")
+                .hasSizeGreaterThanOrEqualTo(24);
+    }
+
+    @Test
+    void thePublicPlanCatalogueIsReadableByAnyAuthenticatedCaller() throws Exception {
+        // GET /public is the read a pricing page makes, and it was gated on the platform-admin
+        // authority along with everything else. A signed-in user who belongs to no organization
+        // yet has to be able to see what plans exist before they can be sold one.
+        Method publicPlans = PlanController.class.getDeclaredMethod("getPublicPlans");
+
+        assertThat(publicPlans.getAnnotation(GetMapping.class).value()).containsExactly("/public");
+        assertThat(publicPlans.getAnnotation(PreAuthorize.class).value())
+                .isEqualTo("isAuthenticated()");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/billing/services/SubscriptionServiceFeatureAccessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/billing/services/SubscriptionServiceFeatureAccessTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -195,6 +196,42 @@ class SubscriptionServiceFeatureAccessTest {
         ArgumentCaptor<UsageRecord> saved = ArgumentCaptor.forClass(UsageRecord.class);
         verify(usageRecordRepository).save(saved.capture());
         assertThat(saved.getValue().getPeriodStart()).isBefore(saved.getValue().getPeriodEnd());
+    }
+
+    /**
+     * Quota windows are UTC, not the container's timezone.
+     *
+     * <p>These bounds are written onto every usage row and are also the window existing usage is
+     * summed over, so the two only agree while every process computing them agrees on where a day
+     * begins. Derived from {@code ZoneId.systemDefault()}, as they were, a deployment in a zone
+     * ahead of UTC starts its day five and a half hours early here, which moves a user between
+     * quota periods and can allow or refuse them against a window that does not match the rows
+     * being counted. Forcing a non-UTC default is what makes this fail against that version; under
+     * UTC the default is irrelevant, which is the whole point. See #644.
+     */
+    @Test
+    void quotaPeriodBoundsAreComputedInUtcWhateverTheContainerTimezone() {
+        TimeZone original = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"));
+        try {
+            Feature f = Feature.builder().id(FEATURE_ID).code(CODE).featureType(FeatureType.QUOTA).build();
+            activeSubscriptionWith(PlanFeature.builder().feature(f).enabled(true)
+                    .quotaLimit(10L).quotaPeriod(QuotaPeriod.DAILY).build());
+
+            svc.recordUsage(USER, CODE, 1L);
+
+            ArgumentCaptor<UsageRecord> saved = ArgumentCaptor.forClass(UsageRecord.class);
+            verify(usageRecordRepository).save(saved.capture());
+
+            Instant utcDayStart = Instant.now().truncatedTo(ChronoUnit.DAYS);
+            assertThat(saved.getValue().getPeriodStart())
+                    .as("the daily window starts at UTC midnight, not at midnight in Asia/Kolkata")
+                    .isEqualTo(utcDayStart);
+            assertThat(saved.getValue().getPeriodEnd())
+                    .isEqualTo(utcDayStart.plus(1, ChronoUnit.DAYS));
+        } finally {
+            TimeZone.setDefault(original);
+        }
     }
 
     /**

--- a/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/multitenancy/TenantFilterTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
 import java.util.List;
 
@@ -120,13 +121,43 @@ class TenantFilterTest {
     }
 
     @Test
-    void billingDeclaresItselfUnscoped() throws Exception {
+    void billingRunsInsideTenantIsolationLikeAnyOtherAuthenticatedSurface() throws Exception {
+        // This assertion used to be its exact opposite, and the opposite was the defect. The
+        // filter declared every /billing path unscoped, which left TenantContext with no
+        // organization id, and every endpoint on the billing surface is guarded by
+        // @orgSecurity.hasAnyOrgRoleForCurrentTenant or isMemberOfCurrentTenant, both of which
+        // refuse a null organization outright. The declaration was therefore refusing the whole
+        // self-service billing surface to every caller in every environment. See #640.
         authenticateWith(ORG_MEMBER_7);
 
         run("/api/v1/billing/subscriptions/web/current");
 
-        assertThat(observed.unscopedReason()).contains("Billing");
-        assertThat(observed.orgId()).isNull();
+        assertThat(observed.orgId()).isEqualTo(7L);
+        assertThat(observed.unscopedReason()).isNull();
+        assertThat(observed.bypassed()).isFalse();
+    }
+
+    @Test
+    void theBillingGuardsThatRefusedEveryoneNowResolve() throws Exception {
+        // The composed statement of #640, and the one worth keeping: it is not the declaration
+        // that mattered but what the declaration did to the guard downstream of it. Running the
+        // real OrganizationSecurityService inside the chain is what makes this a test of the
+        // defect rather than of the filter's internals. Against the old filter both of these
+        // are false for every caller, because both open with a null check on the organization id.
+        OrganizationSecurityService orgSecurity = new OrganizationSecurityService(null, null);
+        authenticateWith(ORG_MEMBER_7, "ORG_7_ROLE_system-admin");
+
+        boolean[] guards = new boolean[2];
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("GET", "/api/v1/billing/subscriptions/web/current");
+        request.setRequestURI("/api/v1/billing/subscriptions/web/current");
+        filter.doFilter(request, response, (req, res) -> {
+            guards[0] = orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin");
+            guards[1] = orgSecurity.isMemberOfCurrentTenant();
+        });
+
+        assertThat(guards[0]).as("hasAnyOrgRoleForCurrentTenant on the billing surface").isTrue();
+        assertThat(guards[1]).as("isMemberOfCurrentTenant on the billing surface").isTrue();
     }
 
     @Test
@@ -169,6 +200,22 @@ class TenantFilterTest {
 
         assertThat(observed.bypassed()).isTrue();
         assertThat(observed.unscopedReason()).isNull();
+    }
+
+    @Test
+    void aMultiOrganizationCallerMustSayWhichOrganizationTheyAreBillingFor() throws Exception {
+        // The one thing removing the billing declaration actually changes for a caller. Billing
+        // now goes down the ordinary org-resolution branch, so a user who belongs to more than
+        // one organization has to name the one they mean, exactly as they already do everywhere
+        // else. Previously this request was declared unscoped and then refused by the guard, so
+        // the caller got a 403 that told them nothing about what to send.
+        authenticateWith(ORG_MEMBER_7, "ORG_MEMBER_9");
+
+        run("/api/v1/billing/subscriptions/web/current");
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getContentAsString()).contains("X-Organization-Id");
+        assertThat(observed).as("the chain is not reached").isNull();
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/organization/OrganizationServiceEntitlementTest.java
@@ -146,13 +146,58 @@ class OrganizationServiceEntitlementTest {
                     // The refusal names the entitlement, so support can tell which one to look at.
                     org.assertj.core.api.Assertions.assertThat(ex.getFeatureCode())
                             .isEqualTo(CREATE_ORGANIZATION);
+                    // The message used to be the raw reason, "No active subscription". True, and
+                    // no use to someone who has never been asked to subscribe to anything and is
+                    // looking at a button that stopped working. It has to say what governs the
+                    // decision. See #642.
                     org.assertj.core.api.Assertions.assertThat(ex.getMessage())
-                            .isEqualTo("No active subscription");
+                            .contains("needs a plan")
+                            .contains("first organization is always free");
                 });
 
         // Nothing was created, and no Keycloak group was left behind for an org that does not exist.
         verify(repository, never()).save(any(Organization.class));
         verifyNoInteractions(keycloakGroupService);
+    }
+
+    @Test
+    void aRefusalOnAQuotaNamesTheLimitAndWhatHasBeenUsedAgainstIt() {
+        // The case once a plan is actually granted, which is what the seeded catalogue makes
+        // possible. A caller who has used their allowance needs to be told the number, not handed
+        // the bare reason "Quota exceeded".
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(true);
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+        when(subscriptionService.checkFeatureAccess(CREATOR_USER_ID, CREATE_ORGANIZATION))
+                .thenReturn(FeatureAccessResultDto.quotaExceeded(3L, 3L));
+
+        assertThatExceptionOfType(SubscriptionAccessDeniedException.class)
+                .isThrownBy(() -> service().addOrganization(creationDto(), null))
+                .satisfies(ex -> {
+                    org.assertj.core.api.Assertions.assertThat(ex.getMessage())
+                            .contains("covers 3 organizations")
+                            .contains("already created 3");
+                    // The numbers still travel on the result for the frontend to render.
+                    org.assertj.core.api.Assertions.assertThat(ex.getQuotaLimit()).isEqualTo(3L);
+                    org.assertj.core.api.Assertions.assertThat(ex.getCurrentUsage()).isEqualTo(3L);
+                });
+
+        verify(repository, never()).save(any(Organization.class));
+    }
+
+    @Test
+    void aRefusalOnASingleOrganizationLimitReadsAsSingular() {
+        // The free tier's limit is 1, so this is the wording most callers will actually meet.
+        creator();
+        when(repository.existsByCreatorId(CREATOR_USER_ID.intValue())).thenReturn(true);
+        when(repository.existsByOrganizationEmail(any())).thenReturn(false);
+        when(subscriptionService.checkFeatureAccess(CREATOR_USER_ID, CREATE_ORGANIZATION))
+                .thenReturn(FeatureAccessResultDto.quotaExceeded(1L, 1L));
+
+        assertThatExceptionOfType(SubscriptionAccessDeniedException.class)
+                .isThrownBy(() -> service().addOrganization(creationDto(), null))
+                .withMessageContaining("covers 1 organization and")
+                .withMessageNotContaining("1 organizations");
     }
 
     @Test


### PR DESCRIPTION
Stage 0 of the payment-gateway work (ClickUp 86d456frt): make the billing surface reachable and the organisation gate configured. **No gateway, no Razorpay, no adapter.** Everything from stage 1 onward stays blocked on the business questions on that ticket, and none of them are guessed here.

Four commits, one per issue, each independently reviewable.

## The headline: the second-organisation block is an unseeded gate, not a bug (#642)

Creating a second organisation fails for every user in every environment that was not seeded by hand, and that is the most user-facing of the findings. I went looking for intent rather than assuming it.

b6e2f63 ("Let a new account create its first organization, and say what a denial wanted", closes #521) introduced this shape deliberately and states the rule in its own message: the first organisation is part of signing up and is exempt, every one after it goes through the feature check. The data model agrees, since `CREATE_ORGANIZATION` is a QUOTA feature named "Organization Limit" whose limit differs per tier. An organisation allowance that varies by plan is a product decision.

So the check is working. Two things were missing under it:

- **Nothing seeded the plans.** No changelog inserts a row into `plan`, `feature` or `plan_feature`. The rows on the IITM box were typed in by hand in May 2026 and exist nowhere else.
- **The refusal did not explain itself.** It reached the caller as the raw reason "No active subscription", which is true and useless to someone who has never been asked to subscribe to anything.

Both are fixed. Each seed changeSet is guarded on its table being empty and marked as run otherwise, so **staging keeps exactly the rows it has and this is a no-op there**. Plan-feature rows resolve their parent ids by code, not by literal id, so an environment that seeded the parents in a different order still attaches each limit to the right tier.

Prices are null and `is_public` is false on every row, deliberately. The price list is an open business question and the RBI e-mandate threshold makes the monthly figure a decision with product consequences, so promoting the May placeholders into every environment would have made them look decided. What the seed does give is a catalogue that exists, which is what lets a plan be granted by hand and the first customers invoiced.

## Billing was refused to everyone, everywhere (#640)

`TenantFilter.preTenantReason()` matched `/api/v1/billing` and called `declareUnscoped`, which records a reason and sets no organisation id. Every billing endpoint is guarded by `hasAnyOrgRoleForCurrentTenant` or `isMemberOfCurrentTenant`, and both refuse a null organisation. The declaration was refusing the whole self-service surface before authentication was even read.

**What removing it breaks: nothing, and I checked rather than assumed.** No billing entity is a `TenantScopedEntity` and neither is `User`, so the Hibernate org filter has nothing to act on and no query changes. #547's audit had enumerated `/billing` among the pre-tenant paths, and its stated reason was a description of how `Subscription` is stored rather than a reason to sit outside isolation. That enumeration is updated in both places it is written down.

One caller-visible change, and it is an improvement: a user in several organisations now gets a 400 naming the `X-Organization-Id` header instead of a 403 that told them nothing. Pinned by a test.

## The admin endpoints were guarded by a string that cannot exist (#641)

`hasAuthority('billing:admin')` occurred 45 times in `src/`, all of them the annotation or a commented-out copy. `JwtAuthConverter` mints a bare `resource:scope` authority only from an RPT `authorization` claim, so it needed a Keycloak resource named `billing` with an `admin` scope. The 2026-08-18 multi-tenancy audit checked the live realm for the identical `organization:admin` and found zero authorization scopes realm-wide, one scopeless Default Resource, one scopeless Default Permission. Not merely unseeded: ungrantable.

Two bars now. Plan catalogue reads are ordinary authenticated reads, since a signed-in user with no organisation has to see what plans exist before being sold one; `GET /plans/public` is the read a pricing page makes and was gated on the admin authority, which is wrong on its own terms. Catalogue writes, the feature catalogue and cross-user subscription administration are platform-staff work and deliberately do **not** fall to a customer's own `system-admin`, which every tenant's administrator holds and which would let any customer rewrite what every other customer is sold. Those are now `ROLE_platform-admin`, a Keycloak client role, which is the grant mechanism this realm has.

**They still refuse until the realm carries that role.** That is now a realm change with a ticket against it rather than an impossibility, and it is called out in the code.

## Quota windows moved with the container timezone (#644)

`calculatePeriodBounds` used `ZoneId.systemDefault()`. The bounds are both the window usage is summed over and the stamps written onto every `UsageRecord`, so the two only agree while every process agrees where a period begins. A month boundary shifts a whole day between zones. Now UTC.

## Stopped deliberately: the rekey to organizationId (#643)

The research recorded this as trivial "because there are no rows anywhere". **That is not the case.** Read-only counts against live staging: `subscription` 2, `usage_record` 2, `plan` 4, `feature` 1, `plan_feature` 2. So it is a data migration, and the mapping is not mechanical: it needs a decision per row about which organisation a user's subscription becomes. Filed with the open questions rather than migrated on an assumption.

Two things that fell out of looking: the two subscriptions are three months past their period end and still read as active, because `findActiveSubscriptionByUserId` filters on status only and `findExpiredSubscriptions` is called from nowhere. And staging's catalogue came from no changelog, so behaviour observed there is not what a fresh environment does.

## Every fix has a test that fails without it

Verified by reverting each fix on the build box and confirming the specific test goes red, not by assuming.

| Test | Pins | Without the fix |
|---|---|---|
| `TenantFilterTest.billingRunsInsideTenantIsolation...` | #640 | FAILED |
| `TenantFilterTest.theBillingGuardsThatRefusedEveryoneNowResolve` | #640, composed with the real `OrganizationSecurityService` | FAILED |
| `TenantFilterTest.aMultiOrganizationCallerMustSayWhich...` | the 400 behaviour change | new |
| `BillingEndpointAuthorityTest.noBillingEndpointIsGuardedBy...` | #641 | FAILED |
| `BillingEndpointAuthorityTest.thePublicPlanCatalogueIsReadable...` | #641 `/public` | FAILED |
| `BillingMappingIT.theChangelogSeedsThePlanCatalogue...` | #642 seed, against a real CockroachDB | FAILED |
| `BillingMappingIT.theSeededCatalogueIsNeitherPricedNorPublic` | #642 price/visibility decision | FAILED |
| `OrganizationServiceEntitlementTest.aSecondOrganizationIsRefused...` | #642 message | FAILED |
| `OrganizationServiceEntitlementTest.aRefusalOnAQuotaNamesTheLimit...` | #642 message | FAILED |
| `OrganizationServiceEntitlementTest.aRefusalOnASingleOrganization...` | #642 singular wording | FAILED |
| `SubscriptionServiceFeatureAccessTest.quotaPeriodBoundsAreComputedInUtc...` | #644 | FAILED |

Two existing tests pinned the old behaviour and were rewritten rather than deleted: `billingDeclaresItselfUnscoped` asserted the exact defect, and the entitlement test asserted the message was literally "No active subscription".

`BillingEndpointAuthorityTest` also pins the endpoint count, so a guard deleted rather than corrected cannot make the rule pass by leaving nothing to check.

## Notes for review

- `docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`, and re-verified after rebasing onto the movement-record work that landed meanwhile.
- Changelog is **082**; 081 was taken by #635 while this was in flight.
- Whether a user on no plan should fall back to the free tier is left alone on purpose. It is a product decision (open question 4 on the ticket) and today such a user is still refused, which is the behaviour that was already there.

Closes #640, #641, #642, #644. #643 stays open by design.
