### PR TITLE
Let a project manager read the balance, and compute the adjustment totals

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16033,12 +16033,12 @@
             "type": "integer"
           },
           "totalAdjustmentValue": {
-            "description": "Total monetary value of the adjustment across all line items.",
+            "description": "Total monetary value of the adjustment across all line items. Summed from the line items, so any value sent here is ignored: it is arithmetic over figures the server states and a header that disagreed with the sum of its own lines would be reporting neither. Approving restates it from what was posted.",
             "example": 18500.0,
             "type": "number"
           },
           "totalVarianceQuantity": {
-            "description": "Total variance quantity across all line items.",
+            "description": "Total variance quantity across all line items. Summed from the line items, so any value sent here is ignored: each line's variance is stamped from the balance it was raised against, so a header total computed by the client is a sum of figures the server has since replaced. Approving restates it from what was posted.",
             "example": -120.0,
             "format": "double",
             "type": "number"
@@ -16322,7 +16322,7 @@
             "type": "number"
           },
           "totalAdjustmentValue": {
-            "description": "Total monetary value of this line's adjustment.",
+            "description": "Total monetary value of this line's adjustment. Computed as the stamped adjustment quantity times the unit value, so any value sent here is ignored whenever both of those are known. A line carrying no unit value keeps what was sent, because there is nothing to multiply by; approving such a line writes its value from the running average cost the ledger entry was posted at.",
             "example": -7600.0,
             "type": "number"
           },
@@ -106979,7 +106979,7 @@
       "name": "Materials"
     },
     {
-      "description": "Web-console counterpart of the materials API, restricted to the system-admin role for the current tenant. Covers the same create, browse, search, update, stock lookup and delete operations as the standard materials endpoints, for use from the admin web console rather than the mobile app.",
+      "description": "Web-console counterpart of the materials API, gated by organization role for the current tenant. Covers the same create, browse, search, update, stock lookup and delete operations as the standard materials endpoints, for use from the admin web console rather than the mobile app. Reads, including the stock lookup, are open to the system-admin and project-manager roles, because a project manager raises and approves stock adjustments and those are documents about a material's balance. Changing the catalogue, its thresholds included, stays with system-admin.",
       "name": "Materials (Web)"
     },
     {
@@ -107095,7 +107095,7 @@
       "name": "Storage Locations"
     },
     {
-      "description": "Web-console counterpart of the storage location API, gated by organization role instead of a flat authority. Covers the same create, read and lookup operations as the mobile API plus partial update and delete, which the mobile API does not expose. Every operation requires the system-admin role in the caller's current tenant.",
+      "description": "Web-console counterpart of the storage location API, gated by organization role instead of a flat authority. Covers the same create, read and lookup operations as the mobile API plus partial update and delete, which the mobile API does not expose. Reads are open to the system-admin and project-manager roles in the caller's current tenant, because a project manager raises and approves stock adjustments and cannot pick a location to count without them. Creating, editing and deleting a location stays with system-admin.",
       "name": "Storage Locations (Web)"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -31,10 +31,13 @@ import java.util.List;
 @Validated
 @Tag(
         name = "Materials (Web)",
-        description = "Web-console counterpart of the materials API, restricted to the system-admin "
-                + "role for the current tenant. Covers the same create, browse, search, update, stock "
-                + "lookup and delete operations as the standard materials endpoints, for use from the "
-                + "admin web console rather than the mobile app."
+        description = "Web-console counterpart of the materials API, gated by organization role for the "
+                + "current tenant. Covers the same create, browse, search, update, stock lookup and "
+                + "delete operations as the standard materials endpoints, for use from the admin web "
+                + "console rather than the mobile app. Reads, including the stock lookup, are open to "
+                + "the system-admin and project-manager roles, because a project manager raises and "
+                + "approves stock adjustments and those are documents about a material's balance. "
+                + "Changing the catalogue, its thresholds included, stays with system-admin."
 )
 public class MaterialControllerWeb {
 
@@ -70,7 +73,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a material by id",
             description = "Returns a single material with its creator and current aggregate stock value."
@@ -86,7 +89,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all materials",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -100,7 +103,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List materials, paginated",
             description = "Returns a single page of materials. The pageNo and pageSize parameters "
@@ -118,7 +121,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/low-stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List materials at or below their reorder level",
             description = "Returns a page of the materials whose stock has reached the reorder level "
@@ -148,7 +151,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/search")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Search materials by name",
             description = "Returns materials whose name matches the given search term, such as \"Cement\" "
@@ -164,7 +167,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{id}/stock")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a material with its current stock",
             description = "Returns a material along with its current stock. When projectId and "
@@ -231,7 +234,7 @@ public class MaterialControllerWeb {
     }
 
     @GetMapping("/{materialId}/location-thresholds")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List a material's per-location threshold overrides",
             description = "Returns every storage-location override of the material's planning thresholds. "

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -33,6 +33,7 @@ import org.tornotron.echno_backend.user.UserNameDirectory;
 import org.tornotron.echno_backend.user.UserNameLookup;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashMap;
@@ -170,6 +171,7 @@ public class StockAdjustmentService {
         stockAdjustment.setSubmittedBy(userContextService.getCurrentUserId());
         stockAdjustment.setSubmittedAt(LocalDateTime.now());
         applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
+        stampHeaderTotals(stockAdjustment);
         StockAdjustment saved = stockAdjustmentRepository.saveAndFlush(stockAdjustment);
         return stockAdjustmentMapper.toDto(saved, namesFor(saved));
     }
@@ -217,6 +219,7 @@ public class StockAdjustmentService {
         // rows) and re-add from the request, keeping Hibernate's collection tracking intact.
         stockAdjustment.getLineItems().clear();
         applyLineItems(stockAdjustment, creationDto.getLineItems(), organization);
+        stampHeaderTotals(stockAdjustment);
 
         // saveAndFlush before mapping so the freshly inserted line-item ids are populated
         // on the returned DTO (documented gotcha: without the flush the child ids are null).
@@ -271,6 +274,12 @@ public class StockAdjustmentService {
      * adjustment exists to correct: the strict rule is written for a new movement, and applying it
      * here would leave a wrongly located balance with no route back at all.
      *
+     * <p>The document's two totals are restated here from what was actually posted, rather than
+     * left at the sums the draft carried. They can differ by a line whose movement came out at
+     * nothing, which is skipped rather than posted, and the value total can differ on any line
+     * with no unit value of its own, because the cost such a line posts at is the running average
+     * at the moment of posting.
+     *
      * <p>Every posted line writes an {@code ADJUST} {@link InventoryTransaction} whose
      * remarks carry the reason, so the balance stays explainable, and only then moves the
      * balance. Both happen in this transaction: an approval that recorded no movement is the
@@ -314,6 +323,7 @@ public class StockAdjustmentService {
                 : postedAt;
         String referenceNumber = referenceNumber(stockAdjustment);
         double totalVariance = 0.0;
+        BigDecimal totalValue = BigDecimal.ZERO;
         // What this approval has already posted to each balance row, so a later line on the same
         // row is measured against the balance as it stood when the approval began. See
         // requireBalanceUnmoved: a document may split one shelf's variance across several lines,
@@ -349,6 +359,7 @@ public class StockAdjustmentService {
 
             if (Math.abs(movement) < NO_MOVEMENT) {
                 line.setAdjustmentQuantity(0.0);
+                line.setTotalAdjustmentValue(atColumnScale(BigDecimal.ZERO));
                 continue;
             }
             double closing = balance + movement;
@@ -382,11 +393,23 @@ public class StockAdjustmentService {
             inventoryService.updateCurrentStock(material, project, location, organization,
                     movement, movement > 0 ? unitCost : null);
 
+            // What the line is worth, at the cost the ledger entry was actually written with, so
+            // the document's money agrees with the movement it posted rather than with whatever
+            // the draft was able to work out. On a line carrying its own unit value this is the
+            // figure the draft already held; on one without, it is what the running average came
+            // to at the moment of posting, which no draft could have stated.
+            BigDecimal postedValue = lineValue(movement, unitCost);
+            if (postedValue != null) {
+                line.setTotalAdjustmentValue(postedValue);
+                totalValue = totalValue.add(postedValue);
+            }
+
             totalVariance += movement;
             postedHere.merge(row, movement, Double::sum);
         }
 
         stockAdjustment.setTotalVarianceQuantity(totalVariance);
+        stockAdjustment.setTotalAdjustmentValue(atColumnScale(totalValue));
         stockAdjustment.setStatus(POSTED_STATUS);
         stockAdjustment.setApprovedBy(approver);
         stockAdjustment.setApprovedAt(postedAt);
@@ -705,6 +728,12 @@ public class StockAdjustmentService {
      * <p>The status is not copied either. It is written here as {@link #DRAFT_STATUS} and moved
      * only by {@link #approve}; a body naming any other status is refused rather than ignored,
      * so a caller who believed they were posting a document finds out that they were not.
+     *
+     * <p>Neither total is copied. {@code totalVarianceQuantity} and {@code totalAdjustmentValue}
+     * are arithmetic over the lines, so they are summed from the lines once those exist, by
+     * {@link #stampHeaderTotals}. Copying them let a document assert a header figure that did not
+     * match the sum of its own lines, which it now always did, because the lines' own figures are
+     * stamped by the server and the client's header was summed from what it sent instead.
      */
     private void applyHeaderFields(StockAdjustment stockAdjustment, StockAdjustmentCreationDto dto) {
         requireDraftStatus(dto.getStatus());
@@ -713,13 +742,11 @@ public class StockAdjustmentService {
         stockAdjustment.setStatus(DRAFT_STATUS);
         stockAdjustment.setAdjustmentDate(dto.getAdjustmentDate());
         stockAdjustment.setEffectiveDate(dto.getEffectiveDate());
-        stockAdjustment.setTotalAdjustmentValue(dto.getTotalAdjustmentValue());
         stockAdjustment.setPrimaryReason(dto.getPrimaryReason());
         stockAdjustment.setJustification(dto.getJustification());
         stockAdjustment.setPhysicalCountDate(dto.getPhysicalCountDate());
         stockAdjustment.setPhysicalCountBy(dto.getPhysicalCountBy());
         stockAdjustment.setCountMethod(dto.getCountMethod());
-        stockAdjustment.setTotalVarianceQuantity(dto.getTotalVarianceQuantity());
 
         stockAdjustment.setLocation(resolveLocation(dto.getLocationId()));
         stockAdjustment.setProject(resolveProject(dto.getProjectId()));
@@ -747,6 +774,8 @@ public class StockAdjustmentService {
             item.setAdjustmentQuantity(lineDto.getAdjustmentQuantity());
             item.setUnit(lineDto.getUnit());
             item.setUnitValue(lineDto.getUnitValue());
+            // Kept only as the fallback for a line whose value cannot be computed, for the same
+            // reason systemQuantity above is; stampLineValue below overwrites it where it can.
             item.setTotalAdjustmentValue(lineDto.getTotalAdjustmentValue());
             item.setReason(lineDto.getReason());
             item.setReasonDetails(lineDto.getReasonDetails());
@@ -756,8 +785,80 @@ public class StockAdjustmentService {
             item.setLocation(resolveLocation(lineDto.getLocationId()));
             item.setOrganization(organization);
             stampOpeningBalance(item, stockAdjustment);
+            stampLineValue(item);
             stockAdjustment.addLineItem(item);
         }
+    }
+
+    /**
+     * Records what a line's variance is worth, from the variance the server stamped on it.
+     *
+     * <p>Same reasoning as {@link #stampOpeningBalance}, one step along: the value is the product
+     * of two figures already on the line, so it belongs where those figures are. Before this it
+     * was whatever the client sent, and once {@link #stampOpeningBalance} began overwriting the
+     * variance the sent value was a product of figures the server had since replaced. A line
+     * showing a quantity, a unit value and a total that is not their product is worse than one
+     * showing no total at all.
+     *
+     * <p>A line with no unit value keeps what was sent. There is nothing to multiply by, and the
+     * cost the posting will actually use is the running average at the time it posts, which is
+     * not a figure a draft can state: it moves with every receipt. {@link #approve} writes the
+     * true value onto such a line from the cost it posted at.
+     *
+     * @param item The line being written, after its variance has been stamped.
+     */
+    private void stampLineValue(StockAdjustmentLineItem item) {
+        BigDecimal value = lineValue(item.getAdjustmentQuantity(), item.getUnitValue());
+        if (value != null) {
+            item.setTotalAdjustmentValue(value);
+        }
+    }
+
+    /**
+     * A signed quantity valued at a unit price, at the scale the column stores, or null when
+     * either figure is missing.
+     */
+    private BigDecimal lineValue(Double quantity, BigDecimal unitValue) {
+        if (quantity == null || unitValue == null) {
+            return null;
+        }
+        return atColumnScale(BigDecimal.valueOf(quantity).multiply(unitValue));
+    }
+
+    /**
+     * Rounds to the two decimal places {@code total_adjustment_value} is declared with, so the
+     * figure held in memory is the figure the database keeps and a document read back straight
+     * after being written does not appear to have changed.
+     */
+    private BigDecimal atColumnScale(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Sums the header totals from the lines the document actually carries.
+     *
+     * <p>Both are arithmetic over the lines and nothing else, so neither is a figure the client
+     * gets to assert. {@link #approve} restates them from what it posted, which can differ: a line
+     * whose movement comes out at nothing is skipped there rather than posted, so a draft and the
+     * document it becomes are each the sum of their own lines at the moment they were written.
+     *
+     * <p>A document with no lines totals zero rather than keeping a number it cannot support.
+     *
+     * @param stockAdjustment The document, with its lines already attached.
+     */
+    private void stampHeaderTotals(StockAdjustment stockAdjustment) {
+        double variance = 0.0;
+        BigDecimal value = BigDecimal.ZERO;
+        for (StockAdjustmentLineItem line : stockAdjustment.getLineItems()) {
+            if (line.getAdjustmentQuantity() != null) {
+                variance += line.getAdjustmentQuantity();
+            }
+            if (line.getTotalAdjustmentValue() != null) {
+                value = value.add(line.getTotalAdjustmentValue());
+            }
+        }
+        stockAdjustment.setTotalVarianceQuantity(variance);
+        stockAdjustment.setTotalAdjustmentValue(atColumnScale(value));
     }
 
     private StorageLocation resolveLocation(Long locationId) {

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -51,7 +51,10 @@ public class StockAdjustmentCreationDto {
     @Schema(description = "Primary reason category for the adjustment.", example = "PHYSICAL_COUNT_VARIANCE")
     private String primaryReason;
 
-    @Schema(description = "Total monetary value of the adjustment across all line items.", example = "18500.00")
+    @Schema(description = "Total monetary value of the adjustment across all line items. Summed from "
+            + "the line items, so any value sent here is ignored: it is arithmetic over figures the "
+            + "server states and a header that disagreed with the sum of its own lines would be "
+            + "reporting neither. Approving restates it from what was posted.", example = "18500.00")
     private BigDecimal totalAdjustmentValue;
 
     @Schema(description = "Date the physical count was performed.", example = "2026-01-14")
@@ -69,7 +72,11 @@ public class StockAdjustmentCreationDto {
             accessMode = Schema.AccessMode.READ_ONLY, example = "18")
     private Long submittedBy;
 
-    @Schema(description = "Total variance quantity across all line items.", example = "-120.0")
+    @Schema(description = "Total variance quantity across all line items. Summed from the line "
+            + "items, so any value sent here is ignored: each line's variance is stamped from the "
+            + "balance it was raised against, so a header total computed by the client is a sum of "
+            + "figures the server has since replaced. Approving restates it from what was posted.",
+            example = "-120.0")
     private Double totalVarianceQuantity;
 
     @Schema(description = "Line items, one per material, listing the system quantity, the counted quantity, and the variance.")

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentLineItemCreationDto.java
@@ -36,7 +36,11 @@ public class StockAdjustmentLineItemCreationDto {
     @Schema(description = "Value per unit.", example = "380.00")
     private BigDecimal unitValue;
 
-    @Schema(description = "Total monetary value of this line's adjustment.", example = "-7600.00")
+    @Schema(description = "Total monetary value of this line's adjustment. Computed as the stamped "
+            + "adjustment quantity times the unit value, so any value sent here is ignored whenever "
+            + "both of those are known. A line carrying no unit value keeps what was sent, because "
+            + "there is nothing to multiply by; approving such a line writes its value from the "
+            + "running average cost the ledger entry was posted at.", example = "-7600.00")
     private BigDecimal totalAdjustmentValue;
 
     @Schema(description = "Reason category for this line's variance.", example = "DAMAGE")

--- a/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWeb.java
@@ -28,8 +28,11 @@ import java.util.List;
         name = "Storage Locations (Web)",
         description = "Web-console counterpart of the storage location API, gated by organization role "
                 + "instead of a flat authority. Covers the same create, read and lookup operations as the "
-                + "mobile API plus partial update and delete, which the mobile API does not expose. Every "
-                + "operation requires the system-admin role in the caller's current tenant."
+                + "mobile API plus partial update and delete, which the mobile API does not expose. Reads "
+                + "are open to the system-admin and project-manager roles in the caller's current tenant, "
+                + "because a project manager raises and approves stock adjustments and cannot pick a "
+                + "location to count without them. Creating, editing and deleting a location stays with "
+                + "system-admin."
 )
 public class StorageLocationControllerWeb {
 
@@ -60,7 +63,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "Get a storage location by id",
             description = "Returns a single storage location, including its resolved project name and "
@@ -77,7 +80,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List all storage locations",
             description = "Returns at most 500 rows. X-Total-Count carries the true total and X-Result-Capped is set when rows were left out; use the paginated variant for a complete result."
@@ -92,7 +95,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List storage locations, paginated",
             description = "Returns a single page of storage locations. The pageNo and pageSize "
@@ -109,7 +112,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/project/{projectId}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List storage locations for a project",
             description = "Returns the storage locations linked to the given project id, for example the "
@@ -125,7 +128,7 @@ public class StorageLocationControllerWeb {
     }
 
     @GetMapping("/type/{locationType}")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
     @Operation(
             summary = "List storage locations by type",
             description = "Returns the storage locations of the given type, for example all WAREHOUSE "

--- a/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
@@ -1,0 +1,206 @@
+package org.tornotron.echno_backend.material;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
+import org.tornotron.echno_backend.material.lowstock.LowStockService;
+import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for MaterialControllerWeb, which splits its guard: the catalogue
+ * and the balances held against it are readable by a system-admin or a project-manager, and only
+ * a system-admin may change any of it.
+ *
+ * <p>The read half exists because of the workflow, not because material data is uninteresting.
+ * A project manager may raise, approve and reject a stock adjustment, and a stock adjustment is a
+ * document about a material's balance: since the approval is checked against the balance the
+ * document was stamped with, a raiser who cannot read that balance is being asked to correct a
+ * figure they are not allowed to see, and cannot be told why an approval was refused. The material
+ * list and search are on the same footing, because the form has to name the material before it can
+ * ask for its balance.
+ *
+ * <p>The write half is the ratchet. Creating a material, editing it, deleting it, or moving its
+ * reorder thresholds are catalogue decisions rather than count decisions, and they stay with
+ * system-admin until the role question in #650 is settled. If a later change widened them along
+ * with the reads, {@code aProjectManagerMayNot*} fails.
+ *
+ * <p>{@code @orgSecurity} is mocked so each branch is exercised on its own: the project-manager
+ * tests deliberately answer false to the system-admin-only expression and true to the pair, which
+ * is exactly a caller holding project-manager and not system-admin.
+ */
+@WebMvcTest(MaterialControllerWeb.class)
+@Import(MaterialControllerWebAuthzTest.TestSecurityConfig.class)
+class MaterialControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MaterialService materialService;
+
+    @MockitoBean
+    private MaterialLocationThresholdService thresholdService;
+
+    @MockitoBean
+    private LowStockService lowStockService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    // RPTExchangeFilter also depends on this cache; mocked for the same reason.
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** A caller holding project-manager and not system-admin. */
+    private void asProjectManager() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+    }
+
+    private void stubReads() {
+        when(materialService.getAllMaterials(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(materialService.searchMaterialsByName(anyString())).thenReturn(List.of());
+        when(lowStockService.findLowStock(any(), any(), any())).thenReturn(Page.empty());
+        when(thresholdService.listForMaterial(anyLong())).thenReturn(List.of());
+        when(materialService.getMaterialStockAtLocation(anyLong(), anyLong(), anyLong()))
+                .thenReturn(new MaterialWithStockDto());
+        when(materialService.getMaterialWithCurrentStock(anyLong(), anyLong()))
+                .thenReturn(new MaterialWithStockDto());
+        when(materialService.getMaterialWithAggregateStock(anyLong()))
+                .thenReturn(new MaterialWithStockDto());
+    }
+
+    /**
+     * Every read on the controller, including the balance lookup the stock-adjustment form is
+     * built on. Before the fix each of these answered 403 to a project manager.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/materials/web",
+            "/api/v1/materials/web/all",
+            "/api/v1/materials/web/1",
+            "/api/v1/materials/web/search?name=Cement",
+            "/api/v1/materials/web/low-stock",
+            "/api/v1/materials/web/1/location-thresholds",
+            "/api/v1/materials/web/1/stock",
+            "/api/v1/materials/web/1/stock?projectId=4",
+            "/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7"
+    })
+    void aProjectManagerMayReadTheCatalogueAndItsBalances(String path) throws Exception {
+        asProjectManager();
+        stubReads();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/materials/web",
+            "/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7"
+    })
+    void aMemberHoldingNeitherRoleIsStillRefusedTheRead(String path) throws Exception {
+        // Widening the read to project-manager is not widening it to everybody. The Resources
+        // domain has no role between member and system-admin (#650) and this does not invent one.
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerMayNotCreateAMaterial() throws Exception {
+        asProjectManager();
+
+        mockMvc.perform(post("/api/v1/materials/web").with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"materialName\":\"OPC 53 Grade Cement\",\"unit\":\"bags\",\"createdBy\":5}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerMayNotEditAMaterial() throws Exception {
+        asProjectManager();
+
+        mockMvc.perform(patch("/api/v1/materials/web/1").with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"materialName\":\"OPC 53 Grade Cement\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerMayNotDeleteAMaterial() throws Exception {
+        asProjectManager();
+
+        mockMvc.perform(delete("/api/v1/materials/web/1").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerMayNotMoveAReorderThreshold() throws Exception {
+        // Reading a threshold explains a balance; setting one is a planning decision.
+        asProjectManager();
+
+        mockMvc.perform(delete("/api/v1/materials/web/1/location-thresholds/7").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aSystemAdminStillReadsTheBalance() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+        stubReads();
+
+        mockMvc.perform(get("/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -496,4 +496,45 @@ class StockAdjustmentApprovalTest {
         verify(inventoryTransactionRepository).save(any(InventoryTransaction.class));
         assertThat(adjustment.getApprovedBy()).isEqualTo(APPROVER);
     }
+
+    @Test
+    void approvingRestatesBothTotalsFromWhatItActuallyPosted() {
+        // The variance total was already restated here; the value total was not, so a posted
+        // document could carry a money figure from a draft that no longer described it.
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setTotalVarianceQuantity(999.0);
+        adjustment.setTotalAdjustmentValue(new BigDecimal("999.00"));
+        StockAdjustmentLineItem line = line(adjustment, 46.0, null, "damage");
+        line.setUnitValue(new BigDecimal("100.00"));
+        line.setTotalAdjustmentValue(new BigDecimal("999.00"));
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        assertThat(line.getAdjustmentQuantity()).isEqualTo(-2.0);
+        assertThat(line.getTotalAdjustmentValue()).isEqualByComparingTo("-200.00");
+        assertThat(adjustment.getTotalVarianceQuantity()).isEqualTo(-2.0);
+        assertThat(adjustment.getTotalAdjustmentValue()).isEqualByComparingTo("-200.00");
+    }
+
+    @Test
+    void aLineThatMovesNothingContributesNothingToEitherTotal() {
+        // The count agrees with the balance, so the line posts no ledger row. A document whose
+        // header still claimed a variance would be reporting a correction that never happened.
+        StockAdjustment adjustment = adjustment(location(LOCATION, PROJECT));
+        adjustment.setTotalVarianceQuantity(999.0);
+        adjustment.setTotalAdjustmentValue(new BigDecimal("999.00"));
+        StockAdjustmentLineItem line = line(adjustment, 48.0, null, "damage");
+        line.setUnitValue(new BigDecimal("100.00"));
+        line.setTotalAdjustmentValue(new BigDecimal("999.00"));
+        balanceAtLocation(48.0);
+
+        service.approve(ADJUSTMENT);
+
+        verify(inventoryTransactionRepository, never()).save(any());
+        assertThat(line.getAdjustmentQuantity()).isEqualTo(0.0);
+        assertThat(line.getTotalAdjustmentValue()).isEqualByComparingTo("0.00");
+        assertThat(adjustment.getTotalVarianceQuantity()).isEqualTo(0.0);
+        assertThat(adjustment.getTotalAdjustmentValue()).isEqualByComparingTo("0.00");
+    }
 }

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentTotalsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentTotalsTest.java
@@ -1,0 +1,248 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The arithmetic a stock-adjustment draft states about itself.
+ *
+ * <p>A line's variance is stamped from the balance the document is raised against, so a header
+ * total the client computed is a sum of figures the server has since replaced, and a document
+ * could show a header variance that did not match the sum of its own lines. Nothing posts from
+ * these fields, so this is a document that misreports itself rather than a wrong stock figure,
+ * but the argument that made the line's opening balance the server's applies unchanged: a number
+ * the server accepts and never checks is one somebody eventually relies on.
+ *
+ * <p>So all three derived figures are computed here rather than guarded. Guarding would have to
+ * refuse a document whose header disagreed with its lines, which fires on a client that rounded
+ * differently rather than on anything worth stopping, and a draft is exactly where a person is
+ * still allowed to be halfway through.
+ *
+ * <p>Posting is covered by {@link StockAdjustmentApprovalTest}, which restates both totals from
+ * what the approval actually wrote.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentTotalsTest {
+
+    private static final Long ORG = 100L;
+    private static final Long MATERIAL = 11L;
+    private static final Long OTHER_MATERIAL = 12L;
+    private static final Long LOCATION = 3L;
+    private static final Long PROJECT = 9L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private StockAdjustmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
+            Organization org = new Organization();
+            org.setId(ORG);
+            return org;
+        });
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Material material = new Material();
+        material.setId(MATERIAL);
+        Material other = new Material();
+        other.setId(OTHER_MATERIAL);
+        StorageLocation location = new StorageLocation();
+        location.setId(LOCATION);
+        Project project = new Project();
+        project.setId(PROJECT);
+        lenient().when(materialRepository.findByIdAndOrganization_Id(MATERIAL, ORG))
+                .thenReturn(Optional.of(material));
+        lenient().when(materialRepository.findByIdAndOrganization_Id(OTHER_MATERIAL, ORG))
+                .thenReturn(Optional.of(other));
+        lenient().when(storageLocationRepository.findByIdAndOrganization_Id(LOCATION, ORG))
+                .thenReturn(Optional.of(location));
+        lenient().when(projectRepository.findByIdAndOrganization_Id(PROJECT, ORG))
+                .thenReturn(Optional.of(project));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    /** A document naming the project and location every line is counted at. */
+    private StockAdjustmentCreationDto baseDto() {
+        StockAdjustmentCreationDto dto = new StockAdjustmentCreationDto();
+        dto.setAdjustmentNumber("SA-2026-0021");
+        dto.setType("physical_count");
+        dto.setStatus("draft");
+        dto.setProjectId(PROJECT);
+        dto.setLocationId(LOCATION);
+        return dto;
+    }
+
+    private StockAdjustmentLineItemCreationDto countedLine(Long materialId, double counted, String unitValue) {
+        StockAdjustmentLineItemCreationDto line = new StockAdjustmentLineItemCreationDto();
+        line.setMaterialId(materialId);
+        line.setPhysicalQuantity(counted);
+        line.setReason("physical_count");
+        if (unitValue != null) {
+            line.setUnitValue(new BigDecimal(unitValue));
+        }
+        return line;
+    }
+
+    private void balance(Long materialId, double quantity) {
+        lenient().when(inventoryService.findStockAtLocation(materialId, PROJECT, LOCATION))
+                .thenReturn(Optional.of(quantity));
+    }
+
+    private StockAdjustment saved() {
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void aLineValueIsRecomputedFromTheStampedVarianceAndTheUnitValue() {
+        // 480 on the shelf, 460 counted, so the line is short 20 bags at 380 apiece. The client
+        // sent a value of its own, computed from a system quantity it typed rather than read.
+        balance(MATERIAL, 480.0);
+        StockAdjustmentCreationDto dto = baseDto();
+        StockAdjustmentLineItemCreationDto line = countedLine(MATERIAL, 460.0, "380.00");
+        line.setSystemQuantity(500.0);
+        line.setTotalAdjustmentValue(new BigDecimal("-15200.00"));
+        dto.setLineItems(List.of(line));
+
+        service.create(dto);
+
+        StockAdjustmentLineItem stamped = saved().getLineItems().get(0);
+        assertThat(stamped.getSystemQuantity()).isEqualTo(480.0);
+        assertThat(stamped.getAdjustmentQuantity()).isEqualTo(-20.0);
+        assertThat(stamped.getTotalAdjustmentValue()).isEqualByComparingTo("-7600.00");
+    }
+
+    @Test
+    void aLineWithNoUnitValueKeepsTheValueItWasSentWith() {
+        // Nothing to multiply by, so the sent figure is better than none. The same reasoning
+        // stampOpeningBalance uses for a line whose balance cannot be read; approving such a line
+        // writes its value from the running average cost it posts at.
+        balance(MATERIAL, 480.0);
+        StockAdjustmentCreationDto dto = baseDto();
+        StockAdjustmentLineItemCreationDto line = countedLine(MATERIAL, 460.0, null);
+        line.setTotalAdjustmentValue(new BigDecimal("-7600.00"));
+        dto.setLineItems(List.of(line));
+
+        service.create(dto);
+
+        assertThat(saved().getLineItems().get(0).getTotalAdjustmentValue())
+                .isEqualByComparingTo("-7600.00");
+    }
+
+    @Test
+    void theHeaderTotalsAreSummedFromTheLinesAndNotTakenFromTheBody() {
+        balance(MATERIAL, 480.0);
+        balance(OTHER_MATERIAL, 100.0);
+        StockAdjustmentCreationDto dto = baseDto();
+        // A header the client computed from the figures it sent, which the server has replaced.
+        dto.setTotalVarianceQuantity(-40.0);
+        dto.setTotalAdjustmentValue(new BigDecimal("-15200.00"));
+        dto.setLineItems(List.of(
+                countedLine(MATERIAL, 460.0, "380.00"),        // -20 at 380 = -7600
+                countedLine(OTHER_MATERIAL, 105.0, "50.00")));  //  +5 at  50 =  +250
+        dto.getLineItems().forEach(line -> line.setLocationId(LOCATION));
+
+        service.create(dto);
+
+        StockAdjustment document = saved();
+        assertThat(document.getTotalVarianceQuantity()).isEqualTo(-15.0);
+        assertThat(document.getTotalAdjustmentValue()).isEqualByComparingTo("-7350.00");
+    }
+
+    @Test
+    void aDocumentWithNoLinesTotalsZeroRatherThanWhateverWasSent() {
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setTotalVarianceQuantity(-40.0);
+        dto.setTotalAdjustmentValue(new BigDecimal("-15200.00"));
+
+        service.create(dto);
+
+        StockAdjustment document = saved();
+        assertThat(document.getTotalVarianceQuantity()).isEqualTo(0.0);
+        assertThat(document.getTotalAdjustmentValue()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void anEditRestatesTheHeaderTotalsFromTheLinesItLeavesBehind() {
+        // The stale totals belong to the lines the edit is about to remove, so keeping them would
+        // leave a document describing a count it no longer carries.
+        balance(MATERIAL, 480.0);
+        StockAdjustment existing = new StockAdjustment();
+        existing.setId(4L);
+        Organization org = new Organization();
+        org.setId(ORG);
+        existing.setOrganization(org);
+        existing.setTotalVarianceQuantity(-40.0);
+        existing.setTotalAdjustmentValue(new BigDecimal("-15200.00"));
+        existing.addLineItem(new StockAdjustmentLineItem());
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(4L, ORG))
+                .thenReturn(Optional.of(existing));
+
+        StockAdjustmentCreationDto dto = baseDto();
+        dto.setTotalVarianceQuantity(-40.0);
+        dto.setTotalAdjustmentValue(new BigDecimal("-15200.00"));
+        StockAdjustmentLineItemCreationDto line = countedLine(MATERIAL, 470.0, "380.00");
+        line.setLocationId(LOCATION);
+        dto.setLineItems(List.of(line));
+
+        service.update(4L, dto);
+
+        assertThat(existing.getTotalVarianceQuantity()).isEqualTo(-10.0);
+        assertThat(existing.getTotalAdjustmentValue()).isEqualByComparingTo("-3800.00");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/storageLocation/StorageLocationControllerWebAuthzTest.java
@@ -1,0 +1,127 @@
+package org.tornotron.echno_backend.storageLocation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.storageLocation.dto.StorageLocationDto;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-slice authorization test for StorageLocationControllerWeb, split the same way as
+ * MaterialControllerWeb: a system-admin or a project-manager may read the locations, only a
+ * system-admin may create, edit or delete one.
+ *
+ * <p>The read is what the stock-adjustment form picks the counted shelf from, and a project
+ * manager may raise and approve those documents. A location list they cannot read leaves the
+ * balance lookup they can now reach with nothing to be scoped by.
+ *
+ * <p>Whether a storekeeper should be able to create a location without also being able to delete
+ * a project is the role question in #650, and this does not answer it: the writes are untouched.
+ */
+@WebMvcTest(StorageLocationControllerWeb.class)
+@Import(StorageLocationControllerWebAuthzTest.TestSecurityConfig.class)
+class StorageLocationControllerWebAuthzTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StorageLocationService storageLocationService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here
+    // because .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    // RPTExchangeFilter also depends on this cache; mocked for the same reason.
+    @MockitoBean
+    private RPTCache rptCache;
+
+    /** A caller holding project-manager and not system-admin. */
+    private void asProjectManager() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(true);
+    }
+
+    private void stubReads() {
+        when(storageLocationService.getAllStorageLocations(anyInt(), anyInt())).thenReturn(Page.empty());
+        when(storageLocationService.getStorageLocationsByProject(anyLong())).thenReturn(List.of());
+        when(storageLocationService.getStorageLocationsByType(any(StorageLocationType.class)))
+                .thenReturn(List.of());
+        when(storageLocationService.getStorageLocationById(anyLong())).thenReturn(new StorageLocationDto());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/storage-locations/web",
+            "/api/v1/storage-locations/web/all",
+            "/api/v1/storage-locations/web/1",
+            "/api/v1/storage-locations/web/project/4",
+            "/api/v1/storage-locations/web/type/WAREHOUSE"
+    })
+    void aProjectManagerMayReadTheLocations(String path) throws Exception {
+        asProjectManager();
+        stubReads();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aMemberHoldingNeitherRoleIsStillRefusedTheRead() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "project-manager")).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/storage-locations/web/project/4").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aProjectManagerMayNotDeleteALocation() throws Exception {
+        asProjectManager();
+
+        mockMvc.perform(delete("/api/v1/storage-locations/web/1").with(jwt()).with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Closes #666. Closes #665.

Both follow #658, which made a stock adjustment's line figures the server's and made approval refuse when the balance has moved. Neither touches that guard or the per-balance-row accounting behind it.

## #666: the role that raises the document cannot read what it is about

A project manager may raise, approve and reject a stock adjustment. Since #658 the balance the document is stamped with is the substance of it: the approval is refused when that balance has moved between raising and approving. Every read on `MaterialControllerWeb` and `StorageLocationControllerWeb` was `system-admin` only, so that role could not read the figure it is being asked to correct, could not list the materials to name one, and could not pick the location it counted.

The full shape, for the whole workflow rather than the one endpoint on the issue:

| What the workflow needs | Endpoint | Project manager, before | After |
|---|---|---|---|
| List and read the documents | `GET /stock-adjustments/web…` | yes (member or role) | unchanged |
| Create, edit, approve, reject, delete | `/stock-adjustments/web` writes | yes | unchanged |
| Pick the project | `GET /projects/web…` | yes (member or role) | unchanged |
| Pick the material | `GET /materials/web`, `/search`, `/{id}` | **403** | yes |
| Read the balance | `GET /materials/web/{id}/stock` | **403** | yes |
| Read the reorder level that explains it | `GET /materials/web/{id}/location-thresholds`, `/low-stock` | **403** | yes |
| Pick the location counted | `GET /storage-locations/web`, `/project/{id}` | **403** | yes |

So widening `/{id}/stock` alone would have left a balance lookup reachable for a material the caller could not name. The reads move together; every write on both controllers stays with `system-admin`, because creating a material, editing it, deleting it and moving its reorder thresholds are catalogue decisions rather than count decisions.

**Not the same defect as the project read inconsistency.** That one was inside a single controller: `ProjectControllerWeb` read on `isMemberOfCurrentTenant()` while its writes read on `hasAnyOrgRole(...)`, so a role holder without `ORG_MEMBER_` could write and not read. It was fixed in `eec6c37` by making the read the union of the two, and `ProjectControllerWeb` reads that way on `development` today. This is the other axis: the guard on `StockAdjustmentControllerWeb` is internally consistent, and the read it depends on sits in a different module gated a tier higher.

**Independent of #650, not a workaround for it.** #650 asks what role a storekeeper should hold to *write* goods receipts, when the only role that can is `system-admin`. Whatever it lands on, `project-manager` will still write stock adjustments and will still need these reads. Nothing here widens anything to plain members, so the two-tier model #650 describes is left as it found it. The ten other Resources controllers are untouched.

## #665: the header totals

`applyHeaderFields` copied `totalVarianceQuantity` and `totalAdjustmentValue` straight from the request, and `applyLineItems` stored the line's `totalAdjustmentValue` verbatim. Once #658 began stamping each line's variance from the balance, a client computing the header from the figures it sent was summing figures the server had already replaced, so a draft could assert a total that did not match the sum of its own lines.

The ledger is written from the lines, so this is a document misreporting itself rather than a wrong stock figure. It is still the shape #658 closed on `systemQuantity`: a number the server accepts and never checks is one somebody eventually relies on.

**Computed, not guarded**, following #658's reasoning. A guard would have to refuse a document whose header disagreed with its lines, which fires on a client that rounded differently rather than on anything worth stopping, and a draft is where a person is still allowed to be halfway through.

- `stampLineValue` derives the line's value from the stamped variance and the unit value. A line with no unit value keeps what was sent, the same rule `stampOpeningBalance` uses for a line with no balance to read: the cost such a line posts at is the running average at the moment of posting, which no draft can state.
- `stampHeaderTotals` sums both header figures from the lines once they are attached, on create and on update alike. A document with no lines totals zero rather than keeping a number it cannot support.
- `approve` restates both from what it actually posted, and writes each posted line's value at the cost the ledger entry was written with. It already did this for the variance and not for the value, which is how a posted document could carry a money figure from a draft that no longer described it. A line whose movement comes out at nothing contributes nothing to either.

Values are rounded to the two decimal places `total_adjustment_value` is declared with, so a document read back straight after being written has not changed.

The three request fields are documented as derived, the way `systemQuantity` now is, and kept on the schema rather than marked read-only, so the field stays where echno-web sends it until the web stops sending it (tornotron/echno-web#383).

## Tests

Nineteen new assertions fail against `development` and pass here.

| Test | Without the fix |
|---|---|
| `MaterialControllerWebAuthzTest.aProjectManagerMayReadTheCatalogueAndItsBalances` (9 paths) | 403 on every read, the balance lookup included |
| `StorageLocationControllerWebAuthzTest.aProjectManagerMayReadTheLocations` (5 paths) | 403, so the counted shelf cannot be named |
| `StockAdjustmentTotalsTest.aLineValueIsRecomputedFromTheStampedVarianceAndTheUnitValue` | Keeps the client's value, computed from a quantity the server replaced |
| `StockAdjustmentTotalsTest.theHeaderTotalsAreSummedFromTheLinesAndNotTakenFromTheBody` | Header says -40 and -15200.00 over lines summing to -15 and -7350.00 |
| `StockAdjustmentTotalsTest.aDocumentWithNoLinesTotalsZeroRatherThanWhateverWasSent` | Keeps a total no line supports |
| `StockAdjustmentTotalsTest.anEditRestatesTheHeaderTotalsFromTheLinesItLeavesBehind` | Keeps the totals of the lines the edit removed |
| `StockAdjustmentApprovalTest.approvingRestatesBothTotalsFromWhatItActuallyPosted` | Posted document keeps the draft's value total |
| `StockAdjustmentApprovalTest.aLineThatMovesNothingContributesNothingToEitherTotal` | Header claims a variance no ledger row backs |

Four more pass either way and are there as ratchets rather than as proof: `aProjectManagerMayNot{Create,Edit,Delete}AMaterial`, `aProjectManagerMayNotMoveAReorderThreshold` and `aProjectManagerMayNotDeleteALocation` fail if a later change widens the writes along with the reads; `aMemberHoldingNeitherRoleIsStillRefusedTheRead` fails if the read is ever widened to plain membership; `aLineWithNoUnitValueKeepsTheValueItWasSentWith` fails if `stampLineValue` is simplified into overwriting unconditionally, which would null the only figure such a line has.

Full `./gradlew build` green on the lab box, test heap 29% of the 2048 MB cap. No schema change, so no changelog. `docs/openapi.json` regenerated after rebasing onto `a899907`; the diff is five description changes and nothing else.
