### PR TITLE
Publish the page size a listing serves, from the type that serves it

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -94775,7 +94775,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20990,7 +20990,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -31654,7 +31654,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 30,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -39061,7 +39061,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -46162,7 +46162,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -46855,7 +46855,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -82589,7 +82589,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -82728,7 +82728,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -83241,7 +83241,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -87315,7 +87315,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -88003,7 +88003,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -90571,7 +90571,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,
@@ -99380,7 +99380,7 @@
             "name": "pageSize",
             "required": false,
             "schema": {
-              "default": 10,
+              "default": 20,
               "description": "Rows per page.",
               "format": "int32",
               "maximum": 500,

--- a/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/asset/AssetControllerWeb.java
@@ -18,6 +18,7 @@ import org.tornotron.echno_backend.asset.dto.AssetMovementDto;
 import org.tornotron.echno_backend.asset.dto.AssetPlacementSpanDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
@@ -154,8 +155,8 @@ public class AssetControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No asset with the given id")
     })
     public ResponseEntity<Page<AssetMovementDto>> readMovements(@PathVariable Long id,
-                                                                @Valid @ParameterObject PageQuery pageQuery) {
-        return new ResponseEntity<>(assetService.getMovements(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)), HttpStatus.OK);
+                                                                @Valid @ParameterObject PageQuery20 pageQuery) {
+        return new ResponseEntity<>(assetService.getMovements(id, pageQuery.getPageNo(), pageQuery.getPageSize()), HttpStatus.OK);
     }
 
     @GetMapping("/{id}/placement-history")

--- a/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/chat/ChatControllerWeb.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
-import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery30;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import jakarta.servlet.http.HttpServletResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -134,8 +134,8 @@ public class ChatControllerWeb {
     })
     public ResponseEntity<Page<ChatMessageDto>> readMessages(
             @PathVariable Long roomId,
-            @Valid @ParameterObject PageQuery pageQuery) {
-        return new ResponseEntity<>(chatService.getMessages(roomId, pageQuery.getPageNo(), pageQuery.pageSizeOr(30)), HttpStatus.OK);
+            @Valid @ParameterObject PageQuery30 pageQuery) {
+        return new ResponseEntity<>(chatService.getMessages(roomId, pageQuery.getPageNo(), pageQuery.getPageSize()), HttpStatus.OK);
     }
 
     @PostMapping(value = "/rooms/web/{roomId}/messages", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
@@ -51,7 +51,7 @@ public class PageQuery {
     private int pageNo = 0;
 
     // No defaultValue is declared here on purpose. It would have to be one number for every
-    // endpoint that takes the pair, and twelve of them do not serve that number, so the one
+    // endpoint that takes the pair, and thirteen of them do not serve that number, so the one
     // written here would be wrong wherever it was not also the endpoint's. PageSizeSchemaCustomizer
     // writes the default onto each operation from the type that operation declares, which is the
     // same value binding will hand the handler.

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery.java
@@ -24,9 +24,14 @@ import org.springdoc.core.annotations.ParameterObject;
  * {@code GlobalExceptionHandler} as a 400 naming {@code pageNo} or {@code pageSize}. The query
  * parameters keep the names and the meaning they already had, so no caller has to change.
  *
- * <p>{@link #getPageSize()} answers the shared default. An endpoint that shipped with a different
- * default keeps it through {@link #pageSizeOr(int)}, which can tell an absent parameter from one
- * the caller set to the same value.
+ * <p>The rows a caller gets when they name no {@code pageSize} is not one number across the API:
+ * most endpoints serve {@link #DEFAULT_PAGE_SIZE}, a handful shipped with twenty, and the chat
+ * message listing shipped with thirty. An endpoint keeps the default it shipped with by declaring
+ * the subtype that carries it, {@link PageQuery20} or {@link PageQuery30}, in place of this class.
+ * The number then exists once, in that subtype's constructor, and
+ * {@link PageSizeSchemaCustomizer} reads it back off the declared type when the document is
+ * assembled, so what the contract publishes is the value the handler will actually be given
+ * rather than a second copy of it written by hand.
  */
 @ParameterObject
 public class PageQuery {
@@ -45,22 +50,38 @@ public class PageQuery {
             minimum = "0")
     private int pageNo = 0;
 
+    // No defaultValue is declared here on purpose. It would have to be one number for every
+    // endpoint that takes the pair, and twelve of them do not serve that number, so the one
+    // written here would be wrong wherever it was not also the endpoint's. PageSizeSchemaCustomizer
+    // writes the default onto each operation from the type that operation declares, which is the
+    // same value binding will hand the handler.
     @Min(value = 1, message = "pageSize must be at least 1")
     @Max(value = UnpagedResultCap.MAX_ROWS,
             message = "pageSize must not exceed " + UnpagedResultCap.MAX_ROWS)
     @Schema(description = "Rows per page.",
-            defaultValue = "" + DEFAULT_PAGE_SIZE,
             minimum = "1",
             maximum = "" + UnpagedResultCap.MAX_ROWS)
-    private int pageSize = DEFAULT_PAGE_SIZE;
+    private int pageSize;
 
     /**
-     * Whether the caller sent {@code pageSize} at all.
+     * Takes the shared default of {@link #DEFAULT_PAGE_SIZE} rows.
      *
-     * <p>Kept because the field carries a default, so its value alone cannot say whether it was
-     * asked for. {@link #pageSizeOr(int)} needs the difference.
+     * <p>Public and argument-free because Spring's model-attribute binding constructs the declared
+     * parameter type this way.
      */
-    private boolean pageSizeGiven;
+    public PageQuery() {
+        this(DEFAULT_PAGE_SIZE);
+    }
+
+    /**
+     * Takes the default a subtype exists to carry.
+     *
+     * @param defaultPageSize Rows per page when the caller names none. The one place this
+     *                        endpoint's default is written down.
+     */
+    protected PageQuery(int defaultPageSize) {
+        this.pageSize = defaultPageSize;
+    }
 
     /**
      * The requested page index, zero when the caller named none.
@@ -76,7 +97,7 @@ public class PageQuery {
     }
 
     /**
-     * The requested page size, {@link #DEFAULT_PAGE_SIZE} when the caller named none.
+     * The requested page size, this endpoint's own default when the caller named none.
      *
      * @return A page size between one and {@link UnpagedResultCap#MAX_ROWS}.
      */
@@ -86,22 +107,5 @@ public class PageQuery {
 
     public void setPageSize(int pageSize) {
         this.pageSize = pageSize;
-        this.pageSizeGiven = true;
-    }
-
-    /**
-     * The requested page size, falling back to this endpoint's own default rather than the shared
-     * one.
-     *
-     * <p>A handful of endpoints shipped with a default of twenty or thirty. Folding them onto the
-     * shared default would quietly shrink the page every caller who omits the parameter already
-     * receives, which is a change to a published contract and has nothing to do with the bound
-     * this class exists to apply.
-     *
-     * @param defaultPageSize Rows per page to use when the caller sent none.
-     * @return The caller's page size, or {@code defaultPageSize} if there was none.
-     */
-    public int pageSizeOr(int defaultPageSize) {
-        return pageSizeGiven ? pageSize : defaultPageSize;
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery20.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery20.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.springdoc.core.annotations.ParameterObject;
+
+/**
+ * The page pair for an endpoint that ships twenty rows to a caller who asks for no particular
+ * number.
+ *
+ * <p>Several listings served twenty long before {@link PageQuery} existed, most of them because
+ * they took a Spring {@code Pageable} and nothing set
+ * {@code spring.data.web.pageable.default-page-size} away from it. Folding them onto
+ * {@link PageQuery#DEFAULT_PAGE_SIZE} would halve what every caller who omits {@code pageSize}
+ * receives today, which is a change to a published contract and no part of describing one.
+ *
+ * <p>The endpoint declares this type instead of writing the number in its handler, so the number
+ * is here and nowhere else. {@link PageSizeSchemaCustomizer} reads it back off the declared type
+ * when the document is assembled: the contract cannot say twenty while the handler serves
+ * something else, because both come from the constructor below.
+ */
+@ParameterObject
+public class PageQuery20 extends PageQuery {
+
+    /** Rows per page when the caller names none. */
+    public static final int PAGE_SIZE = 20;
+
+    public PageQuery20() {
+        super(PAGE_SIZE);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery30.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageQuery30.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import org.springdoc.core.annotations.ParameterObject;
+
+/**
+ * The page pair for the chat message listing, which ships thirty rows to a caller who asks for no
+ * particular number.
+ *
+ * <p>One endpoint uses it, and it is the widest gap the document carried: three times the ten it
+ * published. A room's history is read newest first in blocks, so thirty is the size the client
+ * scrolls by; shrinking it would change what an existing reader receives per request.
+ *
+ * <p>Same arrangement as {@link PageQuery20}: the number lives in the constructor, and
+ * {@link PageSizeSchemaCustomizer} publishes that number rather than a second copy of it.
+ */
+@ParameterObject
+public class PageQuery30 extends PageQuery {
+
+    /** Rows per page when the caller names none. */
+    public static final int PAGE_SIZE = 30;
+
+    public PageQuery30() {
+        super(PAGE_SIZE);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizer.java
@@ -17,12 +17,12 @@ import java.util.List;
  * type that operation declares.
  *
  * <p>{@link PageQuery} is one parameter object shared by fifty-odd endpoints, so a
- * {@code defaultValue} written on its {@code pageSize} field is one number for all of them. Twelve
- * of them do not serve that number: the eleven listings on {@link PageQuery20} serve twenty and
- * the chat messages listing on {@link PageQuery30} serves thirty. The document said ten for all
- * fifty-odd regardless, which is how twelve listings came to publish a page size no caller would
- * ever receive, and how a client reading the contract could plan for ten rows, ask for none, and
- * be handed twenty. Issue #662.
+ * {@code defaultValue} written on its {@code pageSize} field is one number for all of them.
+ * Thirteen of them do not serve that number: the twelve listings on {@link PageQuery20} serve
+ * twenty and the chat messages listing on {@link PageQuery30} serves thirty. The document said ten
+ * for all fifty-odd regardless, which is how thirteen listings came to publish a page size no
+ * caller would ever receive, and how a client reading the contract could plan for ten rows, ask
+ * for none, and be handed twenty. Issue #662.
  *
  * <p>The fix has to be one source of truth rather than two that happen to agree, because two is
  * the arrangement that produced this. So nothing here is declared: the customizer constructs the

--- a/src/main/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizer.java
+++ b/src/main/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizer.java
@@ -1,0 +1,105 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+/**
+ * Writes each paginated operation's {@code pageSize} default into the document from the page-query
+ * type that operation declares.
+ *
+ * <p>{@link PageQuery} is one parameter object shared by fifty-odd endpoints, so a
+ * {@code defaultValue} written on its {@code pageSize} field is one number for all of them. Twelve
+ * of them do not serve that number: the eleven listings on {@link PageQuery20} serve twenty and
+ * the chat messages listing on {@link PageQuery30} serves thirty. The document said ten for all
+ * fifty-odd regardless, which is how twelve listings came to publish a page size no caller would
+ * ever receive, and how a client reading the contract could plan for ten rows, ask for none, and
+ * be handed twenty. Issue #662.
+ *
+ * <p>The fix has to be one source of truth rather than two that happen to agree, because two is
+ * the arrangement that produced this. So nothing here is declared: the customizer constructs the
+ * declared parameter type exactly as Spring's model-attribute binding will, and reads
+ * {@link PageQuery#getPageSize()} off it. That is by construction the value a caller who sends no
+ * {@code pageSize} gets, since binding starts from the same constructor and then writes nothing
+ * over it. An endpoint's default can only move by moving the constructor that sets it, and the
+ * document moves with it.
+ *
+ * <p>Every paginated operation is written, including the ones on the shared default, so the
+ * document has no default that this class did not put there. A springdoc that started sharing one
+ * {@code Schema} instance between operations would then show one number across all of them rather
+ * than quietly corrupting a few, and {@code OpenApiPageSizeDefaultTest} would say so.
+ *
+ * <h2>Why an operation customizer</h2>
+ *
+ * <p>The value belongs to the handler, not to the type being resolved, and an
+ * {@link OperationCustomizer} is the only springdoc hook that is handed both: the assembled
+ * operation and the {@link HandlerMethod} behind it. A model converter sees {@code int} with no
+ * idea which endpoint asked, and a schema annotation on the field cannot vary by caller at all.
+ */
+@Component
+@Slf4j
+public class PageSizeSchemaCustomizer implements OperationCustomizer {
+
+    /** The query parameter this class exists to describe. */
+    private static final String PAGE_SIZE = "pageSize";
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        Integer servedDefault = servedDefault(handlerMethod);
+        if (servedDefault == null) {
+            return operation;
+        }
+        List<Parameter> parameters = operation.getParameters();
+        if (parameters == null) {
+            return operation;
+        }
+        for (Parameter parameter : parameters) {
+            if (!PAGE_SIZE.equals(parameter.getName())) {
+                continue;
+            }
+            Schema<?> schema = parameter.getSchema();
+            if (schema == null) {
+                // Nothing to describe the default on. Worth knowing about rather than silently
+                // skipping, since it would mean the parameter object stopped being expanded.
+                log.warn("pageSize on {} has no schema to carry its default of {}",
+                        handlerMethod.getShortLogMessage(), servedDefault);
+                continue;
+            }
+            schema.setDefault(servedDefault);
+        }
+        return operation;
+    }
+
+    /**
+     * The rows this handler serves a caller who sends no {@code pageSize}.
+     *
+     * @param handlerMethod The handler behind the operation being described.
+     * @return The served default, or {@code null} if the handler takes no page query at all.
+     */
+    private Integer servedDefault(HandlerMethod handlerMethod) {
+        for (MethodParameter methodParameter : handlerMethod.getMethodParameters()) {
+            Class<?> type = methodParameter.getParameterType();
+            if (!PageQuery.class.isAssignableFrom(type)) {
+                continue;
+            }
+            try {
+                return ((PageQuery) type.getDeclaredConstructor().newInstance()).getPageSize();
+            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                     | InvocationTargetException e) {
+                // Binding constructs the same type the same way, so a type that cannot be
+                // constructed here could not have served a request either.
+                throw new IllegalStateException(
+                        "A page query a handler declares must be constructible: " + type.getName(), e);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentControllerWeb.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
@@ -36,19 +36,6 @@ import java.util.UUID;
                 + "system administrators and project managers."
 )
 public class ConstructionPaymentControllerWeb {
-
-    /**
-     * Rows this listing answers with when the caller names no page size.
-     *
-     * <p>Twenty is what the endpoint has been returning, though nothing here said so: it took a
-     * Spring {@code Pageable}, whose default comes from
-     * {@code spring.data.web.pageable.default-page-size}, and that property is not set. The point
-     * of issue #638 is that the number was invisible and unreachable, not that it was twenty, so
-     * it is written down here rather than changed. Folding the endpoint onto
-     * {@link PageQuery#DEFAULT_PAGE_SIZE} would halve what every caller who omits the parameter
-     * receives today, which is a contract change with nothing to do with the fix.
-     */
-    private static final int SHIPPED_PAGE_SIZE = 20;
 
     private final ConstructionPaymentService service;
 
@@ -111,10 +98,10 @@ public class ConstructionPaymentControllerWeb {
                                              @RequestParam(required = false) Long employeeId,
                                              @RequestParam(required = false) Long verifiedBy,
                                              @RequestParam(required = false) Long raisedBy,
-                                             PageQuery pageQuery) {
+                                             PageQuery20 pageQuery) {
         return service.findAll(projectId, vendorId, status, type, payeeType,
                 employeeId, verifiedBy, raisedBy,
-                pageQuery.getPageNo(), pageQuery.pageSizeOr(SHIPPED_PAGE_SIZE));
+                pageQuery.getPageNo(), pageQuery.getPageSize());
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemController.java
@@ -12,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -107,8 +108,8 @@ public class IndentItemController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the indent-item read or admin authority")
     })
     public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
-            @Valid @ParameterObject PageQuery pageQuery) {
-        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
+            @Valid @ParameterObject PageQuery20 pageQuery) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/indentItem/IndentItemControllerWeb.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemCreationDto;
 import org.tornotron.echno_backend.indentItem.dto.IndentItemDto;
@@ -103,8 +104,8 @@ public class IndentItemControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<IndentItemDto>> getIndentItemsPaginated(
-            @Valid @ParameterObject PageQuery pageQuery) {
-        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
+            @Valid @ParameterObject PageQuery20 pageQuery) {
+        return ResponseEntity.ok(indentItemService.getIndentItemsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 
     @GetMapping("/indent/{indentId}")

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectControllerWeb.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -150,9 +151,9 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<ProjectDto>> readAllProjectsPaginated(
-            @Valid @ParameterObject PageQuery pageQuery,
+            @Valid @ParameterObject PageQuery20 pageQuery,
             @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(service.getProjectsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), search));
+        return ResponseEntity.ok(service.getProjectsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), search));
     }
 
     /**
@@ -186,10 +187,10 @@ public class ProjectControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<ProjectSummaryDto>> readAllProjectSummaries(
-            @Valid @ParameterObject PageQuery pageQuery,
+            @Valid @ParameterObject PageQuery20 pageQuery,
             @RequestParam(required = false) String search) {
         return ResponseEntity.ok(
-                service.getProjectsSummaryPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), search));
+                service.getProjectsSummaryPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), search));
     }
 
     /**
@@ -242,9 +243,9 @@ public class ProjectControllerWeb {
     })
     public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
             @PathVariable Long id,
-            @Valid @ParameterObject PageQuery pageQuery) {
+            @Valid @ParameterObject PageQuery20 pageQuery) {
         return new ResponseEntity<>(
-                service.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)),
+                service.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.getPageSize()),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrder/PurchaseOrderControllerWeb.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderCreationDto;
 import org.tornotron.echno_backend.purchaseOrder.dto.PurchaseOrderDto;
@@ -99,9 +100,9 @@ public class PurchaseOrderControllerWeb {
     })
     public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
             @PathVariable Long id,
-            @Valid @ParameterObject PageQuery pageQuery) {
+            @Valid @ParameterObject PageQuery20 pageQuery) {
         return new ResponseEntity<>(
-                purchaseOrderService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)),
+                purchaseOrderService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.getPageSize()),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemResponseDto;
@@ -110,8 +111,8 @@ public class PurchaseOrderItemController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
-            @Valid @ParameterObject PageQuery pageQuery) {
-        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
+            @Valid @ParameterObject PageQuery20 pageQuery) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")

--- a/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/purchaseOrderItem/PurchaseOrderItemControllerWeb.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemCreationDto;
 import org.tornotron.echno_backend.purchaseOrderItem.dto.PurchaseOrderItemResponseDto;
@@ -106,8 +107,8 @@ public class PurchaseOrderItemControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<PurchaseOrderItemResponseDto>> getPurchaseOrderItemsPaginated(
-            @Valid @ParameterObject PageQuery pageQuery) {
-        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
+            @Valid @ParameterObject PageQuery20 pageQuery) {
+        return ResponseEntity.ok(purchaseOrderItemService.getPurchaseOrderItemsPaginated(pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 
     @GetMapping("/purchase-order/{purchaseOrderId}")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCancellationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
@@ -263,8 +264,8 @@ public class SiteTransferControllerWeb {
     })
     public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
             @PathVariable Long id,
-            @Valid @ParameterObject PageQuery pageQuery) {
+            @Valid @ParameterObject PageQuery20 pageQuery) {
         return ResponseEntity.ok(
-                siteTransferService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
+                siteTransferService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.getPageSize()));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskControllerWeb.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.core.annotations.ParameterObject;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.payload.JsonPartBinder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -145,10 +146,10 @@ public class TaskControllerWeb {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Page<TaskDto>> readAllTasksPaginated(
-            @Valid @ParameterObject PageQuery pageQuery,
+            @Valid @ParameterObject PageQuery20 pageQuery,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(service.getTasksPaginated(pageQuery.getPageNo(), pageQuery.pageSizeOr(20), projectId, search));
+        return ResponseEntity.ok(service.getTasksPaginated(pageQuery.getPageNo(), pageQuery.getPageSize(), projectId, search));
     }
 
     @GetMapping("/projectId/{projectId}")

--- a/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
@@ -1,0 +1,282 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.tornotron.echno_backend.common.pagination.PageQuery;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every paginated endpoint publishes the page size it actually serves.
+ *
+ * <p>{@code PageQuery} is one parameter object shared by fifty-odd endpoints, so a page size
+ * written on its field is one number for all of them. Twelve of them do not serve that number:
+ * they serve twenty, and the chat message listing serves thirty. The document said ten for every
+ * one of them, so a client that read the contract, planned for ten rows and sent no
+ * {@code pageSize} was handed twenty with nothing to tell it why. That matters here more than it
+ * would elsewhere, because {@code echno-core} is written against this document rather than against
+ * the running service: the contract is what a caller has. It is also how a payment listing came to
+ * be summed and counted from twenty rows under a label that said all of them. Issue #662.
+ *
+ * <p>{@code PageSizeSchemaCustomizer} closes it by writing each operation's default from the page
+ * query type that operation declares. This test is what keeps it closed, and it is deliberately
+ * not written against the customizer: it takes the served default the same way a caller would
+ * discover it, by constructing the declared parameter type exactly as Spring's binding does and
+ * reading the size a caller who sends nothing is left with. So it fails for a document that is
+ * stale, for a customizer that is removed, and for an endpoint that grows a default the document
+ * was never told about, which is the thirteenth call site this whole arrangement exists to catch.
+ *
+ * <p>Run against {@code docs/openapi.json} as it stood before the fix it reports all twelve.
+ *
+ * <p>It reads the committed document rather than booting an application, for the reason
+ * {@link OpenApiNullabilityTest} gives: {@code OpenApiSnapshotTest} already holds that copy to the
+ * served one in a task of its own, and a second Spring context is the one thing the test JVM has
+ * no room for.
+ */
+@AnalyzeClasses(
+        packages = "org.tornotron.echno_backend",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class OpenApiPageSizeDefaultTest {
+
+    /** The committed contract, relative to the project directory the test task runs in. */
+    private static final Path DOCUMENT = Path.of("docs", "openapi.json");
+
+    /** The query parameter whose default is in question. */
+    private static final String PAGE_SIZE = "pageSize";
+
+    /**
+     * Reports every paginated operation whose documented page size is not the one it serves.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void everyListingDocumentsThePageSizeItServes(JavaClasses productionClasses) {
+        JsonNode document = readDocument();
+        List<String> wrong = new ArrayList<>();
+
+        for (PaginatedEndpoint endpoint : paginatedEndpoints(productionClasses)) {
+            JsonNode schema = pageSizeSchema(document, endpoint.path(), endpoint.httpMethod());
+            if (schema == null) {
+                wrong.add(endpoint + " is not in the document as an operation taking " + PAGE_SIZE);
+                continue;
+            }
+            JsonNode documented = schema.get("default");
+            if (documented == null) {
+                wrong.add(endpoint + " serves " + endpoint.servedDefault()
+                        + " rows and documents no default at all");
+            } else if (documented.asInt() != endpoint.servedDefault()) {
+                wrong.add(endpoint + " serves " + endpoint.servedDefault()
+                        + " rows and documents " + documented.asInt());
+            }
+        }
+
+        assertThat(wrong)
+                .as("a listing that publishes one page size and serves another gives a client no "
+                        + "way to know how many rows it is holding; the default belongs to the page "
+                        + "query type the endpoint declares, and PageSizeSchemaCustomizer publishes "
+                        + "that one rather than a second copy written by hand")
+                .isEmpty();
+    }
+
+    /**
+     * Every {@code pageSize} the document publishes belongs to an endpoint the rule above checked.
+     *
+     * <p>Without this, an endpoint the reflection cannot reach, or a path this test spells
+     * differently from springdoc, would be silently unchecked rather than wrong, and the rule
+     * would pass by looking at nothing.
+     *
+     * @param productionClasses The imported production classes, supplied by ArchUnit.
+     */
+    @ArchTest
+    static void everyDocumentedPageSizeIsCovered(JavaClasses productionClasses) {
+        Set<String> checked = new TreeSet<>();
+        for (PaginatedEndpoint endpoint : paginatedEndpoints(productionClasses)) {
+            checked.add(endpoint.httpMethod() + " " + endpoint.path());
+        }
+
+        Set<String> documented = new TreeSet<>();
+        JsonNode paths = readDocument().get("paths");
+        for (Iterator<Map.Entry<String, JsonNode>> it = paths.fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> path = it.next();
+            for (Iterator<Map.Entry<String, JsonNode>> ops = path.getValue().fields();
+                 ops.hasNext(); ) {
+                Map.Entry<String, JsonNode> operation = ops.next();
+                if (parameterNamed(operation.getValue(), PAGE_SIZE) != null) {
+                    documented.add(operation.getKey().toUpperCase() + " " + path.getKey());
+                }
+            }
+        }
+
+        assertThat(documented)
+                .as("these operations publish a pageSize that the rule above never looked at, so "
+                        + "nothing holds their documented default to the one they serve")
+                .isSubsetOf(checked);
+    }
+
+    /**
+     * Every handler that takes the page pair, with the rows it serves a caller who sends none.
+     */
+    private static List<PaginatedEndpoint> paginatedEndpoints(JavaClasses productionClasses) {
+        List<PaginatedEndpoint> endpoints = new ArrayList<>();
+        productionClasses.stream()
+                .filter(javaClass -> javaClass.isMetaAnnotatedWith(Controller.class))
+                .map(JavaClass::reflect)
+                .forEach(controller -> {
+                    for (Method method : controller.getDeclaredMethods()) {
+                        Class<?> pageQueryType = pageQueryParameterOf(method);
+                        if (pageQueryType == null) {
+                            continue;
+                        }
+                        int served = servedDefault(pageQueryType);
+                        for (String path : pathsOf(controller, method)) {
+                            for (RequestMethod httpMethod : httpMethodsOf(method)) {
+                                endpoints.add(
+                                        new PaginatedEndpoint(path, httpMethod.name(), served));
+                            }
+                        }
+                    }
+                });
+        return endpoints;
+    }
+
+    /** The page query type a handler declares, or {@code null} if it takes none. */
+    private static Class<?> pageQueryParameterOf(Method method) {
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            if (PageQuery.class.isAssignableFrom(parameterType)) {
+                return parameterType;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The rows a caller who sends no {@code pageSize} receives, taken the way binding takes it:
+     * from the declared type's own constructor, with nothing written over it.
+     */
+    private static int servedDefault(Class<?> pageQueryType) {
+        try {
+            return ((PageQuery) pageQueryType.getDeclaredConstructor().newInstance()).getPageSize();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                    "A page query a handler declares must be constructible: "
+                            + pageQueryType.getName(), e);
+        }
+    }
+
+    /** The full paths a handler answers on, class mapping and method mapping joined. */
+    private static Set<String> pathsOf(Class<?> controller, Method method) {
+        Set<String> paths = new LinkedHashSet<>();
+        for (String base : declaredPaths(controller)) {
+            for (String tail : declaredPaths(method)) {
+                paths.add(normalise(base + "/" + tail));
+            }
+        }
+        return paths;
+    }
+
+    /** The paths a single {@code @RequestMapping} or one of its shorthands declares. */
+    private static List<String> declaredPaths(java.lang.reflect.AnnotatedElement element) {
+        RequestMapping mapping =
+                AnnotatedElementUtils.findMergedAnnotation(element, RequestMapping.class);
+        if (mapping == null || mapping.path().length == 0) {
+            return List.of("");
+        }
+        return List.of(mapping.path());
+    }
+
+    /** The verbs a handler answers on, defaulting to every one when the mapping names none. */
+    private static List<RequestMethod> httpMethodsOf(Method method) {
+        RequestMapping mapping =
+                AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class);
+        if (mapping == null || mapping.method().length == 0) {
+            return List.of(RequestMethod.values());
+        }
+        return List.of(mapping.method());
+    }
+
+    /**
+     * Spells a joined mapping the way springdoc publishes it.
+     *
+     * <p>Collapses the doubled and trailing separators joining two mappings leaves, and supplies
+     * the leading one: {@code CategoryController} maps {@code api/v1/workCategories} without it
+     * and is published with it, since Spring treats the two spellings as the same path.
+     */
+    private static String normalise(String path) {
+        String collapsed = path.replaceAll("/{2,}", "/");
+        if (collapsed.length() > 1 && collapsed.endsWith("/")) {
+            collapsed = collapsed.substring(0, collapsed.length() - 1);
+        }
+        return collapsed.startsWith("/") ? collapsed : "/" + collapsed;
+    }
+
+    /** The schema of an operation's {@code pageSize} parameter, or {@code null} if it has none. */
+    private static JsonNode pageSizeSchema(JsonNode document, String path, String httpMethod) {
+        JsonNode operations = document.path("paths").get(path);
+        if (operations == null) {
+            return null;
+        }
+        JsonNode operation = operations.get(httpMethod.toLowerCase());
+        if (operation == null) {
+            return null;
+        }
+        JsonNode parameter = parameterNamed(operation, PAGE_SIZE);
+        return parameter == null ? null : parameter.get("schema");
+    }
+
+    /** An operation's query parameter of the given name, or {@code null} if it declares none. */
+    private static JsonNode parameterNamed(JsonNode operation, String name) {
+        for (JsonNode parameter : operation.path("parameters")) {
+            if (name.equals(parameter.path("name").asText())) {
+                return parameter;
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode readDocument() {
+        try {
+            return new ObjectMapper().readTree(Files.readString(DOCUMENT));
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "The committed OpenAPI document is what this rule reads; regenerate it with "
+                            + "./gradlew openApiSnapshot -PupdateOpenApiSnapshot", e);
+        }
+    }
+
+    /**
+     * One operation that takes the page pair.
+     *
+     * @param path          The full path springdoc publishes it under.
+     * @param httpMethod    The verb, upper case.
+     * @param servedDefault The rows it hands a caller who sends no page size.
+     */
+    private record PaginatedEndpoint(String path, String httpMethod, int servedDefault) {
+
+        @Override
+        public String toString() {
+            return httpMethod + " " + path;
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
@@ -145,13 +145,21 @@ class OpenApiPageSizeDefaultTest {
                 .map(JavaClass::reflect)
                 .forEach(controller -> {
                     for (Method method : controller.getDeclaredMethods()) {
+                        RequestMapping mapping = AnnotatedElementUtils
+                                .findMergedAnnotation(method, RequestMapping.class);
+                        if (mapping == null) {
+                            // Not a request handler. A helper that happens to take the page pair
+                            // has no path and no verb, so treating it as an endpoint would invent
+                            // one on the class's own mapping and on every verb there is.
+                            continue;
+                        }
                         Class<?> pageQueryType = pageQueryParameterOf(method);
                         if (pageQueryType == null) {
                             continue;
                         }
                         int served = servedDefault(pageQueryType);
-                        for (String path : pathsOf(controller, method)) {
-                            for (RequestMethod httpMethod : httpMethodsOf(method)) {
+                        for (String path : pathsOf(controller, mapping)) {
+                            for (RequestMethod httpMethod : httpMethodsOf(mapping)) {
                                 endpoints.add(
                                         new PaginatedEndpoint(path, httpMethod.name(), served));
                             }
@@ -186,10 +194,11 @@ class OpenApiPageSizeDefaultTest {
     }
 
     /** The full paths a handler answers on, class mapping and method mapping joined. */
-    private static Set<String> pathsOf(Class<?> controller, Method method) {
+    private static Set<String> pathsOf(Class<?> controller, RequestMapping mapping) {
         Set<String> paths = new LinkedHashSet<>();
-        for (String base : declaredPaths(controller)) {
-            for (String tail : declaredPaths(method)) {
+        for (String base : declaredPaths(
+                AnnotatedElementUtils.findMergedAnnotation(controller, RequestMapping.class))) {
+            for (String tail : declaredPaths(mapping)) {
                 paths.add(normalise(base + "/" + tail));
             }
         }
@@ -197,20 +206,16 @@ class OpenApiPageSizeDefaultTest {
     }
 
     /** The paths a single {@code @RequestMapping} or one of its shorthands declares. */
-    private static List<String> declaredPaths(java.lang.reflect.AnnotatedElement element) {
-        RequestMapping mapping =
-                AnnotatedElementUtils.findMergedAnnotation(element, RequestMapping.class);
+    private static List<String> declaredPaths(RequestMapping mapping) {
         if (mapping == null || mapping.path().length == 0) {
             return List.of("");
         }
         return List.of(mapping.path());
     }
 
-    /** The verbs a handler answers on, defaulting to every one when the mapping names none. */
-    private static List<RequestMethod> httpMethodsOf(Method method) {
-        RequestMapping mapping =
-                AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class);
-        if (mapping == null || mapping.method().length == 0) {
+    /** The verbs a handler answers on, defaulting to every one when its mapping names none. */
+    private static List<RequestMethod> httpMethodsOf(RequestMapping mapping) {
+        if (mapping.method().length == 0) {
             return List.of(RequestMethod.values());
         }
         return List.of(mapping.method());

--- a/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/OpenApiPageSizeDefaultTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Every paginated endpoint publishes the page size it actually serves.
  *
  * <p>{@code PageQuery} is one parameter object shared by fifty-odd endpoints, so a page size
- * written on its field is one number for all of them. Twelve of them do not serve that number:
+ * written on its field is one number for all of them. Thirteen of them do not serve that number:
  * they serve twenty, and the chat message listing serves thirty. The document said ten for every
  * one of them, so a client that read the contract, planned for ten rows and sent no
  * {@code pageSize} was handed twenty with nothing to tell it why. That matters here more than it
@@ -46,9 +46,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * discover it, by constructing the declared parameter type exactly as Spring's binding does and
  * reading the size a caller who sends nothing is left with. So it fails for a document that is
  * stale, for a customizer that is removed, and for an endpoint that grows a default the document
- * was never told about, which is the thirteenth call site this whole arrangement exists to catch.
+ * was never told about, which is the next call site this whole arrangement exists to catch. The
+ * thirteenth arrived from another branch while this was being written, which is roughly the point.
  *
- * <p>Run against {@code docs/openapi.json} as it stood before the fix it reports all twelve.
+ * <p>Run against {@code docs/openapi.json} as it stood before the fix it reports all thirteen.
  *
  * <p>It reads the committed document rather than booting an application, for the reason
  * {@link OpenApiNullabilityTest} gives: {@code OpenApiSnapshotTest} already holds that copy to the

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/PageSizeSchemaCustomizerTest.java
@@ -1,0 +1,150 @@
+package org.tornotron.echno_backend.common.pagination;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * What the customizer writes onto an operation, per shape of handler.
+ *
+ * <p>The rule that matters is in {@code OpenApiPageSizeDefaultTest}, which holds the committed
+ * document to the endpoints for real. These are the cases that rule cannot reach: a handler with
+ * no page query at all, an operation with no parameters, and a {@code pageSize} the parameter
+ * object failed to give a schema. Each of those is a way the customizer could throw during
+ * document assembly, which fails the build in a place that says nothing about pagination.
+ */
+class PageSizeSchemaCustomizerTest {
+
+    private final PageSizeSchemaCustomizer customizer = new PageSizeSchemaCustomizer();
+
+    @Test
+    void publishesTheSharedDefaultForAHandlerOnTheSharedPageQuery() {
+        Operation operation = operationWithPageSize();
+
+        customizer.customize(operation, handlerFor("shared"));
+
+        assertThat(pageSizeDefault(operation)).isEqualTo(PageQuery.DEFAULT_PAGE_SIZE);
+    }
+
+    @Test
+    void publishesTwentyForAHandlerThatShippedWithTwenty() {
+        Operation operation = operationWithPageSize();
+
+        customizer.customize(operation, handlerFor("twenty"));
+
+        assertThat(pageSizeDefault(operation)).isEqualTo(PageQuery20.PAGE_SIZE);
+    }
+
+    @Test
+    void publishesThirtyForAHandlerThatShippedWithThirty() {
+        Operation operation = operationWithPageSize();
+
+        customizer.customize(operation, handlerFor("thirty"));
+
+        assertThat(pageSizeDefault(operation)).isEqualTo(PageQuery30.PAGE_SIZE);
+    }
+
+    /**
+     * The default is read off the type the handler declares, so it is the size a caller who sends
+     * no {@code pageSize} is actually left holding rather than a number written twice.
+     */
+    @Test
+    void publishesTheSizeBindingWouldLeaveTheHandlerWith() {
+        Operation operation = operationWithPageSize();
+
+        customizer.customize(operation, handlerFor("twenty"));
+
+        assertThat(pageSizeDefault(operation)).isEqualTo(new PageQuery20().getPageSize());
+    }
+
+    @Test
+    void leavesOtherParametersAlone() {
+        Operation operation = operationWithPageSize();
+        Parameter search = new Parameter().name("search").schema(new StringSchema());
+        operation.getParameters().add(search);
+
+        customizer.customize(operation, handlerFor("twenty"));
+
+        assertThat(search.getSchema().getDefault()).isNull();
+    }
+
+    @Test
+    void writesNothingForAHandlerThatTakesNoPageQuery() {
+        Operation operation = operationWithPageSize();
+
+        customizer.customize(operation, handlerFor("unpaginated"));
+
+        assertThat(pageSizeDefault(operation)).isNull();
+    }
+
+    @Test
+    void toleratesAnOperationWithNoParameters() {
+        Operation operation = new Operation();
+
+        assertThatCode(() -> customizer.customize(operation, handlerFor("twenty")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void toleratesAPageSizeParameterWithNoSchema() {
+        Operation operation = new Operation();
+        operation.setParameters(new ArrayList<>(List.of(new Parameter().name("pageSize"))));
+
+        assertThatCode(() -> customizer.customize(operation, handlerFor("twenty")))
+                .doesNotThrowAnyException();
+    }
+
+    private static Operation operationWithPageSize() {
+        Operation operation = new Operation();
+        operation.setParameters(new ArrayList<>(List.of(
+                new Parameter().name("pageNo").schema(new IntegerSchema()),
+                new Parameter().name("pageSize").schema(new IntegerSchema()))));
+        return operation;
+    }
+
+    private static Object pageSizeDefault(Operation operation) {
+        return operation.getParameters().stream()
+                .filter(parameter -> "pageSize".equals(parameter.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getSchema()
+                .getDefault();
+    }
+
+    private static HandlerMethod handlerFor(String methodName) {
+        StubController controller = new StubController();
+        for (Method method : StubController.class.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return new HandlerMethod(controller, method);
+            }
+        }
+        throw new IllegalArgumentException("No stub handler named " + methodName);
+    }
+
+    /** The handler shapes the customizer has to answer for, standing in for a real controller. */
+    @SuppressWarnings("unused")
+    static class StubController {
+
+        public void shared(PageQuery pageQuery) {
+        }
+
+        public void twenty(PageQuery20 pageQuery) {
+        }
+
+        public void thirty(Long roomId, PageQuery30 pageQuery) {
+        }
+
+        public void unpaginated(Long id) {
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/finance/construction/web/ConstructionPaymentListingTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.finance.construction.ConstructionPayeeType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentType;
 import org.tornotron.echno_backend.finance.construction.ConstructionPaymentVoucherStatus;
@@ -64,7 +65,7 @@ class ConstructionPaymentListingTest {
                 .thenReturn(Page.empty());
 
         new ConstructionPaymentControllerWeb(service)
-                .list(null, null, null, null, null, null, null, null, new PageQuery());
+                .list(null, null, null, null, null, null, null, null, new PageQuery20());
 
         verify(service).findAll(isNull(), isNull(), isNull(), isNull(), isNull(),
                 isNull(), isNull(), isNull(),
@@ -79,7 +80,7 @@ class ConstructionPaymentListingTest {
      */
     @Test
     void theCallersPageBoundsReachTheService() {
-        PageQuery pageQuery = new PageQuery();
+        PageQuery20 pageQuery = new PageQuery20();
         pageQuery.setPageNo(2);
         pageQuery.setPageSize(200);
         when(service.findAll(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
@@ -104,7 +105,7 @@ class ConstructionPaymentListingTest {
                 ConstructionPaymentType.SALARY,
                 ConstructionPayeeType.EMPLOYEE,
                 33L, 44L, 55L,
-                new PageQuery());
+                new PageQuery20());
 
         verify(service).findAll(eq(11L), eq(22L),
                 eq(ConstructionPaymentVoucherStatus.COMPLETED),
@@ -129,7 +130,7 @@ class ConstructionPaymentListingTest {
                 .thenReturn(Page.empty());
 
         new ConstructionPaymentControllerWeb(service)
-                .list(null, null, null, null, null, 101L, 202L, 303L, new PageQuery());
+                .list(null, null, null, null, null, 101L, 202L, 303L, new PageQuery20());
 
         verify(service).findAll(isNull(), isNull(), isNull(), isNull(), isNull(),
                 eq(101L), eq(202L), eq(303L),
@@ -148,7 +149,7 @@ class ConstructionPaymentListingTest {
                 .thenAnswer(invocation -> page);
 
         assertThat(new ConstructionPaymentControllerWeb(service)
-                .list(null, null, null, null, null, null, null, null, new PageQuery()))
+                .list(null, null, null, null, null, null, null, null, new PageQuery20()))
                 .isSameAs(page);
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/project/ProjectControllerWebListingTest.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.project.dto.ProjectDto;
 
@@ -169,8 +169,8 @@ class ProjectControllerWebListingTest {
     }
 
     /** The page the request would have bound, built by hand for a direct controller call. */
-    private static PageQuery page(int pageNo, int pageSize) {
-        PageQuery pageQuery = new PageQuery();
+    private static PageQuery20 page(int pageNo, int pageSize) {
+        PageQuery20 pageQuery = new PageQuery20();
         pageQuery.setPageNo(pageNo);
         pageQuery.setPageSize(pageSize);
         return pageQuery;

--- a/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/task/TaskControllerWebListingTest.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.tornotron.echno_backend.common.pagination.PageQuery;
+import org.tornotron.echno_backend.common.pagination.PageQuery20;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 import org.tornotron.echno_backend.task.dto.TaskDto;
 
@@ -170,8 +170,8 @@ class TaskControllerWebListingTest {
     }
 
     /** The page the request would have bound, built by hand for a direct controller call. */
-    private static PageQuery page(int pageNo, int pageSize) {
-        PageQuery pageQuery = new PageQuery();
+    private static PageQuery20 page(int pageNo, int pageSize) {
+        PageQuery20 pageQuery = new PageQuery20();
         pageQuery.setPageNo(pageNo);
         pageQuery.setPageSize(pageSize);
         return pageQuery;


### PR DESCRIPTION
Closes #662.

## The finding

`PageQuery` is one `@ParameterObject` shared by fifty-four endpoints, and its `pageSize` field carried a fixed `@Schema(defaultValue = "10")`. Twelve endpoints did not serve ten. Eleven answered a caller who named no size with twenty rows, and `ChatControllerWeb.getMessages` with thirty, each keeping what it shipped with through `pageQuery.pageSizeOr(n)`. The document said ten for all of them.

That is worse here than it would be elsewhere: `echno-core` is written against this document rather than against the running service, so the contract is what a caller has. It is also the shape of the defect behind #655, where a payment register was summed and counted from twenty rows under a label that said all of them.

The issue's own table lists eleven. The twelfth, `PurchaseOrderControllerWeb.getStatusHistory`, was found by the test rather than by reading, which is roughly the point of having one.

## Which of the three candidates, and why

The issue sketched three. The trade is that only one of them leaves a single source of truth.

- **A per-endpoint `@Schema`** writes the number twice, in the annotation and in the `pageSizeOr` argument. Two declarations that agree today is exactly the arrangement that produced this, so it fixes the instances and keeps the mechanism.
- **Folding every endpoint onto ten** is the tidiest end state but halves eleven listings and cuts the chat page to a third of what a reader receives per request. That is a contract change, and it has nothing to do with describing one. `PageQuery`'s javadoc already says so, having been written when the same temptation came up on #638.
- **Reading the real default** keeps one source, and the question the issue raised against it was whether that value is reachable. It is, if the endpoint declares it as a type rather than as an argument.

So the third, in the form that makes the value statically reachable. An endpoint declares `PageQuery20` or `PageQuery30` in place of `PageQuery` and reads `getPageSize()`; the number lives in that subtype's constructor and nowhere else. `PageSizeSchemaCustomizer` constructs the declared parameter type exactly as Spring's model-attribute binding will and publishes the size it finds, which is by construction what a caller who sends no `pageSize` is left holding. The shared field now declares no default at all, because the value is not one number and never was, so a customizer that stopped running would leave the document visibly silent rather than quietly wrong.

An `OperationCustomizer` is the only springdoc hook handed both the assembled operation and the `HandlerMethod` behind it. A model converter sees `int` with no idea which endpoint asked.

## What a deployed caller receives

Nothing moves. Every endpoint keeps the size it has been serving, `PageQueryBindingTest.keepsAnEndpointsOwnDefaultPageSize` still drives that through the real request pipeline and still expects twenty, and the parameters keep their published names and bounds. Only the description changes.

## Proof

`OpenApiPageSizeDefaultTest` reads the committed `docs/openapi.json`, takes each endpoint's served size from the declared type the way binding does, and fails on a disagreement. It is deliberately not written against the customizer, so it fails for a stale document, for a customizer that is removed, and for the thirteenth call site. Run against `docs/openapi.json` as it stood before this change it reports all twelve:

```
OpenApiPageSizeDefaultTest > everyListingDocumentsThePageSizeItServes FAILED
Expecting empty but was: ["GET /api/v1/purchase-orders/web/{id}/status-history serves 20 rows and documents 10",
    "GET /api/v1/purchase-order-items/paginated serves 20 rows and documents 10",
    "GET /api/v1/tasks/web/paginated serves 20 rows and documents 10",
    "GET /api/v1/project/web/paginated serves 20 rows and documents 10",
    "GET /api/v1/project/web/summary serves 20 rows and documents 10",
    "GET /api/v1/project/web/{id}/status-history serves 20 rows and documents 10",
    "GET /api/v1/indent-items/paginated serves 20 rows and documents 10",
    "GET /api/v1/indent-items/web/paginated serves 20 rows and documents 10",
    "GET /api/v1/finance/construction-payments/web serves 20 rows and documents 10",
    "GET /api/v1/purchase-order-items/web/paginated serves 20 rows and documents 10",
    "GET /api/v1/assets/web/{id}/movements serves 20 rows and documents 10",
    "GET /api/v1/chat/rooms/web/{roomId}/messages serves 30 rows and documents 10"]
```

A companion rule, `everyDocumentedPageSizeIsCovered`, fails if an operation publishes a `pageSize` the first rule never examined, so the check cannot pass by looking at nothing. It earned its place immediately: it caught `CategoryController` mapping `api/v1/workCategories` without a leading slash, which springdoc publishes with one.

`PageSizeSchemaCustomizerTest` covers what that rule cannot reach: a handler with no page query, an operation with no parameters, and a `pageSize` the parameter object gave no schema, each a way the customizer could throw during document assembly and fail the build somewhere that says nothing about pagination.

## Verified on lab .116

- `./gradlew build` green, test heap 575 MB live of 2048 MB (28%)
- `./gradlew openApiSnapshot -PupdateOpenApiSnapshot` regenerated after rebasing onto #657, and the committed copy still matches the code
- the document diff is exactly twelve lines: eleven `"default": 10` becoming 20 and one becoming 30, with the other forty-two untouched, which also rules out springdoc sharing one `Schema` instance between operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected pagination defaults across listing endpoints: most now display 20 items per page by default, while chat messages display 30.
  - Ensured selected page-size values are applied consistently when retrieving paginated results.

- **Documentation**
  - Updated the API reference so documented pagination defaults match the application’s actual behavior.
  - Added automated validation to help keep pagination documentation accurate in future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->