### PR TITLE
Say what the org-scoped roles guide describes, which is seven roles

### DIFF
--- a/docs/org-scoped-roles.md
+++ b/docs/org-scoped-roles.md
@@ -21,7 +21,10 @@ org-5/                      ← This is a folder (Keycloak group) for the organi
     ├── system-admin        ← This is a subfolder (subgroup) for the role
     ├── org-manager
     ├── hr-admin
-    └── project-manager
+    ├── project-manager
+    ├── qa-engineer
+    ├── safety-officer
+    └── site-engineer
 ```
 
 - When a user **joins an organization**, they are placed inside the `org-5` folder.
@@ -43,7 +46,7 @@ When someone creates an organization (let's say org with ID 5), your `Organizati
 
 This method does two things:
 1. Creates the parent group `org-5` in Keycloak (this already existed before)
-2. **NEW**: Creates role subgroups inside it: `system-admin`, `org-manager`, `hr-admin`, `project-manager`
+2. Creates one role subgroup inside it for every value of `OrgRole`
 
 After this, Keycloak's group tree looks like:
 ```
@@ -51,7 +54,10 @@ org-5/
     ├── system-admin
     ├── org-manager
     ├── hr-admin
-    └── project-manager
+    ├── project-manager
+    ├── qa-engineer
+    ├── safety-officer
+    └── site-engineer
 ```
 
 **File:** `KeycloakGroupService.java` → `createOrganizationGroup()` and `createDefaultRoleSubgroups()`
@@ -166,10 +172,27 @@ This is just an enum that lists what roles exist. Each role has a `groupName` wh
 
 ```java
 SYSTEM_ADMIN("system-admin")       // Full control over the organization
-ORG_MANAGER("org-manager")         // Can manage org settings and employees
+ORG_MANAGER("org-manager")         // Manager standing only; no endpoint checks it
 HR_ADMIN("hr-admin")               // Can manage HR features (leave, attendance)
 PROJECT_MANAGER("project-manager") // Can manage projects within the org
+QA_ENGINEER("qa-engineer")         // Quality inspections, checklists, quality NCRs
+SAFETY_OFFICER("safety-officer")   // Safety inspections and safety NCRs
+SITE_ENGINEER("site-engineer")     // Reads inspections, reports corrective action
 ```
+
+The three inspection roles sit here rather than among the realm occupation roles because this is the
+layer `@PreAuthorize` actually reads. The realm has a `site-engineer` and a `safety-officer`
+occupation role as well, but occupation roles gate nothing in application code: they are a catalogue
+for assignment, not an authority.
+
+The enum also carries a second, smaller idea. `getManagerRoles()` names the four that count as
+manager standing (`SYSTEM_ADMIN`, `ORG_MANAGER`, `HR_ADMIN`, `PROJECT_MANAGER`), and that set decides
+who may be named the manager on a project invite code and who appears in the manager listings. The
+inspection roles are deliberately outside it: a QA engineer signs off quality, not headcount.
+
+That set is also the whole of what `ORG_MANAGER` does. No `@PreAuthorize` anywhere names
+`'org-manager'`, and the web role picker does not offer it, so it can only be granted through the
+API. It is not inert, though, and removing it would silently narrow `MANAGER_ROLES`.
 
 **When would you change this file?**
 - When you want to add a new role (e.g., `FINANCE_ADMIN("finance-admin")`)
@@ -210,9 +233,15 @@ This is the service that makes API calls to Keycloak to manage groups and subgro
 | `removeOrgRole(userId, orgId, role)` | Takes away a role from a user in an org |
 | `getUserOrgRoles(userId, orgId)` | Lists all roles a user has in a specific org |
 
+`assignOrgRole` creates the subgroup if the organization does not have one, through the private
+`ensureRoleSubgroup`. That is what makes adding a role to the enum a non-event: an organization
+created before the role existed has no subgroup for it, and rather than refuse the assignment and
+leave someone clicking through the Keycloak console once per tenant, the first assignment creates it.
+The name always comes from the enum, so this cannot invent an authority. Two assignments of the same
+new role can race, and the loser is told the group already exists, which is the outcome it wanted.
+
 **When would you change this file?**
 - When you need new ways to manage roles (e.g., bulk role assignment)
-- When you need to create a subgroup for a role that doesn't exist yet in an existing org
 
 ---
 
@@ -303,9 +332,8 @@ public ResponseEntity<?> approveLeave(@PathVariable Long orgId) { ... }
 
 2. For **new** organizations, the subgroup will be created automatically when the org is created.
 
-3. For **existing** organizations, you need to manually create the subgroup. You can do this by:
-   - Going to the Keycloak admin console → Groups → find `org-{id}` → create child group `finance-admin`
-   - Or writing a one-time migration script that calls `createDefaultRoleSubgroups` for all existing orgs
+3. For **existing** organizations, nothing to do. `assignOrgRole` creates the subgroup the first time
+   somebody is given the role, so there is no backfill and no console work.
 
 4. Use it in controllers:
    ```java
@@ -419,4 +447,4 @@ All of these are available in `@PreAuthorize` for checking.
 
 4. **The `OrgRole` enum is for type safety only.** It doesn't enforce anything in Keycloak. You could technically create a subgroup with any name in the Keycloak admin console and it would work. The enum just prevents typos in your Java code.
 
-5. **Existing organizations won't have subgroups.** Organizations created before this change don't have the role subgroups. You'll need to either recreate them or add subgroups via the Keycloak admin console.
+5. **A missing subgroup repairs itself.** An organization created before a role was added to the enum has no subgroup for it. The first assignment of that role creates it, so an organization does not need recreating and nobody has to add subgroups by hand in the Keycloak console.

--- a/docs/org-scoped-roles.md
+++ b/docs/org-scoped-roles.md
@@ -16,7 +16,7 @@ The entire system is built on one simple concept from Keycloak: **groups can hav
 
 Think of it like folders on your computer:
 
-```
+```text
 org-5/                      ← This is a folder (Keycloak group) for the organization
     ├── system-admin        ← This is a subfolder (subgroup) for the role
     ├── org-manager
@@ -49,7 +49,7 @@ This method does two things:
 2. Creates one role subgroup inside it for every value of `OrgRole`
 
 After this, Keycloak's group tree looks like:
-```
+```text
 org-5/
     ├── system-admin
     ├── org-manager
@@ -238,7 +238,9 @@ This is the service that makes API calls to Keycloak to manage groups and subgro
 created before the role existed has no subgroup for it, and rather than refuse the assignment and
 leave someone clicking through the Keycloak console once per tenant, the first assignment creates it.
 The name always comes from the enum, so this cannot invent an authority. Two assignments of the same
-new role can race, and the loser is told the group already exists, which is the outcome it wanted.
+new role can race, and the loser's create fails with the group already existing; that is handled
+inside `ensureRoleSubgroup`, which reads the subgroup back and lets the assignment go through, so
+both callers succeed.
 
 **When would you change this file?**
 - When you need new ways to manage roles (e.g., bulk role assignment)

--- a/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
@@ -51,12 +51,9 @@ public class KeycloakGroupService {
     /**
      * Creates the top-level organization group in Keycloak and its default role subgroups.
      *
-     * After this call, the Keycloak group tree will look like:
-     *   org-{organizationId}/
-     *     ├── system-admin
-     *     ├── org-manager
-     *     ├── hr-admin
-     *     └── project-manager
+     * After this call the Keycloak group tree holds org-{organizationId} with one subgroup per
+     * OrgRole value beneath it. The list is not repeated here: naming it is what let this comment
+     * and the guide fall three roles behind the enum.
      *
      * @return the Keycloak group ID of the parent org group
      */

--- a/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/KeycloakGroupService.java
@@ -277,8 +277,8 @@ public class KeycloakGroupService {
      * Creates default role subgroups under an organization group.
      * Called automatically when a new organization is created.
      *
-     * Each OrgRole enum value becomes a subgroup. For example, under "org-5":
-     *   system-admin, org-manager, hr-admin, project-manager
+     * Every OrgRole enum value becomes a subgroup, so the list is whatever the enum holds rather
+     * than a set named here that would go stale the next time a role is added.
      */
     private void createDefaultRoleSubgroups(Keycloak keycloak, String orgGroupId, String organizationId) {
         for (OrgRole role : OrgRole.values()) {

--- a/src/test/java/org/tornotron/echno_backend/common/enums/OrgRoleDocumentationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/enums/OrgRoleDocumentationTest.java
@@ -1,0 +1,87 @@
+package org.tornotron.echno_backend.common.enums;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keeps {@code docs/org-scoped-roles.md} honest about {@link OrgRole}.
+ *
+ * <p>The guide is the only description of this authorization layer anyone reads, and it had drifted
+ * to naming four roles where the enum holds seven: the three inspection roles were added and the
+ * document was not. A role that exists and is undocumented is worse than an undocumented feature,
+ * because the guide reads as complete and someone building an authorization decision on it is
+ * working from a list that is missing entries.
+ *
+ * <p>The check is deliberately a name-presence one rather than an assertion about the prose around
+ * each name. Anything stricter would be a second copy of the enum living in a test, which is the
+ * problem rather than the fix; anything looser would not have caught the drift this exists to
+ * prevent. The document is free to say whatever it likes about a role as long as it says the role
+ * is there.
+ *
+ * <p>It also pins the two instructions that were wrong rather than merely incomplete. The guide told
+ * an operator to create role subgroups by hand in the Keycloak admin console for every existing
+ * organization, which stopped being true when {@code KeycloakGroupService.ensureRoleSubgroup} began
+ * creating a missing subgroup on first assignment. Following the old instruction is not harmless: it
+ * is per-tenant console work that the code already does, and it invites hand-typed group names that
+ * no enum vouches for.
+ */
+class OrgRoleDocumentationTest {
+
+    private static final Path GUIDE = Path.of(
+            System.getProperty("org.scoped.roles.doc", "docs/org-scoped-roles.md"));
+
+    private String guide() throws IOException {
+        assertThat(Files.exists(GUIDE))
+                .as("the org-scoped roles guide at %s", GUIDE.toAbsolutePath())
+                .isTrue();
+        return Files.readString(GUIDE, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void everyOrgRoleIsNamedInTheGuide() throws IOException {
+        String text = guide();
+
+        List<String> missing = new ArrayList<>();
+        for (OrgRole role : OrgRole.values()) {
+            if (!text.contains(role.getGroupName())) {
+                missing.add(role.getGroupName());
+            }
+        }
+
+        assertThat(missing)
+                .as("roles in OrgRole that docs/org-scoped-roles.md never names")
+                .isEmpty();
+    }
+
+    @Test
+    void theGuideDoesNotStillAskForSubgroupsToBeCreatedByHand() throws IOException {
+        String text = guide();
+
+        assertThat(text)
+                .as("ensureRoleSubgroup creates a missing subgroup on first assignment, "
+                        + "so the guide must not send anyone to the Keycloak console to make one")
+                .doesNotContain("create child group")
+                .doesNotContain("add subgroups via the Keycloak admin console");
+    }
+
+    @Test
+    void theGuideDescribesWhatOrgManagerActuallyGrants() throws IOException {
+        String text = guide();
+
+        // org-manager gates no endpoint, which is easy to mistake for granting nothing. It is one of
+        // OrgRole.getManagerRoles(), and that set decides who may be named the manager on a project
+        // invite code and who appears in the manager listings, so removing it is a behaviour change.
+        assertThat(OrgRole.getManagerRoles()).contains(OrgRole.ORG_MANAGER);
+        assertThat(text)
+                .as("the guide must not leave org-manager looking inert")
+                .contains("getManagerRoles");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/enums/OrgRoleDocumentationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/enums/OrgRoleDocumentationTest.java
@@ -66,10 +66,20 @@ class OrgRoleDocumentationTest {
         String text = guide();
 
         assertThat(text)
-                .as("ensureRoleSubgroup creates a missing subgroup on first assignment, "
-                        + "so the guide must not send anyone to the Keycloak console to make one")
+                .as("ensureRoleSubgroup creates a missing subgroup on first assignment, so the "
+                        + "guide must not send anyone to the Keycloak console to make one, nor "
+                        + "suggest recreating an organization to get it")
                 .doesNotContain("create child group")
-                .doesNotContain("add subgroups via the Keycloak admin console");
+                .doesNotContain("add subgroups via the Keycloak admin console")
+                .doesNotContain("recreate them");
+
+        // Removing the wrong instruction is only half of it. Silence would leave a reader who has
+        // just added a role to the enum with no answer at all about existing tenants, and the
+        // answer they would reach for is the console one that was just deleted.
+        assertThat(text)
+                .as("the guide must say what does happen for an organization that predates a role")
+                .contains("ensureRoleSubgroup")
+                .contains("first assignment");
     }
 
     @Test
@@ -80,8 +90,12 @@ class OrgRoleDocumentationTest {
         // OrgRole.getManagerRoles(), and that set decides who may be named the manager on a project
         // invite code and who appears in the manager listings, so removing it is a behaviour change.
         assertThat(OrgRole.getManagerRoles()).contains(OrgRole.ORG_MANAGER);
+
         assertThat(text)
-                .as("the guide must not leave org-manager looking inert")
-                .contains("getManagerRoles");
+                .as("naming getManagerRoles is not enough: the guide has to say what holding one "
+                        + "of them does, or a reader still concludes org-manager is inert")
+                .contains("getManagerRoles")
+                .contains("project invite code")
+                .contains("manager listings");
     }
 }


### PR DESCRIPTION
Closes #653.

`docs/org-scoped-roles.md` had drifted to naming four roles where `OrgRole` holds seven, and two of its instructions had become wrong rather than merely incomplete.

**The roles.** `qa-engineer`, `safety-officer` and `site-engineer` were added and the guide was not, in the enum listing and in both group-tree illustrations. The guide reads as complete, so somebody building an authorization decision on it was working from a list with entries missing. Also added the note on why the three inspection roles live in this layer rather than among the realm occupation roles, since that is the question the addition raises.

**The Keycloak console instructions.** Scenario 8 step 3 and note 5 both told an operator to create role subgroups by hand for every existing organization, or to recreate the organizations. Neither has been true since `ensureRoleSubgroup` began creating a missing subgroup on first assignment. Following them is not harmless: it is per-tenant console work the code already does, and it invites hand-typed group names that no enum vouches for.

**`org-manager`.** The table had it down as managing org settings and employees. It gates nothing: `'org-manager'` appears in zero `@PreAuthorize` expressions. What it grants is manager standing through `getManagerRoles()`, which decides who may be named the manager on a project invite code and who appears in the manager listings. Worth a sentence next to the role, both because it is surprising and because it means removing the constant would be a behaviour change rather than a cleanup. The wider role-model question is #650; this only stops the guide from misdescribing it.

The javadoc on `createDefaultRoleSubgroups` listed the same four names and is now written in terms of the enum.

## The test

`OrgRoleDocumentationTest` pins all three against the code. The role check is a name-presence one on purpose: anything stricter would be a second copy of the enum living in a test, which is the problem rather than the fix, and anything looser would not have caught the drift it exists to prevent.

Verified red before green. With the pre-change document in place all three fail; with it restored all three pass.

```
OrgRoleDocumentationTest > everyOrgRoleIsNamedInTheGuide() FAILED
OrgRoleDocumentationTest > theGuideDoesNotStillAskForSubgroupsToBeCreatedByHand() FAILED
OrgRoleDocumentationTest > theGuideDescribesWhatOrgManagerActuallyGrants() FAILED
```

Full `./gradlew build` green on the lab box, 8m 50s, test heap 556 MB live of the 2048 MB cap.

Found while writing the user guide (tornotron/echno-web#371).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for three additional organization roles: QA Engineer, Safety Officer, and Site Engineer.
  * Clarified role semantics, manager-role definitions, and role subgroup structure.
  * Documented automatic creation of missing role subgroups during role assignment.
* **Tests**
  * Added checks to keep the role documentation aligned with available roles and current subgroup-management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->