### PR TITLE
Approve a stock adjustment against the balance it was raised against

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15911,7 +15911,7 @@
         "description": "A single material line on a stock adjustment, comparing the system quantity to the physically counted quantity.",
         "properties": {
           "adjustmentQuantity": {
-            "description": "Adjustment quantity (physical minus system).",
+            "description": "Adjustment quantity (physical minus system). Recomputed from the stamped system quantity whenever a physical count is given, so the line's three figures are one piece of arithmetic. Sent on its own, with no physical count, it is the signed movement the line posts and is kept as sent.",
             "example": -20.0,
             "format": "double",
             "type": "number"
@@ -15960,7 +15960,7 @@
             "type": "string"
           },
           "systemQuantity": {
-            "description": "Quantity on record before the adjustment.",
+            "description": "The quantity on record before the adjustment. Stamped from the balance this line is raised against, so any value sent here is ignored: it is the opening figure the approval is checked against and therefore the server's to state. A value sent for a line naming no material, or on a document naming no project, is kept, because there is no balance to read; such a line cannot be approved either way.",
             "example": 480.0,
             "format": "double",
             "type": "number"
@@ -16052,7 +16052,7 @@
             "type": "string"
           },
           "systemQuantity": {
-            "description": "Quantity on record before the adjustment.",
+            "description": "Quantity on record before the adjustment, read from the balance when the document was last written. An approval is refused if the balance has moved away from it, so on a posted line this is also the opening figure the ledger entry carries.",
             "example": 480.0,
             "format": "double",
             "type": "number"

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -51,10 +51,16 @@ import java.util.stream.Stream;
  * then moves the balance, so the resulting figure stays explainable from the ledger like
  * every other movement.
  *
- * <p>{@link #create} and {@link #update} persist the document only. Posting happens once,
- * through {@link #approve}, and a posted document is then frozen: edits and deletes are
- * refused, because changing the lines afterwards would leave the ledger describing a
- * document that no longer exists.
+ * <p>{@link #create} and {@link #update} persist the document only, with one thing read from
+ * the stock rather than the request: each line is stamped with the balance it is being raised
+ * against, by {@link #stampOpeningBalance}. Posting happens once, through {@link #approve}, and
+ * a posted document is then frozen: edits and deletes are refused, because changing the lines
+ * afterwards would leave the ledger describing a document that no longer exists.
+ *
+ * <p>Those two halves meet at {@link #requireBalanceUnmoved}: an approval is refused when the
+ * balance has moved since the document was raised. The figures approved are then the figures
+ * raised, which on a document whose whole purpose is to be an auditable correction is what the
+ * second signature is a signature on.
  *
  * <p>A draft has one other way off the line: {@link #reject}, which records that an approver
  * looked at the correction and refused it. It moves no stock, and it is the only outcome that
@@ -238,14 +244,19 @@ public class StockAdjustmentService {
      * Approves a stock adjustment and posts its lines to the stock ledger.
      *
      * <p>This is the controlled way to set or correct a balance. Each line resolves the
-     * balance row it applies to, from the line's own storage location or the document's,
-     * and the movement it needs to reach the counted figure. A line carrying a physical
-     * count is posted as the difference between that count and the balance <em>as it stands
-     * now</em>, not the {@code systemQuantity} recorded when the count sheet was written, so
-     * the balance ends at exactly the counted figure even if stock moved in between; the
-     * line is rewritten with the figures actually posted. A line with no count falls back to
+     * balance row it applies to, from the line's own storage location or the document's, and
+     * the movement it needs to reach the counted figure: a line carrying a physical count posts
+     * the difference between that count and the balance, and a line with no count falls back to
      * its signed {@code adjustmentQuantity}. Lines that come out at no movement are skipped
      * rather than writing a ledger row that changes nothing.
+     *
+     * <p>The approval is refused when the balance has moved since the document was raised, so
+     * what is posted is the arithmetic the approver read and not a recomputation of it. See
+     * {@link #requireBalanceUnmoved}, which carries the reasoning; the opening figure it checks
+     * against is stamped onto the line when the document is written, by
+     * {@link #stampOpeningBalance}. Because the balance is then known to be the one on the line,
+     * the figures written back to the line are the raised figures, and the document, the count
+     * sheet and the ledger all describe one movement.
      *
      * <p>The approval is refused up front when the person approving is the one who raised the
      * document, unless they hold the break-glass role, in which case the posting is allowed and
@@ -267,7 +278,7 @@ public class StockAdjustmentService {
      * @param id The document to approve and post.
      * @return The posted document as a DTO.
      * @throws ResourceNotFoundException if no such document exists in this organization.
-     * @throws InvalidRequestException if the document is already posted, is being approved by whoever raised it without the break-glass role, names no project, has no lines, or a line is missing a material, a reason, or a quantity, names a location on another project that holds no balance for it, or would drive a balance negative.
+     * @throws InvalidRequestException if the document is already posted, is being approved by whoever raised it without the break-glass role, names no project, has no lines, or a line is missing a material, a reason, or a quantity, was raised against a balance that has since moved, names a location on another project that holds no balance for it, or would drive a balance negative.
      */
     @Transactional
     public StockAdjustmentDto approve(Long id) {
@@ -314,15 +325,17 @@ public class StockAdjustmentService {
                     ? line.getLocation()
                     : stockAdjustment.getLocation();
 
-            Optional<Double> existingBalance = location != null
-                    ? inventoryService.findStockAtLocation(material.getId(), project.getId(), location.getId())
-                    : inventoryService.findUnlocatedStock(material.getId(), project.getId());
+            Optional<Double> existingBalance = readBalance(material, project, location);
             StorageLocationScope.requireUsableForBalanceCorrection(location, project.getId(),
                     existingBalance::isPresent);
             Double balance = existingBalance.orElse(0.0);
+            requireBalanceUnmoved(line, balance, material, id);
             Double movement = resolveMovement(line, balance, material, id);
 
-            // Record what was actually posted, so the document and the ledger agree.
+            // Record what was posted, so the document and the ledger agree. The guard above has
+            // already established that this is the opening figure the document was raised
+            // against, so on any line carrying one these two writes change nothing; they are
+            // what fills the figures in on a line raised before the opening balance was stamped.
             line.setSystemQuantity(balance);
             line.setAdjustmentQuantity(movement);
 
@@ -527,6 +540,110 @@ public class StockAdjustmentService {
         return reason + detail;
     }
 
+    /**
+     * The balance row a line applies to, empty when no such row exists.
+     *
+     * <p>Shared by the two places that need it and must agree: {@link #stampOpeningBalance},
+     * which records the figure on the draft, and {@link #approve}, which posts against it. If
+     * they read different rows the stamped opening balance would look moved on every approval.
+     *
+     * @param material The material the line adjusts.
+     * @param project The project the document corrects a balance on.
+     * @param location The line's location, else the document's, else null for the unlocated row.
+     * @return The quantity on hand, or empty when the balance row does not exist.
+     */
+    private Optional<Double> readBalance(Material material, Project project, StorageLocation location) {
+        return location != null
+                ? inventoryService.findStockAtLocation(material.getId(), project.getId(), location.getId())
+                : inventoryService.findUnlocatedStock(material.getId(), project.getId());
+    }
+
+    /**
+     * Refuses an approval whose balance has moved since the document was raised.
+     *
+     * <p>This is what makes the second signature mean something. A stock adjustment is approved
+     * by someone other than the person who raised it, and what they are agreeing to is an
+     * arithmetic: this material stood at the opening figure on the line, the count found the
+     * physical figure, so post the difference. If the balance moves in between, approving posts a
+     * different arithmetic from the one on the document, and it does so silently: a line carrying
+     * a count always drives the balance to exactly the counted figure, so a goods receipt booked
+     * after the count is reversed by the approval and nothing anywhere says it was. The receipt
+     * stays on the ledger; the stock does not.
+     *
+     * <p>Refusing is the only outcome that keeps the approval honest. Posting the drafted variance
+     * instead would guess the other way, and it is a guess: whether goods received after a count
+     * were already on the shelf when it was taken is not something the data can answer, so a
+     * default either absorbs a real receipt or double-counts one. Both need a human, and this is
+     * the point at which one is present.
+     *
+     * <p>The way forward is to save the document again, which re-reads the opening balance onto
+     * every line (see {@link #stampOpeningBalance}), and approve it once the count has been
+     * checked against the figure that moved. That keeps the decision with a person and leaves the
+     * document saying what was agreed.
+     *
+     * <p>A line carrying no opening balance is let through: it was raised before the figure was
+     * stamped, so there is nothing to compare and nothing the approver can be said to have
+     * disagreed with. {@link #approve} then fills the figure in from what it posts.
+     *
+     * @param line The line being posted.
+     * @param balance The balance as it stands now.
+     * @param material The material the line adjusts, named in the message.
+     * @param id The document being approved, named in the message.
+     * @throws InvalidRequestException if the line was raised against a different opening balance.
+     */
+    private void requireBalanceUnmoved(StockAdjustmentLineItem line, Double balance, Material material, Long id) {
+        Double opening = line.getSystemQuantity();
+        if (opening == null || Math.abs(opening - balance) < NO_MOVEMENT) {
+            return;
+        }
+        throw new InvalidRequestException("The line adjusting material ID " + material.getId()
+                + " on stock adjustment with ID " + id + " was raised against a balance of " + opening
+                + ", and the balance now stands at " + balance + ". Something moved this stock after "
+                + "the count sheet was written, so approving it would post a correction nobody has "
+                + "agreed to and would silently reverse whatever moved it. Check the count against "
+                + "the figure it now stands at, save the document to take up the current balance, "
+                + "and approve it again.");
+    }
+
+    /**
+     * Records the balance a line is being raised against, and the variance that follows from it.
+     *
+     * <p>{@code systemQuantity} is the system's own figure, not a number the person raising the
+     * document gets to assert, so it is read from the stock here the same way {@code submittedBy}
+     * is read from the session rather than the request body. Before this it
+     * was whatever the client sent: on the web app a hand-typed box defaulting to zero, checked
+     * against nothing. That left it decorative, which mattered once {@link #approve} started
+     * refusing an approval whose balance has moved, because a guard against a hand-typed number
+     * fires on typing mistakes rather than on stock moving.
+     *
+     * <p>Where the line carries a count, the variance is recomputed from the stamped figure too.
+     * The three numbers on a line are one piece of arithmetic and a document showing an opening
+     * balance, a count, and a difference that is not the difference between them is worse than one
+     * showing no opening balance at all.
+     *
+     * <p>A line too incomplete to read a balance for, naming no material or sitting on a document
+     * naming no project, keeps what the client sent. There is no balance to read, and such a line
+     * cannot be approved anyway: {@link #approve} refuses both.
+     *
+     * @param item The line being written.
+     * @param stockAdjustment The document it belongs to, for the project and the fallback location.
+     */
+    private void stampOpeningBalance(StockAdjustmentLineItem item, StockAdjustment stockAdjustment) {
+        Material material = item.getMaterial();
+        Project project = stockAdjustment.getProject();
+        if (material == null || project == null) {
+            return;
+        }
+        StorageLocation location = item.getLocation() != null
+                ? item.getLocation()
+                : stockAdjustment.getLocation();
+        Double balance = readBalance(material, project, location).orElse(0.0);
+        item.setSystemQuantity(balance);
+        if (item.getPhysicalQuantity() != null) {
+            item.setAdjustmentQuantity(item.getPhysicalQuantity() - balance);
+        }
+    }
+
     /** The signed movement a line posts: to the counted figure where there is one, else the stated delta. */
     private Double resolveMovement(StockAdjustmentLineItem line, Double balance, Material material, Long id) {
         if (line.getPhysicalQuantity() != null) {
@@ -580,7 +697,12 @@ public class StockAdjustmentService {
         stockAdjustment.setProject(resolveProject(dto.getProjectId()));
     }
 
-    /** Builds and attaches the line items, resolving each line's material and location. */
+    /**
+     * Builds and attaches the line items, resolving each line's material and location.
+     *
+     * <p>Runs after {@link #applyHeaderFields}, because the opening balance each line is stamped
+     * with is read against the document's project and falls back to its location.
+     */
     private void applyLineItems(StockAdjustment stockAdjustment,
                                 List<StockAdjustmentLineItemCreationDto> lineItemDtos,
                                 Organization organization) {
@@ -590,6 +712,8 @@ public class StockAdjustmentService {
         for (StockAdjustmentLineItemCreationDto lineDto : lineItemDtos) {
             StockAdjustmentLineItem item = new StockAdjustmentLineItem();
             item.setDescription(lineDto.getDescription());
+            // Kept only as the fallback for a line no balance can be read for; where one can be,
+            // stampOpeningBalance below overwrites it with the figure the system actually holds.
             item.setSystemQuantity(lineDto.getSystemQuantity());
             item.setPhysicalQuantity(lineDto.getPhysicalQuantity());
             item.setAdjustmentQuantity(lineDto.getAdjustmentQuantity());
@@ -603,6 +727,7 @@ public class StockAdjustmentService {
             item.setMaterial(resolveMaterial(lineDto.getMaterialId()));
             item.setLocation(resolveLocation(lineDto.getLocationId()));
             item.setOrganization(organization);
+            stampOpeningBalance(item, stockAdjustment);
             stockAdjustment.addLineItem(item);
         }
     }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -35,7 +35,9 @@ import org.tornotron.echno_backend.user.UserNameLookup;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -312,6 +314,11 @@ public class StockAdjustmentService {
                 : postedAt;
         String referenceNumber = referenceNumber(stockAdjustment);
         double totalVariance = 0.0;
+        // What this approval has already posted to each balance row, so a later line on the same
+        // row is measured against the balance as it stood when the approval began. See
+        // requireBalanceUnmoved: a document may split one shelf's variance across several lines,
+        // one per reason, and the approver read all of them.
+        Map<BalanceRow, Double> postedHere = new HashMap<>();
 
         for (StockAdjustmentLineItem line : stockAdjustment.getLineItems()) {
             Material material = line.getMaterial();
@@ -329,7 +336,8 @@ public class StockAdjustmentService {
             StorageLocationScope.requireUsableForBalanceCorrection(location, project.getId(),
                     existingBalance::isPresent);
             Double balance = existingBalance.orElse(0.0);
-            requireBalanceUnmoved(line, balance, material, id);
+            BalanceRow row = new BalanceRow(material.getId(), location != null ? location.getId() : null);
+            requireBalanceUnmoved(line, balance - postedHere.getOrDefault(row, 0.0), material, id);
             Double movement = resolveMovement(line, balance, material, id);
 
             // Record what was posted, so the document and the ledger agree. The guard above has
@@ -375,6 +383,7 @@ public class StockAdjustmentService {
                     movement, movement > 0 ? unitCost : null);
 
             totalVariance += movement;
+            postedHere.merge(row, movement, Double::sum);
         }
 
         stockAdjustment.setTotalVarianceQuantity(totalVariance);
@@ -541,6 +550,19 @@ public class StockAdjustmentService {
     }
 
     /**
+     * Identifies the balance row a line moves, within one document's project.
+     *
+     * <p>Several lines may share one: a count sheet can split a shelf's variance across a line
+     * per reason, so much damaged and so much lost. {@link #approve} needs to tell those apart
+     * from stock that moved underneath the document.
+     *
+     * @param materialId The material.
+     * @param locationId The storage location, or null for the row held against no location.
+     */
+    private record BalanceRow(Long materialId, Long locationId) {
+    }
+
+    /**
      * The balance row a line applies to, empty when no such row exists.
      *
      * <p>Shared by the two places that need it and must agree: {@link #stampOpeningBalance},
@@ -581,12 +603,18 @@ public class StockAdjustmentService {
      * checked against the figure that moved. That keeps the decision with a person and leaves the
      * document saying what was agreed.
      *
+     * <p>What the approval has itself already posted to the same balance row is discounted first,
+     * so this measures stock that moved underneath the document and not the document's own work.
+     * A count sheet may split one shelf's variance across a line per reason, and the approver read
+     * all of those lines; refusing the second because the first had just moved the balance would
+     * refuse a document nobody wrote wrongly.
+     *
      * <p>A line carrying no opening balance is let through: it was raised before the figure was
      * stamped, so there is nothing to compare and nothing the approver can be said to have
      * disagreed with. {@link #approve} then fills the figure in from what it posts.
      *
      * @param line The line being posted.
-     * @param balance The balance as it stands now.
+     * @param balance The balance as it stood when this approval began.
      * @param material The material the line adjusts, named in the message.
      * @param id The document being approved, named in the message.
      * @throws InvalidRequestException if the line was raised against a different opening balance.
@@ -598,11 +626,11 @@ public class StockAdjustmentService {
         }
         throw new InvalidRequestException("The line adjusting material ID " + material.getId()
                 + " on stock adjustment with ID " + id + " was raised against a balance of " + opening
-                + ", and the balance now stands at " + balance + ". Something moved this stock after "
-                + "the count sheet was written, so approving it would post a correction nobody has "
-                + "agreed to and would silently reverse whatever moved it. Check the count against "
-                + "the figure it now stands at, save the document to take up the current balance, "
-                + "and approve it again.");
+                + ", and the balance stood at " + balance + " when this approval began. Something "
+                + "moved this stock after the count sheet was written, so approving it would post a "
+                + "correction nobody has agreed to and would silently reverse whatever moved it. "
+                + "Check the count against the figure it now stands at, save the document to take "
+                + "up the current balance, and approve it again.");
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
@@ -14,13 +14,20 @@ public class StockAdjustmentLineItemCreationDto {
     @Schema(description = "Free-text description of the line item.", example = "OPC 53 Grade Cement, damaged bags found during count")
     private String description;
 
-    @Schema(description = "Quantity on record before the adjustment.", example = "480.0")
+    @Schema(description = "The quantity on record before the adjustment. Stamped from the balance this "
+            + "line is raised against, so any value sent here is ignored: it is the opening figure the "
+            + "approval is checked against and therefore the server's to state. A value sent for a line "
+            + "naming no material, or on a document naming no project, is kept, because there is no "
+            + "balance to read; such a line cannot be approved either way.", example = "480.0")
     private Double systemQuantity;
 
     @Schema(description = "Quantity found during the physical count.", example = "460.0")
     private Double physicalQuantity;
 
-    @Schema(description = "Adjustment quantity (physical minus system).", example = "-20.0")
+    @Schema(description = "Adjustment quantity (physical minus system). Recomputed from the stamped "
+            + "system quantity whenever a physical count is given, so the line's three figures are one "
+            + "piece of arithmetic. Sent on its own, with no physical count, it is the signed movement "
+            + "the line posts and is kept as sent.", example = "-20.0")
     private Double adjustmentQuantity;
 
     @Schema(description = "Unit of measure for the quantities.", example = "bags")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemDto.java
@@ -20,7 +20,10 @@ public class StockAdjustmentLineItemDto {
     @Schema(description = "Free-text description of the line item.", example = "Damaged bags found during count")
     private String description;
 
-    @Schema(description = "Quantity on record before the adjustment.", example = "480.0")
+    @Schema(description = "Quantity on record before the adjustment, read from the balance when the "
+            + "document was last written. An approval is refused if the balance has moved away from it, "
+            + "so on a posted line this is also the opening figure the ledger entry carries.",
+            example = "480.0")
     private Double systemQuantity;
 
     @Schema(description = "Quantity found during the physical count.", example = "460.0")

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -46,7 +46,9 @@ import static org.mockito.Mockito.when;
  * Approving a stock adjustment is the only way to set or correct a balance, so this covers
  * what that has to guarantee: a ledger entry carrying the reason is written before the
  * balance moves, a physical count lands the balance on the counted figure, a movement with
- * no stated reason is refused, an adjustment cannot be posted twice or edited afterwards,
+ * no stated reason is refused, an approval whose balance has moved since the document was
+ * raised is refused so that what is approved is what was raised, an adjustment cannot be
+ * posted twice or edited afterwards,
  * and it cannot be used to book stock onto a location belonging to another project that
  * holds no balance for it, or to push a balance below zero. The one relaxation the
  * adjustment path carries is covered too: a balance that already sits on another project's
@@ -181,11 +183,88 @@ class StockAdjustmentApprovalTest {
     }
 
     @Test
-    void aCountIsPostedAgainstTheBalanceAsItStandsNotTheSystemQuantityOnTheCountSheet() {
+    void aCountedLineIsRefusedWhenTheBalanceHasMovedSinceTheDocumentWasRaised() {
         StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
         StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
-        // The count sheet was written when the system said 48; a receipt has since taken it to 50.
+        // The count sheet was raised when the system said 48; a receipt has since taken it to 50.
         line.setSystemQuantity(48.0);
+        balanceAtLocation(50.0);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("48.0")
+                .withMessageContaining("50.0");
+
+        // Posting it would have driven the balance to the counted 46, quietly taking back the
+        // receipt that moved it. Nothing reaches the ledger and no balance moves.
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+        assertThat(adjustment.getProcessedAt()).isNull();
+        assertThat(adjustment.getStatus()).isNotEqualTo("processed");
+        // And the figures on the document are still the ones it was raised with, so what the
+        // window did is still readable afterwards.
+        assertThat(line.getSystemQuantity()).isEqualTo(48.0);
+    }
+
+    @Test
+    void aSignedDeltaLineIsRefusedWhenTheBalanceHasMovedToo() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        StockAdjustmentLineItem line = line(adjustment, null, 30.0, "data correction");
+        // A line that states no count, only "book 30 more here". Raised when the location stood
+        // at 400, so the approver is agreeing to a closing figure of 430; it now stands at 420,
+        // and posting would land on 450 instead. The closing figure stays well clear of zero, so
+        // nothing but the moved balance can be what refuses this.
+        line.setSystemQuantity(400.0);
+        balanceAtLocation(420.0);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.approve(ADJUSTMENT))
+                .withMessageContaining("400.0")
+                .withMessageContaining("420.0");
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        verify(inventoryService, never()).updateCurrentStock(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void anApprovalPostsTheFiguresTheDocumentWasRaisedWith() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        StockAdjustmentLineItem line = line(adjustment, 46.0, -2.0, "damage");
+        line.setSystemQuantity(48.0);
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getOpeningStock()).isEqualTo(48.0);
+        assertThat(captor.getValue().getQuantityChanged()).isEqualTo(-2.0);
+        assertThat(captor.getValue().getClosingStock()).isEqualTo(46.0);
+        // Approval changed neither figure on the line, so the document that was approved is the
+        // document that was raised and the ledger entry describes the same movement it does.
+        assertThat(line.getSystemQuantity()).isEqualTo(48.0);
+        assertThat(line.getPhysicalQuantity()).isEqualTo(46.0);
+        assertThat(line.getAdjustmentQuantity()).isEqualTo(-2.0);
+    }
+
+    @Test
+    void aBalanceMovedOnlyByFloatingPointResidueIsNotTreatedAsMoved() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
+        line.setSystemQuantity(48.0);
+        balanceAtLocation(48.0 + 1e-12);
+
+        service.approve(ADJUSTMENT);
+
+        verify(inventoryTransactionRepository).save(any());
+    }
+
+    @Test
+    void aLineRaisedWithNoOpeningBalanceIsPostedAndHasItsFiguresFilledIn() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        // Raised before the opening balance was stamped onto lines: there is nothing to compare,
+        // so there is nothing the approver can be said to have disagreed with.
+        StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
         balanceAtLocation(50.0);
 
         service.approve(ADJUSTMENT);
@@ -193,7 +272,8 @@ class StockAdjustmentApprovalTest {
         ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
         verify(inventoryTransactionRepository).save(captor.capture());
         assertThat(captor.getValue().getQuantityChanged()).isEqualTo(-4.0);
-        assertThat(captor.getValue().getClosingStock()).isEqualTo(46.0);
+        assertThat(line.getSystemQuantity()).isEqualTo(50.0);
+        assertThat(line.getAdjustmentQuantity()).isEqualTo(-4.0);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -245,6 +246,31 @@ class StockAdjustmentApprovalTest {
         assertThat(line.getSystemQuantity()).isEqualTo(48.0);
         assertThat(line.getPhysicalQuantity()).isEqualTo(46.0);
         assertThat(line.getAdjustmentQuantity()).isEqualTo(-2.0);
+    }
+
+    @Test
+    void aShelfWhoseVarianceIsSplitAcrossSeveralLinesPostsAllOfThem() {
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        // One shelf, one count, the variance attributed a line per reason. Both lines were raised
+        // against the same opening balance, and the approver read both of them.
+        StockAdjustmentLineItem damaged = line(adjustment, null, -20.0, "damage");
+        damaged.setSystemQuantity(400.0);
+        StockAdjustmentLineItem lost = line(adjustment, null, -10.0, "loss");
+        lost.setSystemQuantity(400.0);
+        // The first line takes the row to 380 before the second is looked at. That is the
+        // document's own work, not stock moving underneath it, so it is not drift.
+        when(inventoryService.findStockAtLocation(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(400.0), Optional.of(380.0));
+
+        service.approve(ADJUSTMENT);
+
+        ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
+        verify(inventoryTransactionRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(0).getQuantityChanged()).isEqualTo(-20.0);
+        assertThat(captor.getAllValues().get(0).getClosingStock()).isEqualTo(380.0);
+        assertThat(captor.getAllValues().get(1).getQuantityChanged()).isEqualTo(-10.0);
+        assertThat(captor.getAllValues().get(1).getClosingStock()).isEqualTo(370.0);
+        assertThat(adjustment.getTotalVarianceQuantity()).isEqualTo(-30.0);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -42,8 +42,9 @@ import static org.mockito.Mockito.when;
  * Unit tests for the drafting half of StockAdjustmentService: an id that names nothing in
  * the current tenant is rejected, a null id resolves to no association rather than an
  * error, line items are wired to their parent and stamped with the organization, and an
- * update replaces the whole line-item collection, and the user who raised the document is
- * taken from the session rather than from the request body. The repositories, mapper, and
+ * update replaces the whole line-item collection, the opening balance a line is raised
+ * against is read from the stock rather than taken from the request body, and the user who
+ * raised the document is taken from the session rather than from the request body. The repositories, mapper, and
  * tenant helper are mocked; assertions read the entity captured on saveAndFlush. Posting to
  * the stock ledger is covered by {@link StockAdjustmentApprovalTest}.
  */
@@ -154,6 +155,93 @@ class StockAdjustmentServiceTest {
         assertThat(saved.getLocation()).isNull();
         assertThat(saved.getProject()).isNull();
         assertThat(saved.getLineItems()).isEmpty();
+    }
+
+    @Test
+    void create_stampsTheOpeningBalanceRatherThanTrustingTheFigureSent() {
+        stubReferenceLookups();
+        when(inventoryService.findStockAtLocation(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(400.0));
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setProjectId(PROJECT);
+        StockAdjustmentLineItemCreationDto line = line(MATERIAL, LOCATION);
+        // On the web form this is a box somebody types into, defaulting to zero and checked
+        // against nothing. It is the figure the approval is now measured against, so the server
+        // reads it rather than taking it on trust.
+        line.setSystemQuantity(999.0);
+        dto.setLineItems(List.of(line));
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getLineItems().get(0).getSystemQuantity()).isEqualTo(400.0);
+    }
+
+    @Test
+    void create_recomputesTheVarianceFromTheStampedOpeningBalance() {
+        stubReferenceLookups();
+        when(inventoryService.findStockAtLocation(MATERIAL, PROJECT, LOCATION))
+                .thenReturn(Optional.of(400.0));
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setProjectId(PROJECT);
+        StockAdjustmentLineItemCreationDto line = line(MATERIAL, LOCATION);
+        line.setSystemQuantity(500.0);
+        line.setPhysicalQuantity(370.0);
+        line.setAdjustmentQuantity(-130.0);
+        dto.setLineItems(List.of(line));
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        StockAdjustmentLineItem saved = captor.getValue().getLineItems().get(0);
+        // The three figures on a line are one piece of arithmetic; a document showing 400, a count
+        // of 370 and a difference of -130 says nothing anyone can act on.
+        assertThat(saved.getSystemQuantity()).isEqualTo(400.0);
+        assertThat(saved.getPhysicalQuantity()).isEqualTo(370.0);
+        assertThat(saved.getAdjustmentQuantity()).isEqualTo(-30.0);
+    }
+
+    @Test
+    void create_lineWithNoMaterial_keepsTheFigureSent() {
+        StockAdjustmentCreationDto dto = baseDto();
+        StockAdjustmentLineItemCreationDto line = line(null, null);
+        line.setSystemQuantity(500.0);
+        dto.setLineItems(List.of(line));
+
+        service.create(dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        // There is no balance to read for a line that names no material, and such a half-filled
+        // line cannot be approved anyway, so nothing is gained by throwing the number away.
+        assertThat(captor.getValue().getLineItems().get(0).getSystemQuantity()).isEqualTo(500.0);
+    }
+
+    @Test
+    void update_restampsTheOpeningBalance() {
+        stubReferenceLookups();
+        when(inventoryService.findUnlocatedStock(MATERIAL, PROJECT)).thenReturn(Optional.of(370.0));
+        StockAdjustment existing = new StockAdjustment();
+        Organization org = new Organization();
+        org.setId(ORG);
+        existing.setOrganization(org);
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(5L, ORG)).thenReturn(Optional.of(existing));
+
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setProjectId(PROJECT);
+        StockAdjustmentLineItemCreationDto line = line(MATERIAL, null);
+        line.setSystemQuantity(400.0);
+        dto.setLineItems(List.of(line));
+
+        service.update(5L, dto);
+
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        // Saving the document again is the way back from an approval refused because the balance
+        // moved, so an edit has to take up the current figure rather than leave the stale one.
+        assertThat(captor.getValue().getLineItems().get(0).getSystemQuantity()).isEqualTo(370.0);
     }
 
     @Test


### PR DESCRIPTION
Closes #651.

## What was wrong

Approval re-read the balance, recomputed the variance from it, and overwrote the line with the result. A line carrying a physical count therefore always landed the balance exactly on the counted figure, so anything booked between the count and the approval was absorbed with nothing anywhere saying so. A goods receipt in that window is reversed: it stays on the ledger, the stock does not. And the `systemQuantity` that would have shown the window mattered was overwritten by the same operation that made it matter.

This is the gap #559 (segregation of duties) and #631/#635 (a verification is stamped by whoever performed it) leave open here. A second signature on figures that changed between raising and approving is not a second signature on anything.

## What the draft's system quantity was actually for

Nothing. `applyLineItems` stored whatever the client sent, nothing validated it, `resolveMovement` ignored it, and approval overwrote it. On the web form (`features/stock-adjustments/components/stock-adjustment-form.tsx`) "Current Stock" is a free-text number input a person types, defaulting to `0`, never read from the stock listing. So it was a hand-typed number the server never looked at.

That fact decides the design. A guard that compared the current balance against a hand-typed number would fire on typing mistakes rather than on stock moving, and with a form defaulting to zero it would refuse nearly every approval. So the field has to become the server's before it can be guarded.

## The decision

**Refuse the approval when the balance has moved.** Of the three options on the issue:

- *Post the drafted variance instead* is not safer, it just guesses the other way. Whether goods received after a count were already on the shelf when it was taken is not something the data can answer, so that default either absorbs a real receipt or double-counts one.
- *Record the drift and keep posting* makes an invisible reversal visible, but still posts it.

Both of the silent options need a person to look, and the approval is the moment a person is standing there. Refusing costs a stall only when the balance actually moved. The way back is to save the document again, which takes up the current balance, then approve once the count has been checked against the figure that moved. That keeps the decision with a person and leaves the document saying what was agreed.

## The change

- `stampOpeningBalance` reads `systemQuantity` from the balance when the document is written, and recomputes the variance from it where the line carries a count, so the line's three figures are one piece of arithmetic. Same reasoning as `submittedBy` being taken from the session rather than the body. A line naming no material, or on a document naming no project, keeps what was sent: there is no balance to read, and such a line cannot be approved either way.
- `requireBalanceUnmoved` refuses the approval when the balance has moved away from that figure, naming both figures and the route forward.
- `readBalance` is extracted so the stamp and the posting read the same row. If they read different rows, every approval would look moved.
- The two writes in `approve` now record rather than rewrite: with the guard passed they change nothing on a line carrying an opening balance. They are what fills the figures in on a line raised before the stamp existed, which posts as before.

`#559` self-approval and `#572` scope narrowing are untouched.

No schema change. `docs/openapi.json` regenerated for the three Schema description changes.

## Evidence from the one real use

`SA-563` on `echno.in` (read-only): raised 14:03, approved 19:11 on 2026-08-30. Its stored line figures agree with the ledger rows exactly (400 / -30 / 370 and -30 / +30 / 0), so the correction is self-explaining. But that holds only because nothing moved in those five hours: the ledger's previous row is 2026-08-28. The rewrite was a no-op by luck of a quiet window, not by design. A five-hour gap between raising and approving is the exposure.

## Tests

Five new tests fail against `development` and pass here.

| Test | Without the fix |
|---|---|
| `aCountedLineIsRefusedWhenTheBalanceHasMovedSinceTheDocumentWasRaised` | Posts, driving the balance to the count and reversing the receipt |
| `aSignedDeltaLineIsRefusedWhenTheBalanceHasMovedToo` | Posts against a balance the approver never saw (figures chosen to keep the closing figure clear of zero, so only the moved balance can refuse it) |
| `create_stampsTheOpeningBalanceRatherThanTrustingTheFigureSent` | Stores the client's 999 |
| `create_recomputesTheVarianceFromTheStampedOpeningBalance` | Stores 400 / 370 / -130, which is not one piece of arithmetic |
| `update_restampsTheOpeningBalance` | Keeps the stale 400, so the route back from a refusal does not work |

Three more pin new code that has no counterpart on `development`, so they pass there by construction: `anApprovalPostsTheFiguresTheDocumentWasRaisedWith` (delete the guard and it fails, because approval writes 50 over the raised 48), `aBalanceMovedOnlyByFloatingPointResidueIsNotTreatedAsMoved` (delete the `NO_MOVEMENT` tolerance and it fails), `aLineRaisedWithNoOpeningBalanceIsPostedAndHasItsFiguresFilledIn` (delete the null check and it throws an NPE). `create_lineWithNoMaterial_keepsTheFigureSent` pins the early return; delete it and `material.getId()` throws.

The old `aCountIsPostedAgainstTheBalanceAsItStandsNotTheSystemQuantityOnTheCountSheet` pinned the defect and is replaced.

Full `./gradlew build` green on `lab-node-116-f`. Test heap 559 MB of 2048 MB (27%), 8 contexts cached.

## Follow-up, not in this PR

The header `totalVarianceQuantity` is still copied from the request on a draft and is not checked against the lines. Approval recomputes it, and the ledger is never written from it, so it is a display looseness rather than an audit one, but it is the same class of problem. Worth a separate issue.

The user guide the issue was found from (echno-web #371) documents the old behaviour and needs the paragraph rewritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock adjustments now record the current opening balance when created or updated.
  * Adjustment quantities are recalculated from recorded and counted values.
  * Approval validates that stock has not changed since the adjustment was created.
  * Approved adjustments retain consistent opening balances and movement values.

* **Bug Fixes**
  * Prevented posting adjustments against outdated stock balances.
  * Improved handling of multi-line adjustments, missing balances, and minor floating-point differences.

* **Documentation**
  * Clarified quantity calculation, balance stamping, and approval behavior in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->