### PR TITLE
Publish the validation constraints the endpoints already enforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,35 @@ Mark only what you have checked. A field the document declares non-null is a fie
 entitled to parse without a guard, so leaving one unmarked is recoverable and marking one wrongly
 is not.
 
+### Saying what a field will be rejected for
+
+Validation constraints on a DTO are published, so writing one is also writing the contract:
+
+```java
+@NotBlank @Size(max = 1000) String reason
+```
+
+comes out as `"minLength": 1, "maxLength": 1000` with `reason` in the schema's `required`.
+
+Left to swagger-core it does not. `required` is written from `@NotNull` and nothing else, so a
+`@NotBlank` field read as optional; `@Size` assigns `minLength` after `@NotBlank` has set it and
+its `min` defaults to 0, so the pairing above published `minLength: 0`, which positively permits
+the empty string the endpoint refuses; and `@Positive`, `@PositiveOrZero`, `@Negative`,
+`@NegativeOrZero` and `@Email` were not read at all. `ValidationConstraintsModelConverter` fills
+those in and `OpenApiValidationConstraintsTest` fails when an annotated field is not described.
+
+It states only what the annotation itself guarantees. `@NotBlank` also rejects a string of blanks
+and `minLength: 1` does not say so, which is deliberate: a document that understates a constraint
+costs a client one rejected request, and one that overstates it makes the client refuse input the
+server would have taken. `@Min`, `@Max`, `@DecimalMin`, `@DecimalMax`, `@Size` and `@Pattern` are
+already published correctly and are left alone; `@Past`, `@Future`, `@Digits`, cross-field rules
+and constraints naming validation groups have no keyword that means what they mean, so the
+document says nothing about them.
+
+Two nested types with the same simple name cannot both be published, and the loser is silently
+replaced by the winner rather than reported. Give one of them a name of its own with
+`@Schema(name = "...")` when that happens.
+
 Serving the document from a deployment is a separate decision: `/v3/api-docs` and the Swagger UI
 answer 401 unless `SWAGGER_PUBLIC_ACCESS=true` is set for that environment.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -446,6 +446,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "AssetDto": {
@@ -684,7 +687,7 @@
             "description": "Why the asset moved. Required: an entry with no stated reason is what makes a ledger unexplainable.",
             "example": "Mobilised to the Marina Heights site for the piling phase",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "referenceNumber": {
@@ -720,6 +723,9 @@
             "type": "integer"
           }
         },
+        "required": [
+          "reason"
+        ],
         "type": "object"
       },
       "AssetMovementDto": {
@@ -1621,7 +1627,8 @@
           "movementTrackingEnabled",
           "photoRequiredOnCheckIn",
           "photoRequiredOnCheckOut",
-          "regularizationApprovalRequired"
+          "regularizationApprovalRequired",
+          "settingName"
         ],
         "type": "object"
       },
@@ -2063,10 +2070,13 @@
             "description": "What was wrong with the voucher.",
             "example": "Duplicate of CPMT-000118, raised twice for the same invoice",
             "maxLength": 1000,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
+        "required": [
+          "reason"
+        ],
         "type": "object"
       },
       "CategoryCreationDto": {
@@ -2076,7 +2086,7 @@
             "description": "Short description of what the category covers.",
             "example": "TMT bars, wire mesh and other reinforcement materials",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "icon": {
@@ -2096,6 +2106,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "description",
+          "name"
+        ],
         "type": "object"
       },
       "CategoryDto": {
@@ -2557,14 +2571,14 @@
             "description": "Grouping the check point belongs to.",
             "example": "Reinforcement",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "checkPoint": {
             "description": "What is being checked.",
             "example": "Main bar spacing matches the bar bending schedule",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "expectedValue": {
@@ -2601,6 +2615,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "category",
+          "checkPoint"
+        ],
         "type": "object"
       },
       "ChecklistTemplateRequest": {
@@ -2628,7 +2646,7 @@
             "description": "Name of the checklist.",
             "example": "Reinforcement inspection checklist",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "trade": {
@@ -2656,6 +2674,8 @@
           }
         },
         "required": [
+          "items",
+          "name",
           "trade"
         ],
         "type": "object"
@@ -3422,7 +3442,7 @@
             "description": "Description of the billed item or work.",
             "example": "Ready-mix concrete M25",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "discountRate": {
@@ -3461,7 +3481,7 @@
             "description": "Unit of measure for the quantity.",
             "example": "cubic metre",
             "maxLength": 50,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "unitPrice": {
@@ -3472,7 +3492,9 @@
           }
         },
         "required": [
+          "description",
           "quantity",
+          "unit",
           "unitPrice"
         ],
         "type": "object"
@@ -3814,7 +3836,7 @@
             "description": "Account name.",
             "example": "Cash and Cash Equivalents",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "parentId": {
@@ -3831,6 +3853,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "CreateCompanyBankAccountRequest": {
@@ -3840,21 +3865,21 @@
             "description": "Name on the account.",
             "example": "Fereydon Pvt Ltd",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "accountNumber": {
             "description": "Account number.",
             "example": 50100234567890,
             "maxLength": 50,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "bankName": {
             "description": "Name of the bank.",
             "example": "HDFC Bank",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "ifscCode": {
@@ -3884,6 +3909,9 @@
           }
         },
         "required": [
+          "accountHolderName",
+          "accountNumber",
+          "bankName",
           "ledgerAccountId"
         ],
         "type": "object"
@@ -4011,6 +4039,7 @@
           "amount": {
             "description": "Amount to pay. Must be positive.",
             "example": 40000.0,
+            "exclusiveMinimum": 0,
             "type": "number"
           },
           "bankName": {
@@ -4202,10 +4231,13 @@
             "description": "Cost category name, unique within the tenant.",
             "example": "Materials",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "CreateCustomerRequest": {
@@ -4219,7 +4251,7 @@
             "description": "Customer code, unique within the tenant.",
             "example": "CUST-0042",
             "maxLength": 30,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "creditLimit": {
@@ -4231,6 +4263,7 @@
           "email": {
             "description": "Contact email address.",
             "example": "accounts@assethomes.example",
+            "format": "email",
             "maxLength": 200,
             "minLength": 0,
             "type": "string"
@@ -4246,7 +4279,7 @@
             "description": "Customer name.",
             "example": "Asset Homes Pvt Ltd",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "pan": {
@@ -4272,6 +4305,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "code",
+          "name"
+        ],
         "type": "object"
       },
       "CreateDirectRoomDto": {
@@ -4373,6 +4410,7 @@
             "description": "Duration of the inspection in minutes.",
             "example": 75,
             "format": "int32",
+            "minimum": 0,
             "type": "integer"
           },
           "inspectorId": {
@@ -4418,7 +4456,7 @@
             "description": "Short title of the inspection.",
             "example": "Foundation Pour - Block C",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "trade": {
@@ -4471,6 +4509,7 @@
         "required": [
           "inspectorId",
           "scheduledDate",
+          "title",
           "type"
         ],
         "type": "object"
@@ -4499,7 +4538,7 @@
           "lines": {
             "description": "Invoice line items. At least one line is required.",
             "items": {
-              "$ref": "#/components/schemas/LineRequest"
+              "$ref": "#/components/schemas/InvoiceLineRequest"
             },
             "maxItems": 2147483647,
             "minItems": 1,
@@ -4534,7 +4573,7 @@
             "description": "What does not conform, and against what requirement.",
             "example": "Clear cover measured at 25 mm against a specified 40 mm at grid C3 to C6.",
             "maxLength": 2000,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "inspectionId": {
@@ -4569,12 +4608,14 @@
             "description": "Short title of the non-conformance.",
             "example": "Cover to slab reinforcement below specification",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
         "required": [
-          "inspectionId"
+          "description",
+          "inspectionId",
+          "title"
         ],
         "type": "object"
       },
@@ -4702,7 +4743,7 @@
             "description": "The photo to draw on, exactly as it appears in the defect's photos list.",
             "example": "https://cdn.example.com/inspections/6f1c-crack.jpg",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "shape": {
@@ -4745,6 +4786,7 @@
           }
         },
         "required": [
+          "photo",
           "shape",
           "x1",
           "x2",
@@ -4763,6 +4805,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "content"
+        ],
         "type": "object"
       },
       "EmployeeCreationDto": {
@@ -4799,7 +4844,7 @@
             "description": "Contact email address.",
             "example": "ravi.kumar@example.com",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
             "type": "string"
           },
@@ -4862,7 +4907,13 @@
           }
         },
         "required": [
-          "dateOfBirth"
+          "dateOfBirth",
+          "department",
+          "designation",
+          "emailAddress",
+          "employeeName",
+          "gender",
+          "phoneNumber"
         ],
         "type": "object"
       },
@@ -5163,6 +5214,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "status"
+        ],
         "type": "object"
       },
       "EmployeeLookupDto": {
@@ -5381,7 +5435,8 @@
           }
         },
         "required": [
-          "amount"
+          "amount",
+          "description"
         ],
         "type": "object"
       },
@@ -5590,7 +5645,8 @@
           }
         },
         "required": [
-          "amount"
+          "amount",
+          "description"
         ],
         "type": "object"
       },
@@ -5641,7 +5697,7 @@
             "description": "Unique code identifying the feature.",
             "example": "report-export",
             "maxLength": 100,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "description": {
@@ -5662,6 +5718,11 @@
             "type": "string"
           }
         },
+        "required": [
+          "code",
+          "featureType",
+          "name"
+        ],
         "type": "object"
       },
       "FeatureDto": {
@@ -5799,6 +5860,7 @@
           }
         },
         "required": [
+          "items",
           "projectId",
           "receivedByEmployeeId",
           "receivedOn",
@@ -6043,7 +6105,8 @@
         },
         "required": [
           "createdByEmployeeId",
-          "projectId"
+          "projectId",
+          "status"
         ],
         "type": "object"
       },
@@ -6149,6 +6212,7 @@
           "requestedQuantity": {
             "description": "Quantity requested.",
             "example": 500,
+            "exclusiveMinimum": 0,
             "format": "int32",
             "type": "integer"
           }
@@ -6208,6 +6272,7 @@
             "type": "string"
           },
           "requestedQuantity": {
+            "exclusiveMinimum": 0,
             "format": "int32",
             "type": "integer"
           }
@@ -6412,14 +6477,14 @@
             "description": "Grouping the check point belongs to.",
             "example": "Reinforcement",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "checkPoint": {
             "description": "What is being checked.",
             "example": "Rebar spacing matches drawing",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "expectedValue": {
@@ -6491,6 +6556,8 @@
           }
         },
         "required": [
+          "category",
+          "checkPoint",
           "status"
         ],
         "type": "object"
@@ -6565,14 +6632,14 @@
             "description": "Action required to correct the defect.",
             "example": "Chip out and re-pour affected section",
             "maxLength": 1000,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "description": {
             "description": "Description of the defect.",
             "example": "Honeycombing observed on column C4 at ground level",
             "maxLength": 1000,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "location": {
@@ -6632,6 +6699,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "correctiveAction",
+          "description"
+        ],
         "type": "object"
       },
       "InspectionDto": {
@@ -7054,6 +7125,11 @@
             "type": "integer"
           }
         },
+        "required": [
+          "department",
+          "designation",
+          "status"
+        ],
         "type": "object"
       },
       "InviteCodePatchDto": {
@@ -7082,6 +7158,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "code"
+        ],
         "type": "object"
       },
       "InvoiceDto": {
@@ -7242,6 +7321,51 @@
         },
         "type": "object"
       },
+      "InvoiceLineRequest": {
+        "description": "A single line on a customer invoice.",
+        "properties": {
+          "description": {
+            "description": "What the line is charging for.",
+            "example": "Structural design consultancy",
+            "maxLength": 500,
+            "minLength": 1,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "Quantity billed. Must be greater than zero.",
+            "example": 10,
+            "minimum": 1.0E-4,
+            "type": "number"
+          },
+          "revenueAccountId": {
+            "description": "Revenue account the line is credited to.",
+            "example": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "taxRate": {
+            "description": "Tax rate applied to the line, as a percentage between 0 and 100.",
+            "example": 18.0,
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "type": "number"
+          },
+          "unitPrice": {
+            "description": "Price per unit.",
+            "example": 5000.0,
+            "minimum": 0.0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "description",
+          "quantity",
+          "revenueAccountId",
+          "taxRate",
+          "unitPrice"
+        ],
+        "type": "object"
+      },
       "IssueCommentCreationDto": {
         "description": "Payload to leave a comment on an issue. The author is taken from the signed-in session, not from the request.",
         "properties": {
@@ -7249,7 +7373,7 @@
             "description": "The comment text.",
             "example": "Rebar spacing on the east face still needs checking.",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "issueId": {
@@ -7260,6 +7384,7 @@
           }
         },
         "required": [
+          "comment",
           "issueId"
         ],
         "type": "object"
@@ -7337,6 +7462,8 @@
           }
         },
         "required": [
+          "description",
+          "title",
           "type"
         ],
         "type": "object"
@@ -7708,6 +7835,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "code",
+          "name"
+        ],
         "type": "object"
       },
       "LabourCreationDto": {
@@ -7749,6 +7880,7 @@
           "email": {
             "description": "Contact email address.",
             "example": "suresh.pillai@example.com",
+            "format": "email",
             "maxLength": 255,
             "minLength": 0,
             "type": "string"
@@ -7771,14 +7903,14 @@
             "description": "Employment arrangement. One of DAILY_WAGE, MONTHLY, CONTRACT, PIECE_RATE.",
             "example": "DAILY_WAGE",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "fullName": {
             "description": "Full name of the worker.",
             "example": "Suresh Pillai",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "ifscCode": {
@@ -7796,7 +7928,7 @@
             "description": "Organization-assigned labour code.",
             "example": "LAB-0087",
             "maxLength": 15,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "overTimeRate": {
@@ -7808,14 +7940,14 @@
             "description": "Ten-digit contact phone number.",
             "example": 9847098470,
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "skillLevel": {
             "description": "Skill level. One of SKILLED, SEMI_SKILLED, HIGHLY_SKILLED, UNSKILLED.",
             "example": "SKILLED",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "specialization": {
@@ -7829,12 +7961,18 @@
             "description": "Employment status. One of ACTIVE, INACTIVE, ON_LEAVE, TERMINATED.",
             "example": "ACTIVE",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
         "required": [
-          "joiningDate"
+          "employmentType",
+          "fullName",
+          "joiningDate",
+          "labourID",
+          "phoneNumber",
+          "skillLevel",
+          "status"
         ],
         "type": "object"
       },
@@ -8122,6 +8260,7 @@
           "email": {
             "description": "Contact email address.",
             "example": "suresh.pillai@example.com",
+            "format": "email",
             "maxLength": 255,
             "minLength": 0,
             "type": "string"
@@ -8350,7 +8489,7 @@
             "description": "Reason for the adjustment.",
             "example": "Correcting a missed accrual for July 2026",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
@@ -8358,7 +8497,8 @@
           "adjustedById",
           "days",
           "employeeId",
-          "leavePolicyId"
+          "leavePolicyId",
+          "reason"
         ],
         "type": "object"
       },
@@ -8639,6 +8779,7 @@
           "annualQuota": {
             "description": "Total days granted per year under this policy.",
             "example": 12.0,
+            "exclusiveMinimum": 0,
             "format": "double",
             "type": "number"
           },
@@ -8687,14 +8828,14 @@
             "description": "Short code identifying the leave type.",
             "example": "CL",
             "maxLength": 50,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "leaveTypeName": {
             "description": "Display name of the leave type.",
             "example": "Casual Leave",
             "maxLength": 100,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "maxDaysPerRequest": {
@@ -8734,6 +8875,8 @@
         },
         "required": [
           "annualQuota",
+          "leaveTypeCode",
+          "leaveTypeName",
           "organizationId"
         ],
         "type": "object"
@@ -9071,7 +9214,7 @@
             "description": "Reason for the leave.",
             "example": "Attending sister's wedding in Coimbatore",
             "maxLength": 1000,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "startDate": {
@@ -9099,6 +9242,7 @@
         "required": [
           "endDate",
           "leavePolicyId",
+          "reason",
           "startDate"
         ],
         "type": "object"
@@ -9587,6 +9731,7 @@
         },
         "required": [
           "consumptionDate",
+          "consumptionType",
           "createdBy",
           "materialId",
           "projectId",
@@ -9786,7 +9931,9 @@
           }
         },
         "required": [
-          "createdBy"
+          "createdBy",
+          "materialName",
+          "unit"
         ],
         "type": "object"
       },
@@ -10377,7 +10524,9 @@
         },
         "required": [
           "attendanceId",
+          "fromLocation",
           "movementType",
+          "purpose",
           "startTime"
         ],
         "type": "object"
@@ -10766,7 +10915,7 @@
           },
           "organizationEmail": {
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,24}$",
             "type": "string"
           },
@@ -10789,6 +10938,12 @@
             "type": "string"
           }
         },
+        "required": [
+          "organizationAddress",
+          "organizationEmail",
+          "organizationName",
+          "organizationPhone"
+        ],
         "type": "object"
       },
       "OrganizationDto": {
@@ -12642,9 +12797,11 @@
       "PayableCreationDto": {
         "properties": {
           "amountPaid": {
+            "minimum": 0,
             "type": "number"
           },
           "amountRecorded": {
+            "exclusiveMinimum": 0,
             "type": "number"
           },
           "contractType": {
@@ -12680,7 +12837,10 @@
         },
         "required": [
           "amountRecorded",
+          "contractType",
+          "contractorName",
           "createdBy",
+          "payableNumber",
           "projectId"
         ],
         "type": "object"
@@ -12830,6 +12990,7 @@
       "PaymentRecordDto": {
         "properties": {
           "paymentAmount": {
+            "exclusiveMinimum": 0,
             "type": "number"
           }
         },
@@ -12870,6 +13031,7 @@
           }
         },
         "required": [
+          "name",
           "policies",
           "resources",
           "scopes"
@@ -12888,7 +13050,7 @@
             "description": "Unique code identifying the plan.",
             "example": "professional-monthly",
             "maxLength": 50,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "currency": {
@@ -12939,7 +13101,9 @@
           }
         },
         "required": [
-          "monthlyPrice"
+          "code",
+          "monthlyPrice",
+          "name"
         ],
         "type": "object"
       },
@@ -13063,6 +13227,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "featureCode"
+        ],
         "type": "object"
       },
       "PlanFeatureDto": {
@@ -13128,7 +13295,7 @@
             "description": "Description of the entry.",
             "example": "Vendor bill CINV-2026-0042 posted",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "entryDate": {
@@ -13155,6 +13322,7 @@
           }
         },
         "required": [
+          "description",
           "entryDate",
           "lines"
         ],
@@ -13473,6 +13641,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "projectAddress",
+          "projectName"
+        ],
         "type": "object"
       },
       "ProjectDto": {
@@ -14258,6 +14430,7 @@
           "unitPrice": {
             "description": "Unit price in INR. Required. Zero is allowed, for a line supplied free of charge, but it has to be sent deliberately: an empty price field is rejected rather than treated as zero, which is how orders were being saved with a total of nothing.",
             "example": 62.5,
+            "minimum": 0,
             "type": "number"
           }
         },
@@ -14485,6 +14658,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "emoji"
+        ],
         "type": "object"
       },
       "ReceiptCreationDto": {
@@ -14599,7 +14775,8 @@
           }
         },
         "required": [
-          "amount"
+          "amount",
+          "receivedFrom"
         ],
         "type": "object"
       },
@@ -14856,7 +15033,8 @@
           }
         },
         "required": [
-          "amount"
+          "amount",
+          "receivedFrom"
         ],
         "type": "object"
       },
@@ -14997,7 +15175,9 @@
           }
         },
         "required": [
-          "attendanceId"
+          "attendanceId",
+          "missingEvents",
+          "reason"
         ],
         "type": "object"
       },
@@ -15047,6 +15227,10 @@
             "uniqueItems": true
           }
         },
+        "required": [
+          "displayName",
+          "name"
+        ],
         "type": "object"
       },
       "ReverseJournalRequest": {
@@ -15060,6 +15244,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "reason"
+        ],
         "type": "object"
       },
       "RoleCreationDto": {
@@ -15072,6 +15259,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "RolePolicyDefinitionDto": {
@@ -15091,6 +15281,9 @@
             "uniqueItems": true
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SearchHit": {
@@ -15142,6 +15335,9 @@
             "type": "integer"
           }
         },
+        "required": [
+          "content"
+        ],
         "type": "object"
       },
       "ShiftTimingCreationDto": {
@@ -15205,6 +15401,7 @@
           "lunchBreakStart",
           "minimumWorkHours",
           "overtimeThreshold",
+          "shiftName",
           "startTime"
         ],
         "type": "object"
@@ -15389,6 +15586,7 @@
         },
         "required": [
           "issueDate",
+          "items",
           "receivingProjectId",
           "sendingPerson",
           "sendingProjectId"
@@ -15742,6 +15940,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "justification"
+        ],
         "type": "object"
       },
       "StockAdjustmentDto": {
@@ -16128,10 +16329,13 @@
             "description": "Why the adjustment is being refused. Required.",
             "example": "Variance not supported by the count sheet",
             "maxLength": 500,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
+        "required": [
+          "reason"
+        ],
         "type": "object"
       },
       "StockDto": {
@@ -16219,6 +16423,10 @@
             "type": "integer"
           }
         },
+        "required": [
+          "locationName",
+          "locationType"
+        ],
         "type": "object"
       },
       "StorageLocationDto": {
@@ -16576,6 +16784,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "contractName",
+          "contractorName"
+        ],
         "type": "object"
       },
       "SubContractDto": {
@@ -16858,6 +17070,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "newPlanCode"
+        ],
         "type": "object"
       },
       "SubscriptionCreateDto": {
@@ -16879,6 +17094,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "planCode"
+        ],
         "type": "object"
       },
       "SubscriptionDto": {
@@ -17081,7 +17299,9 @@
         "required": [
           "categoryId",
           "progress",
-          "projectId"
+          "projectId",
+          "status",
+          "title"
         ],
         "type": "object"
       },
@@ -17504,7 +17724,7 @@
             "description": "Account code, unique within the tenant. Because postings resolve by account id, changing the code is safe.",
             "example": 1100,
             "maxLength": 20,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "description": {
@@ -17518,7 +17738,7 @@
             "description": "Account name.",
             "example": "Cash and Cash Equivalents",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "parentId": {
@@ -17529,7 +17749,9 @@
           }
         },
         "required": [
-          "active"
+          "active",
+          "code",
+          "name"
         ],
         "type": "object"
       },
@@ -17692,6 +17914,7 @@
           "amount": {
             "description": "Amount to pay. Must be positive.",
             "example": 40000.0,
+            "exclusiveMinimum": 0,
             "type": "number"
           },
           "bankName": {
@@ -17902,12 +18125,13 @@
             "description": "Cost category name, unique within the tenant.",
             "example": "Materials",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           }
         },
         "required": [
-          "active"
+          "active",
+          "name"
         ],
         "type": "object"
       },
@@ -17927,6 +18151,7 @@
           "email": {
             "description": "Contact email address.",
             "example": "accounts@assethomes.example",
+            "format": "email",
             "maxLength": 200,
             "minLength": 0,
             "type": "string"
@@ -17942,7 +18167,7 @@
             "description": "Customer name.",
             "example": "Asset Homes Pvt Ltd",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "pan": {
@@ -17968,6 +18193,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "UpdateFinanceSettingsRequest": {
@@ -17976,6 +18204,7 @@
           "approvalThreshold": {
             "description": "Auto-approval threshold. Send null to require manual approval on every construction invoice; send a value T to auto-approve invoices whose total is below T.",
             "example": 50000.0,
+            "minimum": 0,
             "type": "number"
           }
         },
@@ -18065,6 +18294,7 @@
             "description": "Duration of the inspection in minutes.",
             "example": 75,
             "format": "int32",
+            "minimum": 0,
             "type": "integer"
           },
           "inspectorId": {
@@ -18136,7 +18366,7 @@
             "description": "Short title of the inspection.",
             "example": "Foundation Pour - Block C",
             "maxLength": 200,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "trade": {
@@ -18190,6 +18420,7 @@
           "inspectorId",
           "scheduledDate",
           "status",
+          "title",
           "type"
         ],
         "type": "object"
@@ -18257,7 +18488,8 @@
           }
         },
         "required": [
-          "amount"
+          "amount",
+          "featureCode"
         ],
         "type": "object"
       },
@@ -18379,8 +18611,9 @@
             "type": "integer"
           },
           "email": {
+            "format": "email",
             "maxLength": 100,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "gender": {
@@ -18410,7 +18643,13 @@
           }
         },
         "required": [
-          "dateOfBirth"
+          "dateOfBirth",
+          "email",
+          "gender",
+          "name",
+          "password",
+          "phone",
+          "userName"
         ],
         "type": "object"
       },
@@ -18545,6 +18784,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "accountNumber",
+          "bankName"
+        ],
         "type": "object"
       },
       "VendorBankAccountDto": {
@@ -18584,6 +18827,7 @@
             "type": "string"
           },
           "email": {
+            "format": "email",
             "minLength": 1,
             "type": "string"
           },
@@ -18595,6 +18839,11 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "contactPerson",
+          "email",
+          "phone"
+        ],
         "type": "object"
       },
       "VendorContactDto": {
@@ -18677,6 +18926,7 @@
             "type": "string"
           },
           "vendorEmail": {
+            "format": "email",
             "minLength": 1,
             "type": "string"
           },
@@ -18689,6 +18939,12 @@
             "type": "string"
           }
         },
+        "required": [
+          "status",
+          "type",
+          "vendorEmail",
+          "vendorName"
+        ],
         "type": "object"
       },
       "VendorDto": {
@@ -18868,7 +19124,8 @@
           }
         },
         "required": [
-          "type"
+          "type",
+          "value"
         ],
         "type": "object"
       },
@@ -18961,14 +19218,14 @@
             "description": "Name of the WBS element.",
             "example": "RCC Column Casting - Block A",
             "maxLength": 255,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "wbsCode": {
             "description": "Project-unique code identifying this element's position in the WBS hierarchy.",
             "example": "1.2.3",
             "maxLength": 50,
-            "minLength": 0,
+            "minLength": 1,
             "type": "string"
           },
           "weight": {
@@ -18978,6 +19235,10 @@
             "type": "number"
           }
         },
+        "required": [
+          "title",
+          "wbsCode"
+        ],
         "type": "object"
       },
       "WbsElementDto": {

--- a/src/main/java/org/tornotron/echno_backend/common/configuration/ValidationConstraintsModelConverter.java
+++ b/src/main/java/org/tornotron/echno_backend/common/configuration/ValidationConstraintsModelConverter.java
@@ -1,0 +1,342 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Writes into the document the validation constraints the endpoints already enforce and
+ * swagger-core does not carry across.
+ *
+ * <h2>What was wrong</h2>
+ *
+ * <p>The published contract described far less than the code refuses. Three separate gaps, all
+ * of them in {@code ModelResolver.applyBeanValidatorAnnotations}, which is the one place
+ * swagger-core 2.2.29 turns a jakarta constraint into a schema keyword:
+ *
+ * <ul>
+ *   <li><b>{@code required} is written for {@code @NotNull} and nothing else.</b> The list it
+ *       consults is only reached through the {@code @NotNull} branch, so {@code @NotBlank} and
+ *       {@code @NotEmpty} never put a property in {@code required}, although both reject null
+ *       exactly as {@code @NotNull} does. A reader was told the field could be left out
+ *       entirely.
+ *   <li><b>{@code @Size} overwrites the {@code minLength} that {@code @NotBlank} sets.</b>
+ *       {@code @NotBlank} does produce {@code minLength: 1}; the {@code @Size} branch runs after
+ *       it and assigns {@code Size.min()} unconditionally, which defaults to 0. So the common
+ *       pairing {@code @NotBlank @Size(max = 1000)} publishes {@code minLength: 0}, which is
+ *       worse than silence: it positively permits the empty string the endpoint refuses.
+ *   <li><b>{@code @Positive}, {@code @PositiveOrZero}, {@code @Negative},
+ *       {@code @NegativeOrZero} and {@code @Email} are not handled at all,</b> so a field that
+ *       must be a positive amount carried no {@code minimum} and an address field carried no
+ *       {@code format}.
+ * </ul>
+ *
+ * <p>The consequence is not academic. {@code echno-core} reduces this document and checks every
+ * outgoing write call against it, and it reads {@code required} to decide whether a caller may
+ * omit a field; with only the {@code @NotNull} fields listed it passes a request the server will
+ * refuse. On the other side {@code echno-web} has hardcoded a length cap of its own to stand in
+ * for a bound the document never published. See issue #657.
+ *
+ * <h2>Why this is a model converter and not a document customizer</h2>
+ *
+ * <p>{@link NullableSchemaCustomizer} could work on the assembled document because the flag it
+ * reads survives resolution. These constraints do not: they are consumed as each property is
+ * resolved, and {@code required} is written on the parent at that same moment. By the time a
+ * customizer runs, a {@code maxLength: 255} with no {@code minLength} beside it is
+ * indistinguishable from a plain {@code @Size}, and a missing name in {@code required} is
+ * indistinguishable from a field that is genuinely optional. Only something holding the
+ * annotations can tell those apart, which is what this does: it delegates down the converter
+ * chain, then re-reads the class the resolved schema was built from and repairs the properties
+ * against the annotations on its fields.
+ *
+ * <p>Running after the chain rather than before it is deliberate. swagger-core applies
+ * {@code @Size} after {@code @NotBlank}, so a converter that wrote {@code minLength: 1} on the
+ * way in would have it overwritten on the way out.
+ *
+ * <h2>What it will not say</h2>
+ *
+ * <p>A document that overstates a constraint is worse than one that omits it, because a client
+ * will pre-validate against it and refuse input the server would have accepted. So this writes
+ * only what the annotation itself guarantees, and leaves the rest alone:
+ *
+ * <ul>
+ *   <li>{@code @NotBlank} rejects a string of blanks, and {@code minLength: 1} does not. The
+ *       document therefore understates it. Expressing the rest needs a {@code pattern}, which
+ *       would collide with a {@code @Pattern} already on the field.
+ *   <li>a constraint declaring validation {@code groups} is skipped, because whether it applies
+ *       depends on the group the invocation asks for and the document has no way to say
+ *       "sometimes".
+ *   <li>{@code @Min}, {@code @Max}, {@code @DecimalMin}, {@code @DecimalMax}, {@code @Size} and
+ *       {@code @Pattern} are left to swagger-core, which already writes them correctly.
+ *   <li>{@code @Past}, {@code @Future} and {@code @Digits} have no keyword that means what they
+ *       mean, and cross-field or custom class-level constraints have none either.
+ *   <li>constraints on controller method parameters go through springdoc's parameter builder
+ *       rather than this resolver, so a {@code @NotBlank @RequestParam} is untouched.
+ * </ul>
+ */
+@Component
+@Slf4j
+public class ValidationConstraintsModelConverter implements ModelConverter {
+
+    /** The lowest length or item count a "must not be empty" constraint allows. */
+    private static final int NOT_EMPTY_MINIMUM = 1;
+
+    /** The JSON Schema format for a string that has to be an email address. */
+    private static final String EMAIL_FORMAT = "email";
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Schema resolve(AnnotatedType type, ModelConverterContext context,
+                          Iterator<ModelConverter> chain) {
+        if (!chain.hasNext()) {
+            return null;
+        }
+        Schema resolved = chain.next().resolve(type, context, chain);
+        Class<?> beanClass = rawClass(type == null ? null : type.getType());
+        if (beanClass == null) {
+            return resolved;
+        }
+        Schema<?> model = modelBehind(resolved, context);
+        if (model != null && model.getProperties() != null) {
+            describe(beanClass, model);
+        }
+        return resolved;
+    }
+
+    /**
+     * The schema carrying the properties. A model that is already defined comes back from the
+     * chain as a bare {@code $ref}, and the object the reference points at is the one holding
+     * the properties to repair.
+     */
+    private static Schema<?> modelBehind(Schema<?> resolved, ModelConverterContext context) {
+        if (resolved == null) {
+            return null;
+        }
+        String ref = resolved.get$ref();
+        if (ref == null) {
+            return resolved;
+        }
+        if (!ref.startsWith(Components.COMPONENTS_SCHEMAS_REF)) {
+            return null;
+        }
+        Map<String, Schema> defined = context.getDefinedModels();
+        return defined == null
+                ? null
+                : defined.get(ref.substring(Components.COMPONENTS_SCHEMAS_REF.length()));
+    }
+
+    /** The class a resolved type was built from, whatever shape the type arrived in. */
+    private static Class<?> rawClass(Type type) {
+        if (type instanceof JavaType javaType) {
+            return javaType.getRawClass();
+        }
+        if (type instanceof Class<?> raw) {
+            return raw;
+        }
+        if (type instanceof ParameterizedType parameterized) {
+            return rawClass(parameterized.getRawType());
+        }
+        return null;
+    }
+
+    /**
+     * Repairs every property of one model against the constraints on the field behind it.
+     * Idempotent: a model reached twice is described once and then left as it stands, since
+     * every write here either raises a bound to a value it already holds or is a no-op.
+     */
+    private void describe(Class<?> beanClass, Schema<?> model) {
+        for (Class<?> declaring = beanClass;
+             declaring != null && declaring != Object.class;
+             declaring = declaring.getSuperclass()) {
+            for (Field field : declaring.getDeclaredFields()) {
+                if (field.isSynthetic() || Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                String name = propertyName(field);
+                Schema<?> property = model.getProperties().get(name);
+                if (property != null) {
+                    describe(field, name, property, model);
+                }
+            }
+        }
+    }
+
+    /** The name the property carries in the document, which Jackson may have renamed. */
+    private static String propertyName(Field field) {
+        JsonProperty renamed = field.getAnnotation(JsonProperty.class);
+        if (renamed != null && !renamed.value().isEmpty()
+                && !JsonProperty.USE_DEFAULT_NAME.equals(renamed.value())) {
+            return renamed.value();
+        }
+        return field.getName();
+    }
+
+    private void describe(Field field, String name, Schema<?> property, Schema<?> model) {
+        Set<String> types = typesOf(property);
+        boolean rejectsNull = false;
+
+        if (applies(field.getAnnotation(NotBlank.class))) {
+            rejectsNull = true;
+            if (types.contains("string")) {
+                raiseMinLength(property);
+            }
+        }
+        if (applies(field.getAnnotation(NotEmpty.class))) {
+            rejectsNull = true;
+            if (types.contains("string")) {
+                raiseMinLength(property);
+            }
+            if (types.contains("array") && below(property.getMinItems())) {
+                property.setMinItems(NOT_EMPTY_MINIMUM);
+            }
+            if (types.contains("object") && below(property.getMinProperties())) {
+                property.setMinProperties(NOT_EMPTY_MINIMUM);
+            }
+        }
+        if (rejectsNull) {
+            require(model, name, field);
+        }
+        if (isNumber(types) && !hasLowerBound(property)) {
+            if (applies(field.getAnnotation(Positive.class))) {
+                // An exclusive bound rather than minimum 1, which would be right for an integer
+                // and wrong for the BigDecimal amounts most of these are.
+                setExclusiveMinimum(property);
+            } else if (applies(field.getAnnotation(PositiveOrZero.class))) {
+                property.setMinimum(BigDecimal.ZERO);
+            }
+        }
+        if (isNumber(types) && !hasUpperBound(property)) {
+            if (applies(field.getAnnotation(Negative.class))) {
+                setExclusiveMaximum(property);
+            } else if (applies(field.getAnnotation(NegativeOrZero.class))) {
+                property.setMaximum(BigDecimal.ZERO);
+            }
+        }
+        if (applies(field.getAnnotation(Email.class))
+                && types.contains("string") && property.getFormat() == null) {
+            property.setFormat(EMAIL_FORMAT);
+        }
+    }
+
+    /**
+     * States that a value must be above zero. 3.1 spells an exclusive bound as the bound itself,
+     * {@code "exclusiveMinimum": 0}; 3.0 spells it as an inclusive bound with a flag beside it,
+     * and swagger-core writes whichever of the two the document's version calls for while
+     * ignoring the other. Setting the wrong one is not an error, it is silence.
+     */
+    private static void setExclusiveMinimum(Schema<?> property) {
+        if (SpecVersion.V31.equals(property.getSpecVersion())) {
+            property.setExclusiveMinimumValue(BigDecimal.ZERO);
+        } else {
+            property.setMinimum(BigDecimal.ZERO);
+            property.setExclusiveMinimum(Boolean.TRUE);
+        }
+    }
+
+    /** The upper-bound counterpart of {@link #setExclusiveMinimum}. */
+    private static void setExclusiveMaximum(Schema<?> property) {
+        if (SpecVersion.V31.equals(property.getSpecVersion())) {
+            property.setExclusiveMaximumValue(BigDecimal.ZERO);
+        } else {
+            property.setMaximum(BigDecimal.ZERO);
+            property.setExclusiveMaximum(Boolean.TRUE);
+        }
+    }
+
+    /**
+     * Whether a constraint is one the document can state. A constraint that names validation
+     * groups holds only for the invocations that ask for those groups, and a schema keyword
+     * holds for every request, so writing one from the other would put a claim in the contract
+     * that the endpoint does not always enforce.
+     */
+    private static boolean applies(java.lang.annotation.Annotation constraint) {
+        if (constraint == null) {
+            return false;
+        }
+        try {
+            Class<?>[] groups = (Class<?>[]) constraint.annotationType()
+                    .getMethod("groups").invoke(constraint);
+            return groups.length == 0;
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            log.warn("Cannot read the validation groups of {}, so it is left out of the document",
+                    constraint.annotationType().getName(), e);
+            return false;
+        }
+    }
+
+    /** The types a property admits, under 3.1 a set and under 3.0 a single value. */
+    private static Set<String> typesOf(Schema<?> property) {
+        if (property.getTypes() != null && !property.getTypes().isEmpty()) {
+            return property.getTypes();
+        }
+        return property.getType() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(Collections.singletonList(property.getType()));
+    }
+
+    private static boolean isNumber(Set<String> types) {
+        return types.contains("number") || types.contains("integer");
+    }
+
+    private static boolean hasLowerBound(Schema<?> property) {
+        return property.getMinimum() != null || property.getExclusiveMinimumValue() != null;
+    }
+
+    private static boolean hasUpperBound(Schema<?> property) {
+        return property.getMaximum() != null || property.getExclusiveMaximumValue() != null;
+    }
+
+    private static void raiseMinLength(Schema<?> property) {
+        if (below(property.getMinLength())) {
+            property.setMinLength(NOT_EMPTY_MINIMUM);
+        }
+    }
+
+    /** Whether a bound is absent, or present but weaker than the constraint behind it. */
+    private static boolean below(Integer bound) {
+        return bound == null || bound < NOT_EMPTY_MINIMUM;
+    }
+
+    /**
+     * Records that the property may not be left out. {@code addRequiredItem} keeps the list
+     * sorted, so a name is added once and the order does not depend on field order.
+     */
+    private static void require(Schema<?> model, String name, Field field) {
+        io.swagger.v3.oas.annotations.media.Schema declared =
+                field.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (declared != null && io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED
+                .equals(declared.requiredMode())) {
+            // The author has said the field is optional. Believe them over the constraint rather
+            // than publishing a contradiction.
+            return;
+        }
+        if (model.getRequired() == null || !model.getRequired().contains(name)) {
+            model.addRequiredItem(name);
+        }
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/CreateInvoiceRequest.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/invoice/dtos/CreateInvoiceRequest.java
@@ -27,7 +27,14 @@ public record CreateInvoiceRequest(
         @Schema(description = "Invoice line items. At least one line is required.")
         @NotNull @Size(min = 1) @Valid List<LineRequest> lines
 ) {
-    @Schema(description = "A single line on a customer invoice.")
+    /**
+     * Named rather than left to the simple name, which {@code PostJournalRequest.LineRequest}
+     * also carries. Two schemas cannot share one name: the journal line won, so the document
+     * described an invoice line as an account id with a debit and a credit, and a client
+     * following it sent a body this endpoint rejects. Nothing here changes about the journal
+     * line, which keeps the name it had.
+     */
+    @Schema(name = "InvoiceLineRequest", description = "A single line on a customer invoice.")
     public record LineRequest(
             @Schema(description = "What the line is charging for.", example = "Structural design consultancy")
             @NotBlank @Size(max = 500) String description,

--- a/src/test/java/org/tornotron/echno_backend/architecture/OpenApiValidationConstraintsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OpenApiValidationConstraintsTest.java
@@ -1,0 +1,275 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every validation constraint the endpoints enforce is stated in the published document.
+ *
+ * <p>swagger-core turns a jakarta constraint into a schema keyword in one place, and three
+ * things were missing from it. {@code required} is written for {@code @NotNull} and nothing
+ * else, so a {@code @NotBlank} field looked optional. {@code @Size} assigns {@code minLength}
+ * unconditionally and runs after {@code @NotBlank}, so the common pairing
+ * {@code @NotBlank @Size(max = n)} published {@code minLength: 0}, which is worse than saying
+ * nothing: it positively permits the empty string the endpoint refuses. And
+ * {@code @Positive}, {@code @PositiveOrZero}, {@code @Negative}, {@code @NegativeOrZero} and
+ * {@code @Email} were not read at all. Issue #657.
+ *
+ * <p>{@link org.tornotron.echno_backend.common.configuration.ValidationConstraintsModelConverter}
+ * closes that, and this is what keeps it closed. It reads the committed document and fails when
+ * an annotated field is not described the way the annotation behind it behaves, so a springdoc
+ * or swagger-core upgrade that changes the resolution order cannot quietly take the constraints
+ * back out.
+ *
+ * <p>It checks only what the annotation itself guarantees. {@code @NotBlank} also rejects a
+ * string of blanks and {@code minLength: 1} does not say so, so the document understates it on
+ * purpose; a contract that overstates a constraint is the worse failure, because a client
+ * pre-validating against it refuses input the server would have taken.
+ *
+ * <p>It reads {@code docs/openapi.json} rather than booting an application, because the
+ * committed copy is already held to the served document by {@code OpenApiSnapshotTest} in its
+ * own task, and a second Spring context is the one thing the test JVM has no room for.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class OpenApiValidationConstraintsTest {
+
+    /** The committed contract, relative to the project directory the test task runs in. */
+    private static final Path DOCUMENT = Path.of("docs", "openapi.json");
+
+    /** The JSON Schema format a string carrying an email address is given. */
+    private static final String EMAIL_FORMAT = "email";
+
+    /**
+     * Reports every annotated field the document describes more loosely than the endpoint
+     * enforces, grouped by the four things that were wrong.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void everyConstrainedFieldIsDescribed(JavaClasses productionClasses) {
+        JsonNode schemas = readSchemas();
+        Map<String, List<String>> unstated = new LinkedHashMap<>();
+        unstated.put("not in required, although the constraint rejects null", new ArrayList<>());
+        unstated.put("no minimum length or item count, although the constraint rejects empty",
+                new ArrayList<>());
+        unstated.put("no numeric bound, although the constraint rejects the wrong sign",
+                new ArrayList<>());
+        unstated.put("no email format", new ArrayList<>());
+        unstated.put("annotated on a published schema, but the document has no such property",
+                new ArrayList<>());
+        int checked = 0;
+
+        for (JavaClass javaClass : productionClasses) {
+            for (JavaField field : javaClass.getFields()) {
+                boolean notBlank = carries(field, NotBlank.class);
+                boolean notEmpty = carries(field, NotEmpty.class);
+                boolean positive = carries(field, Positive.class);
+                boolean positiveOrZero = carries(field, PositiveOrZero.class);
+                boolean negative = carries(field, Negative.class);
+                boolean negativeOrZero = carries(field, NegativeOrZero.class);
+                boolean email = carries(field, Email.class);
+                if (!(notBlank || notEmpty || positive || positiveOrZero
+                        || negative || negativeOrZero || email)) {
+                    continue;
+                }
+                String schemaName = schemaName(javaClass);
+                JsonNode schema = schemas.path(schemaName);
+                if (schema.isMissingNode()) {
+                    // The class is annotated but not published: an entity, or a type no endpoint
+                    // exposes. The document says nothing about it because it says nothing about
+                    // the class, which is not this test's business.
+                    continue;
+                }
+                checked++;
+
+                String name = propertyName(field);
+                String where = schemaName + "." + name;
+                JsonNode property = schema.path("properties").path(name);
+                if (property.isMissingNode()) {
+                    unstated.get("annotated on a published schema, but the document has no such "
+                            + "property").add(where);
+                    continue;
+                }
+
+                if ((notBlank || notEmpty) && !isRequired(schema, name)) {
+                    unstated.get("not in required, although the constraint rejects null")
+                            .add(where);
+                }
+                if ((notBlank || notEmpty) && !hasFloor(property)) {
+                    unstated.get("no minimum length or item count, although the constraint "
+                            + "rejects empty").add(where + ": " + property);
+                }
+                if ((positive || positiveOrZero) && !hasLowerBound(property, positive)) {
+                    unstated.get("no numeric bound, although the constraint rejects the wrong "
+                            + "sign").add(where + ": " + property);
+                }
+                if ((negative || negativeOrZero) && !hasUpperBound(property, negative)) {
+                    unstated.get("no numeric bound, although the constraint rejects the wrong "
+                            + "sign").add(where + ": " + property);
+                }
+                if (email && !EMAIL_FORMAT.equals(property.path("format").asText(null))) {
+                    unstated.get("no email format").add(where + ": " + property);
+                }
+            }
+        }
+
+        assertThat(checked)
+                .as("no field carries a validation constraint this test knows how to check, so "
+                        + "it is checking nothing. Either the constraints have been removed from "
+                        + "the DTO layer or the class scan has stopped finding them")
+                .isPositive();
+        assertThat(flatten(unstated))
+                .as("these fields are constrained in the code but the committed document does not "
+                        + "say so, so a client reading the contract will send what the endpoint "
+                        + "refuses and a contract check reading it cannot tell. Regenerate with "
+                        + "./gradlew openApiSnapshot -PupdateOpenApiSnapshot, and if a field is "
+                        + "still not described check ValidationConstraintsModelConverter can "
+                        + "express its shape")
+                .isEmpty();
+    }
+
+    /**
+     * Whether the field carries the constraint in a form that holds for every request. A
+     * constraint naming validation groups applies only to the invocations that ask for those
+     * groups, and a schema keyword applies to all of them, so the document leaves it out and so
+     * does this check.
+     */
+    private static boolean carries(JavaField field, Class<? extends Annotation> constraint) {
+        if (!field.isAnnotatedWith(constraint)) {
+            return false;
+        }
+        Annotation present = field.getAnnotationOfType(constraint);
+        try {
+            Class<?>[] groups = (Class<?>[]) constraint.getMethod("groups").invoke(present);
+            return groups.length == 0;
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            return false;
+        }
+    }
+
+    /**
+     * The name the class is published under. Usually the simple name, unless {@code @Schema}
+     * gives it one of its own, which is how a nested type whose simple name another nested type
+     * also carries is kept apart from it.
+     */
+    private static String schemaName(JavaClass javaClass) {
+        if (javaClass.isAnnotatedWith(io.swagger.v3.oas.annotations.media.Schema.class)) {
+            String named = javaClass
+                    .getAnnotationOfType(io.swagger.v3.oas.annotations.media.Schema.class).name();
+            if (!named.isBlank()) {
+                return named;
+            }
+        }
+        return javaClass.getSimpleName();
+    }
+
+    /** The name the property carries in the document, which Jackson may have renamed. */
+    private static String propertyName(JavaField field) {
+        if (field.isAnnotatedWith(JsonProperty.class)) {
+            String renamed = field.getAnnotationOfType(JsonProperty.class).value();
+            if (!renamed.isEmpty() && !JsonProperty.USE_DEFAULT_NAME.equals(renamed)) {
+                return renamed;
+            }
+        }
+        return field.getName();
+    }
+
+    private static boolean isRequired(JsonNode schema, String name) {
+        for (JsonNode required : schema.path("required")) {
+            if (name.equals(required.asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the property states a floor that rules out the empty value, whichever of the three
+     * shapes a "not empty" constraint can land on.
+     */
+    private static boolean hasFloor(JsonNode property) {
+        for (String keyword : List.of("minLength", "minItems", "minProperties")) {
+            if (property.path(keyword).asInt(0) >= 1) {
+                return true;
+            }
+        }
+        // A property that is a reference to another model carries no length of its own, and
+        // required already says it cannot be left out. Nothing further to state.
+        return property.has("$ref") || property.has("allOf");
+    }
+
+    private static boolean hasLowerBound(JsonNode property, boolean strict) {
+        if (property.has("exclusiveMinimum") && property.path("exclusiveMinimum").asDouble() >= 0) {
+            return true;
+        }
+        if (!property.has("minimum")) {
+            return false;
+        }
+        double minimum = property.path("minimum").asDouble();
+        return strict ? minimum > 0 : minimum >= 0;
+    }
+
+    private static boolean hasUpperBound(JsonNode property, boolean strict) {
+        if (property.has("exclusiveMaximum") && property.path("exclusiveMaximum").asDouble() <= 0) {
+            return true;
+        }
+        if (!property.has("maximum")) {
+            return false;
+        }
+        double maximum = property.path("maximum").asDouble();
+        return strict ? maximum < 0 : maximum <= 0;
+    }
+
+    /** The four groups as one list, each entry carrying the heading it was filed under. */
+    private static List<String> flatten(Map<String, List<String>> unstated) {
+        List<String> all = new ArrayList<>();
+        unstated.forEach((heading, entries) -> {
+            if (!entries.isEmpty()) {
+                all.add(entries.size() + " " + heading + ":");
+                all.addAll(entries);
+            }
+        });
+        return all;
+    }
+
+    private static JsonNode readSchemas() {
+        assertThat(DOCUMENT)
+                .as("the committed OpenAPI document is missing; run ./gradlew openApiSnapshot "
+                        + "-PupdateOpenApiSnapshot")
+                .exists();
+        try {
+            return new ObjectMapper().readTree(Files.readString(DOCUMENT))
+                    .path("components").path("schemas");
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot read " + DOCUMENT.toAbsolutePath(), e);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/configuration/ValidationConstraintsModelConverterTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/configuration/ValidationConstraintsModelConverterTest.java
@@ -1,0 +1,231 @@
+package org.tornotron.echno_backend.common.configuration;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What the document says about a constrained field, resolved through the real swagger-core
+ * chain rather than against a hand-built schema.
+ *
+ * <p>Going through {@link ModelConverters} is the point of these cases. The behaviour being
+ * fixed is an ordering one inside {@code ModelResolver}: {@code @Size} assigns
+ * {@code minLength} after {@code @NotBlank} has set it, so a test that built the schema itself
+ * would not reproduce the thing that was wrong.
+ */
+class ValidationConstraintsModelConverterTest {
+
+    /** A three-oh document, to check the version-dependent spelling of an exclusive bound. */
+    private static final boolean OPENAPI_30 = false;
+
+    @Test
+    void aNotBlankFieldIsRequired() {
+        assertThat(resolve(Request.class).getRequired()).contains("reason");
+    }
+
+    @Test
+    void aNotBlankFieldSizedFromAboveStillCarriesALowerBound() {
+        Schema<?> reason = property(resolve(Request.class), "reason");
+
+        assertThat(reason.getMaxLength())
+                .as("the upper bound swagger-core already wrote is left as it stands")
+                .isEqualTo(1000);
+        assertThat(reason.getMinLength())
+                .as("@Size(max) defaults min to 0 and assigns it after @NotBlank, so without "
+                        + "the converter the document permits the empty string the endpoint "
+                        + "refuses")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void aNotEmptyCollectionIsRequiredAndCannotBeEmpty() {
+        Schema<?> model = resolve(Request.class);
+
+        assertThat(model.getRequired()).contains("items");
+        assertThat(property(model, "items").getMinItems()).isEqualTo(1);
+    }
+
+    @Test
+    void aNotEmptyMapCannotBeEmpty() {
+        assertThat(property(resolve(Request.class), "labels").getMinProperties()).isEqualTo(1);
+    }
+
+    @Test
+    void aPositiveAmountIsBoundedAboveZeroRatherThanAtIt() {
+        Schema<?> amount = property(resolve(Request.class), "amount");
+
+        assertThat(amount.getExclusiveMinimumValue())
+                .as("zero is not a positive amount, and minimum: 0 would say it is")
+                .isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(amount.getMinimum()).isNull();
+    }
+
+    @Test
+    void aPositiveOrZeroAmountIsBoundedAtZero() {
+        Schema<?> paid = property(resolve(Request.class), "paid");
+
+        assertThat(paid.getMinimum()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(paid.getExclusiveMinimumValue()).isNull();
+    }
+
+    @Test
+    void aNegativeAmountIsBoundedBelowZero() {
+        Schema<?> model = resolve(Request.class);
+
+        assertThat(property(model, "correction").getExclusiveMaximumValue())
+                .isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(property(model, "drawdown").getMaximum())
+                .isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void anEmailFieldCarriesTheEmailFormat() {
+        assertThat(property(resolve(Request.class), "contact").getFormat()).isEqualTo("email");
+    }
+
+    @Test
+    void aBoundAlreadyStatedIsNotOverwritten() {
+        Schema<?> quantity = property(resolve(Request.class), "quantity");
+
+        assertThat(quantity.getMinimum())
+                .as("@Min said 5, and @Positive saying 0 would loosen it")
+                .isEqualByComparingTo(BigDecimal.valueOf(5));
+        assertThat(quantity.getExclusiveMinimumValue()).isNull();
+    }
+
+    @Test
+    void aConstraintNamingValidationGroupsIsNotStated() {
+        Schema<?> model = resolve(Request.class);
+
+        assertThat(model.getRequired())
+                .as("the constraint holds only for invocations asking for that group, and a "
+                        + "schema keyword would hold for all of them")
+                .doesNotContain("draftOnly");
+        assertThat(property(model, "draftOnly").getMinLength()).isNull();
+    }
+
+    @Test
+    void aFieldTheAuthorCalledOptionalIsLeftOptional() {
+        assertThat(resolve(Request.class).getRequired()).doesNotContain("note");
+    }
+
+    @Test
+    void anUnconstrainedFieldIsUntouched() {
+        Schema<?> model = resolve(Request.class);
+
+        assertThat(model.getRequired()).doesNotContain("comment");
+        assertThat(property(model, "comment").getMinLength()).isNull();
+    }
+
+    @Test
+    void aNotNullFieldKeepsTheRequiredEntrySwaggerCoreAlreadyWrote() {
+        assertThat(resolve(Request.class).getRequired()).contains("projectId");
+    }
+
+    @Test
+    void aRecordComponentIsReadTheSameWayAsAField() {
+        Schema<?> model = resolve(RecordRequest.class);
+
+        assertThat(model.getRequired()).contains("reason");
+        assertThat(property(model, "reason").getMinLength()).isEqualTo(1);
+    }
+
+    @Test
+    void anExclusiveBoundOnAThreeOhDocumentIsSpeltTheWayThreeOhSpellsIt() {
+        Schema<?> amount = property(resolve(Request.class, OPENAPI_30), "amount");
+
+        assertThat(amount.getExclusiveMinimum())
+                .as("3.0 has no exclusiveMinimum value, only a flag beside an inclusive bound")
+                .isTrue();
+        assertThat(amount.getMinimum()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    private static Schema<?> resolve(Class<?> type) {
+        return resolve(type, true);
+    }
+
+    private static Schema<?> resolve(Class<?> type, boolean openapi31) {
+        ModelConverters converters = new ModelConverters(openapi31);
+        converters.addConverter(new ValidationConstraintsModelConverter());
+        Map<String, Schema> models = converters.readAll(type);
+        assertThat(models).containsKey(type.getSimpleName());
+        return models.get(type.getSimpleName());
+    }
+
+    private static Schema<?> property(Schema<?> model, String name) {
+        Schema<?> property = model.getProperties().get(name);
+        assertThat(property).as("the model has no property %s", name).isNotNull();
+        return property;
+    }
+
+    /** A validation group, named only so that a grouped constraint can be written below. */
+    interface Draft {
+    }
+
+    /** One field per shape the converter has an opinion about, and several it must not touch. */
+    @SuppressWarnings("unused")
+    static class Request {
+
+        @NotBlank
+        @Size(max = 1000)
+        public String reason;
+
+        @NotEmpty
+        public List<String> items;
+
+        @NotEmpty
+        public Map<String, String> labels;
+
+        @NotNull
+        @Positive
+        public BigDecimal amount;
+
+        @PositiveOrZero
+        public BigDecimal paid;
+
+        @Negative
+        public BigDecimal correction;
+
+        @NegativeOrZero
+        public BigDecimal drawdown;
+
+        @Email
+        public String contact;
+
+        @Positive
+        @jakarta.validation.constraints.Min(5)
+        public Integer quantity;
+
+        @NotBlank(groups = Draft.class)
+        public String draftOnly;
+
+        @NotBlank
+        @io.swagger.v3.oas.annotations.media.Schema(
+                requiredMode = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED)
+        public String note;
+
+        @NotNull
+        public Long projectId;
+
+        public String comment;
+    }
+
+    /** The same treatment on a record, which is how the newer request DTOs are written. */
+    record RecordRequest(@NotBlank @Size(max = 1000) String reason) {
+    }
+}


### PR DESCRIPTION
Closes #657. Same shape as #661: a focused customization plus a test that reads the committed document and fails when an annotated field is not described correctly.

## The finding

`docs/openapi.json` described far less than the code refuses, in four ways, all of them from `ModelResolver.applyBeanValidatorAnnotations` in swagger-core 2.2.29:

| | count | cause |
|---|---|---|
| fields that reject null but were not in `required` | **127** | `required` is reached only through the `@NotNull` branch, so `@NotBlank` and `@NotEmpty` never put a property in it, although both reject null exactly as `@NotNull` does |
| properties publishing `minLength: 0` | **48** | `@Size` assigns `minLength` from `Size.min()`, which defaults to 0, and runs *after* `@NotBlank` has set it to 1 |
| `@Positive` / `@PositiveOrZero` with no numeric bound | **12** | not read at all |
| `@Email` with no `format` | **7** | not read at all |

`minLength: 0` is the worst of the four, because it is not silence: it positively permits the empty string the endpoint answers 400 for.

The earlier guess on the issue, that the generator drops `@NotBlank`, was wrong. `@NotBlank` alone does produce `minLength: 1`. It is the interaction with `@Size` that loses it, which is why only something seeing both annotations together can settle the value.

## Why a model converter and not a document customizer

Nullability survived resolution onto the assembled document, which is what let #661 work from an `OpenApiCustomizer`. These constraints do not. They are consumed as each property is resolved, and `required` is written on the parent at that same moment, so by the time a customizer runs a `maxLength: 255` with no `minLength` beside it is indistinguishable from a plain `@Size`, and a name missing from `required` is indistinguishable from a genuinely optional field.

`ValidationConstraintsModelConverter` delegates down the chain first and repairs afterwards. Running after rather than before is the point: swagger-core applies `@Size` after `@NotBlank`, so a converter writing `minLength: 1` on the way in would have it overwritten on the way out.

## What it will not say

A document that overstates a constraint is worse than one that omits it, because a client legitimately pre-validates against it and refuses input the server would have accepted. So:

- `@NotBlank` rejects a string of blanks and `minLength: 1` does not say so. Left understated on purpose; the rest needs a `pattern`, which would collide with a `@Pattern` already on the field.
- a constraint naming validation `groups` is skipped, since whether it applies depends on the invocation and a schema keyword applies to all of them. (Nothing in the repo uses groups today; the guard is for the next one that does.)
- `@Min`, `@Max`, `@DecimalMin`, `@DecimalMax`, `@Size` and `@Pattern` are left to swagger-core, which already writes them correctly. An existing bound is never loosened: `@Positive @Min(5)` keeps `minimum: 5`.
- `@Past`, `@Future`, `@Digits`, cross-field and custom class-level constraints have no keyword that means what they mean.
- constraints on controller method parameters go through springdoc's parameter builder rather than this resolver, so a `@NotBlank @RequestParam` is untouched.

`@Positive` is written as `exclusiveMinimum: 0` rather than `minimum: 1`, which would be right for an integer and wrong for the `BigDecimal` amounts most of these are.

## One thing the test found that was not a missing keyword

`CreateInvoiceRequest.LineRequest` and `PostJournalRequest.LineRequest` share a simple name, so only one of the two could be published. The journal line won, and `CreateInvoiceRequest.lines` pointed at a schema describing an account id with a debit and a credit. A client following the document sent a body the endpoint rejects. The invoice line is now `@Schema(name = "InvoiceLineRequest")`; the journal line keeps the name it had, so nothing that reads `LineRequest` today changes meaning. (`BalanceSheetReport.AccountLine` and `ProfitAndLossReport.AccountLine` collide too, but they are structurally identical and carry no constraints, so that one is harmless and left alone.)

## Proof

`OpenApiValidationConstraintsTest` reads the committed document and fails when an annotated field is not described the way the annotation behind it behaves. Run against `docs/openapi.json` as it stood before this change it reports all **195**:

```
OpenApiValidationConstraintsTest > everyConstrainedFieldIsDescribed FAILED
    java.lang.AssertionError at OpenApiValidationConstraintsTest.java:155

  127 not in required, although the constraint rejects null
   48 no minimum length or item count, although the constraint rejects empty
   12 no numeric bound, although the constraint rejects the wrong sign
    7 no email format
    1 annotated on a published schema, but the document has no such property
```

It reads the committed copy rather than booting an application, since `OpenApiSnapshotTest` already holds that copy to the served document in its own task.

`ValidationConstraintsModelConverterTest` runs 15 cases through the real `ModelConverters` chain rather than a hand-built schema, because the behaviour being fixed is an ordering one inside `ModelResolver`: a test that built the schema itself would not reproduce it. It covers each shape the DTO layer produces, plus the four things the converter must leave alone.

## The document diff, audited entry by entry

142 changes, and nothing else in the file:

- 48 `minLength` raised from 0 to 1 (no other value, in either direction)
- 127 names added to `required`, 58 on schemas that had no list at all
- 7 `exclusiveMinimum: 0` and 5 `minimum: 0`
- 7 `format: "email"`
- 1 new schema `InvoiceLineRequest` and the one `$ref` repointed at it

Nothing removed, no bound loosened, no property newly declared that the endpoint does not enforce. Every `@NotBlank` and `@NotEmpty` in the repo sits on a request-reachable schema, so nothing on the response side gained a `required` it cannot honour.

## What this does for the contract check

`echno-core` reduces this document into `etc/backend-request-fields.json` and reports `unsendable-required-field` against every write call site. That check is request-side and reads `required`, so it was working from the `@NotNull` fields alone. Measured over the reduced form:

- 219 operations take a request body. **115 of them named no required field at all; now 65.**
- total required names across operations: **232 → 410**, with 102 operations gaining at least one.

The `required: ["reason"]` CodeRabbit asked for on core PR #82 now comes out of `contract:refresh` rather than needing a hand edit the next refresh would undo.

## Verified on lab `.116`

- `./gradlew test` green (8m 55s, 591 MB live of the 2048 MB cap, 29%)
- `./gradlew openApiSnapshot` green after the rebase onto `development`, so the committed document still matches the code