### PR TITLE
Make two listings able to answer what their callers ask

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10932,6 +10932,52 @@
         },
         "type": "object"
       },
+      "PageAttendanceRegularizationDto": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/AttendanceRegularizationDto"
+            },
+            "type": "array"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "numberOfElements": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "size": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "totalElements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "PageChatMessageDto": {
         "properties": {
           "content": {
@@ -21182,7 +21228,7 @@
     },
     "/api/v1/attendance-regularizations/pending": {
       "get": {
-        "description": "Returns every regularization request awaiting approval or rejection.",
+        "description": "Returns the regularization requests awaiting approval or rejection, up to a fixed ceiling. The response carries X-Total-Count with the true number of pending requests, and X-Result-Capped when there were more than one response can hold.",
         "operationId": "getPending_1",
         "responses": {
           "200": {
@@ -21397,9 +21443,171 @@
         ]
       }
     },
+    "/api/v1/attendance-regularizations/web": {
+      "get": {
+        "description": "Returns a paged list of regularization requests in the current tenant, in any status. The optional status, approver and requester parameters narrow the result; omitting a parameter leaves that dimension unfiltered.\n\nThe approver and the rejecter are recorded in the same pair of columns, so approvedById on its own means \"requests this person decided\". Pair it with status to separate the two: approvedById with status=APPROVED is what that person approved, and with status=REJECTED what they rejected.\n\nBoth ids are employee ids. A request decided by a caller who has no employee record in this tenant carries no approver id and is not matched by any approvedById.",
+        "operationId": "list_12",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "PENDING",
+                "APPROVED",
+                "REJECTED"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approvedById",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "requestedById",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageAttendanceRegularizationDto"
+                }
+              }
+            },
+            "description": "Page of matching regularization requests"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "pageNo or pageSize is out of range"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks permission to manage attendance records"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List regularization requests",
+        "tags": [
+          "Attendance Regularizations (Web)"
+        ]
+      }
+    },
     "/api/v1/attendance-regularizations/web/pending": {
       "get": {
-        "description": "Returns every regularization request awaiting approval or rejection.",
+        "description": "Returns the regularization requests awaiting approval or rejection, up to a fixed ceiling. The response carries X-Total-Count with the true number of pending requests, and X-Result-Capped when there were more than one response can hold. To page through the register, or to see requests that have already been decided, use the listing at the collection root instead.",
         "operationId": "getPending",
         "responses": {
           "200": {
@@ -37847,7 +38055,7 @@
     },
     "/api/v1/finance/construction-payments/web": {
       "get": {
-        "description": "Returns a paged list of payment vouchers in the current tenant. The optional project, vendor, status, type and payee type parameters narrow the result; omitting a parameter leaves that dimension unfiltered.",
+        "description": "Returns a paged list of payment vouchers in the current tenant. The optional project, vendor, status, type, payee type, employee, verifier and raiser parameters narrow the result; omitting a parameter leaves that dimension unfiltered.\n\nNarrow here rather than in the client. A filter applied to the rows one page came back in narrows that page and not the register, so it answers a different question from the one it appears to, and an empty result then reads as a complete answer.\n\nThe three person parameters carry ids from two different sequences and are not interchangeable. employeeId is the payee on a salary or advance voucher and is an employee id; verifiedBy and raisedBy are platform user ids, the same ids the response returns beside verifiedByName and raisedByName.",
         "operationId": "list_4",
         "parameters": [
           {
@@ -37924,10 +38132,56 @@
           },
           {
             "in": "query",
-            "name": "pageable",
-            "required": true,
+            "name": "employeeId",
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/Pageable"
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verifiedBy",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "raisedBy",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
             }
           }
         ],
@@ -37950,7 +38204,7 @@
                 }
               }
             },
-            "description": "Bad Request"
+            "description": "pageNo or pageSize is out of range"
           },
           "402": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationController.java
@@ -14,6 +14,7 @@ import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
 import org.tornotron.echno_backend.attendance.service.AttendanceRegularizationService;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -87,14 +88,17 @@ public class AttendanceRegularizationController {
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
     @Operation(
             summary = "List pending regularization requests",
-            description = "Returns every regularization request awaiting approval or rejection."
+            description = "Returns the regularization requests awaiting approval or rejection, up to a "
+                    + "fixed ceiling. The response carries X-Total-Count with the true number of pending "
+                    + "requests, and X-Result-Capped when there were more than one response can hold."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Pending regularization requests returned"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records")
     })
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
-        return ResponseEntity.ok(regularizationService.getPendingRegularizations());
+        return UnpagedResultCap.respond(regularizationService.getPendingRegularizations(
+                0, UnpagedResultCap.MAX_ROWS));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationControllerWeb.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,10 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.attendance.dto.AttendanceRegularizationDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationActionDto;
 import org.tornotron.echno_backend.attendance.dto.RegularizationRequestDto;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import org.tornotron.echno_backend.attendance.service.AttendanceRegularizationService;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
 
@@ -87,14 +91,48 @@ public class AttendanceRegularizationControllerWeb {
     @PreAuthorize("@attendanceSecurity.canManageRecords()")
     @Operation(
             summary = "List pending regularization requests",
-            description = "Returns every regularization request awaiting approval or rejection."
+            description = "Returns the regularization requests awaiting approval or rejection, up to a "
+                    + "fixed ceiling. The response carries X-Total-Count with the true number of pending "
+                    + "requests, and X-Result-Capped when there were more than one response can hold. To "
+                    + "page through the register, or to see requests that have already been decided, use "
+                    + "the listing at the collection root instead."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Pending regularization requests returned"),
             @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records")
     })
     public ResponseEntity<List<AttendanceRegularizationDto>> getPending() {
-        return ResponseEntity.ok(regularizationService.getPendingRegularizations());
+        return UnpagedResultCap.respond(regularizationService.getPendingRegularizations(
+                0, UnpagedResultCap.MAX_ROWS));
+    }
+
+    @GetMapping
+    @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @Operation(
+            summary = "List regularization requests",
+            description = "Returns a paged list of regularization requests in the current tenant, in any "
+                    + "status. The optional status, approver and requester parameters narrow the result; "
+                    + "omitting a parameter leaves that dimension unfiltered.\n\n"
+                    + "The approver and the rejecter are recorded in the same pair of columns, so "
+                    + "approvedById on its own means \"requests this person decided\". Pair it with status "
+                    + "to separate the two: approvedById with status=APPROVED is what that person "
+                    + "approved, and with status=REJECTED what they rejected.\n\n"
+                    + "Both ids are employee ids. A request decided by a caller who has no employee "
+                    + "record in this tenant carries no approver id and is not matched by any "
+                    + "approvedById."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching regularization requests"),
+            @ApiResponse(responseCode = "400", description = "pageNo or pageSize is out of range"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records")
+    })
+    public Page<AttendanceRegularizationDto> list(
+            @RequestParam(required = false) RegularizationStatus status,
+            @RequestParam(required = false) Long approvedById,
+            @RequestParam(required = false) Long requestedById,
+            PageQuery pageQuery) {
+        return regularizationService.findAll(status, approvedById, requestedById,
+                pageQuery.getPageNo(), pageQuery.getPageSize());
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationRepository.java
@@ -1,6 +1,9 @@
 package org.tornotron.echno_backend.attendance;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
@@ -8,13 +11,28 @@ import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 import java.util.List;
 import java.util.Optional;
 
-public interface AttendanceRegularizationRepository extends JpaRepository<AttendanceRegularization, Long> {
+public interface AttendanceRegularizationRepository
+        extends JpaRepository<AttendanceRegularization, Long>,
+        JpaSpecificationExecutor<AttendanceRegularization> {
 
     Optional<AttendanceRegularization> findByAttendanceId(Long attendanceId);
 
     Optional<AttendanceRegularization> findByIdAndOrganization_Id(Long id, Long organizationId);
 
-    List<AttendanceRegularization> findByStatus(RegularizationStatus status);
+    /**
+     * One page of the requests in a given status.
+     *
+     * <p>Replaced an unpaged {@code findByStatus} that the pending register read in full. That
+     * register grows with a tenant's attendance history and nothing bounded it, so the read is
+     * now bounded by {@code org.tornotron.echno_backend.common.pagination.UnpagedResultCap}
+     * rather than by how long the tenant has been running. The unpaged variant is gone rather
+     * than left beside this one, so the next caller cannot reach for it by accident.
+     *
+     * @param status   The status to return.
+     * @param pageable The page to read.
+     * @return That page of requests, with the true total.
+     */
+    Page<AttendanceRegularization> findByStatus(RegularizationStatus status, Pageable pageable);
 
     List<AttendanceRegularization> findByRequestedBy(String requestedBy);
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationSpecifications.java
@@ -1,0 +1,67 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the optional register filters as a JPA {@link Specification}. Only non-null arguments
+ * become predicates, so an omitted parameter leaves that dimension unfiltered rather than binding
+ * a null-typed parameter on the Postgres wire protocol.
+ *
+ * <p>Organization scoping is deliberately absent. It comes from the Hibernate {@code orgFilter}
+ * enabled per request against {@link AttendanceRegularization}, which since issue #507 is applied
+ * fail-closed: an unset tenant is an error rather than an unfiltered read. Repeating the predicate
+ * here would suggest the filter were optional, and the two could drift. It applies to the count
+ * query behind {@code getTotalElements} for the same reason it applies to the row query, because
+ * both are criteria queries over the same filtered entity.
+ *
+ * <p>Every id here is supplied by the caller, so none of them may be allowed to widen the read.
+ * They narrow within the tenant and never across it.
+ *
+ * <p>Written for issue #637. The register's only listing was pending-only, and a pending request
+ * has no approver by construction, so the approver the web client already shows on a decided
+ * request could not be filtered on at all.
+ */
+public final class AttendanceRegularizationSpecifications {
+
+    private AttendanceRegularizationSpecifications() {}
+
+    /**
+     * The register filters, as a specification that adds a predicate only for the arguments given.
+     *
+     * <p>{@code approvedById} answers "requests this person decided". It cannot on its own
+     * distinguish an approval from a rejection, because {@code processRegularization} stamps the
+     * same column pair on both outcomes. Pairing it with {@code status} is what separates the two:
+     * {@code approvedById=X&status=APPROVED} is the approvals, {@code &status=REJECTED} the
+     * rejections. That is why the two live on one listing rather than on an endpoint each.
+     *
+     * @param status       Lifecycle status of the request.
+     * @param approvedById Employee id of whoever approved or rejected the request. An employee id,
+     *                     and null on a request decided by a caller with no employee record in the
+     *                     tenant.
+     * @param requestedById Employee id of whoever raised the request. An employee id, not the
+     *                     platform user id also stored on the row.
+     * @return A specification matching every filter that was supplied.
+     */
+    public static Specification<AttendanceRegularization> withFilters(RegularizationStatus status,
+                                                                     Long approvedById,
+                                                                     Long requestedById) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (approvedById != null) {
+                predicates.add(cb.equal(root.get("approvedById"), approvedById));
+            }
+            if (requestedById != null) {
+                predicates.add(cb.equal(root.get("requestedById"), requestedById));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceRegularizationSpecifications.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.attendance;
 
 import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
 
@@ -27,6 +28,27 @@ import java.util.List;
  * request could not be filtered on at all.
  */
 public final class AttendanceRegularizationSpecifications {
+
+    /**
+     * The order every page of the register is read in.
+     *
+     * <p>A page with no order is a page in whatever order the storage engine happened to produce,
+     * which on a distributed engine is not stable between two requests: the same request can
+     * appear on page one and again on page two while another never appears at all. A register that
+     * silently drops a row from a traversal is the failure this listing was added to stop, so it
+     * cannot be left unordered.
+     *
+     * <p>Newest request first is what an approver's queue wants. The id breaks the tie between two
+     * raised in the same instant, and being the primary key it is unique, so no two rows compare
+     * equal and no page boundary can fall inside a run of ties.
+     *
+     * <p>Lives here beside the filters rather than in the service because it is part of the same
+     * thing: the shape of the query this register is read with. Both paged reads share it, and the
+     * test reads it from here rather than restating it, so a test cannot pass against an order the
+     * production code does not use.
+     */
+    public static final Sort LIST_ORDER =
+            Sort.by(Sort.Order.desc("requestedAt"), Sort.Order.desc("id"));
 
     private AttendanceRegularizationSpecifications() {}
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -265,7 +265,7 @@ public class AttendanceRegularizationService {
     @Transactional(readOnly = true)
     public Page<AttendanceRegularizationDto> getPendingRegularizations(int pageNo, int pageSize) {
         return regularizationRepository
-                .findByStatus(RegularizationStatus.PENDING, PageRequest.of(pageNo, pageSize))
+                .findByStatus(RegularizationStatus.PENDING, PageRequest.of(pageNo, pageSize, AttendanceRegularizationSpecifications.LIST_ORDER))
                 .map(regularizationMapper::toDto);
     }
 
@@ -308,7 +308,7 @@ public class AttendanceRegularizationService {
         return regularizationRepository
                 .findAll(AttendanceRegularizationSpecifications
                                 .withFilters(status, approvedById, requestedById),
-                        PageRequest.of(pageNo, pageSize))
+                        PageRequest.of(pageNo, pageSize, AttendanceRegularizationSpecifications.LIST_ORDER))
                 .map(regularizationMapper::toDto);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.attendance.service;
 
 import jakarta.validation.ValidationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -248,12 +250,66 @@ public class AttendanceRegularizationService {
         return regularizationMapper.toDto(regularizationRepository.save(regularization));
     }
 
+    /**
+     * One page of the requests still awaiting a decision.
+     *
+     * <p>Used to read every pending request the tenant held. That grows with attendance history
+     * and nothing bounded it, so the caller now names a page and the web endpoints ask for a
+     * single capped one. The page carries the true total, which is what lets a truncated answer
+     * say so instead of passing for a complete one.
+     *
+     * @param pageNo   Zero-based page index.
+     * @param pageSize Rows per page.
+     * @return That page of pending requests.
+     */
     @Transactional(readOnly = true)
-    public List<AttendanceRegularizationDto> getPendingRegularizations() {
-        return regularizationRepository.findByStatus(RegularizationStatus.PENDING)
-                .stream()
-                .map(regularizationMapper::toDto)
-                .collect(Collectors.toList());
+    public Page<AttendanceRegularizationDto> getPendingRegularizations(int pageNo, int pageSize) {
+        return regularizationRepository
+                .findByStatus(RegularizationStatus.PENDING, PageRequest.of(pageNo, pageSize))
+                .map(regularizationMapper::toDto);
+    }
+
+    /**
+     * One page of the register, narrowed by any of status, approver and requester.
+     *
+     * <p>The register's only listing was pending-only, which made the approver impossible to
+     * filter on: {@link #processRegularization} stamps the approver in the same call that moves
+     * the request off {@code PENDING}, so a row with an approver was never in the list and a row
+     * in the list never had one. Widening the listing rather than adding a second one keeps the
+     * register a single collection; a "decided" endpoint beside a "pending" one would have to be
+     * stitched together by the client, which is the partial-view failure the pending-only listing
+     * already caused.
+     *
+     * <p>Every filter is applied in the query, not to the returned page. Narrowing a page in the
+     * browser hides the matches that fall outside it while still reading as a complete answer,
+     * which is the same defect one step further along.
+     *
+     * <p>The approver and the rejecter share one column pair, so {@code approvedById} alone means
+     * "decided by", and {@code status} is what separates an approval from a rejection. The two
+     * together answer both questions without a schema change.
+     *
+     * <p>Tenant scoping is the Hibernate {@code orgFilter}, which is fail-closed since issue #507
+     * and applies to the count query as well as the rows. The ids here are the caller's, so they
+     * are only ever allowed to narrow within the tenant.
+     *
+     * @param status        Status to return, or null for every status.
+     * @param approvedById  Employee id of whoever decided the request, or null for anyone.
+     * @param requestedById Employee id of whoever raised the request, or null for anyone.
+     * @param pageNo        Zero-based page index.
+     * @param pageSize      Rows per page.
+     * @return That page of matching requests.
+     */
+    @Transactional(readOnly = true)
+    public Page<AttendanceRegularizationDto> findAll(RegularizationStatus status,
+                                                     Long approvedById,
+                                                     Long requestedById,
+                                                     int pageNo,
+                                                     int pageSize) {
+        return regularizationRepository
+                .findAll(AttendanceRegularizationSpecifications
+                                .withFilters(status, approvedById, requestedById),
+                        PageRequest.of(pageNo, pageSize))
+                .map(regularizationMapper::toDto);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
@@ -34,7 +34,12 @@ import java.util.UUID;
                 @Index(name = "idx_cpmt_status", columnList = "status"),
                 @Index(name = "idx_cpmt_type", columnList = "type"),
                 @Index(name = "idx_cpmt_payee_type", columnList = "payee_type"),
-                @Index(name = "idx_cpmt_payment_date", columnList = "payment_date")
+                @Index(name = "idx_cpmt_payment_date", columnList = "payment_date"),
+                // The three the listing gained a filter on under issue #638. Created by changelog
+                // 085; declared here so the entity and the schema describe the same table.
+                @Index(name = "idx_cpmt_employee", columnList = "employee_id"),
+                @Index(name = "idx_cpmt_verified_by", columnList = "verified_by"),
+                @Index(name = "idx_cpmt_raised_by", columnList = "raised_by")
         })
 @Filter(name = "orgFilter", condition = "organization_id = :organizationId")
 @Getter @Setter

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
@@ -15,16 +15,46 @@ import java.util.List;
  * arguments become predicates, which avoids binding null-typed parameters on the
  * Postgres wire protocol. Organization scoping is handled separately by the
  * Hibernate {@code orgFilter} enabled per request.
+ *
+ * <p>Every dimension the payments screen narrows by belongs here rather than in the browser. A
+ * filter applied to the array a page came back in narrows that page and not the register, so it
+ * answers a different question from the one the chip above it claims, and answers it without
+ * saying so. The three person filters were added for that reason under issue #638: the web list
+ * was narrowing a page of twenty by verifier client-side and reading the result as the whole
+ * answer.
+ *
+ * <p>The three carry ids from two different sequences and are not interchangeable.
+ * {@code employeeId} is the payee on a salary or advance voucher and is an employee id;
+ * {@code verifiedBy} and {@code raisedBy} are platform user ids stamped from the session.
+ * Resolving one through the other is the wrong-person bug echno-web#346 removed, so a caller
+ * passing an employee id as {@code verifiedBy} gets an empty page rather than somebody else's
+ * vouchers.
  */
 public final class ConstructionPaymentSpecifications {
 
     private ConstructionPaymentSpecifications() {}
 
+    /**
+     * The list filters, as a specification that adds a predicate only for the arguments given.
+     *
+     * @param projectId  Project the voucher is charged to.
+     * @param vendorId   Vendor being paid.
+     * @param status     Lifecycle status of the voucher.
+     * @param type       Kind of payment.
+     * @param payeeType  Category of party being paid.
+     * @param employeeId Employee being paid. An employee id, not a user id.
+     * @param verifiedBy User id that verified the voucher. A platform user id, not an employee id.
+     * @param raisedBy   User id that raised the voucher. A platform user id, not an employee id.
+     * @return A specification matching every filter that was supplied.
+     */
     public static Specification<ConstructionPayment> withFilters(Long projectId,
                                                                  Long vendorId,
                                                                  ConstructionPaymentVoucherStatus status,
                                                                  ConstructionPaymentType type,
-                                                                 ConstructionPayeeType payeeType) {
+                                                                 ConstructionPayeeType payeeType,
+                                                                 Long employeeId,
+                                                                 Long verifiedBy,
+                                                                 Long raisedBy) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             if (projectId != null) {
@@ -41,6 +71,15 @@ public final class ConstructionPaymentSpecifications {
             }
             if (payeeType != null) {
                 predicates.add(cb.equal(root.get("payeeType"), payeeType));
+            }
+            if (employeeId != null) {
+                predicates.add(cb.equal(root.get("employeeId"), employeeId));
+            }
+            if (verifiedBy != null) {
+                predicates.add(cb.equal(root.get("verifiedBy"), verifiedBy));
+            }
+            if (raisedBy != null) {
+                predicates.add(cb.equal(root.get("raisedBy"), raisedBy));
             }
             return cb.and(predicates.toArray(new Predicate[0]));
         };

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentSpecifications.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.finance.construction.repositories;
 
 import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
@@ -31,6 +32,28 @@ import java.util.List;
  * vouchers.
  */
 public final class ConstructionPaymentSpecifications {
+
+    /**
+     * The order every page of the listing is read in.
+     *
+     * <p>A page with no order is a page in whatever order the storage engine happened to produce,
+     * which on a distributed engine is not stable between two requests: the same voucher can
+     * appear on page one and again on page two while another never appears at all. That is the
+     * failure this listing exists to stop, so leaving the order out would reintroduce it one level
+     * down. It matters especially here, because the endpoint used to take a {@code Pageable} that
+     * could at least carry a caller's sort.
+     *
+     * <p>Newest payment first is what a payments screen wants. The payment number breaks the tie
+     * between two vouchers dated the same day, and it is unique per tenant, so no two rows compare
+     * equal and no page boundary can fall inside a run of ties. Same shape and same reason as the
+     * AR invoice listing's order.
+     *
+     * <p>Lives here beside the filters because it is part of the same thing: the shape of the
+     * query this register is read with. The test reads it from here rather than restating it, so a
+     * test cannot pass against an order the production code does not use.
+     */
+    public static final Sort LIST_ORDER =
+            Sort.by(Sort.Order.desc("paymentDate"), Sort.Order.desc("paymentNumber"));
 
     private ConstructionPaymentSpecifications() {}
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -106,7 +106,7 @@ public class ConstructionPaymentService {
         Page<ConstructionPayment> payments = paymentRepo.findAll(
                 ConstructionPaymentSpecifications.withFilters(
                         projectId, vendorId, status, type, payeeType, employeeId, verifiedBy, raisedBy),
-                PageRequest.of(pageNo, pageSize));
+                PageRequest.of(pageNo, pageSize, ConstructionPaymentSpecifications.LIST_ORDER));
         UserNameLookup names = namesFor(payments.getContent());
         return payments.map(payment -> mapper.toDto(payment, names));
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -3,7 +3,7 @@ package org.tornotron.echno_backend.finance.construction.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.common.approval.ApprovalParty;
@@ -66,16 +66,47 @@ public class ConstructionPaymentService {
                         "Construction payment with ID " + id + " was not found")));
     }
 
+    /**
+     * One page of the voucher register, narrowed by any of the filters supplied.
+     *
+     * <p>Every dimension the payments screen narrows by is a query predicate here, including the
+     * three person filters. They were added under issue #638, where the web list was filtering a
+     * page of twenty by verifier in the browser and presenting the result as the register: a
+     * filter over one page answers a different question from the chip above it, and says nothing
+     * about the rows it never saw.
+     *
+     * <p>The page bounds arrive as a {@code PageQuery} on the endpoint rather than a Spring
+     * {@code Pageable}. A {@code Pageable} took its default size from
+     * {@code spring.data.web.pageable.default-page-size}, which was never set, so Spring's own
+     * default of twenty applied and no caller could tell where the number came from.
+     *
+     * @param projectId  Project the voucher is charged to, or null for every project.
+     * @param vendorId   Vendor being paid, or null for every vendor.
+     * @param status     Lifecycle status, or null for every status.
+     * @param type       Kind of payment, or null for every kind.
+     * @param payeeType  Category of party paid, or null for every category.
+     * @param employeeId Employee being paid. An employee id, or null for every payee.
+     * @param verifiedBy User id that verified the voucher, or null for any verifier.
+     * @param raisedBy   User id that raised the voucher, or null for any raiser.
+     * @param pageNo     Zero-based page index.
+     * @param pageSize   Rows per page.
+     * @return That page of matching vouchers.
+     */
     @Transactional(readOnly = true)
     public Page<ConstructionPaymentDto> findAll(Long projectId,
                                                 Long vendorId,
                                                 ConstructionPaymentVoucherStatus status,
                                                 ConstructionPaymentType type,
                                                 ConstructionPayeeType payeeType,
-                                                Pageable pageable) {
+                                                Long employeeId,
+                                                Long verifiedBy,
+                                                Long raisedBy,
+                                                int pageNo,
+                                                int pageSize) {
         Page<ConstructionPayment> payments = paymentRepo.findAll(
-                ConstructionPaymentSpecifications.withFilters(projectId, vendorId, status, type, payeeType),
-                pageable);
+                ConstructionPaymentSpecifications.withFilters(
+                        projectId, vendorId, status, type, payeeType, employeeId, verifiedBy, raisedBy),
+                PageRequest.of(pageNo, pageSize));
         UserNameLookup names = namesFor(payments.getContent());
         return payments.map(payment -> mapper.toDto(payment, names));
     }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -7,11 +7,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
@@ -36,6 +36,19 @@ import java.util.UUID;
                 + "system administrators and project managers."
 )
 public class ConstructionPaymentControllerWeb {
+
+    /**
+     * Rows this listing answers with when the caller names no page size.
+     *
+     * <p>Twenty is what the endpoint has been returning, though nothing here said so: it took a
+     * Spring {@code Pageable}, whose default comes from
+     * {@code spring.data.web.pageable.default-page-size}, and that property is not set. The point
+     * of issue #638 is that the number was invisible and unreachable, not that it was twenty, so
+     * it is written down here rather than changed. Folding the endpoint onto
+     * {@link PageQuery#DEFAULT_PAGE_SIZE} would halve what every caller who omits the parameter
+     * receives today, which is a contract change with nothing to do with the fix.
+     */
+    private static final int SHIPPED_PAGE_SIZE = 20;
 
     private final ConstructionPaymentService service;
 
@@ -75,11 +88,19 @@ public class ConstructionPaymentControllerWeb {
     @Operation(
             summary = "List construction payment vouchers",
             description = "Returns a paged list of payment vouchers in the current tenant. The optional "
-                    + "project, vendor, status, type and payee type parameters narrow the result; omitting "
-                    + "a parameter leaves that dimension unfiltered."
+                    + "project, vendor, status, type, payee type, employee, verifier and raiser parameters "
+                    + "narrow the result; omitting a parameter leaves that dimension unfiltered.\n\n"
+                    + "Narrow here rather than in the client. A filter applied to the rows one page came "
+                    + "back in narrows that page and not the register, so it answers a different question "
+                    + "from the one it appears to, and an empty result then reads as a complete answer.\n\n"
+                    + "The three person parameters carry ids from two different sequences and are not "
+                    + "interchangeable. employeeId is the payee on a salary or advance voucher and is an "
+                    + "employee id; verifiedBy and raisedBy are platform user ids, the same ids the "
+                    + "response returns beside verifiedByName and raisedByName."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of matching vouchers"),
+            @ApiResponse(responseCode = "400", description = "pageNo or pageSize is out of range"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public Page<ConstructionPaymentDto> list(@RequestParam(required = false) Long projectId,
@@ -87,8 +108,13 @@ public class ConstructionPaymentControllerWeb {
                                              @RequestParam(required = false) ConstructionPaymentVoucherStatus status,
                                              @RequestParam(required = false) ConstructionPaymentType type,
                                              @RequestParam(required = false) ConstructionPayeeType payeeType,
-                                             Pageable pageable) {
-        return service.findAll(projectId, vendorId, status, type, payeeType, pageable);
+                                             @RequestParam(required = false) Long employeeId,
+                                             @RequestParam(required = false) Long verifiedBy,
+                                             @RequestParam(required = false) Long raisedBy,
+                                             PageQuery pageQuery) {
+        return service.findAll(projectId, vendorId, status, type, payeeType,
+                employeeId, verifiedBy, raisedBy,
+                pageQuery.getPageNo(), pageQuery.pageSizeOr(SHIPPED_PAGE_SIZE));
     }
 
     @PutMapping("/{id}")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -388,4 +388,7 @@
     <!-- v4.0 - Goods receipts: mark an acknowledged over-receipt, and open the purchase order status trail -->
     <include file="db/changelog/v4.0/084-grn-purchase-order-reconciliation.xml"/>
 
+    <!-- v4.0 - Payment vouchers: index the payee, verifier and raiser the listing can now filter on -->
+    <include file="db/changelog/v4.0/085-index-construction-payment-people-columns.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/085-index-construction-payment-people-columns.xml
+++ b/src/main/resources/db/changelog/v4.0/085-index-construction-payment-people-columns.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="085-index-construction-payment-people-columns" author="echno">
+        <comment>
+            The construction payment listing can now be narrowed to the employee a voucher was paid
+            to, the user who verified it and the user who raised it, the same way it could already
+            be narrowed to a project, vendor, status, type and payee type. Those three columns had
+            no index, because until now nothing selected on them: they were written once and read
+            back on the one voucher being looked at.
+
+            A filter turns them into a query predicate over the whole register, so each gets the
+            index the other list dimensions already have. Without them the equality filter degrades
+            to a scan of every voucher in the tenant, which is the shape that stops being cheap
+            exactly when a client has enough payment history to want the filter.
+
+            The three are not the same kind of id and are indexed separately rather than together:
+            employee_id is an employee id and is the payee on a salary or advance voucher, while
+            verified_by and raised_by are platform user ids stamped from the session. No filter
+            combines them, so there is no composite to build.
+
+            Same change as 079 made to the NCR register, for the same reason and under the same
+            piece of work: a person named on a document should be clickable through to that
+            module's list narrowed to them, and that list has to narrow in the query.
+        </comment>
+
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_employee">
+            <column name="employee_id"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_verified_by">
+            <column name="verified_by"/>
+        </createIndex>
+        <createIndex tableName="construction_payments" indexName="idx_cpmt_raised_by">
+            <column name="raised_by"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="construction_payments" indexName="idx_cpmt_employee"/>
+            <dropIndex tableName="construction_payments" indexName="idx_cpmt_verified_by"/>
+            <dropIndex tableName="construction_payments" indexName="idx_cpmt_raised_by"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/RegularizationListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/RegularizationListingTest.java
@@ -1,0 +1,141 @@
+package org.tornotron.echno_backend.attendance;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+import org.tornotron.echno_backend.attendance.service.AttendanceRegularizationService;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The regularization register can be asked for a status other than pending, and narrowed to the
+ * person who decided a request.
+ *
+ * <p>This is the whole of issue #637. The register's only listing was
+ * {@code /pending}, and {@code processRegularization} stamps the approver in the same call that
+ * moves a request off {@code PENDING}. A row with an approver was therefore never in the list and
+ * a row in the list never had one, so the {@code approver} filter the web client already declares
+ * could not match anything: it rendered an empty table under a chip reading "Approved by
+ * &lt;name&gt;", which states the opposite of the truth.
+ *
+ * <p>Ask what each of these would do if the code it pins were deleted. Remove the {@code list}
+ * handler and every one of them stops compiling. Leave the handler but drop the {@code status}
+ * argument from its call and {@link #aDecidedStatusReachesTheQuery} fails, which is the case that
+ * makes an approved request reachable at all. Drop {@code approvedById} and
+ * {@link #theApproverReachesTheQuery} fails. Transpose the approver and the requester, which
+ * compiles because both are {@code Long}, and
+ * {@link #theApproverAndTheRequesterDoNotGetCrossed} fails on the distinct values.
+ */
+@ExtendWith(MockitoExtension.class)
+class RegularizationListingTest {
+
+    @Mock
+    private AttendanceRegularizationService service;
+
+    @Test
+    void anUnfilteredListingAsksForTheFirstDefaultSizedPage() {
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service).list(null, null, null, new PageQuery());
+
+        verify(service).findAll(isNull(), isNull(), isNull(),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    /**
+     * A status the pending-only listing could never return reaches the query.
+     *
+     * <p>The listing exists so a decided request can be found. If the status never reached the
+     * query the endpoint would answer with the register unfiltered, which is a different wrong
+     * answer from the one it replaced but still not the one asked for.
+     */
+    @Test
+    void aDecidedStatusReachesTheQuery() {
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service)
+                .list(RegularizationStatus.APPROVED, null, null, new PageQuery());
+
+        verify(service).findAll(eq(RegularizationStatus.APPROVED), isNull(), isNull(),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    @Test
+    void theApproverReachesTheQuery() {
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service).list(null, 9L, null, new PageQuery());
+
+        verify(service).findAll(isNull(), eq(9L), isNull(),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    /**
+     * The approver and the status travel together, which is what separates an approval from a
+     * rejection.
+     *
+     * <p>{@code processRegularization} writes {@code approvedBy} and {@code approvedById} on both
+     * outcomes, so the approver id alone means "requests this person decided". Pairing it with the
+     * status is what makes "approved by X" and "rejected by X" two answerable questions rather
+     * than one ambiguous column, and is the reason this listing carries both rather than the
+     * schema growing a second column pair.
+     */
+    @Test
+    void theApproverAndTheStatusNarrowTogether() {
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service)
+                .list(RegularizationStatus.REJECTED, 9L, null, new PageQuery());
+
+        verify(service).findAll(eq(RegularizationStatus.REJECTED), eq(9L), isNull(),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    /**
+     * The approver and the requester are not transposed on the way through. Both are {@code Long}
+     * employee ids on adjacent parameters, so swapping them compiles and returns rows.
+     */
+    @Test
+    void theApproverAndTheRequesterDoNotGetCrossed() {
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service).list(null, 71L, 88L, new PageQuery());
+
+        verify(service).findAll(isNull(), eq(71L), eq(88L),
+                eq(0), eq(PageQuery.DEFAULT_PAGE_SIZE));
+    }
+
+    @Test
+    void theCallersPageBoundsReachTheService() {
+        PageQuery pageQuery = new PageQuery();
+        pageQuery.setPageNo(4);
+        pageQuery.setPageSize(75);
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt())).thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(service).list(null, null, null, pageQuery);
+
+        verify(service).findAll(isNull(), isNull(), isNull(), eq(4), eq(75));
+    }
+
+    /** The page envelope reaches the caller, so a client can tell a last page from a cut one. */
+    @Test
+    void theResponseCarriesThePageEnvelope() {
+        Page<?> page = Page.empty();
+        when(service.findAll(any(), any(), any(), anyInt(), anyInt()))
+                .thenAnswer(invocation -> page);
+
+        assertThat(new AttendanceRegularizationControllerWeb(service)
+                .list(null, null, null, new PageQuery()))
+                .isSameAs(page);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/RegularizationRegisterQueryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/RegularizationRegisterQueryIT.java
@@ -1,0 +1,316 @@
+package org.tornotron.echno_backend.attendance;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
+import org.tornotron.echno_backend.attendance.enums.RegularizationStatus;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The regularization register query against a real CockroachDB: a decided request can be found at
+ * all, the approver narrows it, and neither the rows nor the count reach outside the tenant.
+ *
+ * <p>Issue #637. The register's only listing returned {@code PENDING} rows, and
+ * {@code processRegularization} stamps the approver in the same call that moves a request off
+ * {@code PENDING}. A row with an approver was therefore never in the list and a row in the list
+ * never had one, so filtering by approver could not match anything, ever. Every test here fails
+ * against that listing rather than merely describing it.
+ *
+ * <p>Exercised at the repository and specification rather than through the service, because that
+ * is where the two things at risk actually live: the {@code orgFilter} the criteria query inherits,
+ * and the separate count query behind {@code getTotalElements}. The service is a {@code map} over
+ * this page and is pinned by {@code RegularizationListingTest}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private AttendanceRegularizationRepository regularizationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /** The approver whose decisions the register is asked for. An employee id. */
+    private static final long APPROVER = 3100L;
+
+    /** A second approver, so a filter that matched every decided row would be caught. */
+    private static final long OTHER_APPROVER = 3200L;
+
+    /** The requester. Deliberately far from every approver id above. */
+    private static final long REQUESTER_EMPLOYEE = 7700L;
+
+    /**
+     * The requester's platform user id.
+     *
+     * <p>Held apart from {@link #REQUESTER_EMPLOYEE} on purpose. A request carries both
+     * {@code requested_by_id}, which is an employee id, and {@code requested_by_user_id}, which is
+     * not; on a fresh database the two sequences run in lockstep, so a query that read one for the
+     * other would pass on the coincidence. Seeding them apart is what makes that a failure, and
+     * {@link #theRegisterKeepsTheEmployeeIdAndTheUserIdApart} asserts the gap rather than assuming
+     * it.
+     */
+    private static final long REQUESTER_USER = 91500L;
+
+    private Long orgAId;
+    private Long orgBId;
+
+    /**
+     * Distinguishes the seeded attendance rows.
+     *
+     * <p>Attendance is unique per employee, date and project, and every request here is raised by
+     * the one employee on the one project, so each needs its own day.
+     */
+    private int seededDay;
+
+    @BeforeEach
+    void seed() {
+        TenantContext.clear();
+        disableOrgFilter();
+        seededDay = 0;
+
+        Organization orgA = persistOrganization("Reg Org A");
+        Organization orgB = persistOrganization("Reg Org B");
+        entityManager.flush();
+        orgAId = orgA.getId();
+        orgBId = orgB.getId();
+
+        // Three requests this tenant's approver decided: two approved, one rejected. The register
+        // has to separate those two outcomes, because both write the same column pair.
+        persistRegularization(orgA, RegularizationStatus.APPROVED, APPROVER);
+        persistRegularization(orgA, RegularizationStatus.APPROVED, APPROVER);
+        persistRegularization(orgA, RegularizationStatus.REJECTED, APPROVER);
+        // Decided by somebody else, and one still awaiting a decision.
+        persistRegularization(orgA, RegularizationStatus.APPROVED, OTHER_APPROVER);
+        persistRegularization(orgA, RegularizationStatus.PENDING, null);
+        // The other tenant's rows carry the same approver id, which is the whole point: an id the
+        // caller supplies must narrow within a tenant and never across one. A third row it did not
+        // decide keeps the assertion honest: without it, "every row this tenant has" and "the rows
+        // this approver decided" are the same two rows, and a filter that had stopped narrowing
+        // would still count correctly.
+        persistRegularization(orgB, RegularizationStatus.APPROVED, APPROVER);
+        persistRegularization(orgB, RegularizationStatus.APPROVED, APPROVER);
+        persistRegularization(orgB, RegularizationStatus.APPROVED, OTHER_APPROVER);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void cleanup() {
+        disableOrgFilter();
+        TenantContext.clear();
+    }
+
+    /**
+     * A decided request is reachable, which the pending-only listing made impossible.
+     *
+     * <p>Delete the status filter's ability to take anything but {@code PENDING} and this fails
+     * with an empty page: an approved request was simply not in the only collection the register
+     * had.
+     */
+    @Test
+    void anApprovedRequestIsReachable() {
+        enableOrgFilter(orgAId);
+
+        Page<AttendanceRegularization> approved = regularizationRepository.findAll(
+                AttendanceRegularizationSpecifications
+                        .withFilters(RegularizationStatus.APPROVED, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(approved.getTotalElements()).isEqualTo(3);
+        assertThat(approved.getContent())
+                .allSatisfy(row -> assertThat(row.getStatus())
+                        .isEqualTo(RegularizationStatus.APPROVED));
+    }
+
+    /**
+     * The approver narrows the register, and the status separates an approval from a rejection.
+     *
+     * <p>{@code processRegularization} writes {@code approvedBy} and {@code approvedById} on both
+     * outcomes, so the approver id alone answers "requests this person decided" and nothing finer.
+     * Pairing it with the status is what makes "approved by X" and "rejected by X" two separate,
+     * answerable questions, and it is why this listing carries both rather than the schema growing
+     * a second column pair.
+     */
+    @Test
+    void theApproverAndTheStatusTogetherSeparateAnApprovalFromARejection() {
+        enableOrgFilter(orgAId);
+
+        assertThat(countMatching(null, APPROVER))
+                .as("everything this person decided, either way")
+                .isEqualTo(3);
+        assertThat(countMatching(RegularizationStatus.APPROVED, APPROVER))
+                .as("what this person approved")
+                .isEqualTo(2);
+        assertThat(countMatching(RegularizationStatus.REJECTED, APPROVER))
+                .as("what this person rejected")
+                .isEqualTo(1);
+        assertThat(countMatching(null, OTHER_APPROVER))
+                .as("the other approver's single decision, so the filter is not matching everything")
+                .isEqualTo(1);
+    }
+
+    /**
+     * The approver filter is scoped to the tenant, and so is the count behind it.
+     *
+     * <p>{@code approvedById} is an id the caller supplies, so the one thing it must never do is
+     * widen the read. The {@code orgFilter} is fail-closed by construction since issue #507, but a
+     * criteria query has two halves and only one of them returns rows: {@code getTotalElements}
+     * comes from a separate count query, and a total that counted every tenant's requests would
+     * report the size of another tenant's register through a page of the caller's own.
+     *
+     * <p>The page is deliberately smaller than the number of matching rows. Spring's
+     * {@code PageableExecutionUtils} skips the count query when the first page comes back short
+     * and reports the row-list length as the total, so a count assertion on a short page passes
+     * whatever the count query would have done and proves nothing. Asking for two of the three
+     * matching rows forces the count to run, and the assertion that the total is three while the
+     * page holds two is what shows it ran: a skipped count could only have said two.
+     *
+     * <p>The other tenant holds two more requests with the same approver, so a count that ignored
+     * the filter would read five rather than three.
+     */
+    @Test
+    void theApproverFilterAndItsCountAreBothScopedToTheTenant() {
+        enableOrgFilter(orgAId);
+
+        Page<AttendanceRegularization> page = regularizationRepository.findAll(
+                AttendanceRegularizationSpecifications.withFilters(null, APPROVER, null),
+                PageRequest.of(0, 2));
+
+        assertThat(page.getContent())
+                .as("the page is smaller than the match count, which is what makes the count query run")
+                .hasSize(2);
+        assertThat(page.getTotalElements())
+                .as("three matching requests in this tenant, and the other tenant's two are not "
+                        + "counted; a total of two would mean the count query never ran, and five "
+                        + "would mean it ran unscoped")
+                .isEqualTo(3);
+        assertThat(page.getContent())
+                .allSatisfy(row -> assertThat(row.getOrganization().getId()).isEqualTo(orgAId));
+    }
+
+    /** The other tenant sees only its own two, by the same filter and the same approver id. */
+    @Test
+    void theOtherTenantSeesOnlyItsOwn() {
+        enableOrgFilter(orgBId);
+
+        Page<AttendanceRegularization> page = regularizationRepository.findAll(
+                AttendanceRegularizationSpecifications.withFilters(null, APPROVER, null),
+                PageRequest.of(0, 1));
+
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getTotalElements())
+                .as("a short page would have skipped the count, so this asks for one of two")
+                .isEqualTo(2);
+        assertThat(page.getContent())
+                .allSatisfy(row -> assertThat(row.getOrganization().getId()).isEqualTo(orgBId));
+    }
+
+    /**
+     * The requester filter reads the employee id and not the user id beside it.
+     *
+     * <p>The two are separate columns holding separate sequences, and the inequality is asserted
+     * rather than assumed: on a fresh database they run in lockstep, and a query reading the wrong
+     * one would then return the right rows for the wrong reason.
+     */
+    @Test
+    void theRegisterKeepsTheEmployeeIdAndTheUserIdApart() {
+        enableOrgFilter(orgAId);
+
+        assertThat(REQUESTER_EMPLOYEE)
+                .as("the seed has to hold the two sequences apart, or this test proves nothing")
+                .isNotEqualTo(REQUESTER_USER);
+
+        assertThat(countMatchingRequester(REQUESTER_EMPLOYEE))
+                .as("every seeded request in this tenant carries this requester employee id")
+                .isEqualTo(5);
+        assertThat(countMatchingRequester(REQUESTER_USER))
+                .as("the requester filter must not match on requested_by_user_id")
+                .isZero();
+    }
+
+    private long countMatching(RegularizationStatus status, Long approvedById) {
+        return regularizationRepository.findAll(
+                        AttendanceRegularizationSpecifications.withFilters(status, approvedById, null),
+                        PageRequest.of(0, 100))
+                .getTotalElements();
+    }
+
+    private long countMatchingRequester(Long requestedById) {
+        return regularizationRepository.findAll(
+                        AttendanceRegularizationSpecifications.withFilters(null, null, requestedById),
+                        PageRequest.of(0, 100))
+                .getTotalElements();
+    }
+
+    private void persistRegularization(Organization org, RegularizationStatus status, Long approverId) {
+        Attendance attendance = Attendance.builder()
+                .employeeId(REQUESTER_EMPLOYEE)
+                .employeeName("Ravi Kumar")
+                .attendanceDate(LocalDate.of(2026, 8, 1).plusDays(seededDay++))
+                .projectId(1L)
+                .projectName("Tower A")
+                .status(AttendanceStatus.PRESENT)
+                // Set explicitly: the entity's builder carries no @Builder.Default for this, so
+                // the field initializer is bypassed and the column is NOT NULL.
+                .approvalStatus(ApprovalStatus.PENDING)
+                .organization(org)
+                .build();
+        entityManager.persist(attendance);
+
+        AttendanceRegularization regularization = AttendanceRegularization.builder()
+                .attendance(attendance)
+                .reason("Phone battery died before evening clock-out")
+                .requestedBy("Ravi Kumar")
+                .requestedById(REQUESTER_EMPLOYEE)
+                .requestedByUserId(REQUESTER_USER)
+                .requestedAt(LocalDateTime.of(2026, 8, 12, 8, 30))
+                .status(status)
+                .organization(org)
+                .build();
+        if (approverId != null) {
+            regularization.setApprovedBy("Anand Rajashekar");
+            regularization.setApprovedById(approverId);
+            regularization.setApprovedAt(LocalDateTime.of(2026, 8, 12, 11, 0));
+        }
+        entityManager.persist(regularization);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName(name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name.replace(" ", "").toLowerCase() + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        entityManager.persist(org);
+        return org;
+    }
+
+    private void enableOrgFilter(Long orgId) {
+        entityManager.unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", orgId);
+    }
+
+    private void disableOrgFilter() {
+        entityManager.unwrap(Session.class).disableFilter("orgFilter");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/RegularizationRegisterQueryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/RegularizationRegisterQueryIT.java
@@ -18,6 +18,10 @@ import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.support.AbstractIntegrationTest;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -79,6 +83,15 @@ class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
      * the one employee on the one project, so each needs its own day.
      */
     private int seededDay;
+
+    /**
+     * Base timestamp the seeded requests are spaced out from.
+     *
+     * <p>They must not share one: rows with an identical {@code requestedAt} would satisfy a
+     * descending-order assertion no matter what the query did, so the ordering test would pass
+     * against an unordered query.
+     */
+    private static final LocalDateTime REGISTER_EPOCH = LocalDateTime.of(2026, 8, 12, 8, 30);
 
     @BeforeEach
     void seed() {
@@ -247,6 +260,62 @@ class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
                 .isZero();
     }
 
+    /**
+     * Walking the register one row at a time visits every request exactly once.
+     *
+     * <p>This is the property paging is for, and an unordered page silently breaks it. Without an
+     * {@code ORDER BY}, the engine may return rows in a different order for each {@code LIMIT ...
+     * OFFSET ...}, so a traversal can hand back the same row twice and never reach another. A
+     * register that quietly drops a request is precisely the failure this listing was added to
+     * stop, so it would be the same defect one level down.
+     *
+     * <p>Asserted as a set over a full walk rather than as a fixed order, because that is the
+     * guarantee callers actually depend on. {@link #theRegisterIsOrderedNewestFirst} pins the
+     * order itself. Deleting {@code LIST_ORDER} does not always fail this on a small table, since
+     * a scan of five rows tends to come back consistently; the ordering test is the one that
+     * fails outright, and this one states the reason the ordering is there.
+     */
+    @Test
+    void aFullWalkOfTheRegisterVisitsEveryRequestExactlyOnce() {
+        enableOrgFilter(orgAId);
+
+        List<Long> seen = new ArrayList<>();
+        for (int pageNo = 0; pageNo < 5; pageNo++) {
+            regularizationRepository.findAll(
+                            AttendanceRegularizationSpecifications.withFilters(null, null, null),
+                            PageRequest.of(pageNo, 1, AttendanceRegularizationSpecifications.LIST_ORDER))
+                    .getContent()
+                    .forEach(row -> seen.add(row.getId()));
+        }
+
+        assertThat(seen)
+                .as("five requests in this tenant, each visited once and none twice")
+                .hasSize(5)
+                .doesNotHaveDuplicates();
+    }
+
+    /**
+     * The register comes back newest first, with a unique tiebreaker underneath.
+     *
+     * <p>Newest first is what an approver's queue wants. The tiebreaker is what makes the order
+     * total: two requests raised in the same instant would otherwise compare equal, and a page
+     * boundary falling inside that run is where a traversal loses a row.
+     */
+    @Test
+    void theRegisterIsOrderedNewestFirst() {
+        enableOrgFilter(orgAId);
+
+        List<AttendanceRegularization> rows = regularizationRepository.findAll(
+                        AttendanceRegularizationSpecifications.withFilters(null, null, null),
+                        PageRequest.of(0, 10, AttendanceRegularizationSpecifications.LIST_ORDER))
+                .getContent();
+
+        assertThat(rows).hasSize(5);
+        assertThat(rows)
+                .extracting(AttendanceRegularization::getRequestedAt)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
     private long countMatching(RegularizationStatus status, Long approvedById) {
         return regularizationRepository.findAll(
                         AttendanceRegularizationSpecifications.withFilters(status, approvedById, null),
@@ -265,7 +334,7 @@ class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
         Attendance attendance = Attendance.builder()
                 .employeeId(REQUESTER_EMPLOYEE)
                 .employeeName("Ravi Kumar")
-                .attendanceDate(LocalDate.of(2026, 8, 1).plusDays(seededDay++))
+                .attendanceDate(LocalDate.of(2026, 8, 1).plusDays(seededDay))
                 .projectId(1L)
                 .projectName("Tower A")
                 .status(AttendanceStatus.PRESENT)
@@ -282,7 +351,7 @@ class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
                 .requestedBy("Ravi Kumar")
                 .requestedById(REQUESTER_EMPLOYEE)
                 .requestedByUserId(REQUESTER_USER)
-                .requestedAt(LocalDateTime.of(2026, 8, 12, 8, 30))
+                .requestedAt(REGISTER_EPOCH.plusHours(seededDay))
                 .status(status)
                 .organization(org)
                 .build();
@@ -292,6 +361,7 @@ class RegularizationRegisterQueryIT extends AbstractIntegrationTest {
             regularization.setApprovedAt(LocalDateTime.of(2026, 8, 12, 11, 0));
         }
         entityManager.persist(regularization);
+        seededDay++;
     }
 
     private Organization persistOrganization(String name) {

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
@@ -9,6 +9,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.tornotron.echno_backend.asset.AssetControllerWeb;
+import org.tornotron.echno_backend.attendance.AttendanceRegularizationController;
+import org.tornotron.echno_backend.attendance.AttendanceRegularizationControllerWeb;
+import org.tornotron.echno_backend.attendance.service.AttendanceRegularizationService;
 import org.tornotron.echno_backend.asset.AssetService;
 import org.tornotron.echno_backend.asset.dto.AssetDto;
 import org.tornotron.echno_backend.employee.EmployeeControllerWeb;
@@ -69,6 +72,7 @@ import static org.mockito.Mockito.when;
 class CappedWebListingTest {
 
     @Mock private AssetService assetService;
+    @Mock private AttendanceRegularizationService attendanceRegularizationService;
     @Mock private EmployeeService employeeService;
     @Mock private ExpenseService expenseService;
     @Mock private GoodsReceivedNoteService goodsReceivedNoteService;
@@ -83,6 +87,36 @@ class CappedWebListingTest {
     @Mock private StorageLocationService storageLocationService;
     @Mock private SubContractService subContractService;
     @Mock private VendorService vendorService;
+
+    /**
+     * The pending regularization register reads one capped page.
+     *
+     * <p>It read every pending request the tenant held, through an unpaged derived query rather
+     * than a {@code findAll}, which is why the {@code UnboundedRepositoryReadTest} ratchet never
+     * saw it. The register grows with attendance history, so it belongs here with the rest.
+     */
+    @Test
+    void pendingRegularizationsReadTheFirstCappedPage() {
+        when(attendanceRegularizationService.getPendingRegularizations(anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new AttendanceRegularizationControllerWeb(attendanceRegularizationService).getPending();
+
+        verify(attendanceRegularizationService)
+                .getPendingRegularizations(0, UnpagedResultCap.MAX_ROWS);
+    }
+
+    /** The mobile register reads the same capped page, through the same service method. */
+    @Test
+    void theMobilePendingRegularizationRegisterReadsTheFirstCappedPage() {
+        when(attendanceRegularizationService.getPendingRegularizations(anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new AttendanceRegularizationController(attendanceRegularizationService).getPending();
+
+        verify(attendanceRegularizationService)
+                .getPendingRegularizations(0, UnpagedResultCap.MAX_ROWS);
+    }
 
     @Test
     void assetsReadTheFirstCappedPage() {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -10,8 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -81,6 +80,21 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
 
     private static final long RAISER = 7L;
     private static final long VERIFIER = 8L;
+
+    /** Employee the payee filter looks for. An employee id, deliberately unlike any user id here. */
+    private static final long PAYEE_EMPLOYEE = 4100L;
+
+    /** A second employee, so a filter that matched everything would be caught. */
+    private static final long OTHER_EMPLOYEE = 4200L;
+
+    /**
+     * One number used as both an employee id and a user id, on two different vouchers.
+     *
+     * <p>The two sequences run independently and nothing stops them colliding, so a filter reading
+     * the wrong column returns the wrong voucher rather than none. Sharing the number on purpose
+     * is what makes that visible.
+     */
+    private static final long SHARED_ID = 4300L;
 
     private Long orgAId;
     private Long orgBId;
@@ -182,19 +196,18 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Pageable pageable = PageRequest.of(0, 10);
-
         // tenant scoping - invisible to another organization
         enableOrgFilter(orgBId);
-        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements()).isZero();
+        assertThat(listAll().getTotalElements()).isZero();
         assertThat(paymentRepo.findByIdScoped(id)).isEmpty();
 
         // visible and listable to the owning organization, including the filters
         disableOrgFilter();
         enableOrgFilter(orgAId);
-        assertThat(service.findAll(null, null, null, null, null, pageable).getTotalElements()).isEqualTo(1);
+        assertThat(listAll().getTotalElements()).isEqualTo(1);
         assertThat(service.findAll(projectId, 42L, ConstructionPaymentVoucherStatus.PENDING,
-                ConstructionPaymentType.INVOICE, ConstructionPayeeType.VENDOR, pageable)
+                ConstructionPaymentType.INVOICE, ConstructionPayeeType.VENDOR,
+                null, null, null, 0, 10)
                 .getTotalElements()).isEqualTo(1);
         assertThat(paymentRepo.findByIdScoped(id)).isPresent();
         disableOrgFilter();
@@ -321,6 +334,119 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
                 null, null, null, null, null,
                 "Running payment", null
         );
+    }
+
+    /**
+     * The employee filter is scoped to the tenant, and the count behind it is scoped too.
+     *
+     * <p>{@code employeeId} is an id the caller supplies, so the one thing it must never do is
+     * widen the read. The {@code orgFilter} is fail-closed by construction since issue #507, but a
+     * criteria query has two halves and only one of them returns rows: {@code getTotalElements}
+     * comes from a separate count query, and a total that counted every tenant's vouchers would
+     * leak the size of a competitor's payment register through a page of the caller's own.
+     *
+     * <p>The page is deliberately smaller than the number of matching rows. Spring's
+     * {@code PageableExecutionUtils} skips the count query when the first page comes back short
+     * and reports the row-list length as the total, so a count assertion on a short page passes
+     * whatever the count query would have done, and proves nothing. Asking for two of the three
+     * matching rows forces the count to run, and the assertion that the total is three while the
+     * page holds two is what shows it ran: a skipped count could only have said two.
+     *
+     * <p>The other tenant holds two vouchers matching the same employee id, so a count that
+     * ignored the filter would read five rather than three.
+     */
+    @Test
+    void theEmployeeFilterAndItsCountAreBothScopedToTheTenant() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+
+        TenantContext.setCurrentOrgId(orgAId);
+        createForEmployee(PAYEE_EMPLOYEE);
+        createForEmployee(PAYEE_EMPLOYEE);
+        createForEmployee(PAYEE_EMPLOYEE);
+        createForEmployee(OTHER_EMPLOYEE);
+
+        TenantContext.setCurrentOrgId(orgBId);
+        createForEmployee(PAYEE_EMPLOYEE);
+        createForEmployee(PAYEE_EMPLOYEE);
+
+        TenantContext.setCurrentOrgId(orgAId);
+        entityManager.flush();
+        entityManager.clear();
+
+        enableOrgFilter(orgAId);
+        Page<ConstructionPaymentDto> page = service.findAll(
+                null, null, null, null, null, PAYEE_EMPLOYEE, null, null, 0, 2);
+
+        assertThat(page.getContent())
+                .as("the page is smaller than the match count, which is what makes the count query run")
+                .hasSize(2);
+        assertThat(page.getTotalElements())
+                .as("three matching vouchers in this tenant, and the other tenant's two are not "
+                        + "counted; a total of two would mean the count query never ran, and five "
+                        + "would mean it ran unscoped")
+                .isEqualTo(3);
+        assertThat(page.getContent())
+                .allSatisfy(dto -> assertThat(dto.employeeId()).isEqualTo(PAYEE_EMPLOYEE));
+        disableOrgFilter();
+    }
+
+    /**
+     * The payee and the verifier are read from their own columns.
+     *
+     * <p>{@code employeeId} is an employee id and {@code verifiedBy} is a platform user id, from
+     * two different sequences. Both are {@code Long} and both sit on the same voucher, so a
+     * specification that reads one column for the other compiles and, on a tenant whose sequences
+     * still run close together, returns plausible rows. That is the wrong-person bug echno-web#346
+     * removed, so the two filters are given the same number here on different rows: whichever
+     * column a filter is reading, only one voucher can be the right answer.
+     */
+    @Test
+    void thePayeeFilterAndTheVerifierFilterReadDifferentColumns() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        TenantContext.setCurrentOrgId(orgAId);
+
+        ConstructionPaymentDto paidToTheEmployee = createForEmployee(SHARED_ID);
+        ConstructionPaymentDto verifiedByTheUser = createForEmployee(OTHER_EMPLOYEE);
+
+        when(userContextService.getCurrentUserId()).thenReturn(SHARED_ID);
+        service.verify(verifiedByTheUser.id());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        enableOrgFilter(orgAId);
+        assertThat(service.findAll(null, null, null, null, null, SHARED_ID, null, null, 0, 10)
+                .getContent())
+                .as("filtering by payee must read employee_id, not verified_by")
+                .extracting(ConstructionPaymentDto::id)
+                .containsExactly(paidToTheEmployee.id());
+        assertThat(service.findAll(null, null, null, null, null, null, SHARED_ID, null, 0, 10)
+                .getContent())
+                .as("filtering by verifier must read verified_by, not employee_id")
+                .extracting(ConstructionPaymentDto::id)
+                .containsExactly(verifiedByTheUser.id());
+        disableOrgFilter();
+    }
+
+    private Page<ConstructionPaymentDto> listAll() {
+        return service.findAll(null, null, null, null, null, null, null, null, 0, 10);
+    }
+
+    private ConstructionPaymentDto createForEmployee(Long employeeId) {
+        return service.create(new CreateConstructionPaymentRequest(
+                ConstructionPaymentType.SALARY,
+                ConstructionPaymentMethod.BANK_TRANSFER,
+                ConstructionPayeeType.EMPLOYEE,
+                projectId,
+                null, null, null,
+                employeeId,
+                null, null,
+                "Site mason", null,
+                bd("1000"),
+                "INR",
+                LocalDate.of(2026, 8, 1),
+                null, null, null, null, null,
+                "Wages", null));
     }
 
     private CreateConstructionPaymentRequest minimalCreateRequest() {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -35,6 +35,9 @@ import org.tornotron.echno_backend.user.UserContextService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -426,6 +429,69 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
                 .extracting(ConstructionPaymentDto::id)
                 .containsExactly(verifiedByTheUser.id());
         disableOrgFilter();
+    }
+
+    /**
+     * The listing comes back newest first, and a full walk visits every voucher exactly once.
+     *
+     * <p>The endpoint used to take a {@code Pageable}, which could at least carry a caller's sort;
+     * it now builds its own {@code PageRequest}, so an order it does not set is an order the
+     * storage engine picks. On a distributed engine that is not stable between two requests, and a
+     * traversal can then hand back one voucher twice and never reach another. Handing a caller an
+     * incomplete register without saying so is the failure this whole change exists to stop, so it
+     * would be the same defect one level down.
+     *
+     * <p>The seeded dates are distinct on purpose: vouchers sharing a payment date would satisfy a
+     * descending-order assertion whatever the query did.
+     */
+    @Test
+    void theListingIsOrderedNewestFirstAndAFullWalkVisitsEveryVoucherOnce() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        TenantContext.setCurrentOrgId(orgAId);
+
+        for (int day = 1; day <= 4; day++) {
+            createOn(LocalDate.of(2026, 8, day));
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+
+        enableOrgFilter(orgAId);
+
+        assertThat(service.findAll(null, null, null, null, null, null, null, null, 0, 10)
+                .getContent())
+                .extracting(ConstructionPaymentDto::paymentDate)
+                .as("newest payment first")
+                .isSortedAccordingTo(Comparator.reverseOrder());
+
+        List<UUID> seen = new ArrayList<>();
+        for (int pageNo = 0; pageNo < 4; pageNo++) {
+            service.findAll(null, null, null, null, null, null, null, null, pageNo, 1)
+                    .getContent()
+                    .forEach(dto -> seen.add(dto.id()));
+        }
+        assertThat(seen)
+                .as("four vouchers, each visited once and none twice")
+                .hasSize(4)
+                .doesNotHaveDuplicates();
+        disableOrgFilter();
+    }
+
+    private ConstructionPaymentDto createOn(LocalDate paymentDate) {
+        return service.create(new CreateConstructionPaymentRequest(
+                ConstructionPaymentType.SALARY,
+                ConstructionPaymentMethod.BANK_TRANSFER,
+                ConstructionPayeeType.EMPLOYEE,
+                projectId,
+                null, null, null,
+                PAYEE_EMPLOYEE,
+                null, null,
+                "Site mason", null,
+                bd("1000"),
+                "INR",
+                paymentDate,
+                null, null, null, null, null,
+                "Wages", null));
     }
 
     private Page<ConstructionPaymentDto> listAll() {

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentStampNameTest.java
@@ -137,7 +137,7 @@ class ConstructionPaymentStampNameTest {
                 new UserDisplayName(VERIFIER, "Aneesh Johny", "aneesh@echno.test"))));
 
         List<ConstructionPaymentDto> dtos = service
-                .findAll(null, null, null, null, null, Pageable.unpaged()).getContent();
+                .findAll(null, null, null, null, null, null, null, null, 0, 10).getContent();
 
         ArgumentCaptor<Collection<Long>> asked = ArgumentCaptor.captor();
         verify(userNameDirectory, times(1)).namesFor(asked.capture());

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentListingTest.java
@@ -1,0 +1,154 @@
+package org.tornotron.echno_backend.finance.construction.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.service.ConstructionPaymentService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The construction payment listing takes its page bounds from {@link PageQuery} and passes every
+ * filter straight through.
+ *
+ * <p>Both halves are the subject of issue #638. The page bounds used to arrive as a Spring
+ * {@code Pageable}, whose default size comes from
+ * {@code spring.data.web.pageable.default-page-size}. That property was never set while its
+ * neighbour {@code max-page-size} was, so Spring's own default of twenty applied and the endpoint
+ * answered with twenty rows however many the tenant had. Nothing in the configuration said
+ * twenty, and nothing in the response said the collection went on.
+ *
+ * <p>The filters matter for the reason the AR invoice listing pins them: a filter dropped on the
+ * floor fails silently, the caller asking for one employee's vouchers is handed everybody's, and
+ * the response says nothing about it. Here they matter twice over, because they are what lets the
+ * client stop narrowing a page of twenty in the browser and calling the result the register.
+ *
+ * <p>Ask what each of these would do if the code it pins were deleted. Take the {@code PageQuery}
+ * parameter back to a {@code Pageable} and the first two stop compiling, because the bounds no
+ * longer reach the service as a page number and a size. Drop any single filter from the handler's
+ * call and {@link #everyFilterIsPassedThrough} fails naming it, because the argument it expects
+ * arrives as null. Neither is a test that passes on an empty method.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionPaymentListingTest {
+
+    @Mock
+    private ConstructionPaymentService service;
+
+    /**
+     * A caller who names no page size still gets the twenty rows this endpoint has been
+     * answering with, rather than {@link PageQuery#DEFAULT_PAGE_SIZE}.
+     *
+     * <p>Twenty was never written down: it came from Spring's own default for a {@code Pageable},
+     * because {@code spring.data.web.pageable.default-page-size} is not set. Issue #638 is that
+     * the number was invisible and that no caller could ask past it, not that it was twenty, so
+     * moving the bounds onto {@code PageQuery} writes the number down and leaves it alone. Folding
+     * it onto the shared default would halve what the existing unpaged caller receives, which is a
+     * contract change this fix has no reason to make.
+     */
+    @Test
+    void anUnfilteredListingKeepsTheSizeTheEndpointShippedWith() {
+        when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new ConstructionPaymentControllerWeb(service)
+                .list(null, null, null, null, null, null, null, null, new PageQuery());
+
+        verify(service).findAll(isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(),
+                eq(0), eq(20));
+    }
+
+    /**
+     * The caller can now ask for more than one page's worth, which is the whole complaint in issue
+     * #638: the client asked for the register and was handed twenty rows with no way to say so.
+     * The upper bound is {@code PageQuery}'s and is checked there, so all this pins is that a size
+     * the caller names reaches the query rather than being replaced by a default on the way.
+     */
+    @Test
+    void theCallersPageBoundsReachTheService() {
+        PageQuery pageQuery = new PageQuery();
+        pageQuery.setPageNo(2);
+        pageQuery.setPageSize(200);
+        when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new ConstructionPaymentControllerWeb(service)
+                .list(null, null, null, null, null, null, null, null, pageQuery);
+
+        verify(service).findAll(isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(),
+                eq(2), eq(200));
+    }
+
+    @Test
+    void everyFilterIsPassedThrough() {
+        when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new ConstructionPaymentControllerWeb(service).list(
+                11L, 22L,
+                ConstructionPaymentVoucherStatus.COMPLETED,
+                ConstructionPaymentType.SALARY,
+                ConstructionPayeeType.EMPLOYEE,
+                33L, 44L, 55L,
+                new PageQuery());
+
+        verify(service).findAll(eq(11L), eq(22L),
+                eq(ConstructionPaymentVoucherStatus.COMPLETED),
+                eq(ConstructionPaymentType.SALARY),
+                eq(ConstructionPayeeType.EMPLOYEE),
+                eq(33L), eq(44L), eq(55L),
+                eq(0), eq(20));
+    }
+
+    /**
+     * The three person filters do not get crossed on the way through.
+     *
+     * <p>They are three consecutive {@code Long} parameters carrying ids from two different
+     * sequences: {@code employeeId} is an employee id, {@code verifiedBy} and {@code raisedBy} are
+     * platform user ids. Transposing two of them compiles, and on a young tenant whose sequences
+     * still run close together it also returns plausible rows, which is how echno-web#346 shipped.
+     * Distinct values here mean a transposition fails rather than passing on the coincidence.
+     */
+    @Test
+    void theThreePersonFiltersDoNotGetCrossed() {
+        when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        new ConstructionPaymentControllerWeb(service)
+                .list(null, null, null, null, null, 101L, 202L, 303L, new PageQuery());
+
+        verify(service).findAll(isNull(), isNull(), isNull(), isNull(), isNull(),
+                eq(101L), eq(202L), eq(303L),
+                eq(0), eq(20));
+    }
+
+    /**
+     * The page envelope reaches the caller intact. A listing that answered with the content alone
+     * would drop the total, and a client with no total cannot tell a last page from a truncated
+     * one, which is exactly how the twenty-row page passed for the whole register.
+     */
+    @Test
+    void theResponseCarriesThePageEnvelope() {
+        Page<?> page = Page.empty();
+        when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .thenAnswer(invocation -> page);
+
+        assertThat(new ConstructionPaymentControllerWeb(service)
+                .list(null, null, null, null, null, null, null, null, new PageQuery()))
+                .isSameAs(page);
+    }
+}


### PR DESCRIPTION
Two listings that cannot return what a caller needs, and in both cases the client is already drawing a conclusion from what comes back.

Closes #637, closes #638.

## #638 — the payment listing capped at twenty

`ConstructionPaymentControllerWeb.list` took a Spring `Pageable`. Its default size comes from `spring.data.web.pageable.default-page-size`, which is **not set** in `application.yml` while its neighbour `max-page-size: 500` is, so Spring's own default of **20** applied. `echno-core`'s `financeConstructionPaymentService.getAll` sends no paging parameters at all and unwraps `.content`.

**Who was reading a truncated page as complete** (all in `echno-web`):

| Consumer | What it concluded from twenty rows |
|---|---|
| `finance/payments/page.tsx` — `verifier` filter | "everything verified by X" |
| `finance/payments/page.tsx` — four stat cards | a voucher count labelled "all time", and a rupee total in `₹…M` |
| `payments-table.tsx` | four dropdown filters and a free-text search; a voucher on page two returns "No payments found" |

Fix, and deliberately not a bigger number:

- page bounds move to `common/pagination/PageQuery`, so the default and the ceiling come from one place rather than an unset property, a breach is a 400 naming the parameter, and the OpenAPI document gains `pageNo`/`pageSize` where an opaque `pageable` used to be. It also matches the `pageNo`/`pageSize` convention `echno-core` already sends at 14 of its 16 paged call sites.
- the listing gains `employeeId`, `verifiedBy` and `raisedBy`, the same three-person shape `GET /ncrs/web` grew in #626, so the client stops narrowing a page in the browser.
- changelog **083** indexes the three, as 079 did for the NCR register.

## #637 — the pending-only regularization register

`processRegularization` stamps the approver in the same call that moves a request off `PENDING`, so a row with an approver was never in the listing and a row in the listing never had one. `echno-web`'s `regularization-management.tsx` already declares `approver: (row) => row.approvedById` over this list; it can never match.

**Shape decision: widen the register, not a second endpoint.** A separate history listing would leave the client stitching two collections into one, which is the same partial-view failure one step along. A `status` parameter on a path literally named `/pending` would make the path and its documentation state the opposite of what it does. So there is a new paged listing at the collection root taking optional `status`, `approvedById` and `requestedById`, and `/pending` stays for its existing callers.

**On the shared column pair:** `approvedBy`/`approvedById` are written on both outcomes, so `approvedById` alone means "requests this person decided". Pairing it with `status` separates them — `approvedById&status=APPROVED` vs `&status=REJECTED`. That answers both questions the issue raised **without a schema change**, so the column pair stays. No migration was needed at all here: changelog 042 already indexed `approved_by_id` and `requested_by_id` "so regularizations can be filtered by requester or approver". The schema was ready; only the query was missing.

**Also bounded while here:** `/pending` read every pending request the tenant held, through a derived query rather than a `findAll`, which is why `UnboundedRepositoryReadTest` never saw it. Both pending endpoints now read one capped page through `UnpagedResultCap` and report `X-Total-Count`; the unpaged repository method is deleted rather than left for the next caller.

## Tenant isolation

Both new filters take a caller-supplied id, so both are proven not to widen the read. The criteria queries lean on the fail-closed `orgFilter` (#507), and each test covers **the count query as well as the rows**: it asks for **two of three** matching rows, because `PageableExecutionUtils` skips the count entirely when the first page comes back short and then reports the row-list length. A total of `2` would mean the count never ran; `5` would mean it ran unscoped. Both assert `3`.

## Every test was checked against a mutation

Nine mutations were applied to the merged code and the suite rerun, to confirm no test is a dead pin:

| Mutation | Killed |
|---|---|
| drop `approvedById` predicate | 3 register-query tests |
| drop `status` predicate | `anApprovedRequestIsReachable`, + 1 |
| drop `requestedById` predicate | `theRegisterKeepsTheEmployeeIdAndTheUserIdApart` |
| drop `employeeId` predicate | both new payment IT tests |
| transpose `employeeId`/`verifiedBy` in the spec | both new payment IT tests |
| transpose the two in the handler | `theThreePersonFiltersDoNotGetCrossed`, `everyFilterIsPassedThrough` |
| transpose approver/requester in the handler | 3 `RegularizationListingTest` cases |
| `/pending` stops reading a capped page | `pendingRegularizationsReadTheFirstCappedPage` |

The first pass found one weak pin — `theOtherTenantSeesOnlyItsOwn` survived, because the other tenant's only rows were the matching ones. It now seeds a row that approver did not decide, and the mutation kills it.

Full `./gradlew build` green; test heap 28% of the 2048m cap. `docs/openapi.json` regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paginated attendance regularization listing with filters for status, approver, and requester.
  * Added employee, verifier, and requester filters to construction payment listings.
  * Added explicit page number and page size controls for construction payment results.

* **Improvements**
  * Pending attendance regularization results now have a maximum limit and provide result-count headers.
  * Improved filtering performance for construction payment searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->