### PR TITLE
Let the document say a field may be null, which under 3.1 it never could

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ runs the check on every pull request, so a stale copy fails the build rather tha
 The task needs Docker (it starts CockroachDB through Testcontainers, as the test suite does) and
 runs in a JVM of its own, which is why it is not part of `test` or `check`.
 
+### Saying that a field may be null
+
+A field that can come back null is marked on the DTO:
+
+```java
+@Schema(description = "Finance customer the project is billed to. Null when no client is set.",
+        example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d", nullable = true)
+private UUID customerId;
+```
+
+The document is OpenAPI 3.1, where that is written as a type union rather than a `nullable` flag,
+so the property comes out as `"type": ["string", "null"]`. swagger-core reads the annotation but
+does not translate it under 3.1, so `NullableSchemaCustomizer` does the conversion and
+`OpenApiNullabilityTest` fails if an annotated field is not described that way in the committed
+document. Before that existed the annotation produced no output at all, which is why nothing in
+the document was marked nullable for as long as it has been published.
+
+Mark only what you have checked. A field the document declares non-null is a field a client is
+entitled to parse without a guard, so leaving one unmarked is recoverable and marking one wrongly
+is not.
+
 Serving the document from a deployment is a separate decision: `/v3/api-docs` and the Swagger UI
 answer 401 unless `SWAGGER_PUBLIC_ACCESS=true` is set for that environment.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -34,7 +34,10 @@
             "description": "Parent account id, or null for a root account.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "type": {
             "description": "Root account type this account belongs to.",
@@ -760,7 +763,10 @@
             "description": "Id of the project the asset left, null if it was on none.",
             "example": 3,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "fromProjectName": {
             "description": "Name of the project the asset left, as it read at the time.",
@@ -837,7 +843,10 @@
             "description": "Id of the project the asset moved to, null if it is on none.",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "toProjectName": {
             "description": "Name of the project the asset moved to, as it read at the time.",
@@ -899,7 +908,10 @@
             "description": "Id of the project the asset was on, null if it was on none.",
             "example": 5,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "projectName": {
             "description": "Name of the project the asset was on, as it read at the time.",
@@ -915,7 +927,10 @@
             "description": "When it left. Null on the placement it is still in.",
             "example": "2026-08-04T16:30:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -983,7 +998,10 @@
             "description": "Whole days until the document expires, negative once it has. Null where it carries no expiry.",
             "example": 285,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "documentType": {
             "description": "What kind of document this is, where it is a document.",
@@ -998,13 +1016,19 @@
           "expired": {
             "description": "Whether the document has already expired. Null where it carries no expiry.",
             "example": false,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "expiresOn": {
             "description": "Date the document stops being valid. Null for a file that does not expire.",
             "example": "2027-06-10",
             "format": "date",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "fileName": {
             "description": "Original filename as uploaded.",
@@ -1694,7 +1718,10 @@
             "description": "Id of the project this profile applies to, or null for the organization-level default.",
             "example": 12,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "regularizationApprovalRequired": {
             "description": "Whether a manager must approve a regularization request before it takes effect.",
@@ -2182,7 +2209,10 @@
             "description": "When the message was edited; null if never.",
             "example": "2026-08-22T14:20:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "entityMentions": {
             "description": "Task, issue or project references in the message body.",
@@ -2223,7 +2253,14 @@
             "type": "array"
           },
           "replyTo": {
-            "$ref": "#/components/schemas/ChatMessageReplyDto",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatMessageReplyDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Preview of the replied-to message; null when this is not a reply."
           },
           "replyToId": {
@@ -2295,7 +2332,10 @@
             "description": "How far the employee has read the room; null if never read.",
             "example": "2026-08-22T14:20:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "role": {
             "description": "Role of the participant in the room.",
@@ -2356,13 +2396,23 @@
             "type": "boolean"
           },
           "lastMessage": {
-            "$ref": "#/components/schemas/ChatMessageDto",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatMessageDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The latest non-deleted message in the room; null when the room is empty."
           },
           "name": {
             "description": "Room name; null for a direct room (the client derives it).",
             "example": "Block C site team",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "participants": {
             "description": "Participants of the room.",
@@ -3042,13 +3092,19 @@
           "approvedByName": {
             "description": "Name of the user that approved the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never approved.",
             "example": "Aneesh Johny",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "arInvoiceId": {
             "description": "AR invoice raised for this invoice on approval. Present on a sales or service invoice whose project has a client; null otherwise.",
             "example": "1c9d4b7a-0f2e-4a63-8b11-5d7c2e9f4a88",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "balanceAmount": {
             "description": "Outstanding balance still due.",
@@ -3137,7 +3193,10 @@
           "paymentRecordedByName": {
             "description": "Name of the user that recorded the most recent payment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when no payment has been recorded.",
             "example": "Anand Rajashekar",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "paymentStatus": {
             "description": "Settlement status derived from paid and outstanding amounts.",
@@ -3204,7 +3263,10 @@
           "submittedByName": {
             "description": "Name of the user that submitted the invoice, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the invoice was never submitted.",
             "example": "Anand Rajashekar",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "subtotal": {
             "description": "Sum of line amounts before tax and discount.",
@@ -3554,12 +3616,18 @@
             "description": "User id that raised the voucher, taken from the session that created it. Null on vouchers raised before the voucher recorded this.",
             "example": 8,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "raisedByName": {
             "description": "Name of the user that raised the voucher, on the same fallbacks as the verifier name. Null only where the voucher does not record who raised it.",
             "example": "Hrishi",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "referenceNumber": {
             "description": "Cheque or reference number for the payment.",
@@ -3624,7 +3692,10 @@
           "verifiedByName": {
             "description": "Name of the user that verified the voucher, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the voucher was never verified.",
             "example": "Aneesh Johny",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -3694,13 +3765,19 @@
           "expenseAccountCode": {
             "description": "Code of the mapped expense account, or null.",
             "example": 5100,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "expenseAccountId": {
             "description": "Ledger expense account this head maps to, or null.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Unique cost category id.",
@@ -4967,7 +5044,14 @@
             "type": "number"
           },
           "shiftTiming": {
-            "$ref": "#/components/schemas/ShiftTimingDto",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShiftTimingDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The resolved structured shift assigned to the employee. Null when unassigned."
           },
           "shiftTimingId": {
@@ -5633,7 +5717,10 @@
           "approvalThreshold": {
             "description": "Auto-approval threshold. Null means every construction invoice needs manual approval; a value T auto-approves invoices whose total is below T.",
             "example": 50000.0,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -6140,7 +6227,10 @@
             "description": "Id of the employee who raised the indent. Null where the raiser is no longer recorded.",
             "example": 18,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "createdByName": {
             "description": "Name of the employee who raised the indent.",
@@ -9941,7 +10031,10 @@
           "createdByName": {
             "description": "Display name of the employee who booked the movement. For automated movements this is the actor who triggered the source event. Null when the ledger row records no creator.",
             "example": "Asha Menon",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "direction": {
             "description": "Direction the movement type moves stock in: INCREASE, DECREASE, or EITHER when the sign comes from the signed quantity.",
@@ -10443,7 +10536,10 @@
             "description": "Employee id of the person who verified the movement, null where the verifier has no employee record in this organization.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -12851,7 +12947,10 @@
             "description": "Maximum number of users allowed under this plan, or null for unlimited.",
             "example": 25,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "monthlyPrice": {
             "description": "Price charged per month, in the plan currency.",
@@ -13193,7 +13292,10 @@
             "description": "Cost category (budget head) id, or null for the project total row.",
             "example": "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "costCategoryName": {
             "description": "Cost category name, or 'Total' for the project total row.",
@@ -13347,18 +13449,27 @@
             "description": "Id of the user who created the project. Null on projects created before this was recorded.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "customerId": {
             "description": "Finance customer the project is billed to. Null when no client is set.",
             "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "description": "Free-text description of the project. Null when not recorded.",
             "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employees": {
             "description": "Employees assigned to the project team.",
@@ -13393,7 +13504,10 @@
           "projectCity": {
             "description": "Town or city the site is in. Null when not recorded.",
             "example": "Chennai",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectLatitude": {
             "description": "Site latitude in decimal degrees.",
@@ -13415,12 +13529,18 @@
           "projectPostalCode": {
             "description": "Postal (PIN) code of the site. Null when not recorded.",
             "example": 600004,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectState": {
             "description": "Indian state or union territory the site is in, used to match statutory compliances. Null when not recorded.",
             "example": "Tamil Nadu",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectType": {
             "description": "Construction category of the project.",
@@ -13468,7 +13588,10 @@
             "description": "When the project was last written. Null on projects not written since this was recorded. It is a last-write stamp, so it is overwritten by the next edit to any field: to read who moved the project's status and when, use GET /api/v1/project/web/{id}/status-history.",
             "example": "2026-08-28T16:41:12",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "updatedBy": {
             "description": "Id of the user who last wrote the project.",
@@ -13541,7 +13664,10 @@
             "description": "Finance customer the project is billed to. Null when no client is set.",
             "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "endDate": {
             "description": "Planned completion date of the project.",
@@ -13569,7 +13695,10 @@
           "projectCity": {
             "description": "Town or city the site is in. Null when not recorded.",
             "example": "Chennai",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectLatitude": {
             "description": "Site latitude in decimal degrees.",
@@ -13591,12 +13720,18 @@
           "projectPostalCode": {
             "description": "Postal (PIN) code of the site. Null when not recorded.",
             "example": 600004,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectState": {
             "description": "Indian state or union territory the site is in, used to match statutory compliances. Null when not recorded.",
             "example": "Tamil Nadu",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectType": {
             "description": "Construction category of the project.",
@@ -13649,13 +13784,19 @@
             "description": "Id of the user who created the project. Null on projects created before this was recorded.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "customerId": {
             "description": "Finance customer the project is billed to. Null when no client is set.",
             "example": "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "endDate": {
             "description": "Planned completion date of the project.",
@@ -13683,7 +13824,10 @@
           "projectCity": {
             "description": "Town or city the site is in. Null when not recorded.",
             "example": "Chennai",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectLatitude": {
             "description": "Site latitude in decimal degrees.",
@@ -13705,12 +13849,18 @@
           "projectPostalCode": {
             "description": "Postal (PIN) code of the site. Null when not recorded.",
             "example": 600004,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectState": {
             "description": "Indian state or union territory the site is in, used to match statutory compliances. Null when not recorded.",
             "example": "Tamil Nadu",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectType": {
             "description": "Construction category of the project.",
@@ -13751,7 +13901,10 @@
             "description": "When the project was last written. Null on projects not written since this was recorded.",
             "example": "2026-08-28T16:41:12",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "updatedBy": {
             "description": "Id of the user who last wrote the project.",
@@ -15396,7 +15549,10 @@
             "description": "Id of the user who made the change. Null where no user context was available, which is the case for every BASELINE entry.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "changedByName": {
             "description": "That user's name as it read at the time, kept beside the id so a rename or a removal does not rewrite history.",
@@ -15406,7 +15562,10 @@
           "fromStatus": {
             "description": "Status held before this entry. Null when there was none: the record was created in the status below, or this is the baseline entry written when the trail began.",
             "example": "upcoming",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Database id of the entry.",
@@ -15568,7 +15727,10 @@
           "approvedByName": {
             "description": "Name of the user who approved the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never approved.",
             "example": "Aneesh Johny",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "countMethod": {
             "description": "Method used to perform the physical count.",
@@ -15654,7 +15816,10 @@
           "processedByName": {
             "description": "Name of the user who processed the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never processed.",
             "example": "Aneesh Johny",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectId": {
             "description": "Id of the project the adjustment applies to.",
@@ -15682,7 +15847,10 @@
           "rejectedByName": {
             "description": "Name of the user who rejected the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never rejected.",
             "example": "Aneesh Johny",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "rejectionReason": {
             "description": "Reason given for rejecting the adjustment.",
@@ -15709,7 +15877,10 @@
           "submittedByName": {
             "description": "Name of the user who submitted the adjustment, or their email where the account carries no name. Reads \"User #<id>\" when the account has since been deleted; null only when the adjustment was never submitted.",
             "example": "Anand Rajashekar",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "totalAdjustmentValue": {
             "description": "Total monetary value of the adjustment across all line items.",
@@ -18793,7 +18964,10 @@
             "items": {
               "$ref": "#/components/schemas/WbsElementDto"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "Timestamp the element was created.",
@@ -18837,12 +19011,18 @@
             "description": "Id of the parent WBS element, or null for a root element.",
             "example": 12,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "parentWbsCode": {
             "description": "wbsCode of the parent WBS element, or null for a root element.",
             "example": 1.2,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "progress": {
             "description": "Completion percentage, from 0 to 100, weighted from children if this element is not a leaf.",
@@ -18944,7 +19124,10 @@
             "description": "Id of the parent WBS element, or null for a root element.",
             "example": 12,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "progress": {
             "description": "Completion percentage, from 0 to 100.",

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetMovementDto.java
@@ -21,12 +21,12 @@ public class AssetMovementDto {
             example = "TRANSFER")
     private String movementType;
 
-    @Schema(description = "Id of the project the asset left, null if it was on none.", example = "3")
+    @Schema(description = "Id of the project the asset left, null if it was on none.", example = "3", nullable = true)
     private Long fromProjectId;
     @Schema(description = "Name of the project the asset left, as it read at the time.",
             example = "Central Yard")
     private String fromProjectName;
-    @Schema(description = "Id of the project the asset moved to, null if it is on none.", example = "5")
+    @Schema(description = "Id of the project the asset moved to, null if it is on none.", example = "5", nullable = true)
     private Long toProjectId;
     @Schema(description = "Name of the project the asset moved to, as it read at the time.",
             example = "Silver Oak Residences")

--- a/src/main/java/org/tornotron/echno_backend/asset/dto/AssetPlacementSpanDto.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/dto/AssetPlacementSpanDto.java
@@ -14,7 +14,7 @@ public class AssetPlacementSpanDto {
     @Schema(description = "Id of the ledger entry that started this placement.", example = "412")
     private Long movementId;
 
-    @Schema(description = "Id of the project the asset was on, null if it was on none.", example = "5")
+    @Schema(description = "Id of the project the asset was on, null if it was on none.", example = "5", nullable = true)
     private Long projectId;
     @Schema(description = "Name of the project the asset was on, as it read at the time.",
             example = "Silver Oak Residences")
@@ -36,7 +36,7 @@ public class AssetPlacementSpanDto {
     private LocalDateTime from;
 
     @Schema(description = "When it left. Null on the placement it is still in.",
-            example = "2026-08-04T16:30:00")
+            example = "2026-08-04T16:30:00", nullable = true)
     private LocalDateTime to;
 
     @Schema(description = "How many whole days the placement lasted, counted to now on the "

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
@@ -21,7 +21,7 @@ public class AttendanceSettingsDto {
     @Schema(description = "Id of the owning organization.", example = "1")
     private Long organizationId;
 
-    @Schema(description = "Id of the project this profile applies to, or null for the organization-level default.", example = "12")
+    @Schema(description = "Id of the project this profile applies to, or null for the organization-level default.", example = "12", nullable = true)
     private Long projectId;
 
     @Schema(description = "Display name for this settings profile.", example = "Standard Site Attendance")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/MovementRecordDto.java
@@ -74,7 +74,7 @@ public class MovementRecordDto {
     @Schema(description = "Name of the person who verified the movement, taken from their session.", example = "Anand Rajashekar")
     private String verifiedBy;
 
-    @Schema(description = "Employee id of the person who verified the movement, null where the verifier has no employee record in this organization.", example = "17")
+    @Schema(description = "Employee id of the person who verified the movement, null where the verifier has no employee record in this organization.", example = "17", nullable = true)
     private Long verifiedById;
 
     @Schema(description = "Timestamp the movement was verified.", example = "2026-01-16T09:00:00")

--- a/src/main/java/org/tornotron/echno_backend/billing/dto/PlanDto.java
+++ b/src/main/java/org/tornotron/echno_backend/billing/dto/PlanDto.java
@@ -33,7 +33,7 @@ public class PlanDto {
     Boolean isPublic;
     @Schema(description = "Number of trial days granted on first subscription.", example = "14")
     Integer trialDays;
-    @Schema(description = "Maximum number of users allowed under this plan, or null for unlimited.", example = "25")
+    @Schema(description = "Maximum number of users allowed under this plan, or null for unlimited.", example = "25", nullable = true)
     Integer maxUsers;
     @Schema(description = "Display order relative to other plans, ascending.", example = "2")
     Integer sortOrder;

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatMessageDto.java
@@ -33,14 +33,14 @@ public class ChatMessageDto {
     @Schema(description = "Id of the message this one replies to, if any.", example = "1198")
     private Long replyToId;
 
-    @Schema(description = "Preview of the replied-to message; null when this is not a reply.")
+    @Schema(description = "Preview of the replied-to message; null when this is not a reply.", nullable = true)
     private ChatMessageReplyDto replyTo;
 
     @Schema(description = "Whether the message has been edited.", example = "false")
     @JsonProperty("isEdited")
     private boolean edited;
 
-    @Schema(description = "When the message was edited; null if never.", example = "2026-08-22T14:20:00")
+    @Schema(description = "When the message was edited; null if never.", example = "2026-08-22T14:20:00", nullable = true)
     private LocalDateTime editedAt;
 
     @Schema(description = "Whether the message has been deleted.", example = "false")

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatParticipantDto.java
@@ -18,6 +18,6 @@ public class ChatParticipantDto {
     @Schema(description = "When the employee joined the room.", example = "2026-08-20T09:00:00")
     private LocalDateTime joinedAt;
 
-    @Schema(description = "How far the employee has read the room; null if never read.", example = "2026-08-22T14:20:00")
+    @Schema(description = "How far the employee has read the room; null if never read.", example = "2026-08-22T14:20:00", nullable = true)
     private LocalDateTime lastReadAt;
 }

--- a/src/main/java/org/tornotron/echno_backend/chat/dto/ChatRoomDto.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/dto/ChatRoomDto.java
@@ -21,7 +21,7 @@ public class ChatRoomDto {
     @Schema(description = "Kind of room.", example = "direct")
     private String type;
 
-    @Schema(description = "Room name; null for a direct room (the client derives it).", example = "Block C site team")
+    @Schema(description = "Room name; null for a direct room (the client derives it).", example = "Block C site team", nullable = true)
     private String name;
 
     @Schema(description = "Room description.", example = "Coordination for the block C interior work")
@@ -33,7 +33,7 @@ public class ChatRoomDto {
     @Schema(description = "Participants of the room.")
     private List<ChatParticipantDto> participants = List.of();
 
-    @Schema(description = "The latest non-deleted message in the room; null when the room is empty.")
+    @Schema(description = "The latest non-deleted message in the room; null when the room is empty.", nullable = true)
     private ChatMessageDto lastMessage;
 
     @Schema(description = "Number of messages the caller has not yet read.", example = "3")

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/NullableSchemaCustomizer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/NullableSchemaCustomizer.java
@@ -1,0 +1,225 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Renders {@code @Schema(nullable = true)} into the document, which OpenAPI 3.1 otherwise drops
+ * on the floor.
+ *
+ * <h2>What was wrong</h2>
+ *
+ * <p>The document this application serves is OpenAPI 3.1: springdoc 2.8 defaults
+ * {@code springdoc.api-docs.version} to {@code openapi_3_1}, and nothing here overrides it. In
+ * 3.0 a field that may be null is written {@code "type": "string", "nullable": true}; 3.1 dropped
+ * that keyword in favour of a type union, {@code "type": ["string", "null"]}.
+ *
+ * <p>swagger-core 2.2.29 reads the annotation either way: {@code @Schema(nullable = true)} lands
+ * on the model as {@code Schema.nullable}. What it does not do is translate it. Its 3.1
+ * serializer mixin marks {@code getNullable()} as ignored and writes {@code types} instead, so
+ * under 3.1 the annotation resolves, is held in memory, and is then silently discarded on the way
+ * out. Setting it produced no diff on the document at all, which is why nobody had set it: the
+ * one annotation an author would reach for looked like it did nothing.
+ *
+ * <p>The result was a 3 MB contract in which not one of 3069 properties said anything about being
+ * null, while a large share of them are null in practice. A consumer reading it is told every
+ * field is always present, and the {@code ?? 0} written on the strength of that turns a value
+ * nobody measured into a confident wrong one. See issue #645.
+ *
+ * <h2>What this does</h2>
+ *
+ * <p>Runs after the document is assembled and before it is serialized, and converts every schema
+ * carrying {@code nullable = true} into the 3.1 form:
+ *
+ * <ul>
+ *   <li>a schema with a type gains {@code "null"} as a second member of it, giving
+ *       {@code "type": ["string", "null"]};
+ *   <li>a schema that is a bare {@code $ref} to another model becomes
+ *       {@code "anyOf": [{"$ref": ...}, {"type": "null"}]}, because a union needs a type to add
+ *       to and a reference has none.
+ * </ul>
+ *
+ * <p>Anything else carrying the flag is logged rather than changed, since guessing at a form for
+ * it would put a claim in the contract that nothing verified. A document served as 3.0, which
+ * {@code springdoc.api-docs.version} can still ask for, is left alone: the keyword is written out
+ * as it stands there, and rewriting it into a union would lose it.
+ *
+ * <h2>Why a customizer and not a model converter</h2>
+ *
+ * <p>A {@code ModelConverter} sees each type as it is resolved and would have to reproduce
+ * swagger-core's rules for when a property is inlined and when it becomes a reference. The flag
+ * survives on the assembled document either way, so reading it there needs none of that: one walk
+ * over the finished object, keyed on a field that is about to be thrown away regardless.
+ */
+@Component
+@Slf4j
+public class NullableSchemaCustomizer implements OpenApiCustomizer {
+
+    /** The JSON Schema type that admits only null. */
+    private static final String NULL_TYPE = "null";
+
+    @Override
+    public void customise(OpenAPI openApi) {
+        if (!SpecVersion.V31.equals(openApi.getSpecVersion())) {
+            // Only 3.1 needs the translation. Serve the document as 3.0 and the keyword is
+            // written out as it stands, so rewriting it into a union there would lose it.
+            return;
+        }
+        Set<Schema<?>> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Schema<?> root : rootsOf(openApi)) {
+            visit(root, visited);
+        }
+    }
+
+    /**
+     * Every schema the document reaches from somewhere other than another schema: the named
+     * models, and the schemas written inline on parameters, request bodies and responses.
+     */
+    private static List<Schema<?>> rootsOf(OpenAPI openApi) {
+        List<Schema<?>> roots = new ArrayList<>();
+        Components components = openApi.getComponents();
+        if (components != null) {
+            addAll(roots, components.getSchemas());
+            if (components.getParameters() != null) {
+                components.getParameters().values().forEach(p -> add(roots, p.getSchema()));
+            }
+            if (components.getRequestBodies() != null) {
+                components.getRequestBodies().values()
+                        .forEach(body -> addContent(roots, body.getContent()));
+            }
+            if (components.getResponses() != null) {
+                components.getResponses().values()
+                        .forEach(response -> addContent(roots, response.getContent()));
+            }
+            if (components.getHeaders() != null) {
+                components.getHeaders().values().forEach(h -> add(roots, h.getSchema()));
+            }
+        }
+        if (openApi.getPaths() != null) {
+            for (PathItem path : openApi.getPaths().values()) {
+                addParameters(roots, path.getParameters());
+                path.readOperations().forEach(operation -> addOperation(roots, operation));
+            }
+        }
+        return roots;
+    }
+
+    private static void addOperation(List<Schema<?>> roots, Operation operation) {
+        addParameters(roots, operation.getParameters());
+        RequestBody body = operation.getRequestBody();
+        if (body != null) {
+            addContent(roots, body.getContent());
+        }
+        if (operation.getResponses() != null) {
+            for (ApiResponse response : operation.getResponses().values()) {
+                addContent(roots, response.getContent());
+                if (response.getHeaders() != null) {
+                    response.getHeaders().values().forEach(h -> add(roots, h.getSchema()));
+                }
+            }
+        }
+    }
+
+    private static void addParameters(List<Schema<?>> roots, List<Parameter> parameters) {
+        if (parameters != null) {
+            parameters.forEach(parameter -> add(roots, parameter.getSchema()));
+        }
+    }
+
+    private static void addContent(List<Schema<?>> roots, Content content) {
+        if (content != null) {
+            content.values().stream().map(MediaType::getSchema)
+                    .forEach(schema -> add(roots, schema));
+        }
+    }
+
+    private static void addAll(List<Schema<?>> roots, Map<String, Schema> schemas) {
+        if (schemas != null) {
+            schemas.values().forEach(schema -> add(roots, schema));
+        }
+    }
+
+    private static void add(List<Schema<?>> roots, Schema<?> schema) {
+        if (schema != null) {
+            roots.add(schema);
+        }
+    }
+
+    /**
+     * Applies the conversion to one schema and everything nested inside it. Identity-keyed
+     * because a schema instance is shared between the places that reference it, and because a
+     * self-referencing model (a WBS element with child elements) would otherwise not terminate.
+     */
+    private void visit(Schema<?> schema, Set<Schema<?>> visited) {
+        if (schema == null || !visited.add(schema)) {
+            return;
+        }
+        admitNull(schema);
+
+        if (schema.getProperties() != null) {
+            schema.getProperties().values().forEach(property -> visit(property, visited));
+        }
+        visit(schema.getItems(), visited);
+        if (schema.getAdditionalProperties() instanceof Schema<?> additional) {
+            visit(additional, visited);
+        }
+        visitAll(schema.getAllOf(), visited);
+        visitAll(schema.getAnyOf(), visited);
+        visitAll(schema.getOneOf(), visited);
+        visit(schema.getNot(), visited);
+    }
+
+    private void visitAll(Collection<Schema> schemas, Set<Schema<?>> visited) {
+        if (schemas != null) {
+            schemas.forEach(schema -> visit(schema, visited));
+        }
+    }
+
+    /**
+     * Rewrites one schema so that the document says it admits null, and clears the flag once it
+     * has, so that a second build over the same model is a no-op rather than a second rewrite.
+     */
+    private void admitNull(Schema<?> schema) {
+        if (!Boolean.TRUE.equals(schema.getNullable())) {
+            return;
+        }
+        if (schema.getTypes() != null && !schema.getTypes().isEmpty()) {
+            schema.addType(NULL_TYPE);
+            schema.setNullable(null);
+            return;
+        }
+        if (schema.get$ref() != null) {
+            Schema<?> nullType = new Schema<>();
+            nullType.addType(NULL_TYPE);
+            List<Schema> union = new ArrayList<>();
+            union.add(new Schema<>().$ref(schema.get$ref()));
+            union.add(nullType);
+            schema.set$ref(null);
+            schema.setAnyOf(union);
+            schema.setNullable(null);
+            return;
+        }
+        log.warn("A schema is marked nullable but has neither a type nor a $ref to build a union "
+                + "from, so the document cannot say it admits null: {}", schema.getName());
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/entity/AttachmentDto.java
@@ -42,14 +42,14 @@ public class AttachmentDto {
     private LocalDate issuedOn;
 
     @Schema(description = "Date the document stops being valid. Null for a file that does not expire.",
-            example = "2027-06-10")
+            example = "2027-06-10", nullable = true)
     private LocalDate expiresOn;
 
     @Schema(description = "Whether the document has already expired. Null where it carries no expiry.",
-            example = "false")
+            example = "false", nullable = true)
     private Boolean expired;
 
     @Schema(description = "Whole days until the document expires, negative once it has. Null where "
-            + "it carries no expiry.", example = "285")
+            + "it carries no expiry.", example = "285", nullable = true)
     private Long daysUntilExpiry;
 }

--- a/src/main/java/org/tornotron/echno_backend/common/history/dto/StatusTransitionDto.java
+++ b/src/main/java/org/tornotron/echno_backend/common/history/dto/StatusTransitionDto.java
@@ -17,7 +17,7 @@ public class StatusTransitionDto {
     @Schema(description = "Status held before this entry. Null when there was none: the record was "
             + "created in the status below, or this is the baseline entry written when the trail "
             + "began.",
-            example = "upcoming")
+            example = "upcoming", nullable = true)
     private String fromStatus;
 
     @Schema(description = "Status held after this entry.", example = "approved")
@@ -37,7 +37,7 @@ public class StatusTransitionDto {
 
     @Schema(description = "Id of the user who made the change. Null where no user context was "
             + "available, which is the case for every BASELINE entry.",
-            example = "17")
+            example = "17", nullable = true)
     private Long changedBy;
 
     @Schema(description = "That user's name as it read at the time, kept beside the id so a rename "

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeDto.java
@@ -70,7 +70,7 @@ public class EmployeeDto {
     @Schema(description = "Id of the structured shift timing assigned to the employee.", example = "5")
     private Long shiftTimingId;
 
-    @Schema(description = "The resolved structured shift assigned to the employee. Null when unassigned.")
+    @Schema(description = "The resolved structured shift assigned to the employee. Null when unassigned.", nullable = true)
     private ShiftTimingDto shiftTiming;
 
     @Schema(description = "Employment status.", example = "ACTIVE")

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/CostCategoryDto.java
@@ -17,10 +17,10 @@ public record CostCategoryDto(
         String code,
 
         @Schema(description = "Ledger expense account this head maps to, or null.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID expenseAccountId,
 
-        @Schema(description = "Code of the mapped expense account, or null.", example = "5100")
+        @Schema(description = "Code of the mapped expense account, or null.", example = "5100", nullable = true)
         String expenseAccountCode,
 
         @Schema(description = "Whether the head is active and available for tagging.", example = "true")

--- a/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/budget/dtos/ProjectCostControlLineDto.java
@@ -9,7 +9,7 @@ import java.util.UUID;
         + "what has been committed and spent, and what remains.")
 public record ProjectCostControlLineDto(
         @Schema(description = "Cost category (budget head) id, or null for the project total row.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID costCategoryId,
 
         @Schema(description = "Cost category name, or 'Total' for the project total row.", example = "Materials")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionInvoiceDto.java
@@ -91,7 +91,7 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Name of the user that submitted the invoice, or their email where the "
                 + "account carries no name. Reads \"User #<id>\" when the account has since been "
                 + "deleted; null only when the invoice was never submitted.",
-                example = "Anand Rajashekar")
+                example = "Anand Rajashekar", nullable = true)
         String submittedByName,
 
         @Schema(description = "Timestamp the invoice was submitted.", example = "2026-08-02T09:15:00Z")
@@ -103,7 +103,7 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Name of the user that approved the invoice, or their email where the "
                 + "account carries no name. Reads \"User #<id>\" when the account has since been "
                 + "deleted; null only when the invoice was never approved.",
-                example = "Aneesh Johny")
+                example = "Aneesh Johny", nullable = true)
         String approvedByName,
 
         @Schema(description = "Timestamp the invoice was approved.", example = "2026-08-03T11:40:00Z")
@@ -115,7 +115,7 @@ public record ConstructionInvoiceDto(
         @Schema(description = "Name of the user that recorded the most recent payment, or their email "
                 + "where the account carries no name. Reads \"User #<id>\" when the account has since "
                 + "been deleted; null only when no payment has been recorded.",
-                example = "Anand Rajashekar")
+                example = "Anand Rajashekar", nullable = true)
         String paymentRecordedByName,
 
         @Schema(description = "Ledger journal entry posted when the invoice was approved.",
@@ -127,7 +127,7 @@ public record ConstructionInvoiceDto(
 
         @Schema(description = "AR invoice raised for this invoice on approval. Present on a sales or "
                 + "service invoice whose project has a client; null otherwise.",
-                example = "1c9d4b7a-0f2e-4a63-8b11-5d7c2e9f4a88")
+                example = "1c9d4b7a-0f2e-4a63-8b11-5d7c2e9f4a88", nullable = true)
         UUID arInvoiceId,
 
         @Schema(description = "Invoice line items.")

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/dtos/ConstructionPaymentDto.java
@@ -85,12 +85,12 @@ public record ConstructionPaymentDto(
         String ifscCode,
 
         @Schema(description = "User id that raised the voucher, taken from the session that created "
-                + "it. Null on vouchers raised before the voucher recorded this.", example = "8")
+                + "it. Null on vouchers raised before the voucher recorded this.", example = "8", nullable = true)
         Long raisedBy,
 
         @Schema(description = "Name of the user that raised the voucher, on the same fallbacks as "
                 + "the verifier name. Null only where the voucher does not record who raised it.",
-                example = "Hrishi")
+                example = "Hrishi", nullable = true)
         String raisedByName,
 
         @Schema(description = "User id that verified the voucher, taken from the session that "
@@ -100,7 +100,7 @@ public record ConstructionPaymentDto(
         @Schema(description = "Name of the user that verified the voucher, or their email where the "
                 + "account carries no name. Reads \"User #<id>\" when the account has since been "
                 + "deleted; null only when the voucher was never verified.",
-                example = "Aneesh Johny")
+                example = "Aneesh Johny", nullable = true)
         String verifiedByName,
 
         @Schema(description = "Timestamp the voucher was verified.", example = "2026-08-06T10:20:00Z")

--- a/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/ledger/dtos/AccountDto.java
@@ -20,7 +20,7 @@ public record AccountDto(
         AccountType type,
 
         @Schema(description = "Parent account id, or null for a root account.",
-                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10")
+                example = "9b2f1c44-7a1e-4e2b-9f0a-2c8d5e6f7a10", nullable = true)
         UUID parentId,
 
         @Schema(description = "Whether the account is active and available for posting.", example = "true")

--- a/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/FinanceSettingsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/settings/dtos/FinanceSettingsDto.java
@@ -9,6 +9,6 @@ public record FinanceSettingsDto(
 
         @Schema(description = "Auto-approval threshold. Null means every construction invoice needs "
                 + "manual approval; a value T auto-approves invoices whose total is below T.",
-                example = "50000.0000")
+                example = "50000.0000", nullable = true)
         BigDecimal approvalThreshold
 ) {}

--- a/src/main/java/org/tornotron/echno_backend/indent/dto/IndentSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/indent/dto/IndentSummaryDto.java
@@ -23,7 +23,7 @@ public class IndentSummaryDto {
     private LocalDateTime createdAt;
 
     @Schema(description = "Id of the employee who raised the indent. Null where the raiser is no "
-            + "longer recorded.", example = "18")
+            + "longer recorded.", example = "18", nullable = true)
     private Long createdById;
 
     @Schema(description = "Name of the employee who raised the indent.", example = "Ramesh Kumar")

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/dto/MaterialMovementHistoryDto.java
@@ -60,7 +60,7 @@ public class MaterialMovementHistoryDto {
 
     @Schema(description = "Display name of the employee who booked the movement. For automated movements this "
             + "is the actor who triggered the source event. Null when the ledger row records no creator.",
-            example = "Asha Menon")
+            example = "Asha Menon", nullable = true)
     private String createdByName;
 
     @Schema(description = "Source document reference for the movement, for example a GRN or challan number.",

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectDto.java
@@ -23,34 +23,35 @@ public class ProjectDto {
     private String projectName;
 
     @Schema(description = "Free-text description of the project. Null when not recorded.",
-            example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
+            example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
+            nullable = true)
     private String description;
 
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
 
-    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai", nullable = true)
     private String projectCity;
 
     @Schema(description = "Indian state or union territory the site is in, used to match statutory "
-            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+            + "compliances. Null when not recorded.", example = "Tamil Nadu", nullable = true)
     private String projectState;
 
-    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004", nullable = true)
     private String projectPostalCode;
 
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
 
     @Schema(description = "Id of the user who created the project. Null on projects created before "
-            + "this was recorded.", example = "17")
+            + "this was recorded.", example = "17", nullable = true)
     private Long createdBy;
 
     @Schema(description = "When the project was last written. Null on projects not written since "
             + "this was recorded. It is a last-write stamp, so it is overwritten by the next edit "
             + "to any field: to read who moved the project's status and when, use "
             + "GET /api/v1/project/web/{id}/status-history.",
-            example = "2026-08-28T16:41:12")
+            example = "2026-08-28T16:41:12", nullable = true)
     private LocalDateTime updatedAt;
 
     @Schema(description = "Id of the user who last wrote the project.", example = "17")
@@ -63,7 +64,7 @@ public class ProjectDto {
     private ProjectType projectType;
 
     @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
-            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d", nullable = true)
     private UUID customerId;
 
     @Schema(description = "Employees assigned to the project team.")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSimpleDto.java
@@ -22,14 +22,14 @@ public class ProjectSimpleDto {
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
 
-    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai", nullable = true)
     private String projectCity;
 
     @Schema(description = "Indian state or union territory the site is in, used to match statutory "
-            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+            + "compliances. Null when not recorded.", example = "Tamil Nadu", nullable = true)
     private String projectState;
 
-    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004", nullable = true)
     private String projectPostalCode;
 
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
@@ -42,7 +42,7 @@ public class ProjectSimpleDto {
     private ProjectType projectType;
 
     @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
-            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d", nullable = true)
     private UUID customerId;
 
     @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectSummaryDto.java
@@ -24,25 +24,25 @@ public class ProjectSummaryDto {
     @Schema(description = "Street address of the site, as one line.", example = "12 Marina Road, Mylapore")
     private String projectAddress;
 
-    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai")
+    @Schema(description = "Town or city the site is in. Null when not recorded.", example = "Chennai", nullable = true)
     private String projectCity;
 
     @Schema(description = "Indian state or union territory the site is in, used to match statutory "
-            + "compliances. Null when not recorded.", example = "Tamil Nadu")
+            + "compliances. Null when not recorded.", example = "Tamil Nadu", nullable = true)
     private String projectState;
 
-    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004")
+    @Schema(description = "Postal (PIN) code of the site. Null when not recorded.", example = "600004", nullable = true)
     private String projectPostalCode;
 
     @Schema(description = "Creation timestamp.", example = "2026-08-01T09:00:00")
     private LocalDateTime createdAt;
 
     @Schema(description = "Id of the user who created the project. Null on projects created before "
-            + "this was recorded.", example = "17")
+            + "this was recorded.", example = "17", nullable = true)
     private Long createdBy;
 
     @Schema(description = "When the project was last written. Null on projects not written since "
-            + "this was recorded.", example = "2026-08-28T16:41:12")
+            + "this was recorded.", example = "2026-08-28T16:41:12", nullable = true)
     private LocalDateTime updatedAt;
 
     @Schema(description = "Id of the user who last wrote the project.", example = "17")
@@ -55,7 +55,7 @@ public class ProjectSummaryDto {
     private ProjectType projectType;
 
     @Schema(description = "Finance customer the project is billed to. Null when no client is set.",
-            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d")
+            example = "6b1e9c22-9f8a-4a1b-9c0e-1d2f3a4b5c6d", nullable = true)
     private UUID customerId;
 
     @Schema(description = "Site latitude in decimal degrees.", example = "13.0827")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -68,7 +68,7 @@ public class StockAdjustmentDto {
     @Schema(description = "Name of the user who submitted the adjustment, or their email where the "
             + "account carries no name. Reads \"User #<id>\" when the account has since been "
             + "deleted; null only when the adjustment was never submitted.",
-            example = "Anand Rajashekar")
+            example = "Anand Rajashekar", nullable = true)
     private String submittedByName;
 
     @Schema(description = "Date and time the adjustment was submitted.", example = "2026-01-15T10:00:00")
@@ -80,7 +80,7 @@ public class StockAdjustmentDto {
     @Schema(description = "Name of the user who approved the adjustment, or their email where the "
             + "account carries no name. Reads \"User #<id>\" when the account has since been "
             + "deleted; null only when the adjustment was never approved.",
-            example = "Aneesh Johny")
+            example = "Aneesh Johny", nullable = true)
     private String approvedByName;
 
     @Schema(description = "Date and time the adjustment was approved.", example = "2026-01-16T09:00:00")
@@ -92,7 +92,7 @@ public class StockAdjustmentDto {
     @Schema(description = "Name of the user who rejected the adjustment, or their email where the "
             + "account carries no name. Reads \"User #<id>\" when the account has since been "
             + "deleted; null only when the adjustment was never rejected.",
-            example = "Aneesh Johny")
+            example = "Aneesh Johny", nullable = true)
     private String rejectedByName;
 
     @Schema(description = "Date and time the adjustment was rejected, if it was rejected.", example = "2026-01-16T09:00:00")
@@ -107,7 +107,7 @@ public class StockAdjustmentDto {
     @Schema(description = "Name of the user who processed the adjustment, or their email where the "
             + "account carries no name. Reads \"User #<id>\" when the account has since been "
             + "deleted; null only when the adjustment was never processed.",
-            example = "Aneesh Johny")
+            example = "Aneesh Johny", nullable = true)
     private String processedByName;
 
     @Schema(description = "Date and time the adjustment was processed.", example = "2026-01-16T11:00:00")

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementDto.java
@@ -49,9 +49,9 @@ public class WbsElementDto {
     private Long projectId;
     @Schema(description = "Name of the project this element belongs to.", example = "Asset Homes - Kochi Riverside Phase 2")
     private String projectName;
-    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12")
+    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12", nullable = true)
     private Long parentId;
-    @Schema(description = "wbsCode of the parent WBS element, or null for a root element.", example = "1.2")
+    @Schema(description = "wbsCode of the parent WBS element, or null for a root element.", example = "1.2", nullable = true)
     private String parentWbsCode;
     @Schema(description = "Employee who created this element.")
     private EmployeeDto createdBy;
@@ -59,6 +59,6 @@ public class WbsElementDto {
     private LocalDateTime createdAt;
     @Schema(description = "Timestamp the element was last updated.", example = "2026-02-05T14:12:00")
     private LocalDateTime updatedAt;
-    @Schema(description = "Child elements, present on tree responses; empty or null on other reads.")
+    @Schema(description = "Child elements, present on tree responses; empty or null on other reads.", nullable = true)
     private List<WbsElementDto> children;
 }

--- a/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementFlatDto.java
+++ b/src/main/java/org/tornotron/echno_backend/wbs/dto/WbsElementFlatDto.java
@@ -29,6 +29,6 @@ public class WbsElementFlatDto {
     private Double progress;
     @Schema(description = "Whether this element has no children.", example = "true")
     private Boolean isLeaf;
-    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12")
+    @Schema(description = "Id of the parent WBS element, or null for a root element.", example = "12", nullable = true)
     private Long parentId;
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/OpenApiNullabilityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OpenApiNullabilityTest.java
@@ -1,0 +1,142 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every field marked {@code @Schema(nullable = true)} says so in the published document.
+ *
+ * <p>The annotation is not self-enforcing, and for the life of this document it did nothing at
+ * all. springdoc serves OpenAPI 3.1, where nullability is a type union rather than a keyword, and
+ * swagger-core reads {@code nullable} into the model and then drops it on the way out. So an
+ * author could write the one annotation that means "this may be null", regenerate, see no diff,
+ * and reasonably conclude the document had no way to say it. That is how a 3 MB contract came to
+ * describe 3069 properties without marking a single one nullable, while a large share of them are
+ * null on most rows. Issue #645.
+ *
+ * <p>{@link org.tornotron.echno_backend.common.configuration.NullableSchemaCustomizer} closes
+ * that. This test is what keeps it closed: it reads the committed document and fails if any
+ * annotated field is not actually described as admitting null. Without the customizer every
+ * annotated field fails here, which is the point. A future springdoc or swagger-core that changes
+ * how the union is written will fail here too, rather than quietly reverting the document to
+ * saying nothing.
+ *
+ * <p>It reads {@code docs/openapi.json} rather than booting an application, because the committed
+ * copy is already held to the served document by {@code OpenApiSnapshotTest} in its own task, and
+ * a second Spring context is the one thing the test JVM has no room for.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class OpenApiNullabilityTest {
+
+    /** The committed contract, relative to the project directory the test task runs in. */
+    private static final Path DOCUMENT = Path.of("docs", "openapi.json");
+
+    /** The JSON Schema type that admits only null. */
+    private static final String NULL_TYPE = "null";
+
+    /**
+     * Reports every annotated field the document does not describe as nullable.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void everyNullableFieldIsDeclaredNullable(JavaClasses productionClasses) {
+        JsonNode schemas = readSchemas();
+        List<String> annotated = new ArrayList<>();
+        List<String> undeclared = new ArrayList<>();
+
+        for (JavaClass javaClass : productionClasses) {
+            for (JavaField field : javaClass.getFields()) {
+                if (!isMarkedNullable(field)) {
+                    continue;
+                }
+                String property = javaClass.getSimpleName() + "." + field.getName();
+                annotated.add(property);
+
+                JsonNode declared = schemas.path(javaClass.getSimpleName())
+                        .path("properties").path(field.getName());
+                if (declared.isMissingNode()) {
+                    undeclared.add(property + ": the document has no such property. A renamed "
+                            + "field, or a schema springdoc names differently");
+                } else if (!admitsNull(declared)) {
+                    undeclared.add(property + ": " + declared);
+                }
+            }
+        }
+
+        assertThat(annotated)
+                .as("no field carries @Schema(nullable = true), so this test is checking nothing. "
+                        + "Either the annotation has been removed from the DTO layer or the class "
+                        + "scan has stopped finding it")
+                .isNotEmpty();
+        assertThat(undeclared)
+                .as("these fields are marked nullable in the code but the committed document does "
+                        + "not say they admit null, so a client reading the contract will write no "
+                        + "guard for them. Regenerate with ./gradlew openApiSnapshot "
+                        + "-PupdateOpenApiSnapshot, and if the field is still not described as "
+                        + "nullable check NullableSchemaCustomizer can express its shape")
+                .isEmpty();
+    }
+
+    private static boolean isMarkedNullable(JavaField field) {
+        return field.isAnnotatedWith(Schema.class)
+                && field.getAnnotationOfType(Schema.class).nullable();
+    }
+
+    /**
+     * Whether a property schema admits null: either as a member of its type union, or as a branch
+     * of the {@code anyOf} a reference has to be wrapped in to say the same thing.
+     */
+    private static boolean admitsNull(JsonNode property) {
+        JsonNode type = property.path("type");
+        if (type.isArray()) {
+            for (JsonNode member : type) {
+                if (NULL_TYPE.equals(member.asText())) {
+                    return true;
+                }
+            }
+        }
+        if (NULL_TYPE.equals(type.asText())) {
+            return true;
+        }
+        for (String composition : List.of("anyOf", "oneOf")) {
+            for (JsonNode branch : property.path(composition)) {
+                if (admitsNull(branch)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static JsonNode readSchemas() {
+        assertThat(DOCUMENT)
+                .as("the committed OpenAPI document is missing; run ./gradlew openApiSnapshot "
+                        + "-PupdateOpenApiSnapshot")
+                .exists();
+        try {
+            return new ObjectMapper().readTree(Files.readString(DOCUMENT))
+                    .path("components").path("schemas");
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot read " + DOCUMENT.toAbsolutePath(), e);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/NullableSchemaCustomizerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/NullableSchemaCustomizerTest.java
@@ -1,0 +1,154 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The conversion from {@code nullable = true} to the OpenAPI 3.1 form it has to take.
+ *
+ * <p>Each case here is a shape the DTO layer actually produces: a scalar property, a property that
+ * is a reference to another model, a collection, and a model that contains itself.
+ */
+class NullableSchemaCustomizerTest {
+
+    private final NullableSchemaCustomizer customizer = new NullableSchemaCustomizer();
+
+    @Test
+    void aNullableScalarGainsNullAsASecondType() {
+        Schema<?> property = nullable(typed("string"));
+        customise(documentWith("Dto", objectWith("name", property)));
+
+        assertThat(property.getTypes()).containsExactly("string", "null");
+    }
+
+    @Test
+    void aNonNullablePropertyIsLeftAlone() {
+        Schema<?> property = typed("string");
+        customise(documentWith("Dto", objectWith("name", property)));
+
+        assertThat(property.getTypes()).containsExactly("string");
+        assertThat(property.getAnyOf()).isNull();
+    }
+
+    @Test
+    void aNullableReferenceBecomesAUnionWithTheNullType() {
+        Schema<?> property = nullable(new Schema<>().$ref("#/components/schemas/ShiftTimingDto"));
+        customise(documentWith("Dto", objectWith("shiftTiming", property)));
+
+        assertThat(property.get$ref())
+                .as("a reference cannot carry a type union, so the reference moves into the union")
+                .isNull();
+        assertThat(property.getAnyOf()).hasSize(2);
+        assertThat(property.getAnyOf().get(0).get$ref())
+                .isEqualTo("#/components/schemas/ShiftTimingDto");
+        assertThat(property.getAnyOf().get(1).getTypes()).containsExactly("null");
+    }
+
+    @Test
+    void aNullableCollectionIsMarkedRatherThanItsElements() {
+        Schema<?> element = typed("string");
+        Schema<?> property = nullable(typed("array"));
+        property.setItems(element);
+        customise(documentWith("Dto", objectWith("tags", property)));
+
+        assertThat(property.getTypes()).containsExactly("array", "null");
+        assertThat(element.getTypes()).containsExactly("string");
+    }
+
+    @Test
+    void aSchemaThatContainsItselfIsVisitedOnce() {
+        Schema<Object> tree = new Schema<>();
+        tree.addType("object");
+        Schema<?> children = nullable(typed("array"));
+        children.setItems(tree);
+        tree.addProperty("children", children);
+
+        customise(documentWith("WbsElementDto", tree));
+
+        assertThat(children.getTypes()).containsExactly("array", "null");
+    }
+
+    @Test
+    void anInlineParameterSchemaIsReachedToo() {
+        Schema<?> parameter = nullable(typed("string"));
+        OpenAPI document = new OpenAPI(SpecVersion.V31).components(new Components());
+        Operation operation = new Operation()
+                .addParametersItem(new Parameter().name("status").schema(parameter));
+        document.setPaths(new Paths());
+        document.getPaths().addPathItem("/tasks", new PathItem().get(operation));
+
+        customise(document);
+
+        assertThat(parameter.getTypes()).containsExactly("string", "null");
+    }
+
+    @Test
+    void anInlineRequestBodySchemaIsReachedToo() {
+        Schema<?> property = nullable(typed("string"));
+        OpenAPI document = new OpenAPI(SpecVersion.V31).components(new Components());
+        Content content = new Content().addMediaType("application/json",
+                new MediaType().schema(objectWith("remarks", property)));
+        Operation operation = new Operation();
+        operation.setRequestBody(new io.swagger.v3.oas.models.parameters.RequestBody()
+                .content(content));
+        document.setPaths(new Paths());
+        document.getPaths().addPathItem("/tasks", new PathItem().post(operation));
+
+        customise(document);
+
+        assertThat(property.getTypes()).containsExactly("string", "null");
+    }
+
+    @Test
+    void aThreePointZeroDocumentKeepsTheKeywordItCanStillWrite() {
+        Schema<?> property = nullable(typed("string"));
+        OpenAPI document = new OpenAPI(SpecVersion.V30).components(new Components());
+        document.getComponents().addSchemas("Dto", objectWith("name", property));
+
+        customise(document);
+
+        assertThat(property.getNullable())
+                .as("3.0 serializes the keyword as it stands, so rewriting it would lose it")
+                .isTrue();
+        assertThat(property.getTypes()).containsExactly("string");
+    }
+
+    private void customise(OpenAPI document) {
+        customizer.customise(document);
+    }
+
+    private static OpenAPI documentWith(String name, Schema<?> schema) {
+        OpenAPI document = new OpenAPI(SpecVersion.V31).components(new Components());
+        document.getComponents().addSchemas(name, schema);
+        return document;
+    }
+
+    private static Schema<Object> objectWith(String property, Schema<?> schema) {
+        Schema<Object> object = new Schema<>();
+        object.addType("object");
+        object.addProperty(property, schema);
+        return object;
+    }
+
+    private static Schema<Object> typed(String type) {
+        Schema<Object> schema = new Schema<>();
+        schema.addType(type);
+        return schema;
+    }
+
+    private static Schema<Object> nullable(Schema<Object> schema) {
+        schema.setNullable(true);
+        return schema;
+    }
+}


### PR DESCRIPTION
Closes part of #645. The wiring is done; the remainder is specified in a comment on the issue rather than left implied.

## The finding

`docs/openapi.json` said nothing about null on any of its 3069 properties, and the reason is not that nobody annotated anything.

springdoc 2.8.6 defaults `springdoc.api-docs.version` to `OPENAPI_3_1`, which is why the document reads `"openapi": "3.1.0"` with no configuration saying so. In 3.1 nullability is a type union rather than the 3.0 `nullable` keyword. swagger-core 2.2.29 reads `@Schema(nullable = true)` onto the model and then discards it: `Schema31Mixin` marks `getNullable()` ignored and writes `types` instead, with no translation between them. Running the resolver directly over an annotated field shows both halves:

```
annotatedNullable   specVersion=V31 nullable=true types=[string]
Json30 render: { "description": "...", "nullable": true }
Json31 render: { "type": "string", "description": "..." }
```

So the one annotation an author would reach for resolved, was held in memory, and produced no diff. Nothing else fills the gap either: `Optional`, JSpecify `@Nullable` and boxed types carry nothing into the schema, and `@NotNull` produces `required`, which is presence rather than nullability. `@Column(nullable = false)` is real information but it sits on the entities, and the DTOs are separate Lombok classes filled by MapStruct.

## The change

`NullableSchemaCustomizer` runs on the assembled document and writes the flag in the form 3.1 uses: a typed property gains `"null"` as a second member of its type, and a bare `$ref` becomes `anyOf` of the reference and the null type, since a reference has no type to add to. A document served as 3.0 is left alone, because the keyword is written out as it stands there.

57 response properties across 25 schemas are then marked. The selector is deliberate rather than opportunistic: they are the properties whose own `description` already said the value may be null, written as prose because the schema could not hold it. Each was established before this change rather than by it, and six were re-checked against the column or the mapper behind them. Nothing is newly declared non-null, so an unmarked field says exactly what it said before, which is nothing.

## Proof

`OpenApiNullabilityTest` reads the committed document and fails when an annotated field is not described as admitting null. Run against `docs/openapi.json` as it stood before this change it reports all 57:

```
OpenApiNullabilityTest > everyNullableFieldIsDeclaredNullable FAILED
    java.lang.AssertionError at OpenApiNullabilityTest.java:96
```

It reads the committed copy rather than booting an application, since `OpenApiSnapshotTest` already holds that copy to the served document in its own task.

`NullableSchemaCustomizerTest` covers the shapes the DTO layer produces: scalar, reference, collection, a model that contains itself, an inline parameter and request body, and the 3.0 document that is left alone.

## Verified on lab `.116`

- `./gradlew test` green (8m 37s, heap 571 MB live of 2048 MB, 28%)
- `./gradlew openApiSnapshot` green after the rebase onto `development`, so the committed document still matches the code
- the document diff is 54 type unions plus 3 `anyOf` conversions and nothing else

## Not in this change

The request side (1094 properties in schemas reachable from a request body) needs null told from absent, and the partial-update surfaces need one decision per class rather than per field: `TaskUpdateFieldsDto` says at class level that a field sent as null is cleared while `categoryId` on the same class cannot be cleared, and `LeaveRequestUpdateFieldsDto.startDate` rejects null outright. The response fields nobody has written down yet (1975 properties in response-only schemas) are per-field reading work, tractable module by module. Both are set out on #645.
