### PR TITLE
Post a goods receipt back onto the purchase order it cites

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5639,8 +5639,13 @@
         "type": "object"
       },
       "GoodsReceivedNoteCreationDto": {
-        "description": "Payload to record a goods received note. The received quantities on the items are posted into stock at the given storage location. The GRN number is allocated by the server and returned on the created note; it is not part of this payload.",
+        "description": "Payload to record a goods received note. The received quantities on the items are posted into stock at the given storage location and added to the matching lines of the purchase order, whose status then follows from the quantities received against it. The GRN number is allocated by the server and returned on the created note; it is not part of this payload.",
         "properties": {
+          "allowOverReceipt": {
+            "description": "Set this when the delivery really did exceed the purchase order and the site took it anyway. Without it, a line that would take a material past the quantity ordered is refused, which is what catches a mistyped quantity. With it the excess is recorded and the note is marked as an acknowledged over-receipt. It has no effect on a receipt that stays within the order.",
+            "example": false,
+            "type": "boolean"
+          },
           "deliveryChallanNumber": {
             "description": "Vendor delivery challan number.",
             "example": "DC-88213",
@@ -5750,6 +5755,11 @@
               "$ref": "#/components/schemas/GrnItemDto"
             },
             "type": "array"
+          },
+          "overReceiptAcknowledged": {
+            "description": "True when this receipt took a material past the quantity its purchase order asked for and the excess was acknowledged on the payload.",
+            "example": false,
+            "type": "boolean"
           },
           "projectId": {
             "description": "Project the goods were received for.",
@@ -5878,7 +5888,7 @@
             "type": "string"
           },
           "orderedQuantity": {
-            "description": "Quantity ordered for this material.",
+            "description": "Quantity ordered for this material. Where the material is on the cited purchase order, the value returned is the order's, not the one submitted: the order is the authority on what was ordered.",
             "example": 100,
             "format": "int32",
             "minimum": 0,
@@ -43022,7 +43032,7 @@
         ]
       },
       "post": {
-        "description": "Records a goods receipt from a vendor with its line items. The received quantities are posted into stock at the given storage location as GRN transactions.",
+        "description": "Records a goods receipt from a vendor with its line items. The received quantities are posted into stock at the given storage location as GRN transactions, and added to the matching lines of the purchase order the note cites, whose status then follows from the quantities received against it. A line that would take a material past the quantity ordered is refused unless the payload sets allowOverReceipt, and nothing is posted when it is refused.",
         "operationId": "createGrn",
         "requestBody": {
           "content": {
@@ -43053,7 +43063,7 @@
                 }
               }
             },
-            "description": "Validation failed on the request body"
+            "description": "Validation failed on the request body, or a line would take a material past the quantity its purchase order asked for and the over-receipt was not acknowledged"
           },
           "402": {
             "content": {
@@ -43719,7 +43729,7 @@
         ]
       },
       "post": {
-        "description": "Creates a GRN recording materials received against a vendor with its line items.",
+        "description": "Creates a GRN recording materials received against a vendor with its line items. The received quantities are posted into stock and added to the matching lines of the purchase order the note cites, whose status then follows from the quantities received against it. A line that would take a material past the quantity ordered is refused unless the payload sets allowOverReceipt, and nothing is posted when it is refused.",
         "operationId": "createGrn_1",
         "requestBody": {
           "content": {
@@ -43750,7 +43760,7 @@
                 }
               }
             },
-            "description": "A field failed validation"
+            "description": "A field failed validation, or a line would take a material past the quantity its purchase order asked for and the over-receipt was not acknowledged"
           },
           "402": {
             "content": {
@@ -81764,7 +81774,7 @@
     "/api/v1/project/web/{id}/status-history": {
       "get": {
         "description": "Returns a page of the project's status entries, newest first: what it moved from, what it moved to, when, by whom, and whether the status was set when the project was created or changed afterwards. Approval is the transition that carries behaviour, since it draws up the project's compliance inspections, so this is where to read who approved a project and when. Entries begin where recording began: a project created before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment, with no actor and no earlier status, because nothing else can truthfully be said about a history nobody recorded.",
-        "operationId": "readStatusHistory",
+        "operationId": "readStatusHistory_1",
         "parameters": [
           {
             "in": "path",
@@ -89086,6 +89096,146 @@
           }
         },
         "summary": "Update a purchase order's status",
+        "tags": [
+          "Purchase Orders (Web)"
+        ]
+      }
+    },
+    "/api/v1/purchase-orders/web/{id}/status-history": {
+      "get": {
+        "description": "Returns a page of the order's status entries, newest first: what it moved from, what it moved to, when, and by whom. An entry sourced SYSTEM names no person because none decided it: the order reached PARTIALLY_RECEIVED or FULLY_RECEIVED because the quantities received against it said so, and the note on the entry names the goods receipt that last moved it. Follow that receipt to find who filed it. Entries begin where recording began, so an order raised before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment.",
+        "operationId": "readStatusHistory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageStatusTransitionDto"
+                }
+              }
+            },
+            "description": "Page of status entries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No purchase order with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Read a purchase order's status trail",
         "tags": [
           "Purchase Orders (Web)"
         ]

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorder.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionRecorder.java
@@ -68,6 +68,34 @@ public class StatusTransitionRecorder {
                 StatusTransitionSource.UPDATE, actor, note);
     }
 
+    /**
+     * Records a change of status the application worked out for itself, if it is one.
+     *
+     * <p>The same rule as {@link #recordChange}: nothing is written when the two statuses are
+     * equal. What differs is that there is no acting user and none is invented. The entry is
+     * sourced {@link StatusTransitionSource#SYSTEM} and the note is where the caller names the
+     * document whose arithmetic moved the status, so a reader can follow it to the person who
+     * filed that document.
+     *
+     * @param entityType   The kind of record, for example {@code PURCHASE_ORDER}.
+     * @param entityId     The record's id.
+     * @param organization The organization the record belongs to.
+     * @param fromStatus   The status held before the change, possibly null.
+     * @param toStatus     The status held after it.
+     * @param note         The document or rule that moved it. Give one; an unexplained system
+     *                     transition is the thing this method exists to avoid.
+     * @return The entry that was written, or null when nothing changed.
+     */
+    public StatusTransition recordSystemChange(String entityType, Long entityId,
+                                               Organization organization, String fromStatus,
+                                               String toStatus, String note) {
+        if (Objects.equals(fromStatus, toStatus)) {
+            return null;
+        }
+        return append(entityType, entityId, organization, fromStatus, toStatus,
+                StatusTransitionSource.SYSTEM, null, note);
+    }
+
     private StatusTransition append(String entityType, Long entityId, Organization organization,
                                     String fromStatus, String toStatus,
                                     StatusTransitionSource source, User actor, String note) {

--- a/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionSource.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/StatusTransitionSource.java
@@ -18,6 +18,20 @@ public enum StatusTransitionSource {
     UPDATE,
 
     /**
+     * The status was moved by the application itself, working it out from records the user
+     * changed rather than from a status the user asked for.
+     *
+     * <p>It is separate from {@code UPDATE} because there is no actor to name. A purchase order
+     * reaching {@code FULLY_RECEIVED} because the quantities received against it finally met the
+     * quantities ordered is nobody's decision: the person filed a goods receipt, and the order's
+     * status is arithmetic over that receipt and the ones before it. Recording it as an
+     * {@code UPDATE} with a null actor would leave a reader unable to tell a transition nobody
+     * made from one whose actor was lost. The document that caused it is named in the note, and
+     * that document carries the person who filed it.
+     */
+    SYSTEM,
+
+    /**
      * The status a record was observed to hold when its trail began, written once by the
      * migration that introduced the trail.
      *

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNote.java
@@ -71,6 +71,19 @@ public class GoodsReceivedNote implements TenantScopedEntity {
     @JoinColumn(name = "purchase_order_id")
     private PurchaseOrder purchaseOrder;
 
+    /**
+     * Whether this receipt took a material past the quantity its purchase order asked for, and
+     * whoever filed it said in the payload that the excess was real.
+     *
+     * <p>An over-receipt is refused by default, so a note carrying this flag is one somebody
+     * deliberately let through. It is kept on the document rather than derived later because the
+     * order's quantities go on moving after this receipt, and a reader six months on needs to
+     * know that this delivery was the one that exceeded the order and that it was not an
+     * accident.
+     */
+    @Column(name = "over_receipt_acknowledged", nullable = false)
+    private boolean overReceiptAcknowledged = false;
+
     @OneToMany(mappedBy = "goodsReceivedNote")
     private List<Payable> payables = new ArrayList<>();
 

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteController.java
@@ -46,11 +46,15 @@ public class GoodsReceivedNoteController {
     @Operation(
             summary = "Create a goods received note",
             description = "Records a goods receipt from a vendor with its line items. The received "
-                    + "quantities are posted into stock at the given storage location as GRN transactions."
+                    + "quantities are posted into stock at the given storage location as GRN transactions, "
+                    + "and added to the matching lines of the purchase order the note cites, whose status "
+                    + "then follows from the quantities received against it. A line that would take a "
+                    + "material past the quantity ordered is refused unless the payload sets "
+                    + "allowOverReceipt, and nothing is posted when it is refused."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "GRN created and returned"),
-            @ApiResponse(responseCode = "400", description = "Validation failed on the request body"),
+            @ApiResponse(responseCode = "400", description = "Validation failed on the request body, or a line would take a material past the quantity its purchase order asked for and the over-receipt was not acknowledged"),
             @ApiResponse(responseCode = "403", description = "Caller lacks the grn create or admin authority"),
             @ApiResponse(responseCode = "404", description = "A referenced vendor, project, storage location or material was not found")
     })

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteControllerWeb.java
@@ -43,11 +43,15 @@ public class GoodsReceivedNoteControllerWeb {
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
     @Operation(
             summary = "Create a goods received note",
-            description = "Creates a GRN recording materials received against a vendor with its line items."
+            description = "Creates a GRN recording materials received against a vendor with its line items. "
+                    + "The received quantities are posted into stock and added to the matching lines of the "
+                    + "purchase order the note cites, whose status then follows from the quantities received "
+                    + "against it. A line that would take a material past the quantity ordered is refused "
+                    + "unless the payload sets allowOverReceipt, and nothing is posted when it is refused."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Goods received note created"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A field failed validation, or a line would take a material past the quantity its purchase order asked for and the over-receipt was not acknowledged"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<GoodsReceivedNoteDto> createGrn(@Valid @RequestBody GoodsReceivedNoteCreationDto creationDto) {

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteService.java
@@ -29,6 +29,7 @@ import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderReceiptReconciler;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
@@ -49,6 +50,12 @@ import java.util.stream.Collectors;
  * purchase order, storage location, and each line's material) against the current tenant,
  * persists the note and its line items, then publishes a {@link GrnCreatedEvent} so the
  * inventory ledger raises stock for the received materials in the same transaction.
+ *
+ * <p>The receipt is also posted back onto the purchase order it cites, by
+ * {@link PurchaseOrderReceiptReconciler}: the received quantities are added to the order's
+ * lines, an over-receipt is refused unless the payload acknowledged it, and the order's status
+ * follows from the arithmetic. That runs inside the create transaction and before the stock
+ * event is published, so an order that refuses a delivery refuses it before any stock moves.
  */
 @Service
 public class GoodsReceivedNoteService {
@@ -66,6 +73,7 @@ public class GoodsReceivedNoteService {
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final DocumentNumberAllocator documentNumberAllocator;
     private final TransactionRetryTemplate retryTemplate;
+    private final PurchaseOrderReceiptReconciler purchaseOrderReceiptReconciler;
 
     public GoodsReceivedNoteService(GoodsReceivedNoteRepository goodsReceivedNoteRepository,
                                     GrnItemRepository grnItemRepository,
@@ -80,7 +88,8 @@ public class GoodsReceivedNoteService {
                                     StorageLocationRepository storageLocationRepository,
                                     PurchaseOrderRepository purchaseOrderRepository,
                                     DocumentNumberAllocator documentNumberAllocator,
-                                    TransactionRetryTemplate retryTemplate) {
+                                    TransactionRetryTemplate retryTemplate,
+                                    PurchaseOrderReceiptReconciler purchaseOrderReceiptReconciler) {
         this.goodsReceivedNoteRepository = goodsReceivedNoteRepository;
         this.grnItemRepository = grnItemRepository;
         this.vendorRepository = vendorRepository;
@@ -94,6 +103,7 @@ public class GoodsReceivedNoteService {
         this.purchaseOrderRepository = purchaseOrderRepository;
         this.documentNumberAllocator = documentNumberAllocator;
         this.retryTemplate = retryTemplate;
+        this.purchaseOrderReceiptReconciler = purchaseOrderReceiptReconciler;
     }
 
     /**
@@ -113,6 +123,9 @@ public class GoodsReceivedNoteService {
      * @param creationDto The GRN header fields and the list of received line items.
      * @return The created GRN as a DTO.
      * @throws ResourceNotFoundException if any referenced vendor, employee, project, purchase order, storage location, or material is not found in this organization.
+     * @throws org.tornotron.echno_backend.common.exception.InvalidRequestException if a line would
+     *     take a material past the quantity the purchase order asked for and the payload did not
+     *     set {@code allowOverReceipt}.
      */
     public GoodsReceivedNoteDto createGoodsReceivedNote(GoodsReceivedNoteCreationDto creationDto) {
         return retryTemplate.execute(
@@ -183,6 +196,21 @@ public class GoodsReceivedNoteService {
 
         grnItemRepository.saveAll(items);
         grn.setItems(items);
+
+        // Post the receipt back onto the order it cites. This runs before the stock event so a
+        // refused over-receipt takes the whole note with it and no stock is raised for a
+        // delivery the order would not accept. The reconciler may correct a line's ordered
+        // quantity from the order, so the lines are saved again after it.
+        PurchaseOrderReceiptReconciler.ReceiptOutcome outcome = purchaseOrderReceiptReconciler.applyReceipt(
+                purchaseOrder, grn, items, Boolean.TRUE.equals(creationDto.getAllowOverReceipt()));
+        if (outcome.matchedLines() > 0) {
+            grnItemRepository.saveAll(items);
+        }
+        if (outcome.overReceipt()) {
+            grn.setOverReceiptAcknowledged(true);
+            grn = goodsReceivedNoteRepository.save(grn);
+            grn.setItems(items);
+        }
 
         // Publish GrnCreatedEvent for automatic inventory update
         eventPublisher.publishEvent(new GrnCreatedEvent(this, grn));

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteCreationDto.java
@@ -12,8 +12,10 @@ import java.util.List;
 
 @Data
 @Schema(description = "Payload to record a goods received note. The received quantities on the items are "
-        + "posted into stock at the given storage location. The GRN number is allocated by the server "
-        + "and returned on the created note; it is not part of this payload.")
+        + "posted into stock at the given storage location and added to the matching lines of the "
+        + "purchase order, whose status then follows from the quantities received against it. The GRN "
+        + "number is allocated by the server and returned on the created note; it is not part of this "
+        + "payload.")
 public class GoodsReceivedNoteCreationDto {
 
     @Schema(description = "When the goods were received.", example = "2026-08-01T10:30:00")
@@ -53,4 +55,11 @@ public class GoodsReceivedNoteCreationDto {
     @NotEmpty(message = "items list cannot be empty")
     @Valid
     private List<GrnItemDto> items;
+
+    @Schema(description = "Set this when the delivery really did exceed the purchase order and the site "
+            + "took it anyway. Without it, a line that would take a material past the quantity ordered "
+            + "is refused, which is what catches a mistyped quantity. With it the excess is recorded "
+            + "and the note is marked as an acknowledged over-receipt. It has no effect on a receipt "
+            + "that stays within the order.", example = "false")
+    private Boolean allowOverReceipt;
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GoodsReceivedNoteDto.java
@@ -59,4 +59,8 @@ public class GoodsReceivedNoteDto {
 
     @Schema(description = "Received line items.")
     private List<GrnItemDto> items;
+
+    @Schema(description = "True when this receipt took a material past the quantity its purchase order "
+            + "asked for and the excess was acknowledged on the payload.", example = "false")
+    private boolean overReceiptAcknowledged;
 }

--- a/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GrnItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/goodsReceivedNote/dto/GrnItemDto.java
@@ -21,7 +21,9 @@ public class GrnItemDto {
     @Schema(description = "Material name.", example = "Portland Cement 53 grade")
     private String materialName;
 
-    @Schema(description = "Quantity ordered for this material.", example = "100")
+    @Schema(description = "Quantity ordered for this material. Where the material is on the cited "
+            + "purchase order, the value returned is the order's, not the one submitted: the order is "
+            + "the authority on what was ordered.", example = "100")
     @NotNull(message = "ordered quantity is required")
     @Min(value = 0, message = "ordered quantity must be at least 0")
     private Integer orderedQuantity;

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
@@ -69,6 +70,39 @@ public class PurchaseOrderControllerWeb {
     public ResponseEntity<PurchaseOrderDto> getPurchaseOrderById(@PathVariable Long id) {
         PurchaseOrderDto purchaseOrder = purchaseOrderService.getPurchaseOrderById(id);
         return ResponseEntity.ok(purchaseOrder);
+    }
+
+    /**
+     * Reads a purchase order's status trail.
+     *
+     * @param id        The ID of the purchase order whose trail to read.
+     * @param pageQuery The page bounds.
+     * @return A {@link ResponseEntity} containing a page of trail entries and HTTP status 200 (OK).
+     */
+    @GetMapping("/{id}/status-history")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Read a purchase order's status trail",
+            description = "Returns a page of the order's status entries, newest first: what it moved "
+                    + "from, what it moved to, when, and by whom. An entry sourced SYSTEM names no "
+                    + "person because none decided it: the order reached PARTIALLY_RECEIVED or "
+                    + "FULLY_RECEIVED because the quantities received against it said so, and the "
+                    + "note on the entry names the goods receipt that last moved it. Follow that "
+                    + "receipt to find who filed it. Entries begin where recording began, so an order "
+                    + "raised before the trail existed carries a single BASELINE entry naming the "
+                    + "status it was observed to hold at that moment."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of status entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No purchase order with the given id")
+    })
+    public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
+            @PathVariable Long id,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return new ResponseEntity<>(
+                purchaseOrderService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)),
+                HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderReceiptReconciler.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderReceiptReconciler.java
@@ -1,0 +1,309 @@
+package org.tornotron.echno_backend.purchaseOrder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Posts a goods receipt back onto the purchase order it cites.
+ *
+ * <p>Until this existed a receipt and its order never met. {@code receivedQuantity} on an order
+ * line was written zero at creation and never again, so an order for ten bags read as fully
+ * outstanding after ten thousand had been received against it, the delete guard that refuses to
+ * remove a line with stock against it was permanently satisfied, and
+ * {@code PARTIALLY_RECEIVED} and {@code FULLY_RECEIVED} were statuses no code could reach.
+ *
+ * <p>Three things happen here, in one transaction with the receipt that triggered them, so a
+ * refusal takes the receipt with it and no stock is posted for a delivery the order rejected:
+ *
+ * <ol>
+ *   <li>Each receipt line is matched to the order lines for the same material and the quantity
+ *       received is added to them. The order now says what has actually arrived.</li>
+ *   <li>A receipt that would take a material past the quantity ordered is refused, unless the
+ *       caller said in the payload that the over-receipt is real. See
+ *       {@link #applyReceipt} for why it is refused rather than silently accepted, and why the
+ *       refusal has a way past it rather than being absolute.</li>
+ *   <li>The order's status is worked out from its lines and moved if it has changed, and the
+ *       move is written to the shared status trail as a {@code SYSTEM} transition naming the
+ *       receipt that caused it.</li>
+ * </ol>
+ *
+ * <p>A receipt line whose material is not on the order reconciles nothing, which is the truth
+ * about it. It still posts stock exactly as before. Refusing it would be wrong: a lorry can
+ * carry an item that was ordered separately or supplied free, and a receipt that cannot be
+ * recorded leaves stock standing at a site that the ledger cannot account for.
+ */
+@Component
+public class PurchaseOrderReceiptReconciler {
+
+    private static final Logger logger = LoggerFactory.getLogger(PurchaseOrderReceiptReconciler.class);
+
+    /**
+     * The statuses from which a receipt may move an order.
+     *
+     * <p>{@code DRAFT} is left alone because an order that was never approved was never placed,
+     * and moving it straight to {@code FULLY_RECEIVED} would erase the fact that nobody approved
+     * it. {@code CANCELLED} is left alone because a receipt must not quietly reinstate an order
+     * somebody cancelled. In both cases the received quantities are still written: what arrived
+     * is a fact and is recorded whatever state the order is in. Only the status, which is a
+     * lifecycle claim, is withheld.
+     */
+    private static final Set<PurchaseOrderStatus> MOVABLE = EnumSet.of(
+            PurchaseOrderStatus.APPROVED,
+            PurchaseOrderStatus.SENT_TO_VENDOR,
+            PurchaseOrderStatus.PARTIALLY_RECEIVED,
+            PurchaseOrderStatus.FULLY_RECEIVED);
+
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final PurchaseOrderItemRepository purchaseOrderItemRepository;
+    private final StatusTransitionRecorder statusTransitionRecorder;
+
+    public PurchaseOrderReceiptReconciler(PurchaseOrderRepository purchaseOrderRepository,
+                                          PurchaseOrderItemRepository purchaseOrderItemRepository,
+                                          StatusTransitionRecorder statusTransitionRecorder) {
+        this.purchaseOrderRepository = purchaseOrderRepository;
+        this.purchaseOrderItemRepository = purchaseOrderItemRepository;
+        this.statusTransitionRecorder = statusTransitionRecorder;
+    }
+
+    /**
+     * What the receipt did to the order, for the caller to record on the receipt itself.
+     *
+     * @param matchedLines      How many receipt lines found a line on the order.
+     * @param overReceipt       Whether any material ended up received beyond the quantity ordered.
+     * @param movedTo           The status the order was moved to, or null if it did not move.
+     */
+    public record ReceiptOutcome(int matchedLines, boolean overReceipt, PurchaseOrderStatus movedTo) {
+    }
+
+    /**
+     * Adds a receipt's quantities to the order it cites and moves the order's status if the
+     * arithmetic has changed it.
+     *
+     * <p><strong>Over-receipt is refused by default and recorded on request.</strong> Neither
+     * extreme is right on a construction site. Accepting any quantity silently is what this
+     * class replaced: a mistyped ten thousand against an order for ten raised stock by ten
+     * thousand and nothing anywhere noticed. Refusing outright is worse than it looks, because
+     * the supplier who delivers a hundred and five bags against an order for a hundred has left
+     * a hundred and five bags on the site whether the system likes it or not, and a receipt that
+     * cannot be filed puts them outside the stock ledger, where no later count can be explained.
+     * So the default refuses and says exactly which line, how much was ordered, how much had
+     * already arrived and how much this note adds, which is enough for the person to see a typed
+     * digit; and a payload that sets {@code allowOverReceipt} records the excess and has the
+     * receipt marked as an acknowledged over-receipt, so the document explains itself to whoever
+     * reads it next.
+     *
+     * <p>The order's lines are taken under a write lock, so two receipts against the same order
+     * cannot each judge themselves against the figure that stood before the other.
+     *
+     * @param purchaseOrder      The order the receipt cites.
+     * @param goodsReceivedNote  The receipt, used to name the cause of a status move.
+     * @param receivedLines      The receipt's lines.
+     * @param overReceiptAllowed Whether the payload acknowledged an over-receipt in advance.
+     * @return What the receipt did to the order.
+     * @throws InvalidRequestException if a line would be over-received and the payload did not
+     *     acknowledge it.
+     */
+    public ReceiptOutcome applyReceipt(PurchaseOrder purchaseOrder,
+                                       GoodsReceivedNote goodsReceivedNote,
+                                       List<GrnItem> receivedLines,
+                                       boolean overReceiptAllowed) {
+        List<PurchaseOrderItem> orderLines = purchaseOrderItemRepository
+                .lockByPurchaseOrderIdAndOrganizationId(purchaseOrder.getId(), TenantContext.getCurrentOrgId());
+        if (orderLines.isEmpty()) {
+            return new ReceiptOutcome(0, false, null);
+        }
+
+        Map<Long, List<PurchaseOrderItem>> orderLinesByMaterial = new LinkedHashMap<>();
+        for (PurchaseOrderItem line : orderLines) {
+            if (line.getMaterial() == null) {
+                continue;
+            }
+            orderLinesByMaterial
+                    .computeIfAbsent(line.getMaterial().getId(), key -> new ArrayList<>())
+                    .add(line);
+        }
+        orderLinesByMaterial.values().forEach(lines -> lines.sort(Comparator.comparing(PurchaseOrderItem::getId)));
+
+        Map<Long, Integer> receivedByMaterial = new LinkedHashMap<>();
+        for (GrnItem receivedLine : receivedLines) {
+            if (receivedLine.getMaterial() == null || receivedLine.getReceivedQuantity() == null) {
+                continue;
+            }
+            receivedByMaterial.merge(receivedLine.getMaterial().getId(), receivedLine.getReceivedQuantity(), Integer::sum);
+        }
+
+        List<String> overReceipts = new ArrayList<>();
+        for (Map.Entry<Long, Integer> entry : receivedByMaterial.entrySet()) {
+            List<PurchaseOrderItem> lines = orderLinesByMaterial.get(entry.getKey());
+            if (lines == null) {
+                continue;
+            }
+            int ordered = lines.stream().mapToInt(PurchaseOrderReceiptReconciler::orderedQuantity).sum();
+            int already = lines.stream().mapToInt(PurchaseOrderReceiptReconciler::receivedQuantity).sum();
+            int total = already + entry.getValue();
+            if (total > ordered) {
+                overReceipts.add(describeOverReceipt(purchaseOrder, lines.get(0), ordered, already,
+                        entry.getValue(), total));
+            }
+        }
+
+        boolean overReceipt = !overReceipts.isEmpty();
+        if (overReceipt && !overReceiptAllowed) {
+            throw new InvalidRequestException(String.join(" ", overReceipts)
+                    + " If the delivery really did exceed the order, send the note again with "
+                    + "allowOverReceipt set, which records the excess and marks the note as an "
+                    + "acknowledged over-receipt.");
+        }
+
+        int matchedLines = 0;
+        for (GrnItem receivedLine : receivedLines) {
+            if (receivedLine.getMaterial() == null) {
+                continue;
+            }
+            List<PurchaseOrderItem> lines = orderLinesByMaterial.get(receivedLine.getMaterial().getId());
+            if (lines == null) {
+                continue;
+            }
+            matchedLines++;
+            // The order is the authority on how much was ordered, so the receipt's own copy of
+            // that figure is taken from it rather than from whatever the client typed.
+            receivedLine.setOrderedQuantity(
+                    lines.stream().mapToInt(PurchaseOrderReceiptReconciler::orderedQuantity).sum());
+        }
+
+        for (Map.Entry<Long, Integer> entry : receivedByMaterial.entrySet()) {
+            List<PurchaseOrderItem> lines = orderLinesByMaterial.get(entry.getKey());
+            if (lines == null) {
+                continue;
+            }
+            allocate(lines, entry.getValue());
+            purchaseOrderItemRepository.saveAll(lines);
+        }
+
+        PurchaseOrderStatus movedTo = moveStatus(purchaseOrder, orderLines, goodsReceivedNote);
+        return new ReceiptOutcome(matchedLines, overReceipt, movedTo);
+    }
+
+    /**
+     * Spreads a received quantity across the order lines for one material.
+     *
+     * <p>An order may carry the same material on more than one line, and a receipt does not say
+     * which of them it answers. The quantity fills the lines in id order, each taking what it
+     * still has outstanding, and anything left once they are all met goes onto the last line.
+     * Putting the excess somewhere specific rather than nowhere is what keeps the sum of the
+     * lines equal to the quantity actually received.
+     */
+    private static void allocate(List<PurchaseOrderItem> lines, int quantity) {
+        int remaining = quantity;
+        for (PurchaseOrderItem line : lines) {
+            if (remaining <= 0) {
+                return;
+            }
+            int outstanding = orderedQuantity(line) - receivedQuantity(line);
+            if (outstanding <= 0) {
+                continue;
+            }
+            int take = Math.min(outstanding, remaining);
+            line.setReceivedQuantity(receivedQuantity(line) + take);
+            remaining -= take;
+        }
+        if (remaining > 0) {
+            PurchaseOrderItem last = lines.get(lines.size() - 1);
+            last.setReceivedQuantity(receivedQuantity(last) + remaining);
+        }
+    }
+
+    /**
+     * Works the order's status out from its lines and moves it if it has changed.
+     *
+     * <p>The move is derived, so it has no actor. It is written to the shared status trail as a
+     * {@code SYSTEM} transition whose note names the receipt that caused it; that receipt records
+     * who filed it, which is as close to a person as a derived transition honestly gets.
+     *
+     * @return The status moved to, or null if it did not move.
+     */
+    private PurchaseOrderStatus moveStatus(PurchaseOrder purchaseOrder,
+                                           List<PurchaseOrderItem> orderLines,
+                                           GoodsReceivedNote goodsReceivedNote) {
+        PurchaseOrderStatus current = purchaseOrder.getStatus();
+        if (current == null || !MOVABLE.contains(current)) {
+            return null;
+        }
+
+        PurchaseOrderStatus derived = derive(orderLines);
+        if (derived == null || derived == current) {
+            return null;
+        }
+
+        purchaseOrder.setStatus(derived);
+        purchaseOrderRepository.save(purchaseOrder);
+        statusTransitionRecorder.recordSystemChange(
+                PurchaseOrderService.HISTORY_ENTITY_TYPE,
+                purchaseOrder.getId(),
+                purchaseOrder.getOrganization(),
+                current.name(),
+                derived.name(),
+                "Derived from the quantities received against this order, most recently by goods "
+                        + "receipt " + goodsReceivedNote.getGrnNumber() + ".");
+        logger.info("Purchase order {} moved from {} to {} on goods receipt {}",
+                purchaseOrder.getPoNumber(), current, derived, goodsReceivedNote.getGrnNumber());
+        return derived;
+    }
+
+    /**
+     * The status an order's lines say it is in, or null when nothing has been received against
+     * it and the lines therefore say nothing about receipt at all.
+     */
+    private static PurchaseOrderStatus derive(List<PurchaseOrderItem> orderLines) {
+        boolean anyReceived = false;
+        boolean allMet = true;
+        for (PurchaseOrderItem line : orderLines) {
+            int received = receivedQuantity(line);
+            if (received > 0) {
+                anyReceived = true;
+            }
+            if (received < orderedQuantity(line)) {
+                allMet = false;
+            }
+        }
+        if (!anyReceived) {
+            return null;
+        }
+        return allMet ? PurchaseOrderStatus.FULLY_RECEIVED : PurchaseOrderStatus.PARTIALLY_RECEIVED;
+    }
+
+    private static String describeOverReceipt(PurchaseOrder purchaseOrder, PurchaseOrderItem line,
+                                              int ordered, int already, int arriving, int total) {
+        String material = line.getMaterial() != null && line.getMaterial().getMaterialName() != null
+                ? line.getMaterial().getMaterialName()
+                : "material " + (line.getMaterial() != null ? line.getMaterial().getId() : "unknown");
+        return "Purchase order " + purchaseOrder.getPoNumber() + " orders " + ordered + " of "
+                + material + ", " + already + " has already been received against it, and this note "
+                + "receives a further " + arriving + ", which would take it to " + total + ".";
+    }
+
+    private static int orderedQuantity(PurchaseOrderItem line) {
+        return line.getOrderedQuantity() != null ? line.getOrderedQuantity() : 0;
+    }
+
+    private static int receivedQuantity(PurchaseOrderItem line) {
+        return line.getReceivedQuantity() != null ? line.getReceivedQuantity() : 0;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderService.java
@@ -9,6 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
@@ -33,6 +37,8 @@ import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
 import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.vendor.Vendor;
 import org.tornotron.echno_backend.vendor.VendorRepository;
 
@@ -53,9 +59,19 @@ import java.util.stream.Collectors;
  * to the vendor and every later state change go through the status endpoint, so that approval
  * is a separate act on an order that already exists rather than a value the create form can
  * choose for itself.
+ *
+ * <p>Every status an order holds is written to the shared status trail. A change somebody made
+ * carries that person; the moves into {@link PurchaseOrderStatus#PARTIALLY_RECEIVED} and
+ * {@link PurchaseOrderStatus#FULLY_RECEIVED} are made by
+ * {@link PurchaseOrderReceiptReconciler} out of the quantities received and carry the receipt
+ * that caused them instead. Recording only the manual ones would leave a trail that skips
+ * exactly the transitions nobody typed.
  */
 @Service
 public class PurchaseOrderService {
+
+    /** The kind this module files its status trail under. */
+    public static final String HISTORY_ENTITY_TYPE = "PURCHASE_ORDER";
 
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final VendorRepository vendorRepository;
@@ -69,6 +85,10 @@ public class PurchaseOrderService {
     private final IndentItemRepository indentItemRepository;
     private final DocumentNumberAllocator documentNumberAllocator;
     private final TransactionRetryTemplate retryTemplate;
+    private final StatusTransitionRecorder statusTransitionRecorder;
+    private final StatusTransitionRepository statusTransitionRepository;
+    private final StatusTransitionMapper statusTransitionMapper;
+    private final UserContextService userContextService;
 
     public PurchaseOrderService(PurchaseOrderRepository purchaseOrderRepository,
                                 VendorRepository vendorRepository,
@@ -81,7 +101,11 @@ public class PurchaseOrderService {
                                 MaterialRepository materialRepository,
                                 IndentItemRepository indentItemRepository,
                                 DocumentNumberAllocator documentNumberAllocator,
-                                TransactionRetryTemplate retryTemplate) {
+                                TransactionRetryTemplate retryTemplate,
+                                StatusTransitionRecorder statusTransitionRecorder,
+                                StatusTransitionRepository statusTransitionRepository,
+                                StatusTransitionMapper statusTransitionMapper,
+                                UserContextService userContextService) {
         this.purchaseOrderRepository = purchaseOrderRepository;
         this.vendorRepository = vendorRepository;
         this.indentRepository = indentRepository;
@@ -94,6 +118,10 @@ public class PurchaseOrderService {
         this.indentItemRepository = indentItemRepository;
         this.documentNumberAllocator = documentNumberAllocator;
         this.retryTemplate = retryTemplate;
+        this.statusTransitionRecorder = statusTransitionRecorder;
+        this.statusTransitionRepository = statusTransitionRepository;
+        this.statusTransitionMapper = statusTransitionMapper;
+        this.userContextService = userContextService;
     }
 
     /**
@@ -173,6 +201,9 @@ public class PurchaseOrderService {
         }
 
         purchaseOrder = purchaseOrderRepository.save(purchaseOrder);
+        statusTransitionRecorder.recordCreation(HISTORY_ENTITY_TYPE, purchaseOrder.getId(),
+                purchaseOrder.getOrganization(), purchaseOrder.getStatus().name(),
+                userContextService.getCurrentUser());
         return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
@@ -284,6 +315,7 @@ public class PurchaseOrderService {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findByIdAndOrganization_Id(updateDto.getId(),TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Purchase order with ID " + updateDto.getId() + " was not found in this organization"));
 
+        PurchaseOrderStatus previousStatus = purchaseOrder.getStatus();
         if (updateDto.getStatus() != null) {
             purchaseOrder.setStatus(PurchaseOrderStatus.valueOf(updateDto.getStatus()));
         }
@@ -304,6 +336,7 @@ public class PurchaseOrderService {
         }
 
         purchaseOrder = purchaseOrderRepository.save(purchaseOrder);
+        recordStatusChange(purchaseOrder, previousStatus);
         return purchaseOrderMapper.toDto(purchaseOrder);
     }
 
@@ -319,11 +352,58 @@ public class PurchaseOrderService {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Purchase order with ID " + id + " was not found in this organization"));
 
+        PurchaseOrderStatus previousStatus = purchaseOrder.getStatus();
         purchaseOrder.setStatus(status);
         purchaseOrderRepository.save(purchaseOrder);
+        recordStatusChange(purchaseOrder, previousStatus);
+    }
+
+    /**
+     * Reads a purchase order's status trail.
+     *
+     * <p>This is where the receipt-driven moves are explained. An entry sourced {@code SYSTEM}
+     * names no person because none decided it: its note names the goods receipt whose quantities
+     * moved the order, and that receipt records who filed it.
+     *
+     * @param id The purchase order whose trail to read.
+     * @param pageNo Zero-based page index.
+     * @param pageSize Entries per page.
+     * @return A page of trail entries, newest first.
+     * @throws ResourceNotFoundException if no purchase order with the given id exists in this organization.
+     */
+    @Transactional(readOnly = true)
+    public Page<StatusTransitionDto> getStatusHistory(Long id, int pageNo, int pageSize) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (purchaseOrderRepository.findByIdAndOrganization_Id(id, orgId).isEmpty()) {
+            throw new ResourceNotFoundException(
+                    "Purchase order with ID " + id + " was not found in this organization");
+        }
+        return statusTransitionRepository
+                .findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+                        HISTORY_ENTITY_TYPE, id, orgId, PageRequest.of(pageNo, pageSize))
+                .map(statusTransitionMapper::toDto);
     }
 
     // ==================== Helper Methods ====================
+
+    /**
+     * Files a status change somebody made, against the person who made it.
+     *
+     * <p>{@link StatusTransitionRecorder#recordChange} writes nothing when the two statuses are
+     * equal, so this is safe to call on every save without first working out whether the status
+     * moved.
+     */
+    private void recordStatusChange(PurchaseOrder purchaseOrder, PurchaseOrderStatus previousStatus) {
+        User actor = userContextService.getCurrentUser();
+        statusTransitionRecorder.recordChange(
+                HISTORY_ENTITY_TYPE,
+                purchaseOrder.getId(),
+                purchaseOrder.getOrganization(),
+                previousStatus != null ? previousStatus.name() : null,
+                purchaseOrder.getStatus() != null ? purchaseOrder.getStatus().name() : null,
+                actor,
+                null);
+    }
 
     private PurchaseOrderItem mapToPurchaseOrderItemEntity(PurchaseOrderItemCreationDto dto) {
         Material material = materialRepository.findByIdAndOrganization_Id(dto.getMaterialId(),TenantContext.getCurrentOrgId())

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemRepository.java
@@ -1,7 +1,9 @@
 package org.tornotron.echno_backend.purchaseOrderItem;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +23,26 @@ public interface PurchaseOrderItemRepository extends JpaRepository<PurchaseOrder
 
     @Query("SELECT SUM(poi.totalPrice) FROM PurchaseOrderItem poi WHERE poi.purchaseOrder.id = :purchaseOrderId")
     BigDecimal sumTotalPriceByPurchaseOrderId(@Param("purchaseOrderId") Long purchaseOrderId);
+
+    /**
+     * Loads an order's lines for a read-modify-write on {@code receivedQuantity} under a
+     * pessimistic write lock, ordered by id so two callers take the rows in the same sequence
+     * and cannot deadlock against each other.
+     *
+     * <p>Recording a receipt reads the quantity already received on a line, decides whether the
+     * new quantity over-receives it, and writes the sum back. Two goods receipts against the
+     * same order at the same time would each read the figure as it stood before the other, so
+     * both would pass the over-receipt check and the second write would erase the first. The
+     * order would then read as under-received while the stock ledger holds both deliveries,
+     * which is the shape of balance nobody can explain. On CockroachDB {@code SELECT … FOR
+     * UPDATE} queues the second caller rather than aborting it, so it reads the committed
+     * figure and is judged against the truth.
+     *
+     * <p>Reads that only display an order keep {@link #findByPurchaseOrderId}.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT poi FROM PurchaseOrderItem poi WHERE poi.purchaseOrder.id = :purchaseOrderId "
+            + "AND poi.organization.id = :orgId ORDER BY poi.id")
+    List<PurchaseOrderItem> lockByPurchaseOrderIdAndOrganizationId(
+            @Param("purchaseOrderId") Long purchaseOrderId, @Param("orgId") Long orgId);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -385,4 +385,7 @@
     <!-- v4.0 - Payment vouchers: record why one was voided, now that cancelling is how a verified voucher is corrected -->
     <include file="db/changelog/v4.0/083-add-construction-payment-cancellation-reason.xml"/>
 
+    <!-- v4.0 - Goods receipts: mark an acknowledged over-receipt, and open the purchase order status trail -->
+    <include file="db/changelog/v4.0/084-grn-purchase-order-reconciliation.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/084-grn-purchase-order-reconciliation.xml
+++ b/src/main/resources/db/changelog/v4.0/084-grn-purchase-order-reconciliation.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="084-01-add-grn-over-receipt-acknowledged" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="goods_received_note" columnName="over_receipt_acknowledged"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Whether a receipt took a material past the quantity its purchase order asked for, and
+            whoever filed it said in the payload that the excess was real.
+
+            An over-receipt is now refused unless the payload acknowledges it, so a note carrying
+            this flag is one somebody deliberately let through. It is stored on the document rather
+            than worked out later because the order's received quantities go on moving with every
+            further delivery: months on, the arithmetic no longer says which receipt was the one
+            that exceeded the order, and nothing at all says the excess was deliberate.
+
+            Every receipt that already exists is false. That is accurate for them: nothing refused
+            an over-receipt before this, so none of them was acknowledged.
+        </comment>
+
+        <addColumn tableName="goods_received_note">
+            <column name="over_receipt_acknowledged" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="goods_received_note" columnName="over_receipt_acknowledged"/>
+        </rollback>
+    </changeSet>
+
+    <!--
+        Where the trail begins for purchase orders that already exist.
+
+        One BASELINE row each, naming the status the order is observed to hold at the moment its
+        trail is introduced, exactly as 073 did for projects. It is not a transition and does not
+        claim to be one: it lets a reader tell an order whose status has not moved since recording
+        began from one whose history was never recorded at all.
+
+        Dated CURRENT_TIMESTAMP and not the order's created_at, because dating the observed status
+        at creation time would assert the order was created in that state, which is the one claim
+        that cannot be made about anything predating the trail. changed_by and changed_by_name are
+        null for the same reason: nothing recorded who moved these orders, and inventing an actor
+        would be worse than leaving the columns empty.
+    -->
+    <changeSet id="084-02-seed-purchase-order-status-baseline" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM status_transition WHERE entity_type = 'PURCHASE_ORDER'
+            </sqlCheck>
+        </preConditions>
+
+        <sql>
+            INSERT INTO status_transition (
+                entity_type, entity_id, organization_id,
+                from_status, to_status, source, occurred_at, note
+            )
+            SELECT 'PURCHASE_ORDER',
+                   po.id,
+                   po.organization_id,
+                   NULL,
+                   po.status,
+                   'BASELINE',
+                   CURRENT_TIMESTAMP,
+                   'The status this purchase order was observed to hold when its status trail began. What it was before that date, and who set it, was not recorded.'
+            FROM purchase_order po
+            WHERE po.status IS NOT NULL;
+        </sql>
+        <rollback>
+            <sql>DELETE FROM status_transition WHERE entity_type = 'PURCHASE_ORDER' AND source = 'BASELINE';</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteReconciliationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteReconciliationTest.java
@@ -1,0 +1,215 @@
+package org.tornotron.echno_backend.goodsReceivedNote;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
+import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteCreationDto;
+import org.tornotron.echno_backend.goodsReceivedNote.dto.GrnItemDto;
+import org.tornotron.echno_backend.goodsReceivedNote.mapper.GoodsReceivedNoteMapper;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+import org.tornotron.echno_backend.grnItem.GrnItemRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderReceiptReconciler;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserRepository;
+import org.tornotron.echno_backend.vendor.Vendor;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests how a goods receipt is wired to the purchase order it cites: that the reconciliation
+ * runs, that it runs before the stock event so a refused delivery raises no stock, and that a
+ * receipt let through as an over-receipt says so on the document.
+ *
+ * <p>The reconciler's own arithmetic is covered in {@code PurchaseOrderReceiptReconcilerTest};
+ * here it is a mock, and what is asserted is the order of events around it.
+ */
+@ExtendWith(MockitoExtension.class)
+class GoodsReceivedNoteReconciliationTest {
+
+    private static final Long ORG = 100L;
+
+    @Mock private GoodsReceivedNoteRepository goodsReceivedNoteRepository;
+    @Mock private GrnItemRepository grnItemRepository;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private GoodsReceivedNoteMapper goodsReceivedNoteMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private PurchaseOrderReceiptReconciler purchaseOrderReceiptReconciler;
+
+    private GoodsReceivedNoteService service;
+    private PurchaseOrder purchaseOrder;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new GoodsReceivedNoteService(goodsReceivedNoteRepository, grnItemRepository,
+                vendorRepository, userRepository, materialRepository, eventPublisher,
+                goodsReceivedNoteMapper, tenantEntityHelper, employeeRepository, projectRepository,
+                storageLocationRepository, purchaseOrderRepository,
+                documentNumberAllocator, retryTemplate, purchaseOrderReceiptReconciler);
+        lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
+
+        Vendor vendor = new Vendor();
+        vendor.setId(5L);
+        Employee employee = new Employee();
+        employee.setId(7L);
+        Project project = new Project();
+        project.setId(9L);
+        purchaseOrder = new PurchaseOrder();
+        purchaseOrder.setId(3L);
+        purchaseOrder.setPoNumber("PO-2026-000001");
+        purchaseOrder.setStatus(PurchaseOrderStatus.SENT_TO_VENDOR);
+        Organization organization = new Organization();
+        organization.setId(ORG);
+
+        lenient().when(vendorRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(vendor));
+        lenient().when(employeeRepository.findByIdAndOrganizationId(7L, ORG)).thenReturn(Optional.of(employee));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(9L, ORG)).thenReturn(Optional.of(project));
+        lenient().when(purchaseOrderRepository.findByIdAndOrganization_Id(3L, ORG)).thenReturn(Optional.of(purchaseOrder));
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenReturn(organization);
+        lenient().when(goodsReceivedNoteRepository.save(any(GoodsReceivedNote.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(documentNumberAllocator.allocate(DocumentNumberType.GOODS_RECEIVED_NOTE, ORG))
+                .thenReturn("GRN-2026-000042");
+        lenient().when(materialRepository.findByIdAndOrganization_Id(eq(11L), eq(ORG)))
+                .thenAnswer(invocation -> {
+                    Material material = new Material();
+                    material.setId(11L);
+                    return Optional.of(material);
+                });
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void postsTheReceiptBackOntoTheOrderItCites() {
+        stubOutcome(new PurchaseOrderReceiptReconciler.ReceiptOutcome(1, false, null));
+
+        service.createGoodsReceivedNote(creationDto(9, null));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<GrnItem>> lines = ArgumentCaptor.forClass(List.class);
+        verify(purchaseOrderReceiptReconciler).applyReceipt(
+                eq(purchaseOrder), any(GoodsReceivedNote.class), lines.capture(), eq(false));
+        assertThat(lines.getValue()).hasSize(1);
+        assertThat(lines.getValue().get(0).getReceivedQuantity()).isEqualTo(9);
+    }
+
+    @Test
+    void passesTheAcknowledgementFromThePayloadThrough() {
+        stubOutcome(new PurchaseOrderReceiptReconciler.ReceiptOutcome(1, true, null));
+
+        service.createGoodsReceivedNote(creationDto(105, true));
+
+        verify(purchaseOrderReceiptReconciler).applyReceipt(
+                any(PurchaseOrder.class), any(GoodsReceivedNote.class), any(), eq(true));
+    }
+
+    @Test
+    void raisesNoStockWhenTheOrderRefusesTheDelivery() {
+        when(purchaseOrderReceiptReconciler.applyReceipt(any(), any(), any(), anyBoolean()))
+                .thenThrow(new InvalidRequestException("would take it to 10000"));
+
+        assertThatThrownBy(() -> service.createGoodsReceivedNote(creationDto(10_000, null)))
+                .isInstanceOf(InvalidRequestException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(GrnCreatedEvent.class));
+    }
+
+    @Test
+    void marksTheNoteWhenTheOverReceiptWasLetThrough() {
+        stubOutcome(new PurchaseOrderReceiptReconciler.ReceiptOutcome(1, true, null));
+
+        service.createGoodsReceivedNote(creationDto(105, true));
+
+        ArgumentCaptor<GoodsReceivedNote> saved = ArgumentCaptor.forClass(GoodsReceivedNote.class);
+        verify(goodsReceivedNoteRepository, org.mockito.Mockito.atLeastOnce()).save(saved.capture());
+        assertThat(saved.getValue().isOverReceiptAcknowledged()).isTrue();
+    }
+
+    @Test
+    void leavesTheNoteUnmarkedWhenTheReceiptStaysWithinTheOrder() {
+        stubOutcome(new PurchaseOrderReceiptReconciler.ReceiptOutcome(1, false, null));
+
+        service.createGoodsReceivedNote(creationDto(9, null));
+
+        ArgumentCaptor<GoodsReceivedNote> saved = ArgumentCaptor.forClass(GoodsReceivedNote.class);
+        verify(goodsReceivedNoteRepository, org.mockito.Mockito.atLeastOnce()).save(saved.capture());
+        assertThat(saved.getValue().isOverReceiptAcknowledged()).isFalse();
+    }
+
+    private void stubOutcome(PurchaseOrderReceiptReconciler.ReceiptOutcome outcome) {
+        when(purchaseOrderReceiptReconciler.applyReceipt(any(), any(), any(), anyBoolean()))
+                .thenReturn(outcome);
+    }
+
+    private GoodsReceivedNoteCreationDto creationDto(int received, Boolean allowOverReceipt) {
+        GrnItemDto item = new GrnItemDto();
+        item.setMaterialId(11L);
+        item.setOrderedQuantity(10);
+        item.setReceivedQuantity(received);
+        item.setUnitCost(new BigDecimal("25.50"));
+
+        GoodsReceivedNoteCreationDto dto = new GoodsReceivedNoteCreationDto();
+        dto.setReceivedOn(LocalDateTime.of(2026, 8, 3, 10, 0));
+        dto.setReceivedByEmployeeId(7L);
+        dto.setVendorId(5L);
+        dto.setProjectId(9L);
+        dto.setPurchaseOrderId(3L);
+        dto.setItems(List.of(item));
+        dto.setAllowOverReceipt(allowOverReceipt);
+        return dto;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/goodsReceivedNote/GoodsReceivedNoteServiceTest.java
@@ -28,6 +28,7 @@ import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrder;
+import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderReceiptReconciler;
 import org.tornotron.echno_backend.purchaseOrder.PurchaseOrderRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserRepository;
@@ -44,6 +45,7 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -78,6 +80,7 @@ class GoodsReceivedNoteServiceTest {
     @Mock private PurchaseOrderRepository purchaseOrderRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private PurchaseOrderReceiptReconciler purchaseOrderReceiptReconciler;
 
     private GoodsReceivedNoteService service;
 
@@ -89,7 +92,9 @@ class GoodsReceivedNoteServiceTest {
                 vendorRepository, userRepository, materialRepository, eventPublisher,
                 goodsReceivedNoteMapper, tenantEntityHelper, employeeRepository, projectRepository,
                 storageLocationRepository, purchaseOrderRepository,
-                documentNumberAllocator, retryTemplate);
+                documentNumberAllocator, retryTemplate, purchaseOrderReceiptReconciler);
+        lenient().when(purchaseOrderReceiptReconciler.applyReceipt(any(), any(), any(), anyBoolean()))
+                .thenReturn(new PurchaseOrderReceiptReconciler.ReceiptOutcome(0, false, null));
         // The template's own behaviour is covered by its own tests; here it just runs the work.
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderReceiptReconcilerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderReceiptReconcilerTest.java
@@ -1,0 +1,311 @@
+package org.tornotron.echno_backend.purchaseOrder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
+import org.tornotron.echno_backend.grnItem.GrnItem;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItem;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the reconciliation a goods receipt performs against the purchase order it cites.
+ *
+ * <p>Every case here fails on the code as it stood before this class existed, where
+ * {@code receivedQuantity} was written zero at creation and never again and no code compared a
+ * receipt with an order. The repositories and the status-trail recorder are mocked and the
+ * entity graph is built in memory; the assertions read the entities the reconciler mutated and
+ * the arguments it passed to the recorder.
+ */
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderReceiptReconcilerTest {
+
+    private static final Long ORG = 100L;
+    private static final Long PO_ID = 204L;
+    private static final Long CEMENT = 44L;
+    private static final Long STEEL = 45L;
+
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private PurchaseOrderItemRepository purchaseOrderItemRepository;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+
+    private PurchaseOrderReceiptReconciler reconciler;
+    private Organization organization;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        organization = new Organization();
+        organization.setId(ORG);
+        reconciler = new PurchaseOrderReceiptReconciler(purchaseOrderRepository,
+                purchaseOrderItemRepository, statusTransitionRecorder);
+        lenient().when(purchaseOrderRepository.save(any(PurchaseOrder.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void addsTheReceivedQuantityToTheMatchingOrderLine() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 0);
+        stubLines(line);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000001"), List.of(received(CEMENT, 40)), false);
+
+        assertThat(line.getReceivedQuantity()).isEqualTo(40);
+    }
+
+    @Test
+    void addsToTheQuantityAlreadyReceivedRatherThanReplacingIt() {
+        PurchaseOrder order = order(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 40);
+        stubLines(line);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000002"), List.of(received(CEMENT, 25)), false);
+
+        assertThat(line.getReceivedQuantity()).isEqualTo(65);
+    }
+
+    @Test
+    void refusesAnOverReceiptThatWasNotAcknowledged() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem line = line(1L, CEMENT, 10, 0);
+        stubLines(line);
+
+        assertThatThrownBy(() -> reconciler.applyReceipt(
+                order, grn("GRN-2026-000003"), List.of(received(CEMENT, 10_000)), false))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("PO-2026-000001")
+                .hasMessageContaining("Portland Cement")
+                .hasMessageContaining("10000")
+                .hasMessageContaining("allowOverReceipt");
+
+        assertThat(line.getReceivedQuantity()).isZero();
+        verify(purchaseOrderItemRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void countsWhatIsAlreadyReceivedWhenJudgingAnOverReceipt() {
+        PurchaseOrder order = order(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 95);
+        stubLines(line);
+
+        assertThatThrownBy(() -> reconciler.applyReceipt(
+                order, grn("GRN-2026-000004"), List.of(received(CEMENT, 20)), false))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("115");
+    }
+
+    @Test
+    void recordsAnOverReceiptThatWasAcknowledged() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 0);
+        stubLines(line);
+
+        PurchaseOrderReceiptReconciler.ReceiptOutcome outcome = reconciler.applyReceipt(
+                order, grn("GRN-2026-000005"), List.of(received(CEMENT, 105)), true);
+
+        assertThat(outcome.overReceipt()).isTrue();
+        assertThat(line.getReceivedQuantity()).isEqualTo(105);
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.FULLY_RECEIVED);
+    }
+
+    @Test
+    void movesTheOrderToPartiallyReceivedWhileSomethingIsOutstanding() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        stubLines(line(1L, CEMENT, 100, 0), line(2L, STEEL, 50, 0));
+
+        PurchaseOrderReceiptReconciler.ReceiptOutcome outcome = reconciler.applyReceipt(
+                order, grn("GRN-2026-000006"), List.of(received(CEMENT, 100)), false);
+
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+        assertThat(outcome.movedTo()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    }
+
+    @Test
+    void movesTheOrderToFullyReceivedWhenEveryLineIsMet() {
+        PurchaseOrder order = order(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+        stubLines(line(1L, CEMENT, 100, 100), line(2L, STEEL, 50, 30));
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000007"), List.of(received(STEEL, 20)), false);
+
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.FULLY_RECEIVED);
+    }
+
+    @Test
+    void recordsTheDerivedMoveAsASystemTransitionNamingTheReceipt() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        stubLines(line(1L, CEMENT, 100, 0));
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000008"), List.of(received(CEMENT, 100)), false);
+
+        ArgumentCaptor<String> note = ArgumentCaptor.forClass(String.class);
+        verify(statusTransitionRecorder).recordSystemChange(
+                eq("PURCHASE_ORDER"), eq(PO_ID), eq(organization),
+                eq("SENT_TO_VENDOR"), eq("FULLY_RECEIVED"), note.capture());
+        assertThat(note.getValue()).contains("GRN-2026-000008");
+    }
+
+    @Test
+    void leavesADraftOrderWhereItIsWhileStillRecordingWhatArrived() {
+        PurchaseOrder order = order(PurchaseOrderStatus.DRAFT);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 0);
+        stubLines(line);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000009"), List.of(received(CEMENT, 100)), false);
+
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.DRAFT);
+        assertThat(line.getReceivedQuantity()).isEqualTo(100);
+        verify(statusTransitionRecorder, never())
+                .recordSystemChange(anyString(), anyLong(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void leavesACancelledOrderWhereItIs() {
+        PurchaseOrder order = order(PurchaseOrderStatus.CANCELLED);
+        stubLines(line(1L, CEMENT, 100, 0));
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000010"), List.of(received(CEMENT, 100)), false);
+
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.CANCELLED);
+    }
+
+    @Test
+    void reconcilesNothingForAReceiptLineThatIsNotOnTheOrder() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem line = line(1L, CEMENT, 100, 0);
+        stubLines(line);
+
+        PurchaseOrderReceiptReconciler.ReceiptOutcome outcome = reconciler.applyReceipt(
+                order, grn("GRN-2026-000011"), List.of(received(STEEL, 500)), false);
+
+        assertThat(outcome.matchedLines()).isZero();
+        assertThat(outcome.overReceipt()).isFalse();
+        assertThat(line.getReceivedQuantity()).isZero();
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.SENT_TO_VENDOR);
+    }
+
+    @Test
+    void takesTheOrderedQuantityOnTheReceiptLineFromTheOrder() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        stubLines(line(1L, CEMENT, 100, 0));
+        GrnItem receiptLine = received(CEMENT, 40);
+        receiptLine.setOrderedQuantity(7);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000012"), List.of(receiptLine), false);
+
+        assertThat(receiptLine.getOrderedQuantity()).isEqualTo(100);
+    }
+
+    @Test
+    void spreadsAQuantityAcrossTwoOrderLinesForTheSameMaterial() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem first = line(1L, CEMENT, 30, 0);
+        PurchaseOrderItem second = line(2L, CEMENT, 70, 0);
+        stubLines(first, second);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000013"), List.of(received(CEMENT, 50)), false);
+
+        assertThat(first.getReceivedQuantity()).isEqualTo(30);
+        assertThat(second.getReceivedQuantity()).isEqualTo(20);
+        assertThat(order.getStatus()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    }
+
+    @Test
+    void putsAnAcknowledgedExcessOnTheLastLineSoTheLinesStillSumToWhatArrived() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        PurchaseOrderItem first = line(1L, CEMENT, 30, 0);
+        PurchaseOrderItem second = line(2L, CEMENT, 70, 0);
+        stubLines(first, second);
+
+        reconciler.applyReceipt(order, grn("GRN-2026-000014"), List.of(received(CEMENT, 120)), true);
+
+        assertThat(first.getReceivedQuantity() + second.getReceivedQuantity()).isEqualTo(120);
+        assertThat(second.getReceivedQuantity()).isEqualTo(90);
+    }
+
+    @Test
+    void sumsTwoReceiptLinesForTheSameMaterialBeforeJudgingTheOverReceipt() {
+        PurchaseOrder order = order(PurchaseOrderStatus.SENT_TO_VENDOR);
+        stubLines(line(1L, CEMENT, 100, 0));
+
+        assertThatThrownBy(() -> reconciler.applyReceipt(order, grn("GRN-2026-000015"),
+                List.of(received(CEMENT, 60), received(CEMENT, 60)), false))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("120");
+    }
+
+    private void stubLines(PurchaseOrderItem... lines) {
+        when(purchaseOrderItemRepository.lockByPurchaseOrderIdAndOrganizationId(PO_ID, ORG))
+                .thenReturn(new ArrayList<>(List.of(lines)));
+    }
+
+    private PurchaseOrder order(PurchaseOrderStatus status) {
+        PurchaseOrder order = new PurchaseOrder();
+        order.setId(PO_ID);
+        order.setPoNumber("PO-2026-000001");
+        order.setStatus(status);
+        order.setOrganization(organization);
+        return order;
+    }
+
+    private PurchaseOrderItem line(Long id, Long materialId, int ordered, int received) {
+        PurchaseOrderItem line = new PurchaseOrderItem();
+        line.setId(id);
+        line.setMaterial(material(materialId));
+        line.setOrderedQuantity(ordered);
+        line.setReceivedQuantity(received);
+        line.setOrganization(organization);
+        return line;
+    }
+
+    private GrnItem received(Long materialId, int quantity) {
+        GrnItem item = new GrnItem();
+        item.setMaterial(material(materialId));
+        item.setOrderedQuantity(quantity);
+        item.setReceivedQuantity(quantity);
+        item.setOrganization(organization);
+        return item;
+    }
+
+    private static Material material(Long id) {
+        Material material = new Material();
+        material.setId(id);
+        material.setMaterialName(CEMENT.equals(id) ? "Portland Cement 53 grade" : "TMT Bar Fe 500D, 12mm");
+        return material;
+    }
+
+    private static GoodsReceivedNote grn(String number) {
+        GoodsReceivedNote grn = new GoodsReceivedNote();
+        grn.setGrnNumber(number);
+        return grn;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderServiceTest.java
@@ -72,6 +72,10 @@ class PurchaseOrderServiceTest {
     @Mock private IndentItemRepository indentItemRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private org.tornotron.echno_backend.common.history.StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private org.tornotron.echno_backend.common.history.StatusTransitionRepository statusTransitionRepository;
+    @Mock private org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper statusTransitionMapper;
+    @Mock private org.tornotron.echno_backend.user.UserContextService userContextService;
 
     private PurchaseOrderService service;
 
@@ -82,7 +86,8 @@ class PurchaseOrderServiceTest {
         service = new PurchaseOrderService(purchaseOrderRepository, vendorRepository, indentRepository,
                 purchaseOrderMapper, tenantEntityHelper, employeeRepository, projectRepository,
                 purchaseOrderItemRepository, materialRepository, indentItemRepository,
-                documentNumberAllocator, retryTemplate);
+                documentNumberAllocator, retryTemplate, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper, userContextService);
         // The template's own behaviour is covered by its own tests; here it just runs the work.
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderStatusTrailTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderStatusTrailTest.java
@@ -1,0 +1,123 @@
+package org.tornotron.echno_backend.purchaseOrder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.indent.IndentRepository;
+import org.tornotron.echno_backend.indentItem.IndentItemRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.purchaseOrder.enums.PurchaseOrderStatus;
+import org.tornotron.echno_backend.purchaseOrder.mapper.PurchaseOrderMapper;
+import org.tornotron.echno_backend.purchaseOrderItem.PurchaseOrderItemRepository;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.vendor.VendorRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that a status change somebody made is written to the shared trail against that person.
+ *
+ * <p>The derived moves the reconciler makes are covered in
+ * {@code PurchaseOrderReceiptReconcilerTest}. Both halves are needed: a trail holding only the
+ * derived moves would read as though the system made every change an order ever went through.
+ */
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderStatusTrailTest {
+
+    private static final Long ORG = 100L;
+    private static final Long PO_ID = 204L;
+
+    @Mock private PurchaseOrderRepository purchaseOrderRepository;
+    @Mock private VendorRepository vendorRepository;
+    @Mock private IndentRepository indentRepository;
+    @Mock private PurchaseOrderMapper purchaseOrderMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private PurchaseOrderItemRepository purchaseOrderItemRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private IndentItemRepository indentItemRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
+    @Mock private UserContextService userContextService;
+
+    private PurchaseOrderService service;
+    private Organization organization;
+    private User actor;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        organization = new Organization();
+        organization.setId(ORG);
+        actor = new User();
+        actor.setId(77L);
+        service = new PurchaseOrderService(purchaseOrderRepository, vendorRepository, indentRepository,
+                purchaseOrderMapper, tenantEntityHelper, employeeRepository, projectRepository,
+                purchaseOrderItemRepository, materialRepository, indentItemRepository,
+                documentNumberAllocator, retryTemplate, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper, userContextService);
+        lenient().when(userContextService.getCurrentUser()).thenReturn(actor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void recordsAStatusChangeSomebodyMadeAgainstThatPerson() {
+        PurchaseOrder order = order(PurchaseOrderStatus.DRAFT);
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(PO_ID, ORG)).thenReturn(Optional.of(order));
+        when(purchaseOrderRepository.save(any(PurchaseOrder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.updatePurchaseOrderStatus(PO_ID, PurchaseOrderStatus.APPROVED);
+
+        verify(statusTransitionRecorder).recordChange(
+                eq("PURCHASE_ORDER"), eq(PO_ID), eq(organization),
+                eq("DRAFT"), eq("APPROVED"), eq(actor), isNull());
+    }
+
+    @Test
+    void refusesToReadTheTrailOfAnOrderThatIsNotInThisOrganization() {
+        when(purchaseOrderRepository.findByIdAndOrganization_Id(PO_ID, ORG)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getStatusHistory(PO_ID, 0, 20))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    private PurchaseOrder order(PurchaseOrderStatus status) {
+        PurchaseOrder order = new PurchaseOrder();
+        order.setId(PO_ID);
+        order.setPoNumber("PO-2026-000001");
+        order.setStatus(status);
+        order.setOrganization(organization);
+        return order;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderUpdateFieldsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderUpdateFieldsTest.java
@@ -72,6 +72,10 @@ class PurchaseOrderUpdateFieldsTest {
     @Mock private IndentItemRepository indentItemRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private org.tornotron.echno_backend.common.history.StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private org.tornotron.echno_backend.common.history.StatusTransitionRepository statusTransitionRepository;
+    @Mock private org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper statusTransitionMapper;
+    @Mock private org.tornotron.echno_backend.user.UserContextService userContextService;
     @Mock private PurchaseOrderService purchaseOrderService;
 
     @BeforeEach
@@ -97,7 +101,11 @@ class PurchaseOrderUpdateFieldsTest {
                 materialRepository,
                 indentItemRepository,
                 documentNumberAllocator,
-                retryTemplate);
+                retryTemplate,
+                statusTransitionRecorder,
+                statusTransitionRepository,
+                statusTransitionMapper,
+                userContextService);
     }
 
     private PurchaseOrderItemService itemService() {


### PR DESCRIPTION
Closes the goods-receipt half of #648. The site-transfer half is specified in a separate issue rather than half-built, because it changes what the document means to the people using it.

## What was wrong

`PurchaseOrderItem.receivedQuantity` was written `0` twice at creation and never again. Nothing in `src/main` compared a goods receipt with the order it cited. Three consequences followed from the one gap: an order for ten read as fully outstanding after ten thousand had been received against it; the delete guard at `PurchaseOrderItemService:179` was permanently satisfied, so any line could always be deleted however much had arrived; and `PARTIALLY_RECEIVED` and `FULLY_RECEIVED` were statuses no code could reach, so an order only moved when somebody patched it by hand from a screen showing zeroes.

Live staging shows it exactly. One purchase order, `PO-2026-000001`, one line for material 3 ordered 1, received 0. Five goods receipts cite it: four are for a material that is not on the order at all, and the fifth received 5 against an order for 1. The order still reads `DRAFT` with nothing received.

## The three decisions

**Over-receipt is refused by default and recorded on request.** Neither extreme survives contact with a site. Accepting any quantity silently is the behaviour being replaced. Refusing outright is worse than it looks: the supplier who delivers 105 bags against an order for 100 has left 105 bags on the site whether the system likes it or not, and a receipt that cannot be filed puts them outside the stock ledger, which is exactly the condition SA-563 showed makes a balance unexplainable. So the default refuses and names the line, the quantity ordered, the quantity already received and the quantity now offered, which is enough for a person to recognise a typed digit; and a payload that sets `allowOverReceipt` records the excess and marks the note `overReceiptAcknowledged`, so the document explains itself to whoever reads it six months on. Whatever the answer, `receivedQuantity` now reflects what arrived.

A receipt line for a material that is **not** on the order reconciles nothing, which is the truth about it, and posts stock exactly as before. Refusing it would be wrong: a lorry can carry an item ordered separately or supplied free.

**The order's status moves on its own, and the actor is the receipt.** `PARTIALLY_RECEIVED` when something is outstanding, `FULLY_RECEIVED` when every line is met. A move like that has no person behind it, so inventing one would be worse than admitting it. It is written to the shared status trail (#565) under a new `StatusTransitionSource.SYSTEM` whose note names the goods receipt that caused it; that receipt carries `receivedBy`, which is as close to a person as a derived transition honestly gets. Manual status changes are now filed against the person who made them too, otherwise the trail would read as though the system made every change an order ever went through, and existing orders get one `BASELINE` entry the way projects did in 073. `GET /api/v1/purchase-orders/web/{id}/status-history` reads it.

`DRAFT` and `CANCELLED` orders keep their status while still recording what arrived. A received quantity is a fact; a status is a lifecycle claim, and a receipt must not quietly approve an order nobody approved or reinstate one somebody cancelled.

**Site transfers are specified, not built.** See the linked follow-up issue.

## Ledger safety

No new inventory movement shapes. The stock posting path is untouched. The only new writes are `purchase_order_item.received_quantity`, `purchase_order.status`, `status_transition`, and the new `goods_received_note.over_receipt_acknowledged`. The one change to when movements happen is that a refused over-receipt now writes none, and the caller is told which line and given the way past it. Reconciliation runs inside the create transaction and before `GrnCreatedEvent`, so a refusal takes the note with it.

Concurrency: the order's lines are taken with `SELECT ... FOR UPDATE` ordered by id, so two receipts against the same order queue rather than each judging themselves against the figure that stood before the other. Without it both would pass the over-receipt check and the second write would erase the first, leaving an order reading as under-received while the ledger held both deliveries.

## Verified against live staging

- `status_transition.source` is `VARCHAR NOT NULL` with no check constraint, so `SYSTEM` stores without a schema change.
- 28 `PROJECT` `BASELINE` rows exist, no `PURCHASE_ORDER` rows, so changeset `084-02`'s precondition passes and seeds the one existing order.
- `goods_received_note.over_receipt_acknowledged` does not exist, so `084-01` adds it.
- Under this change, `GRN-2026-000002` (5 against an order for 1) would have been refused with the figures named. The four receipts for the unordered material would post as before.

## Tests

22 new, all failing without the change (a mutation run neutering `applyReceipt` fails 17 of them; the rest are the service wiring and trail tests, which cannot compile against the old code because the collaborator does not exist).

| Test | What it pins |
|---|---|
| `addsTheReceivedQuantityToTheMatchingOrderLine` | the field that never moved off zero |
| `addsToTheQuantityAlreadyReceivedRatherThanReplacingIt` | successive deliveries accumulate |
| `refusesAnOverReceiptThatWasNotAcknowledged` | 10,000 against 10 is stopped, with the figures |
| `countsWhatIsAlreadyReceivedWhenJudgingAnOverReceipt` | the check is cumulative, not per note |
| `recordsAnOverReceiptThatWasAcknowledged` | reality can still be recorded |
| `movesTheOrderToPartiallyReceivedWhileSomethingIsOutstanding` | the status is reachable |
| `movesTheOrderToFullyReceivedWhenEveryLineIsMet` | and so is the other one |
| `recordsTheDerivedMoveAsASystemTransitionNamingTheReceipt` | the actor question |
| `leavesADraftOrderWhereItIsWhileStillRecordingWhatArrived` | quantities are facts, statuses are claims |
| `leavesACancelledOrderWhereItIs` | a receipt does not reinstate an order |
| `reconcilesNothingForAReceiptLineThatIsNotOnTheOrder` | unmatched lines are honest, not refused |
| `takesTheOrderedQuantityOnTheReceiptLineFromTheOrder` | the order is the authority on what was ordered |
| `spreadsAQuantityAcrossTwoOrderLinesForTheSameMaterial` | split lines |
| `putsAnAcknowledgedExcessOnTheLastLineSoTheLinesStillSumToWhatArrived` | the lines sum to reality |
| `sumsTwoReceiptLinesForTheSameMaterialBeforeJudgingTheOverReceipt` | the check cannot be split around |
| `postsTheReceiptBackOntoTheOrderItCites` | the wiring exists |
| `passesTheAcknowledgementFromThePayloadThrough` | the flag reaches the check |
| `raisesNoStockWhenTheOrderRefusesTheDelivery` | no event on refusal |
| `marksTheNoteWhenTheOverReceiptWasLetThrough` | the document says so |
| `leavesTheNoteUnmarkedWhenTheReceiptStaysWithinTheOrder` | and does not say so otherwise |
| `recordsAStatusChangeSomebodyMadeAgainstThatPerson` | manual moves keep their actor |
| `refusesToReadTheTrailOfAnOrderThatIsNotInThisOrganization` | tenant scoping on the new read |

Full suite on `.116`: 1679 tests, 0 failures. Test heap 570 MB live of 2048 MB (28%), 8 contexts cached of 8. `docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.

## Contract

Additive for `echno-core`: `allowOverReceipt` on the GRN creation payload, `overReceiptAcknowledged` on the response, and a new status-history endpoint. The one behaviour change a client can see is a 400 where an unacknowledged over-receipt previously returned 201. The web app needs a way to offer the acknowledgement; filed separately.
