### PR TITLE
Answer which materials have reached their reorder level

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9525,6 +9525,69 @@
         },
         "type": "object"
       },
+      "LowStockMaterialDto": {
+        "description": "A material whose stock has reached or fallen below the reorder level in force at the scope that was asked about.",
+        "properties": {
+          "currentStock": {
+            "description": "Quantity on hand at the scope that was asked about. Zero when the material has no stock there at all.",
+            "example": 3501,
+            "format": "double",
+            "type": "number"
+          },
+          "materialId": {
+            "description": "Material id.",
+            "example": 12,
+            "format": "int64",
+            "type": "integer"
+          },
+          "materialName": {
+            "description": "Name of the material.",
+            "example": "TMT Bar 12mm",
+            "type": "string"
+          },
+          "moq": {
+            "description": "The minimum order quantity in force at that scope, as the smallest quantity a purchase can be raised for. Null when none is recorded.",
+            "example": 10000,
+            "format": "double",
+            "type": "number"
+          },
+          "projectId": {
+            "description": "Project the stock was counted within, null when the whole organization was counted.",
+            "example": 5,
+            "format": "int64",
+            "type": "integer"
+          },
+          "reorderLevel": {
+            "description": "The reorder level that was applied. At storage-location scope this is the location's override when it has one, and the material's own level otherwise.",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "shortfall": {
+            "description": "How far below the reorder level the stock is, never negative. Zero for a material sitting exactly on its level.",
+            "example": 7499,
+            "format": "double",
+            "type": "number"
+          },
+          "sku": {
+            "description": "Stock keeping unit code.",
+            "example": "TMT-12MM-001",
+            "type": "string"
+          },
+          "storageLocationId": {
+            "description": "Storage location the stock was counted at, null unless one was asked about.",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          },
+          "unit": {
+            "description": "Unit of measure for the material.",
+            "example": "kg",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "MaterialConsumptionCreationDto": {
         "description": "Payload to record material consumed against a project. Stock sufficiency is checked at the material and project level, or at the storage location level when one is given.",
         "properties": {
@@ -11723,6 +11786,52 @@
           "content": {
             "items": {
               "$ref": "#/components/schemas/LeaveRequestDto"
+            },
+            "type": "array"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "numberOfElements": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "size": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "totalElements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PageLowStockMaterialDto": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/LowStockMaterialDto"
             },
             "type": "array"
           },
@@ -72198,6 +72307,155 @@
         ]
       }
     },
+    "/api/v1/materials/low-stock": {
+      "get": {
+        "description": "Returns a page of the materials whose stock has reached the reorder level in force, most depleted first as a fraction of that level. With neither id, stock is totalled across the organization and every material in the catalogue is a candidate, including one holding nothing anywhere. With projectId, stock is totalled over that project's storage locations and only materials held on the project are candidates. With both ids, stock is read at that one location and its threshold override applies in place of the material's global level. A material with no reorder level set is never reported. The comparison is at or below, matching the low-stock badge in the console. X-Total-Count is not used here: the page's totalElements is the true count, so a caller wanting only the number can ask for pageSize=1 and read it.",
+        "operationId": "getLowStockMaterials_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "storageLocationId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageLowStockMaterialDto"
+                }
+              }
+            },
+            "description": "Page of low-stock materials returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "A storage location was given without a project, or belongs to a different project"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the material read or admin authority"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No project or storage location with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List materials at or below their reorder level",
+        "tags": [
+          "Materials"
+        ]
+      }
+    },
     "/api/v1/materials/search": {
       "get": {
         "description": "Returns materials whose name matches the given search term, such as \"Cement\" or \"TMT\".",
@@ -72654,6 +72912,155 @@
           }
         },
         "summary": "List materials, paginated",
+        "tags": [
+          "Materials (Web)"
+        ]
+      }
+    },
+    "/api/v1/materials/web/low-stock": {
+      "get": {
+        "description": "Returns a page of the materials whose stock has reached the reorder level in force, most depleted first as a fraction of that level. With neither id, stock is totalled across the organization and every material in the catalogue is a candidate, including one holding nothing anywhere. With projectId, stock is totalled over that project's storage locations and only materials held on the project are candidates. With both ids, stock is read at that one location and its threshold override applies in place of the material's global level. A material with no reorder level set is never reported. The comparison is at or below, matching the low-stock badge in the console. X-Total-Count is not used here: the page's totalElements is the true count, so a caller wanting only the number can ask for pageSize=1 and read it.",
+        "operationId": "getLowStockMaterials",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "storageLocationId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageLowStockMaterialDto"
+                }
+              }
+            },
+            "description": "Page of low-stock materials returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "A storage location was given without a project, or belongs to a different project"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No project or storage location with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List materials at or below their reorder level",
         "tags": [
           "Materials (Web)"
         ]

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,9 +14,11 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.material.dto.LowStockMaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
+import org.tornotron.echno_backend.material.lowstock.LowStockService;
 import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
@@ -38,11 +41,14 @@ public class MaterialController {
 
     private final MaterialService materialService;
     private final MaterialLocationThresholdService thresholdService;
+    private final LowStockService lowStockService;
 
     public MaterialController(MaterialService materialService,
-                             MaterialLocationThresholdService thresholdService) {
+                             MaterialLocationThresholdService thresholdService,
+                             LowStockService lowStockService) {
         this.materialService = materialService;
         this.thresholdService = thresholdService;
+        this.lowStockService = lowStockService;
     }
 
     @PostMapping
@@ -110,6 +116,36 @@ public class MaterialController {
     ) {
         Page<MaterialDto> materials = materialService.getAllMaterials(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(materials);
+    }
+
+    @GetMapping("/low-stock")
+    @PreAuthorize("hasAuthority('material:read') or hasAuthority('material:admin')")
+    @Operation(
+            summary = "List materials at or below their reorder level",
+            description = "Returns a page of the materials whose stock has reached the reorder level "
+                    + "in force, most depleted first as a fraction of that level. With neither id, "
+                    + "stock is totalled across the organization and every material in the catalogue "
+                    + "is a candidate, including one holding nothing anywhere. With projectId, stock "
+                    + "is totalled over that project's storage locations and only materials held on "
+                    + "the project are candidates. With both ids, stock is read at that one location "
+                    + "and its threshold override applies in place of the material's global level. A "
+                    + "material with no reorder level set is never reported. The comparison is at or "
+                    + "below, matching the low-stock badge in the console. X-Total-Count is not used "
+                    + "here: the page's totalElements is the true count, so a caller wanting only the "
+                    + "number can ask for pageSize=1 and read it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of low-stock materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A storage location was given without a project, or belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the material read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or storage location with the given id")
+    })
+    public ResponseEntity<Page<LowStockMaterialDto>> getLowStockMaterials(
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) Long storageLocationId,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(lowStockService.findLowStock(projectId, storageLocationId,
+                PageRequest.of(pageQuery.getPageNo(), pageQuery.getPageSize())));
     }
 
     @GetMapping("/search")

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,9 +14,11 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.material.dto.LowStockMaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
+import org.tornotron.echno_backend.material.lowstock.LowStockService;
 import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
@@ -37,11 +40,14 @@ public class MaterialControllerWeb {
 
     private final MaterialService materialService;
     private final MaterialLocationThresholdService thresholdService;
+    private final LowStockService lowStockService;
 
     public MaterialControllerWeb(MaterialService materialService,
-                                MaterialLocationThresholdService thresholdService) {
+                                MaterialLocationThresholdService thresholdService,
+                                LowStockService lowStockService) {
         this.materialService = materialService;
         this.thresholdService = thresholdService;
+        this.lowStockService = lowStockService;
     }
 
     @PostMapping
@@ -109,6 +115,36 @@ public class MaterialControllerWeb {
     ) {
         Page<MaterialDto> materials = materialService.getAllMaterials(pageQuery.getPageNo(), pageQuery.getPageSize());
         return ResponseEntity.ok(materials);
+    }
+
+    @GetMapping("/low-stock")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "List materials at or below their reorder level",
+            description = "Returns a page of the materials whose stock has reached the reorder level "
+                    + "in force, most depleted first as a fraction of that level. With neither id, "
+                    + "stock is totalled across the organization and every material in the catalogue "
+                    + "is a candidate, including one holding nothing anywhere. With projectId, stock "
+                    + "is totalled over that project's storage locations and only materials held on "
+                    + "the project are candidates. With both ids, stock is read at that one location "
+                    + "and its threshold override applies in place of the material's global level. A "
+                    + "material with no reorder level set is never reported. The comparison is at or "
+                    + "below, matching the low-stock badge in the console. X-Total-Count is not used "
+                    + "here: the page's totalElements is the true count, so a caller wanting only the "
+                    + "number can ask for pageSize=1 and read it."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of low-stock materials returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "A storage location was given without a project, or belongs to a different project"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project or storage location with the given id")
+    })
+    public ResponseEntity<Page<LowStockMaterialDto>> getLowStockMaterials(
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) Long storageLocationId,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(lowStockService.findLowStock(projectId, storageLocationId,
+                PageRequest.of(pageQuery.getPageNo(), pageQuery.getPageSize())));
     }
 
     @GetMapping("/search")

--- a/src/main/java/org/tornotron/echno_backend/material/dto/LowStockMaterialDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/LowStockMaterialDto.java
@@ -1,0 +1,47 @@
+package org.tornotron.echno_backend.material.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "A material whose stock has reached or fallen below the reorder level in "
+        + "force at the scope that was asked about.")
+@Data
+public class LowStockMaterialDto {
+
+    @Schema(description = "Material id.", example = "12")
+    private Long materialId;
+
+    @Schema(description = "Stock keeping unit code.", example = "TMT-12MM-001")
+    private String sku;
+
+    @Schema(description = "Name of the material.", example = "TMT Bar 12mm")
+    private String materialName;
+
+    @Schema(description = "Unit of measure for the material.", example = "kg")
+    private String unit;
+
+    @Schema(description = "Quantity on hand at the scope that was asked about. Zero when the "
+            + "material has no stock there at all.", example = "3501")
+    private Double currentStock;
+
+    @Schema(description = "The reorder level that was applied. At storage-location scope this is "
+            + "the location's override when it has one, and the material's own level otherwise.",
+            example = "11000")
+    private Double reorderLevel;
+
+    @Schema(description = "How far below the reorder level the stock is, never negative. Zero for "
+            + "a material sitting exactly on its level.", example = "7499")
+    private Double shortfall;
+
+    @Schema(description = "The minimum order quantity in force at that scope, as the smallest "
+            + "quantity a purchase can be raised for. Null when none is recorded.", example = "10000")
+    private Double moq;
+
+    @Schema(description = "Project the stock was counted within, null when the whole organization "
+            + "was counted.", example = "5")
+    private Long projectId;
+
+    @Schema(description = "Storage location the stock was counted at, null unless one was asked "
+            + "about.", example = "2")
+    private Long storageLocationId;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRepository.java
@@ -1,0 +1,186 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.material.Material;
+
+/**
+ * The reorder-level comparison, at each of the three scopes stock is held at.
+ *
+ * <p>Kept off {@code MaterialRepository} because these are three long grouped reads answering one
+ * question, and none of them returns a material: they return a material's position against a
+ * threshold, which is a different thing and has its own projection.
+ *
+ * <h2>What counts as configured</h2>
+ *
+ * <p>A null reorder level means nobody set one, and a material with none is not a candidate at any
+ * scope. A level of zero is treated as set, because the web app treats it as set and the point of
+ * this query is to agree with the badge the user is already looking at rather than to disagree with
+ * it by a rule of its own. It flags the material only once it has nothing on hand.
+ *
+ * <h2>At or below, not below</h2>
+ *
+ * <p>The comparison is {@code <=}. A reorder level is the level at which a reorder is placed, so
+ * sitting exactly on it is the moment to act, not the moment before. The web app's six client-side
+ * comparisons are all {@code <=} as well, which is the other half of the reason: an endpoint that
+ * disagreed with the badge by one boundary case would be worse than no endpoint.
+ *
+ * <h2>Why organization scope left-joins and the other two do not</h2>
+ *
+ * <p>At organization scope the candidate set is the catalogue, so a material with no stock row
+ * anywhere has to appear: it has nothing on hand, which is as far below its level as it is possible
+ * to be, and an inner join would silently drop exactly the materials most worth seeing. At project
+ * and storage-location scope the candidate set is what is held there. Every catalogue material would
+ * otherwise be reported as out of stock at every project that has never carried it, which is a list
+ * of everything and tells nobody anything.
+ *
+ * <h2>Ordering</h2>
+ *
+ * <p>Most depleted first, as the fraction of the level that is missing rather than the absolute
+ * shortfall, because absolute shortfall is in the material's own unit and 25,000 bricks would
+ * outrank a site with no cement at all. A level of zero cannot be divided by, and a material at or
+ * below a level of zero has nothing, so it sorts as fully depleted. The material id breaks ties, so
+ * paging over the result is stable.
+ */
+public interface LowStockRepository extends Repository<Material, Long> {
+
+    /**
+     * Every material in the catalogue whose stock across the whole organization has reached its
+     * reorder level.
+     *
+     * <p>The count query re-states the aggregate as a correlated subquery rather than counting the
+     * groups, because a JPQL count cannot be derived from a query carrying {@code GROUP BY} and
+     * {@code HAVING}.
+     *
+     * @param organizationId The tenant to read within.
+     * @param pageable Which page to return. Pass it unsorted: the query orders by severity.
+     * @return A page of materials at or below their level, most depleted first.
+     */
+    @Query(value = """
+            SELECT new org.tornotron.echno_backend.material.lowstock.LowStockRow(
+                       m.id, m.sku, m.materialName, m.unit, m.moq, m.reorderLevel,
+                       COALESCE(SUM(cs.currentQuantity), 0.0))
+            FROM Material m
+            LEFT JOIN CurrentStock cs ON cs.material = m AND cs.organization.id = :organizationId
+            WHERE m.organization.id = :organizationId AND m.reorderLevel IS NOT NULL
+            GROUP BY m.id, m.sku, m.materialName, m.unit, m.moq, m.reorderLevel
+            HAVING COALESCE(SUM(cs.currentQuantity), 0.0) <= m.reorderLevel
+            ORDER BY CASE WHEN m.reorderLevel > 0
+                          THEN (m.reorderLevel - COALESCE(SUM(cs.currentQuantity), 0.0)) / m.reorderLevel
+                          ELSE 1.0 END DESC,
+                     m.id ASC
+            """,
+            countQuery = """
+            SELECT COUNT(m) FROM Material m
+            WHERE m.organization.id = :organizationId AND m.reorderLevel IS NOT NULL
+              AND COALESCE((SELECT SUM(cs.currentQuantity) FROM CurrentStock cs
+                            WHERE cs.material = m AND cs.organization.id = :organizationId), 0.0)
+                  <= m.reorderLevel
+            """)
+    Page<LowStockRow> findLowStockForOrganization(@Param("organizationId") Long organizationId,
+                                                  Pageable pageable);
+
+    /**
+     * Every material held on one project whose stock across that project's storage locations has
+     * reached the material's reorder level.
+     *
+     * <p>Per-location overrides are not consulted here and cannot be: a project holds stock at
+     * several locations, so there is no single override that applies to the total.
+     *
+     * @param organizationId The tenant to read within.
+     * @param projectId The project whose stock to total.
+     * @param pageable Which page to return. Pass it unsorted: the query orders by severity.
+     * @return A page of materials at or below their level on that project, most depleted first.
+     */
+    @Query(value = """
+            SELECT new org.tornotron.echno_backend.material.lowstock.LowStockRow(
+                       m.id, m.sku, m.materialName, m.unit, m.moq, m.reorderLevel,
+                       SUM(cs.currentQuantity))
+            FROM CurrentStock cs
+            JOIN cs.material m
+            WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId
+              AND m.reorderLevel IS NOT NULL
+            GROUP BY m.id, m.sku, m.materialName, m.unit, m.moq, m.reorderLevel
+            HAVING SUM(cs.currentQuantity) <= m.reorderLevel
+            ORDER BY CASE WHEN m.reorderLevel > 0
+                          THEN (m.reorderLevel - SUM(cs.currentQuantity)) / m.reorderLevel
+                          ELSE 1.0 END DESC,
+                     m.id ASC
+            """,
+            countQuery = """
+            SELECT COUNT(DISTINCT m.id)
+            FROM CurrentStock cs
+            JOIN cs.material m
+            WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId
+              AND m.reorderLevel IS NOT NULL
+              AND (SELECT SUM(sub.currentQuantity) FROM CurrentStock sub
+                   WHERE sub.material = m AND sub.project.id = :projectId
+                     AND sub.organization.id = :organizationId)
+                  <= m.reorderLevel
+            """)
+    Page<LowStockRow> findLowStockForProject(@Param("organizationId") Long organizationId,
+                                             @Param("projectId") Long projectId,
+                                             Pageable pageable);
+
+    /**
+     * Every material held at one storage location whose stock there has reached the reorder level
+     * in force at that location.
+     *
+     * <p>This is the only scope where a {@code MaterialLocationThreshold} means anything, and it is
+     * consulted for the reorder level and the minimum order quantity both. A location with no
+     * override, or one whose override leaves the field null, falls back to the material's global
+     * level, which is the fallback the override entity documents.
+     *
+     * <p>The material is a candidate only if some level survives that fallback, so a material with
+     * neither an override nor a global level is left alone here exactly as it is at the other two
+     * scopes.
+     *
+     * <p>One row per material: the unique constraint on {@code CurrentStock} allows only one
+     * balance per material, project and location, so nothing needs grouping.
+     *
+     * @param organizationId The tenant to read within.
+     * @param projectId The project the location holds stock for.
+     * @param storageLocationId The storage location to read at.
+     * @param pageable Which page to return. Pass it unsorted: the query orders by severity.
+     * @return A page of materials at or below their effective level there, most depleted first.
+     */
+    @Query(value = """
+            SELECT new org.tornotron.echno_backend.material.lowstock.LowStockRow(
+                       m.id, m.sku, m.materialName, m.unit,
+                       COALESCE(t.moq, m.moq), COALESCE(t.reorderLevel, m.reorderLevel),
+                       cs.currentQuantity)
+            FROM CurrentStock cs
+            JOIN cs.material m
+            LEFT JOIN MaterialLocationThreshold t
+                 ON t.material = m AND t.storageLocation.id = :storageLocationId
+                    AND t.organization.id = :organizationId
+            WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId
+              AND cs.storageLocation.id = :storageLocationId
+              AND COALESCE(t.reorderLevel, m.reorderLevel) IS NOT NULL
+              AND cs.currentQuantity <= COALESCE(t.reorderLevel, m.reorderLevel)
+            ORDER BY CASE WHEN COALESCE(t.reorderLevel, m.reorderLevel) > 0
+                          THEN (COALESCE(t.reorderLevel, m.reorderLevel) - cs.currentQuantity)
+                               / COALESCE(t.reorderLevel, m.reorderLevel)
+                          ELSE 1.0 END DESC,
+                     m.id ASC
+            """,
+            countQuery = """
+            SELECT COUNT(cs)
+            FROM CurrentStock cs
+            JOIN cs.material m
+            LEFT JOIN MaterialLocationThreshold t
+                 ON t.material = m AND t.storageLocation.id = :storageLocationId
+                    AND t.organization.id = :organizationId
+            WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId
+              AND cs.storageLocation.id = :storageLocationId
+              AND COALESCE(t.reorderLevel, m.reorderLevel) IS NOT NULL
+              AND cs.currentQuantity <= COALESCE(t.reorderLevel, m.reorderLevel)
+            """)
+    Page<LowStockRow> findLowStockAtStorageLocation(@Param("organizationId") Long organizationId,
+                                                    @Param("projectId") Long projectId,
+                                                    @Param("storageLocationId") Long storageLocationId,
+                                                    Pageable pageable);
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRow.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockRow.java
@@ -1,0 +1,36 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+/**
+ * One material found at or below its reorder level, as the repository reads it.
+ *
+ * <p>A flat projection rather than the {@code Material} entity, because the only thing wanted
+ * from the material is five scalars and the quantity beside them is an aggregate the entity
+ * does not carry. Reading the entity would load the catalogue row and then still need the
+ * grouped stock read, and the association graph hanging off it is of no use to a caller who
+ * asked what is running out.
+ *
+ * <p>The threshold is the one that was actually applied, not necessarily the material's own:
+ * at storage-location scope a {@code MaterialLocationThreshold} override takes its place, and
+ * the same goes for the minimum order quantity. Which one it was is not recorded here, because
+ * a caller acting on the row wants the level that decided the row, and the material's global
+ * level is one read away for anyone who wants both.
+ *
+ * @param materialId The material at or below its level.
+ * @param sku Its stock keeping unit code, null when the material has none.
+ * @param materialName Its name.
+ * @param unit Its unit of measure.
+ * @param moq The minimum order quantity in force at the scope that was asked about.
+ * @param reorderLevel The reorder level in force at that scope: what {@code currentStock} was
+ *         compared against.
+ * @param currentStock The quantity on hand at that scope. Zero, never null: a material with no
+ *         stock row at all reads as nothing on hand rather than as unknown.
+ */
+public record LowStockRow(
+        Long materialId,
+        String sku,
+        String materialName,
+        String unit,
+        Double moq,
+        Double reorderLevel,
+        Double currentStock) {
+}

--- a/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/lowstock/LowStockService.java
@@ -1,0 +1,141 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.material.dto.LowStockMaterialDto;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
+
+/**
+ * Answers which materials have reached their reorder level.
+ *
+ * <p>Setting a reorder level is an act somebody performs expecting a consequence, and until this
+ * existed the only consequence anywhere was a badge the web app computed for itself over whatever
+ * materials that browser had loaded. That comparison is not wrong so much as partial: it is made
+ * over one uncapped list endpoint's worth of catalogue, it is made against the material's global
+ * level even on the screen that breaks stock down by storage location, and it exists only while
+ * somebody has the screen open. This is the same comparison made where the data is, over all of it,
+ * at the scope the caller asks about.
+ *
+ * <h2>Scope</h2>
+ *
+ * <p>Three, matching the scopes the material stock endpoint already reads at, because the answer is
+ * genuinely different at each and picking one would be picking wrong for somebody. A material can
+ * be comfortable across an organization and nearly out at four of its sites, and on this
+ * installation one is: the aggregate figure the dashboard shows says it is fine.
+ *
+ * <h2>Nothing is scheduled, and nothing is raised</h2>
+ *
+ * <p>This is a query. It costs nothing when nobody asks, and it tells nobody anything at two in the
+ * morning. Making it tell somebody needs a delivery path, and the one this installation has does
+ * not work: see the issue this was built for.
+ */
+@Service
+public class LowStockService {
+
+    private final LowStockRepository lowStockRepository;
+    private final ProjectRepository projectRepository;
+    private final StorageLocationRepository storageLocationRepository;
+
+    public LowStockService(LowStockRepository lowStockRepository,
+                           ProjectRepository projectRepository,
+                           StorageLocationRepository storageLocationRepository) {
+        this.lowStockRepository = lowStockRepository;
+        this.projectRepository = projectRepository;
+        this.storageLocationRepository = storageLocationRepository;
+    }
+
+    /**
+     * The materials at or below their reorder level, at the scope the arguments describe.
+     *
+     * <p>Both ids absent reads the whole organization; a project alone totals that project's
+     * locations; a project and a location read that one location, and only there is a per-location
+     * threshold override applied.
+     *
+     * <p>A project or location that does not exist in this tenant is a 404 rather than an empty
+     * page. On this endpoint the difference matters more than it usually does: an empty page means
+     * "nothing has run out", which is the most reassuring answer the endpoint can give, and it must
+     * never be the answer to a question that was never actually asked of any real project.
+     *
+     * @param projectId The project to scope to, or null for the whole organization.
+     * @param storageLocationId The storage location to scope to. Requires a project, because stock
+     *         is held per project and location together.
+     * @param pageable Which page to return. Any sort on it is dropped: the query orders by severity.
+     * @return A page of materials at or below their level, most depleted first.
+     * @throws InvalidRequestException if a storage location is given without a project, or if it
+     *         belongs to a different project.
+     * @throws ResourceNotFoundException if the project or storage location is not in this tenant.
+     */
+    @Transactional(readOnly = true)
+    public Page<LowStockMaterialDto> findLowStock(Long projectId, Long storageLocationId,
+                                                  Pageable pageable) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+
+        if (storageLocationId != null && projectId == null) {
+            throw new InvalidRequestException(
+                    "A storage location can only be read within a project, so projectId is required "
+                            + "when storageLocationId is given");
+        }
+
+        if (projectId != null && !projectRepository.existsByIdAndOrganization_Id(projectId, orgId)) {
+            throw new ResourceNotFoundException(
+                    "Project with ID " + projectId + " was not found in this organization");
+        }
+        if (storageLocationId != null) {
+            StorageLocation location = storageLocationRepository
+                    .findByIdAndOrganization_Id(storageLocationId, orgId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Storage location with ID "
+                            + storageLocationId + " was not found in this organization"));
+            // A location belonging to another project can hold no stock for this one, so the
+            // query over that pairing would return nothing and read as "nothing has run out".
+            // The same rule every write path applies, applied here for that reason.
+            StorageLocationScope.requireUsableFromProject(location, projectId);
+        }
+
+        Page<LowStockRow> rows;
+        if (storageLocationId != null) {
+            rows = lowStockRepository.findLowStockAtStorageLocation(orgId, projectId, storageLocationId, unsorted);
+        } else if (projectId != null) {
+            rows = lowStockRepository.findLowStockForProject(orgId, projectId, unsorted);
+        } else {
+            rows = lowStockRepository.findLowStockForOrganization(orgId, unsorted);
+        }
+
+        return rows.map(row -> toDto(row, projectId, storageLocationId));
+    }
+
+    /**
+     * One row as the API returns it.
+     *
+     * <p>The shortfall is computed here rather than in the query because it is arithmetic on two
+     * numbers the row already carries, and it is floored at zero so a material sitting exactly on
+     * its level reports nothing missing rather than a negative quantity. The scope ids are echoed
+     * from the request rather than joined for, since the caller named them and a join to fetch back
+     * what was passed in would be two more tables for no new information.
+     */
+    private LowStockMaterialDto toDto(LowStockRow row, Long projectId, Long storageLocationId) {
+        LowStockMaterialDto dto = new LowStockMaterialDto();
+        dto.setMaterialId(row.materialId());
+        dto.setSku(row.sku());
+        dto.setMaterialName(row.materialName());
+        dto.setUnit(row.unit());
+        dto.setCurrentStock(row.currentStock());
+        dto.setReorderLevel(row.reorderLevel());
+        dto.setMoq(row.moq());
+        dto.setProjectId(projectId);
+        dto.setStorageLocationId(storageLocationId);
+
+        double shortfall = row.reorderLevel() - row.currentStock();
+        dto.setShortfall(Math.max(0.0, shortfall));
+        return dto;
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
@@ -191,7 +191,7 @@ class CappedWebListingTest {
     void materialsReadTheFirstCappedPage() {
         when(materialService.getAllMaterials(anyInt(), anyInt())).thenReturn(Page.empty());
 
-        new MaterialControllerWeb(materialService, null).getAllMaterials();
+        new MaterialControllerWeb(materialService, null, null).getAllMaterials();
 
         verify(materialService).getAllMaterials(0, UnpagedResultCap.MAX_ROWS);
     }

--- a/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.material.lowstock;
 
+import org.hibernate.Session;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -176,6 +177,35 @@ class LowStockRepositoryIT extends AbstractIntegrationTest {
         // number and not the rows. A count derived from the page would report two.
         assertThat(firstOfFive.getContent()).hasSize(2);
         assertThat(firstOfFive.getTotalElements()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("the tenant filter does not turn the organization-scope outer join into an inner one")
+    void organizationScope_survivesTheTenantFilterBeingEnabled() {
+        Organization org = persistOrganization("filter-on");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+        Material stocked = persistMaterial(org, "FLT-1", "Cement", 100.0);
+        persistStock(org, stocked, project, store, 10.0);
+        Material neverStocked = persistMaterial(org, "FLT-2", "Red Bricks", 25000.0);
+        em.flush();
+        em.clear();
+
+        // Every entity this query touches carries the orgFilter, which is enabled per request in
+        // the running application and not in a plain @DataJpaTest. A filter restriction placed in
+        // the WHERE clause rather than the ON clause would silently turn the outer join into an
+        // inner one and drop the material with no stock row, which is the one case the
+        // organization scope exists to catch. The filter is enabled here so that cannot regress
+        // unnoticed on a Hibernate upgrade.
+        em.getEntityManager().unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", org.getId());
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        assertThat(page.getContent()).extracting(LowStockRow::materialId)
+                .containsExactly(neverStocked.getId(), stocked.getId());
+        assertThat(page.getTotalElements()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockRepositoryIT.java
@@ -1,0 +1,351 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStock;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.threshold.MaterialLocationThreshold;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The reorder-level comparison against a real CockroachDB.
+ *
+ * <p>Every case here is one the web app's client-side comparison gets wrong or cannot see, so the
+ * assertions are as much a statement of what the endpoint is for as they are a regression net. The
+ * ones that would pass just as happily against a naive query are the two joins and the boundary:
+ * an inner join at organization scope silently loses the material with no stock row at all, which
+ * is the most depleted material there can be, and a strict {@code <} loses the material sitting
+ * exactly on its level, which is the moment the level exists to name.
+ *
+ * <p>Runs under the same {@code @DataJpaTest} configuration as the other repository tests, so it
+ * shares their Spring context rather than adding one.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LowStockRepositoryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private LowStockRepository lowStockRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private static final PageRequest FIRST_PAGE = PageRequest.of(0, 50);
+
+    @Test
+    @DisplayName("organization scope reports a material that has no stock row anywhere")
+    void organizationScope_reportsAMaterialWithNoStockRowAtAll() {
+        Organization org = persistOrganization("no-stock-row");
+        Material bricks = persistMaterial(org, "BRK-1", "Red Bricks", 25000.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        // A material stocked nowhere holds nothing, which is as far below its level as it goes.
+        // An inner join to CurrentStock would drop it and report the organization as healthy.
+        assertThat(page.getContent()).extracting(LowStockRow::materialId).containsExactly(bricks.getId());
+        assertThat(page.getContent().get(0).currentStock()).isEqualTo(0.0);
+        assertThat(page.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("organization scope reports a material sitting exactly on its reorder level")
+    void organizationScope_reportsAMaterialExactlyOnItsLevel() {
+        Organization org = persistOrganization("on-the-level");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+        Material plywood = persistMaterial(org, "PLY-1", "Plywood", 500.0);
+        persistStock(org, plywood, project, store, 500.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        assertThat(page.getContent()).extracting(LowStockRow::materialId).containsExactly(plywood.getId());
+    }
+
+    @Test
+    @DisplayName("organization scope ignores a material with no reorder level set")
+    void organizationScope_ignoresAMaterialWithNoReorderLevel() {
+        Organization org = persistOrganization("no-level");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+        Material wood = persistMaterial(org, "WD-1", "Wood", null);
+        persistStock(org, wood, project, store, 5.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        // Five units left and nobody said what "low" means for this material, so there is nothing
+        // to report. A threshold nobody set is not a threshold that was crossed.
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("organization scope totals every project and location, so a healthy total hides a short site")
+    void organizationScope_totalsAcrossProjectsAndLocations() {
+        Organization org = persistOrganization("totals");
+        Project siteA = persistProject(org, "Site A");
+        Project siteB = persistProject(org, "Site B");
+        StorageLocation store = persistLocation(org, "Store");
+        Material steel = persistMaterial(org, "STL-1", "TNT Steel", 30.0);
+        persistStock(org, steel, siteA, store, 59.0);
+        persistStock(org, steel, siteB, store, 1.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> orgWide = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+        Page<LowStockRow> onSiteB = lowStockRepository.findLowStockForProject(org.getId(), siteB.getId(), FIRST_PAGE);
+
+        // Sixty units across the organization against a level of thirty, so nothing is reported
+        // there. Site B has one unit, and that is what the aggregate figure on the dashboard
+        // cannot say. Both answers are correct and they are answers to different questions.
+        assertThat(orgWide.getContent()).isEmpty();
+        assertThat(onSiteB.getContent()).extracting(LowStockRow::materialId).containsExactly(steel.getId());
+        assertThat(onSiteB.getContent().get(0).currentStock()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("organization scope stays inside the tenant")
+    void organizationScope_staysInsideTheTenant() {
+        Organization mine = persistOrganization("mine");
+        Organization theirs = persistOrganization("theirs");
+        Material ours = persistMaterial(mine, "OUR-1", "Cement", 100.0);
+        persistMaterial(theirs, "THR-1", "Cement", 100.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(mine.getId(), FIRST_PAGE);
+
+        assertThat(page.getContent()).extracting(LowStockRow::materialId).containsExactly(ours.getId());
+    }
+
+    @Test
+    @DisplayName("organization scope orders by the fraction of the level that is missing, not by quantity")
+    void organizationScope_ordersByFractionMissingRatherThanQuantity() {
+        Organization org = persistOrganization("ordering");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+
+        Material bricks = persistMaterial(org, "BRK-2", "Red Bricks", 25000.0);
+        persistStock(org, bricks, project, store, 20000.0);   // 20% missing, 5,000 units
+        Material cement = persistMaterial(org, "CEM-2", "Cement", 100.0);
+        persistStock(org, cement, project, store, 10.0);      // 90% missing, 90 units
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        // Ordering on the absolute shortfall would put the bricks first on the strength of a
+        // number measured in bricks. The site is far closer to running out of cement.
+        assertThat(page.getContent()).extracting(LowStockRow::materialId)
+                .containsExactly(cement.getId(), bricks.getId());
+    }
+
+    @Test
+    @DisplayName("organization scope counts every match, not just the page")
+    void organizationScope_countsEveryMatchAcrossPages() {
+        Organization org = persistOrganization("paging");
+        for (int i = 0; i < 5; i++) {
+            persistMaterial(org, "PG-" + i, "Material " + i, 10.0);
+        }
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> firstOfFive = lowStockRepository
+                .findLowStockForOrganization(org.getId(), PageRequest.of(0, 2));
+
+        // The count is the whole point of the endpoint for the dashboard card, which wants the
+        // number and not the rows. A count derived from the page would report two.
+        assertThat(firstOfFive.getContent()).hasSize(2);
+        assertThat(firstOfFive.getTotalElements()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("a reorder level of zero sorts as fully depleted rather than dividing by zero")
+    void organizationScope_survivesAReorderLevelOfZero() {
+        Organization org = persistOrganization("zero-level");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+
+        Material zeroLevel = persistMaterial(org, "ZRO-1", "Sand", 0.0);
+        persistStock(org, zeroLevel, project, store, 0.0);
+        Material cement = persistMaterial(org, "CEM-7", "Cement", 100.0);
+        persistStock(org, cement, project, store, 90.0);   // 10% missing
+        em.flush();
+        em.clear();
+
+        // The severity ordering divides by the level, and the database raises on a division by
+        // zero rather than returning null, so an unguarded expression would turn this into a 500
+        // for any tenant that ever typed a zero into the field.
+        Page<LowStockRow> page = lowStockRepository.findLowStockForOrganization(org.getId(), FIRST_PAGE);
+
+        assertThat(page.getContent()).extracting(LowStockRow::materialId)
+                .containsExactly(zeroLevel.getId(), cement.getId());
+    }
+
+    @Test
+    @DisplayName("project scope ignores a material the project has never held")
+    void projectScope_ignoresAMaterialNeverHeldOnTheProject() {
+        Organization org = persistOrganization("never-held");
+        Project siteA = persistProject(org, "Site A");
+        Project siteB = persistProject(org, "Site B");
+        StorageLocation store = persistLocation(org, "Store");
+
+        Material cement = persistMaterial(org, "CEM-3", "Cement", 100.0);
+        persistStock(org, cement, siteA, store, 5.0);
+        persistMaterial(org, "TILE-3", "Ceramic Tiles", 100.0);   // in the catalogue, held nowhere
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository.findLowStockForProject(org.getId(), siteB.getId(), FIRST_PAGE);
+
+        // Site B holds neither. Reporting the whole catalogue as out of stock at every project
+        // that never carried it would be a list of everything, which is a list of nothing.
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("storage-location scope applies the location's override in place of the material's level")
+    void locationScope_appliesTheLocationOverride() {
+        Organization org = persistOrganization("override");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+        Material cement = persistMaterial(org, "CEM-4", "Cement", 100.0);
+        persistStock(org, cement, project, store, 150.0);
+        persistThreshold(org, cement, store, 200.0, 500.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository
+                .findLowStockAtStorageLocation(org.getId(), project.getId(), store.getId(), FIRST_PAGE);
+
+        // 150 on hand is comfortable against the material's global level of 100 and short against
+        // this location's own level of 200. The console's stock-by-location table compares against
+        // the global level even here, which is the comparison this scope exists to replace.
+        assertThat(page.getContent()).extracting(LowStockRow::materialId).containsExactly(cement.getId());
+        assertThat(page.getContent().get(0).reorderLevel()).isEqualTo(200.0);
+        assertThat(page.getContent().get(0).moq()).isEqualTo(500.0);
+    }
+
+    @Test
+    @DisplayName("storage-location scope falls back to the material's level when the override leaves it null")
+    void locationScope_fallsBackWhenTheOverrideLeavesTheLevelNull() {
+        Organization org = persistOrganization("partial-override");
+        Project project = persistProject(org, "Site");
+        StorageLocation store = persistLocation(org, "Store");
+        Material cement = persistMaterial(org, "CEM-5", "Cement", 100.0);
+        persistStock(org, cement, project, store, 80.0);
+        persistThreshold(org, cement, store, null, null);   // an override that overrides nothing
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> page = lowStockRepository
+                .findLowStockAtStorageLocation(org.getId(), project.getId(), store.getId(), FIRST_PAGE);
+
+        assertThat(page.getContent()).extracting(LowStockRow::materialId).containsExactly(cement.getId());
+        assertThat(page.getContent().get(0).reorderLevel()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("storage-location scope reads that one location, not the project total")
+    void locationScope_readsOnlyThatLocation() {
+        Organization org = persistOrganization("one-location");
+        Project project = persistProject(org, "Site");
+        StorageLocation yard = persistLocation(org, "Yard");
+        StorageLocation shed = persistLocation(org, "Shed");
+        Material cement = persistMaterial(org, "CEM-6", "Cement", 100.0);
+        persistStock(org, cement, project, yard, 500.0);
+        persistStock(org, cement, project, shed, 4.0);
+        em.flush();
+        em.clear();
+
+        Page<LowStockRow> atShed = lowStockRepository
+                .findLowStockAtStorageLocation(org.getId(), project.getId(), shed.getId(), FIRST_PAGE);
+        Page<LowStockRow> atYard = lowStockRepository
+                .findLowStockAtStorageLocation(org.getId(), project.getId(), yard.getId(), FIRST_PAGE);
+
+        assertThat(atShed.getContent()).extracting(LowStockRow::currentStock).containsExactly(4.0);
+        assertThat(atYard.getContent()).isEmpty();
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName("Low stock " + name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Project persistProject(Organization org, String name) {
+        Project project = new Project();
+        project.setProjectName(name);
+        project.setProjectAddress(name + " road");
+        project.setOrganization(org);
+        em.persist(project);
+        return project;
+    }
+
+    private StorageLocation persistLocation(Organization org, String name) {
+        StorageLocation location = new StorageLocation();
+        location.setLocationName(name);
+        location.setLocationType(StorageLocationType.WAREHOUSE);
+        location.setOrganization(org);
+        em.persist(location);
+        return location;
+    }
+
+    private Material persistMaterial(Organization org, String sku, String name, Double reorderLevel) {
+        Material material = new Material();
+        material.setSku(sku);
+        material.setMaterialName(name);
+        material.setUnit("units");
+        material.setOrganization(org);
+        material.setReorderLevel(reorderLevel);
+        em.persist(material);
+        return material;
+    }
+
+    private void persistStock(Organization org, Material material, Project project,
+                              StorageLocation location, Double quantity) {
+        CurrentStock stock = new CurrentStock();
+        stock.setOrganization(org);
+        stock.setMaterial(material);
+        stock.setProject(project);
+        stock.setStorageLocation(location);
+        stock.setCurrentQuantity(quantity);
+        stock.setStockValue(BigDecimal.ZERO);
+        em.persist(stock);
+    }
+
+    private void persistThreshold(Organization org, Material material, StorageLocation location,
+                                  Double reorderLevel, Double moq) {
+        MaterialLocationThreshold threshold = new MaterialLocationThreshold();
+        threshold.setOrganization(org);
+        threshold.setMaterial(material);
+        threshold.setStorageLocation(location);
+        threshold.setReorderLevel(reorderLevel);
+        threshold.setMoq(moq);
+        em.persist(threshold);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/lowstock/LowStockServiceTest.java
@@ -1,0 +1,199 @@
+package org.tornotron.echno_backend.material.lowstock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.material.dto.LowStockMaterialDto;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * How the low-stock read picks its scope and what it refuses.
+ *
+ * <p>The refusals are the substance here. An empty page from this endpoint reads as "nothing has
+ * run out", which is the most reassuring answer it can give, so every way of asking a question
+ * about somewhere that does not exist has to be an error rather than an empty page. A typo in a
+ * project id returning "all clear" is the kind of wrong answer nobody checks.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LowStockServiceTest {
+
+    @Mock private LowStockRepository lowStockRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+
+    private LowStockService service;
+
+    private static final Pageable PAGE = PageRequest.of(0, 10);
+
+    @BeforeEach
+    void setUp() {
+        service = new LowStockService(lowStockRepository, projectRepository, storageLocationRepository);
+        TenantContext.setCurrentOrgId(1L);
+        when(lowStockRepository.findLowStockForOrganization(any(), any())).thenReturn(Page.empty());
+        when(lowStockRepository.findLowStockForProject(any(), any(), any())).thenReturn(Page.empty());
+        when(lowStockRepository.findLowStockAtStorageLocation(any(), any(), any(), any()))
+                .thenReturn(Page.empty());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("no ids reads the whole organization")
+    void noIds_readsTheOrganization() {
+        service.findLowStock(null, null, PAGE);
+
+        verify(lowStockRepository).findLowStockForOrganization(eq(1L), any());
+        verify(lowStockRepository, never()).findLowStockForProject(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a project alone reads that project")
+    void projectOnly_readsTheProject() {
+        when(projectRepository.existsByIdAndOrganization_Id(5L, 1L)).thenReturn(true);
+
+        service.findLowStock(5L, null, PAGE);
+
+        verify(lowStockRepository).findLowStockForProject(eq(1L), eq(5L), any());
+    }
+
+    @Test
+    @DisplayName("a storage location without a project is refused")
+    void locationWithoutProject_isRefused() {
+        assertThatThrownBy(() -> service.findLowStock(null, 2L, PAGE))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("projectId is required");
+
+        verifyNoInteractions(lowStockRepository);
+    }
+
+    @Test
+    @DisplayName("an unknown project is not found rather than an empty page")
+    void unknownProject_isNotFound() {
+        when(projectRepository.existsByIdAndOrganization_Id(99L, 1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.findLowStock(99L, null, PAGE))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Project with ID 99");
+
+        verifyNoInteractions(lowStockRepository);
+    }
+
+    @Test
+    @DisplayName("an unknown storage location is not found rather than an empty page")
+    void unknownLocation_isNotFound() {
+        when(projectRepository.existsByIdAndOrganization_Id(5L, 1L)).thenReturn(true);
+        when(storageLocationRepository.findByIdAndOrganization_Id(99L, 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findLowStock(5L, 99L, PAGE))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Storage location with ID 99");
+
+        verifyNoInteractions(lowStockRepository);
+    }
+
+    @Test
+    @DisplayName("a storage location belonging to another project is refused, not answered with all clear")
+    void locationOnAnotherProject_isRefused() {
+        Project otherProject = new Project();
+        otherProject.setId(7L);
+        StorageLocation location = new StorageLocation();
+        location.setId(2L);
+        location.setProject(otherProject);
+
+        when(projectRepository.existsByIdAndOrganization_Id(5L, 1L)).thenReturn(true);
+        when(storageLocationRepository.findByIdAndOrganization_Id(2L, 1L)).thenReturn(Optional.of(location));
+
+        // That pairing can hold no stock at all, so the query over it returns nothing. Answering
+        // "nothing has run out" to a question about a location that cannot hold anything is worse
+        // than answering nothing.
+        assertThatThrownBy(() -> service.findLowStock(5L, 2L, PAGE))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("belongs to project");
+
+        verifyNoInteractions(lowStockRepository);
+    }
+
+    @Test
+    @DisplayName("an organisation-level location is readable from any project")
+    void organisationLevelLocation_isAccepted() {
+        StorageLocation central = new StorageLocation();
+        central.setId(2L);   // no project: a central yard every project draws from
+
+        when(projectRepository.existsByIdAndOrganization_Id(5L, 1L)).thenReturn(true);
+        when(storageLocationRepository.findByIdAndOrganization_Id(2L, 1L)).thenReturn(Optional.of(central));
+
+        service.findLowStock(5L, 2L, PAGE);
+
+        verify(lowStockRepository).findLowStockAtStorageLocation(eq(1L), eq(5L), eq(2L), any());
+    }
+
+    @Test
+    @DisplayName("the shortfall is the gap to the level, and never negative")
+    void shortfall_isTheGapAndNeverNegative() {
+        LowStockRow short_ = new LowStockRow(1L, "TMT-1", "TMT bars", "kg", 10000.0, 11000.0, 3501.0);
+        LowStockRow exactly = new LowStockRow(2L, "PLY-1", "Plywood", "sheets", 500.0, 500.0, 500.0);
+        when(lowStockRepository.findLowStockForOrganization(any(), any()))
+                .thenReturn(new PageImpl<>(List.of(short_, exactly)));
+
+        List<LowStockMaterialDto> rows = service.findLowStock(null, null, PAGE).getContent();
+
+        assertThat(rows).extracting(LowStockMaterialDto::getShortfall)
+                .containsExactly(7499.0, 0.0);
+        assertThat(rows.get(0).getMoq()).isEqualTo(10000.0);
+        assertThat(rows.get(0).getProjectId()).isNull();
+        assertThat(rows.get(0).getStorageLocationId()).isNull();
+    }
+
+    @Test
+    @DisplayName("the scope the caller asked about comes back on every row")
+    void scopeIsEchoedOnEveryRow() {
+        StorageLocation central = new StorageLocation();
+        central.setId(2L);
+        when(projectRepository.existsByIdAndOrganization_Id(5L, 1L)).thenReturn(true);
+        when(storageLocationRepository.findByIdAndOrganization_Id(2L, 1L)).thenReturn(Optional.of(central));
+        when(lowStockRepository.findLowStockAtStorageLocation(any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(
+                        new LowStockRow(1L, "CEM-1", "Cement", "bags", 100.0, 200.0, 150.0))));
+
+        LowStockMaterialDto row = service.findLowStock(5L, 2L, PAGE).getContent().get(0);
+
+        assertThat(row.getProjectId()).isEqualTo(5L);
+        assertThat(row.getStorageLocationId()).isEqualTo(2L);
+        assertThat(row.getReorderLevel()).isEqualTo(200.0);
+        assertThat(row.getShortfall()).isEqualTo(50.0);
+    }
+}


### PR DESCRIPTION
Closes #652.

A reorder level is stored on every material and, at a material's location, on `MaterialLocationThreshold`. Nothing on the server has ever compared it to stock. The only low-stock signal in the product is a badge the web console computes in the browser, over whatever materials that page had loaded, visible while somebody has the screen open.

## What the levels look like on real data

Read on `echno.in`, read only:

| | |
|---|---|
| materials | 15 |
| with a reorder level set | 14 |
| **at or below it, organization wide** | **9** (8 strictly below) |
| per-location threshold overrides in the whole database | 0 |
| (material, project, location) balances at or below the material's level | **14**, across 7 projects |

`TNT Steel` holds 60 against a level of 30, so the console counts it as healthy. It is at 1, 18, 1, 7 and 1 unit at five separate project locations. The aggregate the console compares against is the one figure that cannot see a site running out.

The level itself is authored, not computed: `material-form.tsx` derives it in the browser as `safetyStock + 2*ltc` and posts the result as a plain number. `ltc` is persisted only since #078, and is NULL on all 15 existing rows, so the backend cannot re-derive it.

## What this adds

`GET /api/v1/materials/low-stock`, and the `/web` twin. Paginated through `PageQuery`, `@PreAuthorize` on both, `docs/openapi.json` regenerated.

Three scopes, matching the ones `GET /materials/{id}/stock` already reads at, because the answer differs at each:

- **neither id**: totalled across the organization, every catalogue material a candidate.
- **`projectId`**: totalled over that project's locations, only materials the project holds.
- **`projectId` + `storageLocationId`**: that one location, and here the `MaterialLocationThreshold` override replaces the material's global level, for the reorder level and the minimum order quantity both.

Decisions a second implementation would get wrong, each pinned by a test:

- **At or below**, not below. The console's six comparisons are all `<=`, and a reorder level is the level at which you reorder.
- **Organization scope left-joins** the stock rows, so a material stocked nowhere is reported rather than dropped. It is the most depleted material there can be.
- **Project and location scope inner-join**, so the catalogue is not reported as out of stock at every project that never carried it.
- **Ordering by the fraction of the level that is missing**, since an absolute shortfall is measured in the material's own unit. A level of zero sorts as fully depleted rather than dividing by zero, which the database would raise on.
- **A null level is never reported; a zero counts as set**, matching the console.
- **A project or location that does not exist is a 404**, and one belonging to another project is refused through the existing `StorageLocationScope` rule. An empty page here reads as "nothing has run out", and that must never be the answer to a question about somewhere that does not exist.
- **`totalElements` is the count**, so the dashboard card can ask for `pageSize=1` and read the true number without pulling a row.

## What this deliberately does not add

A scheduled sweep. Alert delivery is failing end to end on both stagings (echno-deployment#66: the Discord webhook targets a forum channel and every send is refused), and the backend has no notification package, no mail sender and no in-app inbox. A job emitting into that would reproduce that failure per material per tenant per night. There is also no stores role, so the only recipient today is an organization administrator.

The design for one, following `ComplianceRuleSweep` and off by default for the same reasons, is written up on the issue along with the three product decisions that gate it.

## Tests

Every query decision was checked by mutating it and confirming the matching test fails.

| Mutation | Test that fails |
|---|---|
| organization scope `LEFT JOIN` to `JOIN` | reports a material that has no stock row anywhere |
| `<=` to `<` | reports a material sitting exactly on its reorder level |
| severity ordering unguarded against a zero level | a reorder level of zero sorts as fully depleted rather than dividing by zero |
| severity ordering by absolute shortfall | orders by the fraction of the level that is missing, not by quantity |
| location scope ignores the override | storage-location scope applies the location's override |
| organization count query changed | organization scope counts every match, not just the page |

`LowStockRepositoryIT` (12 cases, real CockroachDB, shares the existing `@DataJpaTest` context) and `LowStockServiceTest` (9 cases, plain Mockito). 108 tests green across `material`, `common.pagination` and `architecture`; test heap 278 MB of 2048 MB.