### PR TITLE
Freeze a payment voucher once it is verified, and make cancelling the way back

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2029,6 +2029,19 @@
         },
         "type": "object"
       },
+      "CancelConstructionPaymentRequest": {
+        "description": "Why a payment voucher is being voided. Required: a cancelled voucher that does not say what was wrong with it explains nothing, and on a verified voucher this is the only record of why the verification was set aside.",
+        "properties": {
+          "reason": {
+            "description": "What was wrong with the voucher.",
+            "example": "Duplicate of CPMT-000118, raised twice for the same invoice",
+            "maxLength": 1000,
+            "minLength": 0,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "CategoryCreationDto": {
         "description": "Payload to create a work category used to classify tasks.",
         "properties": {
@@ -3418,6 +3431,11 @@
           "bankName": {
             "description": "Bank the payment was drawn on.",
             "example": "HDFC Bank",
+            "type": "string"
+          },
+          "cancellationReason": {
+            "description": "Why the voucher was voided, recorded by the cancel action. Null on a voucher that has not been cancelled.",
+            "example": "Duplicate of CPMT-000118, raised twice for the same invoice",
             "type": "string"
           },
           "currency": {
@@ -37349,7 +37367,7 @@
     "/api/v1/finance/construction-invoices/web/{id}/cancel": {
       "post": {
         "description": "Cancels an invoice and records the supplied reason. If the invoice was already posted, the ledger entry is reversed. The reason is recorded on the reversing entry's description, which also carries a prefix naming the entry being reversed, so it must be present and at most 455 characters.",
-        "operationId": "cancel_1",
+        "operationId": "cancel_2",
         "parameters": [
           {
             "in": "path",
@@ -38224,7 +38242,7 @@
         ]
       },
       "put": {
-        "description": "Replaces the editable fields of a payment voucher, including its status, which is set directly. No ledger journal entry is created on any status transition.",
+        "description": "Replaces the editable fields of a payment voucher, including its status, which is set directly. No ledger journal entry is created on any status transition. A verified voucher is frozen and cannot be edited, because the verification would then stand against figures nobody checked; cancel it and raise a replacement. The cancelled status cannot be set here either: use the cancel action, which records why.",
         "operationId": "update_4",
         "parameters": [
           {
@@ -38266,7 +38284,7 @@
                 }
               }
             },
-            "description": "Validation failed, or the voucher is not in an editable state"
+            "description": "Validation failed, the voucher is verified or cancelled, or the payload asks for the cancelled status"
           },
           "402": {
             "content": {
@@ -38340,6 +38358,129 @@
           }
         },
         "summary": "Update a construction payment voucher",
+        "tags": [
+          "Construction Payments"
+        ]
+      }
+    },
+    "/api/v1/finance/construction-payments/web/{id}/cancel": {
+      "post": {
+        "description": "Voids a voucher and records why. This is the only route to the cancelled status, and it is how a verified voucher is corrected, since a verified voucher can no longer be edited: cancel it and raise a replacement. The verification stamp stays on the cancelled voucher, so the record still shows who checked it. Cancelling is one-way, and a cancelled voucher's reason is not replaced.",
+        "operationId": "cancel_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelConstructionPaymentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConstructionPaymentDto"
+                }
+              }
+            },
+            "description": "Voucher cancelled, and returned carrying the reason"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No reason given, or the voucher is already cancelled"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No voucher with the given id in the current tenant"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Cancel a construction payment voucher",
         "tags": [
           "Construction Payments"
         ]

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/domain/ConstructionPayment.java
@@ -135,6 +135,14 @@ public class ConstructionPayment extends BaseEntity implements TenantScopedEntit
     @Column(name = "verified_at")
     private Instant verifiedAt;
 
+    /**
+     * Why the voucher was voided, written only by the cancel action and never replaced. On a
+     * voucher that had been verified this is the only record of why somebody's check was set
+     * aside, which is why the action requires it.
+     */
+    @Column(name = "cancellation_reason", length = 1000)
+    private String cancellationReason;
+
     @Column(length = 1000)
     private String description;
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CancelConstructionPaymentRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/CancelConstructionPaymentRequest.java
@@ -1,0 +1,24 @@
+package org.tornotron.echno_backend.finance.construction.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Why a payment voucher is being voided.
+ *
+ * <p>The reason is required rather than optional. A voucher exists to explain a payment, so
+ * voiding one without saying what was wrong with it leaves nothing behind but a gap, and on a
+ * voucher that had been verified it is also the only record of why somebody's check was set
+ * aside. The same rule {@code StockAdjustmentService.reject} applies to a refused adjustment.
+ *
+ * @param reason What was wrong with the voucher.
+ */
+@Schema(description = "Why a payment voucher is being voided. Required: a cancelled voucher that "
+        + "does not say what was wrong with it explains nothing, and on a verified voucher this is "
+        + "the only record of why the verification was set aside.")
+public record CancelConstructionPaymentRequest(
+        @Schema(description = "What was wrong with the voucher.",
+                example = "Duplicate of CPMT-000118, raised twice for the same invoice")
+        @NotBlank @Size(max = 1000) String reason
+) {}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -106,6 +106,11 @@ public record ConstructionPaymentDto(
         @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")
         Instant verifiedAt,
 
+        @Schema(description = "Why the voucher was voided, recorded by the cancel action. Null on a "
+                + "voucher that has not been cancelled.",
+                example = "Duplicate of CPMT-000118, raised twice for the same invoice")
+        String cancellationReason,
+
         @Schema(description = "Description of what the payment covers.", example = "Payment for cement supply, batch 2")
         String description,
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/repositories/ConstructionPaymentRepository.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.finance.construction.repositories;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +22,22 @@ public interface ConstructionPaymentRepository
      */
     @Query("SELECT cp FROM ConstructionPayment cp WHERE cp.id = :id")
     Optional<ConstructionPayment> findByIdScoped(@Param("id") UUID id);
+
+    /**
+     * The same org-scoped lookup, holding the row until the transaction ends.
+     *
+     * <p>Every write path here reads the voucher's state, decides on it, and then changes it:
+     * an update refuses a verified or cancelled voucher before replacing its fields, a
+     * verification refuses one already verified before stamping it, and a cancellation refuses
+     * one already cancelled. Two of those running at once would each read the voucher as it was
+     * before the other, both pass the guard, and both act, so an edit could land on a voucher
+     * that had just been verified, or a second verification could replace the first. With the
+     * lock the second caller waits, reads what the first committed, and is refused. Reads that
+     * only display a voucher keep the unlocked lookup above.
+     *
+     * <p>The same lock the stock-adjustment, leave-approval and payable paths take.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cp FROM ConstructionPayment cp WHERE cp.id = :id")
+    Optional<ConstructionPayment> lockByIdScoped(@Param("id") UUID id);
 }

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentService.java
@@ -115,9 +115,37 @@ public class ConstructionPaymentService {
         return toDto(saved);
     }
 
+    /**
+     * Replaces the editable fields of a voucher that has not been checked yet.
+     *
+     * <p><b>A verified voucher is frozen.</b> The verification says somebody looked at these
+     * figures; leaving them editable afterwards meant the stamp went on attesting to whatever
+     * replaced them, so a voucher raised for 1,000 and verified by a colleague could be edited to
+     * 100,000 with the verification still reading as current. The stamp itself has been
+     * unwritable from a payload since #631, which stopped it being forged but not being
+     * outlived. Freezing the document is the half that makes it mean something, and it is the
+     * rule {@code StockAdjustmentService} already applies once a document is posted.
+     *
+     * <p>The correction route is {@link #cancel} and raise a fresh voucher, not an edit and not an
+     * unverify. An unverify would be the same silent rewrite of the record from the other
+     * direction, which #631 declined for the same reason. A cancellation leaves the wrong voucher
+     * standing with its verification, its reason for being voided, and the replacement raised
+     * beside it, which is what makes the correction explainable afterwards.
+     *
+     * <p>Cancelling is not done here either, even on an unverified voucher. It is a transition
+     * with meaning rather than a field to set, it has to record why, and routing it through a full
+     * replacement of every other field is how a cancellation ends up also changing an amount.
+     *
+     * @param id The voucher to replace.
+     * @param req The replacement fields.
+     * @return The updated voucher.
+     * @throws ResourceNotFoundException if no such voucher exists in this organization.
+     * @throws InvalidRequestException if the voucher is verified or cancelled, or if the payload
+     *         asks for the cancelled status.
+     */
     @Transactional
     public ConstructionPaymentDto update(UUID id, UpdateConstructionPaymentRequest req) {
-        ConstructionPayment payment = paymentRepo.findByIdScoped(id)
+        ConstructionPayment payment = paymentRepo.lockByIdScoped(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Construction payment with ID " + id + " was not found"));
 
@@ -125,6 +153,19 @@ public class ConstructionPaymentService {
             throw new InvalidRequestException(
                     "Construction payment " + payment.getPaymentNumber()
                             + " is cancelled and cannot be updated");
+        }
+        if (payment.getVerifiedAt() != null) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber() + " was verified on "
+                            + payment.getVerifiedAt() + " and cannot be edited, because the "
+                            + "verification would then stand against figures nobody checked. "
+                            + "Cancel it and raise a replacement.");
+        }
+        if (req.status() == ConstructionPaymentVoucherStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber() + " cannot be cancelled "
+                            + "through an update. Use the cancel action, which records why the "
+                            + "voucher was voided.");
         }
 
         payment.setType(req.type());
@@ -184,7 +225,7 @@ public class ConstructionPaymentService {
      */
     @Transactional
     public ConstructionPaymentDto verify(UUID id) {
-        ConstructionPayment payment = paymentRepo.findByIdScoped(id)
+        ConstructionPayment payment = paymentRepo.lockByIdScoped(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Construction payment with ID " + id + " was not found"));
 
@@ -209,6 +250,48 @@ public class ConstructionPaymentService {
         payment.setVerifiedAt(Instant.now());
 
         log.info("Verified construction payment {}", payment.getPaymentNumber());
+        return toDto(payment);
+    }
+
+    /**
+     * Voids a voucher, recording why.
+     *
+     * <p>This is the only route to the cancelled status, and it is the correction route for a
+     * voucher that has been verified, since {@link #update} freezes one. A verified voucher can be
+     * cancelled: voiding a document is not editing the figures its verification attested to, it
+     * withdraws the document those figures were on, and the stamp stays where it is so the record
+     * still shows who checked what and that it was later thrown out.
+     *
+     * <p>The reason is required, for the reason {@code StockAdjustmentService.reject} requires
+     * one: a voided document whose purpose was to explain a payment explains nothing if the
+     * voiding does not say what was wrong with it, and on a verified voucher it is also the only
+     * record of why somebody's check was set aside.
+     *
+     * <p>Cancelling is deliberately one-way. There is no action to bring a voucher back, for the
+     * same reason there is no unverify: the replacement is raised alongside it.
+     *
+     * @param id The voucher to void.
+     * @param reason Why it is being voided.
+     * @return The cancelled voucher.
+     * @throws ResourceNotFoundException if no such voucher exists in this organization.
+     * @throws InvalidRequestException if the voucher is already cancelled.
+     */
+    @Transactional
+    public ConstructionPaymentDto cancel(UUID id, String reason) {
+        ConstructionPayment payment = paymentRepo.lockByIdScoped(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Construction payment with ID " + id + " was not found"));
+
+        if (payment.getStatus() == ConstructionPaymentVoucherStatus.CANCELLED) {
+            throw new InvalidRequestException(
+                    "Construction payment " + payment.getPaymentNumber()
+                            + " is already cancelled, and the reason it was cancelled for is not replaced");
+        }
+
+        payment.setStatus(ConstructionPaymentVoucherStatus.CANCELLED);
+        payment.setCancellationReason(reason);
+
+        log.info("Cancelled construction payment {}", payment.getPaymentNumber());
         return toDto(payment);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.dtos.CancelConstructionPaymentRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
 import org.tornotron.echno_backend.finance.construction.dtos.CreateConstructionPaymentRequest;
 import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
@@ -95,11 +96,14 @@ public class ConstructionPaymentControllerWeb {
     @Operation(
             summary = "Update a construction payment voucher",
             description = "Replaces the editable fields of a payment voucher, including its status, which "
-                    + "is set directly. No ledger journal entry is created on any status transition."
+                    + "is set directly. No ledger journal entry is created on any status transition. A "
+                    + "verified voucher is frozen and cannot be edited, because the verification would "
+                    + "then stand against figures nobody checked; cancel it and raise a replacement. The "
+                    + "cancelled status cannot be set here either: use the cancel action, which records why."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Voucher updated"),
-            @ApiResponse(responseCode = "400", description = "Validation failed, or the voucher is not in an editable state"),
+            @ApiResponse(responseCode = "400", description = "Validation failed, the voucher is verified or cancelled, or the payload asks for the cancelled status"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @ApiResponse(responseCode = "404", description = "No voucher with the given id in the current tenant")
     })
@@ -126,5 +130,26 @@ public class ConstructionPaymentControllerWeb {
     })
     public ConstructionPaymentDto verify(@PathVariable UUID id) {
         return service.verify(id);
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin', 'project-manager')")
+    @Operation(
+            summary = "Cancel a construction payment voucher",
+            description = "Voids a voucher and records why. This is the only route to the cancelled "
+                    + "status, and it is how a verified voucher is corrected, since a verified voucher "
+                    + "can no longer be edited: cancel it and raise a replacement. The verification stamp "
+                    + "stays on the cancelled voucher, so the record still shows who checked it. "
+                    + "Cancelling is one-way, and a cancelled voucher's reason is not replaced."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Voucher cancelled, and returned carrying the reason"),
+            @ApiResponse(responseCode = "400", description = "No reason given, or the voucher is already cancelled"),
+            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "404", description = "No voucher with the given id in the current tenant")
+    })
+    public ConstructionPaymentDto cancel(@PathVariable UUID id,
+                                          @Valid @RequestBody CancelConstructionPaymentRequest req) {
+        return service.cancel(id, req.reason());
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -382,4 +382,7 @@
     <!-- v4.0 - Billing: seed the plan catalogue the organization-creation gate reads -->
     <include file="db/changelog/v4.0/082-seed-billing-plans.xml"/>
 
+    <!-- v4.0 - Payment vouchers: record why one was voided, now that cancelling is how a verified voucher is corrected -->
+    <include file="db/changelog/v4.0/083-add-construction-payment-cancellation-reason.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/083-add-construction-payment-cancellation-reason.xml
+++ b/src/main/resources/db/changelog/v4.0/083-add-construction-payment-cancellation-reason.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="083-add-construction-payment-cancellation-reason" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="construction_payments" columnName="cancellation_reason"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Record why a payment voucher was voided. A verified voucher can no longer be edited,
+            because the verification would otherwise stand against figures nobody checked, so
+            cancelling and raising a replacement becomes the correction route. A cancellation that
+            does not say what was wrong with the voucher explains nothing, and on a verified one it
+            is the only record of why somebody's check was set aside. Vouchers cancelled before this
+            column exists keep a null here.
+        </comment>
+
+        <addColumn tableName="construction_payments">
+            <column name="cancellation_reason" type="VARCHAR(1000)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/ConstructionPaymentServiceIT.java
@@ -267,6 +267,62 @@ class ConstructionPaymentServiceIT extends AbstractIntegrationTest {
         assertThat(service.findById(created.id()).verifiedAt()).isNull();
     }
 
+    @Test
+    void aVerifiedVoucherIsFrozen_andCancellingIsWhatCorrectsIt() {
+        when(userContextService.getCurrentUserId()).thenReturn(RAISER);
+        ConstructionPaymentDto created = service.create(minimalCreateRequest());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+        service.verify(created.id());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Read back from the row rather than from the object verify left behind.
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(created.id(), anEditRaisingTheAmount()))
+                .withMessageContaining("cannot be edited");
+        assertThat(service.findById(created.id()).amount()).isEqualByComparingTo(bd("1000"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // This half only passes because changelog 082 ran: cancellation_reason is a real column
+        // here, not a field on a mock.
+        ConstructionPaymentDto cancelled = service.cancel(created.id(), "Duplicate of the August run");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        ConstructionPaymentDto reread = service.findById(cancelled.id());
+        assertThat(reread.status()).isEqualTo(ConstructionPaymentVoucherStatus.CANCELLED);
+        assertThat(reread.cancellationReason()).isEqualTo("Duplicate of the August run");
+        assertThat(reread.verifiedBy()).isEqualTo(VERIFIER);
+    }
+
+    /** An edit that moves the figure the verification was about. */
+    private UpdateConstructionPaymentRequest anEditRaisingTheAmount() {
+        return new UpdateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                ConstructionPaymentVoucherStatus.COMPLETED,
+                ConstructionPaymentMethod.BANK_TRANSFER,
+                ConstructionPayeeType.VENDOR,
+                projectId,
+                null, null,
+                42L,
+                null, null, null,
+                "Acme Supplies", null,
+                bd("100000"),
+                "INR",
+                LocalDate.of(2026, 8, 1),
+                null, null, null, null, null,
+                "Running payment", null
+        );
+    }
+
     private CreateConstructionPaymentRequest minimalCreateRequest() {
         return new CreateConstructionPaymentRequest(
                 ConstructionPaymentType.INVOICE,

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentFreezeAndCancelTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentFreezeAndCancelTest.java
@@ -1,0 +1,244 @@
+package org.tornotron.echno_backend.finance.construction.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.numbering.EntryNumberGenerator;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentMethod;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
+import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
+import org.tornotron.echno_backend.finance.construction.domain.ConstructionPayment;
+import org.tornotron.echno_backend.finance.construction.dtos.ConstructionPaymentDto;
+import org.tornotron.echno_backend.finance.construction.dtos.UpdateConstructionPaymentRequest;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapper;
+import org.tornotron.echno_backend.finance.construction.mapper.ConstructionPaymentMapperImpl;
+import org.tornotron.echno_backend.finance.construction.repositories.ConstructionPaymentRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+import org.tornotron.echno_backend.user.UserNameLookup;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A verified voucher is frozen, and cancelling is how it gets corrected.
+ *
+ * <p>#631 made the verification stamp unwritable from a payload, which stopped it being forged. It
+ * did not stop it being outlived: the amount, the payee, the bank details and the payment date
+ * could all still be replaced underneath a stamp that stayed where it was, so a voucher raised for
+ * 1,000 and checked by a colleague could become one for 100,000 with the verification still
+ * reading as current. Freezing the document is the half that makes the stamp mean something.
+ *
+ * <p>Three shapes were available and the choice matters, so it is recorded here rather than only
+ * in the pull request. **Clearing the stamp on an edit** was rejected: it never strands anyone, but
+ * it turns every edit into an unverify, which is the silent rewrite of the record #631 declined to
+ * build as an action and would be no better arriving by the back door. **Freezing only the fields
+ * the verification is about** was rejected because the boundary is a judgement that drifts: every
+ * field added later has to be classified, and misclassifying one reopens the hole with nothing to
+ * catch it. **Refusing the edit outright** is what is implemented, on the rule
+ * {@code StockAdjustmentService} already applies to a posted document. Its failure mode is being
+ * stuck, and that is answered by {@code cancel} rather than by leaving the document editable.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConstructionPaymentFreezeAndCancelTest {
+
+    private static final long ORG_ID = 9L;
+    private static final long RAISER = 51L;
+    private static final long VERIFIER = 52L;
+    private static final BigDecimal CHECKED_AMOUNT = new BigDecimal("1000.00");
+
+    @Mock private ConstructionPaymentRepository paymentRepo;
+    @Mock private EntryNumberGenerator numberGen;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private UserNameDirectory userNameDirectory;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private final ConstructionPaymentMapper mapper = new ConstructionPaymentMapperImpl();
+
+    private ConstructionPaymentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new ConstructionPaymentService(paymentRepo, numberGen, mapper, tenantEntityHelper,
+                userNameDirectory, userContextService, new SelfApprovalPolicy(orgSecurity));
+        lenient().when(userNameDirectory.namesFor(anyCollection())).thenReturn(UserNameLookup.none());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    // ── The freeze ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("a verified voucher cannot have its amount replaced")
+    void aVerifiedVoucherCannotBeEdited() {
+        ConstructionPayment payment = verified();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(payment.getId(), anEditRaisingTheAmount()))
+                .withMessageContaining("cannot be edited");
+
+        assertThat(payment.getAmount()).isEqualByComparingTo(CHECKED_AMOUNT);
+        assertThat(payment.getPayeeName()).isEqualTo("Sundar Building Materials");
+    }
+
+    @Test
+    @DisplayName("the refusal names the correction route, rather than leaving the voucher stuck")
+    void theRefusalNamesTheCorrectionRoute() {
+        ConstructionPayment payment = verified();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(payment.getId(), anEditRaisingTheAmount()))
+                .withMessageContaining("Cancel it and raise a replacement");
+    }
+
+    @Test
+    @DisplayName("a voucher nobody has checked is still fully editable")
+    void anUnverifiedVoucherIsStillEditable() {
+        ConstructionPayment payment = pending();
+
+        service.update(payment.getId(), anEditRaisingTheAmount());
+
+        // MoneyUtils rescales on the way in, so compare the value rather than the scale.
+        assertThat(payment.getAmount()).isEqualByComparingTo(new BigDecimal("100000.00"));
+    }
+
+    // ── Cancelling ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("cancelling records the reason and leaves the verification standing")
+    void cancellingRecordsTheReasonAndKeepsTheStamp() {
+        ConstructionPayment payment = verified();
+        Instant stampedAt = payment.getVerifiedAt();
+
+        ConstructionPaymentDto cancelled = service.cancel(
+                payment.getId(), "Duplicate of CPMT-000118, raised twice for the same invoice");
+
+        assertThat(payment.getStatus()).isEqualTo(ConstructionPaymentVoucherStatus.CANCELLED);
+        assertThat(cancelled.cancellationReason())
+                .isEqualTo("Duplicate of CPMT-000118, raised twice for the same invoice");
+        // The stamp stays: the record has to keep showing who checked the voucher that was voided.
+        assertThat(payment.getVerifiedBy()).isEqualTo(VERIFIER);
+        assertThat(payment.getVerifiedAt()).isEqualTo(stampedAt);
+        assertThat(payment.getAmount()).isEqualByComparingTo(CHECKED_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("a cancelled voucher's reason is not replaced by a second cancellation")
+    void aSecondCancellationIsRefused() {
+        ConstructionPayment payment = verified();
+        service.cancel(payment.getId(), "Duplicate of CPMT-000118");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.cancel(payment.getId(), "Changed my mind"))
+                .withMessageContaining("already cancelled");
+
+        assertThat(payment.getCancellationReason()).isEqualTo("Duplicate of CPMT-000118");
+    }
+
+    @Test
+    @DisplayName("an update cannot cancel a voucher, so no cancellation escapes recording a reason")
+    void anUpdateCannotCancel() {
+        ConstructionPayment payment = pending();
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(payment.getId(), anEditThatCancels()))
+                .withMessageContaining("Use the cancel action");
+
+        assertThat(payment.getStatus()).isEqualTo(ConstructionPaymentVoucherStatus.PENDING);
+        assertThat(payment.getCancellationReason()).isNull();
+    }
+
+    // ── The read that all three decisions hang off ───────────────────────────
+
+    @Test
+    @DisplayName("every write path reads the voucher under a write lock")
+    void everyWritePathReadsUnderAWriteLock() {
+        ConstructionPayment payment = pending();
+
+        service.update(payment.getId(), anEditRaisingTheAmount());
+        service.cancel(payment.getId(), "Duplicate");
+
+        // Each of update, verify and cancel reads the voucher's state, decides on it and then
+        // writes. Two arriving together would each read it as it was before the other, both pass,
+        // and both act. This pins that they read through the locking finder; it cannot demonstrate
+        // the database behaviour, which the lock annotation is responsible for.
+        verify(paymentRepo, never()).findByIdScoped(payment.getId());
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    /** A pending voucher raised by {@link #RAISER}, registered with the repository stub. */
+    private ConstructionPayment pending() {
+        UUID id = UUID.randomUUID();
+        ConstructionPayment payment = new ConstructionPayment();
+        payment.setId(id);
+        payment.setPaymentNumber("CPMT-2026-0031");
+        payment.setStatus(ConstructionPaymentVoucherStatus.PENDING);
+        payment.setAmount(CHECKED_AMOUNT);
+        payment.setPayeeName("Sundar Building Materials");
+        payment.setRaisedBy(RAISER);
+        when(paymentRepo.lockByIdScoped(id)).thenReturn(Optional.of(payment));
+        return payment;
+    }
+
+    /** The same voucher after somebody checked it, verified through the action rather than stubbed. */
+    private ConstructionPayment verified() {
+        ConstructionPayment payment = pending();
+        when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
+        service.verify(payment.getId());
+        return payment;
+    }
+
+    /** An edit that moves the figures the verification was about. */
+    private UpdateConstructionPaymentRequest anEditRaisingTheAmount() {
+        return anEdit(ConstructionPaymentVoucherStatus.COMPLETED, new BigDecimal("100000.00"));
+    }
+
+    /** An edit whose only intent is to void the voucher, which is what the cancel action is for. */
+    private UpdateConstructionPaymentRequest anEditThatCancels() {
+        return anEdit(ConstructionPaymentVoucherStatus.CANCELLED, CHECKED_AMOUNT);
+    }
+
+    private UpdateConstructionPaymentRequest anEdit(ConstructionPaymentVoucherStatus status,
+                                                     BigDecimal amount) {
+        return new UpdateConstructionPaymentRequest(
+                ConstructionPaymentType.INVOICE,
+                status,
+                ConstructionPaymentMethod.UPI,
+                ConstructionPayeeType.VENDOR,
+                42L,
+                null, null, 17L, null, null, null,
+                "Someone Else Entirely", null,
+                amount,
+                "INR",
+                LocalDate.of(2026, 8, 2),
+                null, null, null, null, null,
+                "Revised running payment", "Settled");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentVerifyActionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/service/ConstructionPaymentVerifyActionTest.java
@@ -94,18 +94,25 @@ class ConstructionPaymentVerifyActionTest {
     }
 
     @Test
-    void anUpdateCannotWriteTheStamp_soAVerifiedVoucherSurvivesAnEdit() {
+    void anEditIsRefusedOnceTheVoucherIsVerified_ratherThanOutlivingTheStamp() {
         ConstructionPayment payment = pending();
         when(userContextService.getCurrentUserId()).thenReturn(VERIFIER);
         service.verify(payment.getId());
 
         Long stampedBy = payment.getVerifiedBy();
         Instant stampedAt = payment.getVerifiedAt();
+        BigDecimal checkedAmount = payment.getAmount();
 
-        service.update(payment.getId(), anEdit());
+        // This case used to assert only that the stamp survived the edit. It did survive, and
+        // that was the wrong half of the answer: the figures underneath it changed, so the stamp
+        // went on attesting to an amount nobody had checked. See #636.
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.update(payment.getId(), anEdit()))
+                .withMessageContaining("cannot be edited");
 
         assertThat(payment.getVerifiedBy()).isEqualTo(stampedBy);
         assertThat(payment.getVerifiedAt()).isEqualTo(stampedAt);
+        assertThat(payment.getAmount()).isEqualByComparingTo(checkedAmount);
     }
 
     @Test
@@ -209,8 +216,9 @@ class ConstructionPaymentVerifyActionTest {
         payment.setId(id);
         payment.setPaymentNumber("CPMT-2026-0031");
         payment.setStatus(ConstructionPaymentVoucherStatus.PENDING);
+        payment.setAmount(new BigDecimal("1000.00"));
         payment.setRaisedBy(RAISER);
-        when(paymentRepo.findByIdScoped(id)).thenReturn(Optional.of(payment));
+        when(paymentRepo.lockByIdScoped(id)).thenReturn(Optional.of(payment));
         return payment;
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentVerificationStampTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentVerificationStampTest.java
@@ -145,6 +145,33 @@ class ConstructionPaymentVerificationStampTest {
         verify(service).verify(id);
     }
 
+    @Test
+    void cancel_isRoleGated_andRefusesAVoucherVoidedWithNoReasonGiven() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
+                .thenReturn(false);
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web/{id}/cancel", id)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\": \"Duplicate of CPMT-000118\"}"))
+                .andExpect(status().isForbidden());
+
+        allowElevatedRole();
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web/{id}/cancel", id)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\": \"   \"}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/v1/finance/construction-payments/web/{id}/cancel", id)
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\": \"Duplicate of CPMT-000118\"}"))
+                .andExpect(status().isOk());
+        verify(service).cancel(id, "Duplicate of CPMT-000118");
+    }
+
     private void allowElevatedRole() {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager"))
                 .thenReturn(true);


### PR DESCRIPTION
Closes #636.

## What was wrong

`ConstructionPaymentService.update` was a full replacement whose only lifecycle guard was that a cancelled voucher could not be touched. A verified voucher was fully editable: the amount, the payee, the bank details and the payment date could all be replaced while `verifiedBy` and `verifiedAt` stood untouched.

PR #634 added a test pinning that the stamp survives an edit. It does survive, and that turned out to be the right half of the answer and the wrong whole one, which is what #636 was raised for: the stamp then attests to figures nobody checked. Raise a voucher for 1,000, have a colleague verify it, edit it to 100,000, and the verification still reads as current. #631 stopped the stamp being forged; it did not stop it being outlived.

## The shape, and why not the other two

The issue offered three, and they fail differently, so the choice is argued rather than picked.

**Clearing the verification when the voucher is edited.** Rejected. It never strands anyone, which is its real merit, but it makes every edit an unverify. #631 deliberately left out an unverify action because clearing a verification is the same silent rewrite of the record as forging one, from the other direction, and it is no better for arriving as a side effect of an edit than as a button. It also hands anyone who wants a verification gone a trivial way to get it: change a note.

**Freezing only the fields the verification is about.** Rejected. The boundary between "the figures" and "the annotations" is a judgement, and it drifts: every field added later has to be classified, nothing catches a misclassification, and the hole reopens silently. The voucher has 22 editable fields today.

**Refusing the edit outright.** Implemented. It is the rule `StockAdjustmentService` already applies once a document is posted, for the same reason its comment gives: changing the lines afterwards would leave the record describing a document that no longer exists. Its failure mode is being stuck, and that is answered below rather than by leaving the document editable.

## Freezing needs a route back, and there wasn't one

This is the part that turned out to matter. The issue names cancel-and-re-raise as the correction route, and it existed only in theory:

- the sole way to reach `CANCELLED` was `PUT /{id}` with `status: CANCELLED`, which is exactly the call the freeze now blocks;
- nothing in `echno-web` or `echno-core` cancels a voucher at all, so there is no cancel path to preserve.

Freezing on its own would therefore have left a verified voucher with no way out. So cancelling becomes an action of its own, `POST /{id}/cancel`, on the same argument that made verification one in #631: it is a transition with meaning rather than a field to set, and routing it through a full replacement of every other field is how a cancellation ends up also changing an amount.

- **A verified voucher can be cancelled.** Voiding a document is not editing the figures its verification attested to; it withdraws the document those figures were on. The stamp stays where it is, so the record still shows who checked what and that it was later thrown out.
- **The reason is required**, for the reason `StockAdjustmentService.reject` requires one: a voided voucher that does not say what was wrong with it explains nothing, and on a verified voucher it is the only record of why somebody's check was set aside. Changelog **083** adds `cancellation_reason`.
- **`update` refuses to set the cancelled status**, so there is one cancellation route and it always records a reason.
- **Cancelling is one-way**, and there is still no unverify. The replacement is raised alongside.

## Also here: the same race review found on #639

Every write path on this voucher reads its state, decides on it, and then writes. Two arriving together each read the voucher as it was before the other, both pass the guard, and both act: an edit could land on a voucher that had just been verified, or a second verification could replace the first. `update`, `verify` and `cancel` now read through a locking finder, the way the stock-adjustment, leave-approval and payable paths do. Reads that only display a voucher keep the unlocked lookup.

## The status question the issue asked

Verification stays refused on a cancelled voucher only, and that is deliberate rather than an oversight. A `FAILED` or `REFUNDED` payment still has figures worth checking, and a verification of one is a meaningful record. `CANCELLED` is the only status that says the document itself is void, so it is the only one with nothing left to verify.

## Tests

Each case was proved red by deleting exactly the code it pins, one deletion at a time, on the build machine.

| Test | Reddened by deleting |
|---|---|
| `ConstructionPaymentVerifyActionTest.anEditIsRefusedOnceTheVoucherIsVerified_ratherThanOutlivingTheStamp` | the freeze guard |
| `ConstructionPaymentFreezeAndCancelTest.aVerifiedVoucherCannotBeEdited` | the freeze guard |
| `...theRefusalNamesTheCorrectionRoute` | the freeze guard |
| `...anUnverifiedVoucherIsStillEditable` | nothing, by design: it is the pin against an over-broad freeze, and goes red when the guard is made unconditional |
| `...cancellingRecordsTheReasonAndKeepsTheStamp` | the reason write |
| `...aSecondCancellationIsRefused` | the reason write |
| `...anUpdateCannotCancel` | the update-cancel guard |
| `...everyWritePathReadsUnderAWriteLock` | the locking finder |
| `ConstructionPaymentVerificationStampTest.cancel_isRoleGated_andRefusesAVoucherVoidedWithNoReasonGiven` | the endpoint, its `@PreAuthorize`, or the `@NotBlank` on the reason |
| `ConstructionPaymentServiceIT.aVerifiedVoucherIsFrozen_andCancellingIsWhatCorrectsIt` | the freeze guard or the reason write |

Two things worth saying plainly about these.

`anUpdateCannotWriteTheStamp_soAVerifiedVoucherSurvivesAnEdit`, which #634 added, is **replaced** rather than kept. It asserted that the stamp survived the edit, which is the behaviour this PR removes; keeping it would have pinned the defect. The case is rewritten in place, under the name above, so the history of what it used to assert stays visible, and it now also pins that the amount did not move. The fixture gained a distinct amount for that: it was defaulting to zero, so an amount assertion would have compared zero to zero and passed whether or not the edit went through.

**The IT case only passes because the migration ran.** `cancellation_reason` is a real column there, against a real CockroachDB, not a field on a mock, which is what makes it evidence that changelog 083 works rather than that the code compiles.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`. Full suite green on the build machine: 599 MB live of the 2048 MB cap, 29% used.

## Client

`POST /{id}/cancel` is new and nothing calls it yet, so nothing breaks. The client work is filed rather than built.
