### PR TITLE
Say which partial-update fields a null clears, and refuse the rest

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5269,67 +5269,100 @@
         "type": "object"
       },
       "EmployeeUpdateFieldsDto": {
-        "description": "Fields a partial employee update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial employee update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "dateOfBirth": {
             "description": "Date of birth.",
             "example": "1998-04-12T00:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "department": {
             "description": "Department the employee belongs to.",
             "example": "Execution",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "designation": {
             "description": "Job title held.",
             "example": "Site Engineer",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "emailAddress": {
             "description": "Work email address.",
             "example": "hrishi@echno.xyz",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeId": {
             "description": "Employee code within the organization.",
             "example": "ECH-0412",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "employeeName": {
             "description": "Full name of the employee.",
             "example": "Hrishikesh R",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "joiningDate": {
             "description": "Date the employee joined.",
             "example": "2024-06-01T00:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "managerId": {
-            "description": "Id of the employee's manager. Must belong to the caller's organization, and may not introduce a cycle in the reporting line.",
+            "description": "Id of the employee's manager. Must belong to the caller's organization, and may not introduce a cycle in the reporting line. Send null to detach the employee from their manager.",
             "example": 7,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "phoneNumber": {
             "description": "Contact phone number.",
             "example": "+91 99400 00000",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "salary": {
             "description": "Monthly salary. Must be sent as a decimal number.",
             "example": 62000.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "shiftTimingId": {
             "description": "Id of the shift timing the employee works. Must belong to the employee's organization; null clears the assignment.",
             "example": 3,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "status": {
             "description": "Employment status of the employee.",
@@ -5342,7 +5375,10 @@
               "probation",
               "suspended"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -7636,21 +7672,27 @@
         "type": "object"
       },
       "IssueUpdateFieldsDto": {
-        "description": "Fields a partial issue update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial issue update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "assignedToId": {
-            "description": "Id of the employee the issue is assigned to. The employee must belong to the caller's organization.",
+            "description": "Id of the employee the issue is assigned to. The employee must belong to the caller's organization. Send null to unassign the issue.",
             "example": 17,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "description": {
             "description": "Longer description of the issue.",
             "example": "Spacing measured at 220 mm against a specified 200 mm across grid C.",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
-            "description": "Lifecycle status of the issue.",
+            "description": "Lifecycle status of the issue. Cannot be cleared: a null or blank value is refused with a 400 rather than applied.",
             "enum": [
               "open",
               "inProgress",
@@ -7666,10 +7708,13 @@
           "title": {
             "description": "Short issue title.",
             "example": "Rebar spacing off on grid C",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "type": {
-            "description": "Category of the issue.",
+            "description": "Category of the issue. Cannot be cleared: a null or blank value is refused with a 400 rather than applied.",
             "enum": [
               "technical",
               "design",
@@ -9060,27 +9105,36 @@
         "type": "object"
       },
       "LeavePolicyUpdateFieldsDto": {
-        "description": "Fields a partial leave-policy update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial leave-policy update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "accrualRatePerMonth": {
             "description": "Days accrued per completed month.",
             "example": 1.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "advanceNoticeDays": {
             "description": "Minimum days of notice required before the leave starts.",
             "example": 2,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "allowHalfDay": {
             "description": "Whether requests under this policy can be for half a day.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "annualQuota": {
-            "description": "Total days granted per year under this policy. Must be a number; null is rejected.",
+            "description": "Total days granted per year under this policy. Cannot be cleared: the column is NOT NULL, so a null is refused with a 400 rather than applied. It is the one numeric field here that refuses a null; every other numeric column on a policy is nullable and clears.",
             "example": 12.0,
             "format": "double",
             "type": "number"
@@ -9088,79 +9142,121 @@
           "applicableGenders": {
             "description": "Genders this policy applies to.",
             "example": "ALL",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "attachmentRequiredAfterDays": {
             "description": "Consecutive days after which an attachment becomes required.",
             "example": 3,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "carryForwardExpiryMonths": {
             "description": "Months into the next year before carried-forward days expire.",
             "example": 3,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "carryForwardLimit": {
             "description": "Maximum days that can be carried forward into the next year.",
             "example": 5.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "description": {
             "description": "Description of the leave type and when it applies.",
             "example": "Short-notice leave for personal matters.",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "displayOrder": {
             "description": "Order this policy is shown in, relative to the organization's others.",
             "example": 1,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "isActive": {
             "description": "Whether the policy is available for new requests.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "isPaid": {
             "description": "Whether leave taken under this policy is paid.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "leaveTypeName": {
             "description": "Display name of the leave type.",
             "example": "Casual Leave",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "maxDaysPerRequest": {
             "description": "Largest number of days that can be requested at once.",
             "example": 15.0,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "minDaysPerRequest": {
             "description": "Smallest number of days that can be requested at once.",
             "example": 0.5,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "minServiceMonths": {
             "description": "Months of service before an employee becomes eligible.",
             "example": 6,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "multiLevelApprovalEnabled": {
             "description": "Whether requests go through the full multi-level approval chain.",
             "example": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "requiresAttachment": {
             "description": "Whether a supporting attachment is required.",
             "example": false,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -9421,15 +9517,18 @@
         "type": "object"
       },
       "LeaveRequestUpdateFieldsDto": {
-        "description": "Fields a partial leave-request update may change, accepted only while the request is a draft. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial leave-request update may change, accepted only while the request is a draft. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "contactDuringLeave": {
             "description": "How to reach the employee during the leave.",
             "example": "+91 99400 00000",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "endDate": {
-            "description": "Last day of leave. Must be a date; null is rejected.",
+            "description": "Last day of leave. Cannot be cleared: the column is NOT NULL and the total-days figure is recomputed from both dates after every update, so a null is refused with a 400 rather than applied.",
             "example": "2026-09-18",
             "format": "date",
             "type": "string"
@@ -9441,26 +9540,38 @@
               "FIRST_HALF",
               "SECOND_HALF"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "handoverNotes": {
             "description": "Notes for the person taking over.",
             "example": "Block A pour is scheduled for the 16th; drawings are in the shared folder.",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "handoverToId": {
             "description": "Id of the employee taking over the work.",
             "example": 7,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "reason": {
             "description": "Reason given for the leave.",
             "example": "Family function",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "startDate": {
-            "description": "First day of leave. Must be a date; null is rejected.",
+            "description": "First day of leave. Cannot be cleared: the column is NOT NULL and the total-days figure is recomputed from both dates after every update, so a null is refused with a 400 rather than applied.",
             "example": "2026-09-14",
             "format": "date",
             "type": "string"
@@ -9472,7 +9583,10 @@
               "FIRST_HALF",
               "SECOND_HALF"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -11119,37 +11233,55 @@
         "type": "object"
       },
       "OrganizationUpdateFieldsDto": {
-        "description": "Fields a partial organization update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial organization update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "organizationAddress": {
             "description": "Postal address of the organization.",
             "example": "IIT Madras Research Park, Chennai 600113",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationEmail": {
             "description": "Contact email for the organization.",
             "example": "info@echno.xyz",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationLogo": {
             "description": "Stored key or URL of the organization logo.",
             "example": "organizations/2/logo.png",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationName": {
             "description": "Registered name of the organization.",
             "example": "Asset Homes",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationPhone": {
             "description": "Contact phone number for the organization.",
             "example": "+91 44 4000 0000",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "organizationWebsite": {
             "description": "Public website of the organization.",
             "example": "https://echno.xyz",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -14243,62 +14375,92 @@
         "type": "object"
       },
       "ProjectUpdateFieldsDto": {
-        "description": "Fields a partial project update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial project update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "customerId": {
             "description": "Id of the finance customer the project bills to, as a UUID string. The customer must belong to the caller's organization; null or blank clears the link.",
             "example": "3f2a1c64-7b21-4d1e-9c8f-0a2b3c4d5e6f",
             "format": "uuid",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "description": "Free-text description of the project.",
             "example": "Twelve-storey residential tower, two basement levels, handover Q2 2027.",
             "maxLength": 2000,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "endDate": {
             "description": "Planned end of the project.",
             "example": "2027-03-31T18:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectAddress": {
             "description": "Street address of the site.",
             "example": 12,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectCity": {
             "description": "City the site is in. Trimmed, and cleared when blank.",
             "example": "Chennai",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectLatitude": {
             "description": "Site latitude, between -90 and 90.",
             "example": 12.9915,
             "format": "float",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "projectLongitude": {
             "description": "Site longitude, between -180 and 180.",
             "example": 80.2412,
             "format": "float",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "projectName": {
             "description": "Name of the project.",
             "example": "Marina Heights, phase 2",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectPostalCode": {
             "description": "Postal code of the site. Trimmed, and cleared when blank.",
             "example": 600113,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectState": {
             "description": "State the site is in. Recorded in the canonical spelling for the state.",
             "example": "Tamil Nadu",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "projectType": {
             "description": "Kind of work the project covers.",
@@ -14311,13 +14473,19 @@
               "MIXED_USE",
               "OTHER"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "startDate": {
             "description": "Planned start of the project.",
             "example": "2026-09-01T09:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Lifecycle status of the project.",
@@ -14331,7 +14499,10 @@
               "cancelled",
               "approved"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -17667,7 +17838,7 @@
         "type": "object"
       },
       "TaskUpdateFieldsDto": {
-        "description": "Fields a partial task update may change. Every field is optional; only the fields present in the request are applied, and a field sent as null is cleared. Keys not listed here are ignored.",
+        "description": "Fields a partial task update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "assigneeIds": {
             "description": "Employees the task is assigned to. Replaces the existing assignees rather than adding to them, so a shorter list unassigns and an empty list or a null clears the task. Every id must belong to an employee of the caller's organization.",
@@ -17679,10 +17850,13 @@
               "format": "int64",
               "type": "integer"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "categoryId": {
-            "description": "Work category the task belongs to. Cannot be cleared: a task is created with a category and a task without one is a state creation cannot produce.",
+            "description": "Work category the task belongs to. Cannot be cleared: a task is created with a category and a task without one is a state creation cannot produce. This one is a product rule rather than a column rule, since the join column itself is nullable. A null is refused with a 400.",
             "example": 4,
             "format": "int64",
             "type": "integer"
@@ -17690,28 +17864,40 @@
           "description": {
             "description": "Longer description of the work to be done.",
             "example": "Complete formwork, reinforcement and concrete pour for the block A raft.",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "endDate": {
             "description": "Planned end of the task.",
             "example": "2026-09-07T17:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "progress": {
             "description": "Fraction of the task completed, between 0 and 1. A value that is neither null nor a number is ignored.",
             "example": 0.4,
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "startDate": {
             "description": "Planned start of the task.",
             "example": "2026-09-05T08:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
-            "description": "Lifecycle status of the task.",
+            "description": "Lifecycle status of the task. Cannot be cleared: the column is NOT NULL, so a null is refused with a 400 rather than applied.",
             "enum": [
               "upcoming",
               "onGoing",
@@ -17729,12 +17915,18 @@
             "items": {
               "type": "string"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "title": {
             "description": "Short task title.",
             "example": "Pour foundation slab, block A",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -18763,17 +18955,23 @@
         "type": "object"
       },
       "UserUpdateFieldsDto": {
-        "description": "Fields a partial user update may change. Every field is optional; only the fields present in the request are applied. Keys not listed here are ignored.",
+        "description": "Fields a partial user update may change. Every field is optional and an absent field is left untouched. A field this schema declares nullable is cleared by sending an explicit null; a field it does not declare nullable refuses a null with a 400 rather than clearing. Keys not listed here are ignored.",
         "properties": {
           "address": {
             "description": "Postal address of the user.",
             "example": 18,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "bloodGroup": {
             "description": "Blood group recorded for the user.",
             "example": "O+",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "certifications": {
             "description": "Certifications recorded for the user. Replaces the existing list rather than adding to it.",
@@ -18783,65 +18981,101 @@
             "items": {
               "type": "string"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "cvUrl": {
             "description": "Stored key or URL of the uploaded CV.",
             "example": "users/31/cv.pdf",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dateOfBirth": {
             "description": "Date of birth, sent as an ISO date-time string.",
             "example": "1998-04-12T00:00:00",
             "format": "date-time",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "defaultOrganizationId": {
             "description": "Id of the organization the user lands in after signing in. Must be sent as a number.",
             "example": 2,
             "format": "int64",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "email": {
             "description": "Contact email of the user.",
             "example": "hrishi@echno.xyz",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "emergencyContact": {
             "description": "Emergency contact for the user.",
             "example": "Anand, +91 88485 42511",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "experience": {
             "description": "Years of experience. Must be sent as a whole number.",
             "example": 6,
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "gender": {
             "description": "Gender recorded for the user.",
             "example": "MALE",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "name": {
             "description": "Full name of the user.",
             "example": "Hrishikesh R",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "phone": {
             "description": "Contact phone number of the user.",
             "example": "+91 99400 00000",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "profilePictureUrl": {
             "description": "Stored key or URL of the profile picture.",
             "example": "users/31/profile.jpg",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "qualification": {
             "description": "Highest qualification held.",
             "example": "B.Tech Civil Engineering",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "role": {
             "description": "Platform role held by the user.",
@@ -18854,7 +19088,10 @@
               "MANAGEMENT",
               "ADMINISTRATOR"
             ],
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "skills": {
             "description": "Skills recorded for the user. Replaces the existing list rather than adding to it.",
@@ -18865,7 +19102,10 @@
             "items": {
               "type": "string"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           }
         },
         "type": "object"

--- a/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/EmployeeService.java
@@ -30,6 +30,7 @@ import org.tornotron.echno_backend.user.User;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -332,7 +333,7 @@ public class EmployeeService {
                     employee.setEmployeeId((String) value);
                     break;
                 case "status":
-                    employee.setStatus(EmployeeStatus.valueOf((String) value));
+                    employee.setStatus(value != null ? EmployeeStatus.valueOf((String) value) : null);
                     break;
                 case "employeeName":
                     employee.setEmployeeName((String) value);
@@ -367,12 +368,7 @@ public class EmployeeService {
                     employee.setDateOfBirth(DateConversion.parseLocalDateTime(value));
                     break;
                 case "managerId":
-                    Long managerId = ((Number) value).longValue();
-                    Employee manager = employeeRepository.findByIdAndOrganizationId(managerId,TenantContext.getCurrentOrgId())
-                            .orElseThrow(() -> new ResourceNotFoundException(
-                                    "Manager with ID " + managerId + " was not found in this organization"));
-                    employeeHierarchyService.validateManager(employee, manager);
-                    employee.setManager(manager);
+                    employee.setManager(resolveManager(value, employee));
                     break;
                 default:
                     // Nothing is dropped on purpose here. The keys echno-core sends that this
@@ -385,6 +381,36 @@ public class EmployeeService {
             }
         });
     }
+
+    /**
+     * Reads the {@code managerId} key of a partial employee update.
+     *
+     * <p>Null clears the manager, which is what {@code manager_id} being a nullable join column
+     * already allows and what the top of a reporting line is. Before this branch existed the value
+     * went straight into {@code ((Number) value).longValue()} and a null answered 500, so there
+     * was no way to detach an employee from their manager. See #645.
+     *
+     * @param value The raw map value: an employee id, or null to clear the manager.
+     * @param employee The employee being updated, needed to check the hierarchy stays acyclic.
+     * @return The resolved manager, or null.
+     * @throws InvalidRequestException if the value is neither null nor a number.
+     * @throws ResourceNotFoundException if no such employee belongs to the caller's organization.
+     */
+    private Employee resolveManager(Object value, Employee employee) {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Number number)) {
+            throw new InvalidRequestException("managerId must be a number");
+        }
+        Long managerId = number.longValue();
+        Employee manager = employeeRepository.findByIdAndOrganizationId(managerId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Manager with ID " + managerId + " was not found in this organization"));
+        employeeHierarchyService.validateManager(employee, manager);
+        return manager;
+    }
+
 
     /**
      * Assigns a manager to an employee. Delegates to {@link EmployeeHierarchyService}.

--- a/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/employee/dto/EmployeeUpdateFieldsDto.java
@@ -17,46 +17,50 @@ import java.time.LocalDateTime;
  * The same keys reach the batch endpoint, which routes each element's updates through the same
  * method.
  */
-@Schema(description = "Fields a partial employee update may change. Every field is optional; only "
-        + "the fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial employee update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class EmployeeUpdateFieldsDto {
 
-    @Schema(description = "Employee code within the organization.", example = "ECH-0412")
+    @Schema(nullable = true, description = "Employee code within the organization.", example = "ECH-0412")
     private String employeeId;
 
-    @Schema(description = "Employment status of the employee.")
+    @Schema(nullable = true, description = "Employment status of the employee.")
     private EmployeeStatus status;
 
-    @Schema(description = "Full name of the employee.", example = "Hrishikesh R")
+    @Schema(nullable = true, description = "Full name of the employee.", example = "Hrishikesh R")
     private String employeeName;
 
-    @Schema(description = "Job title held.", example = "Site Engineer")
+    @Schema(nullable = true, description = "Job title held.", example = "Site Engineer")
     private String designation;
 
-    @Schema(description = "Date the employee joined.", example = "2024-06-01T00:00:00")
+    @Schema(nullable = true, description = "Date the employee joined.", example = "2024-06-01T00:00:00")
     private LocalDateTime joiningDate;
 
-    @Schema(description = "Contact phone number.", example = "+91 99400 00000")
+    @Schema(nullable = true, description = "Contact phone number.", example = "+91 99400 00000")
     private String phoneNumber;
 
-    @Schema(description = "Monthly salary. Must be sent as a decimal number.", example = "62000.0")
+    @Schema(nullable = true, description = "Monthly salary. Must be sent as a decimal number.", example = "62000.0")
     private Double salary;
 
-    @Schema(description = "Id of the shift timing the employee works. Must belong to the employee's "
+    @Schema(nullable = true, description = "Id of the shift timing the employee works. Must belong to the employee's "
             + "organization; null clears the assignment.", example = "3")
     private Long shiftTimingId;
 
-    @Schema(description = "Department the employee belongs to.", example = "Execution")
+    @Schema(nullable = true, description = "Department the employee belongs to.", example = "Execution")
     private String department;
 
-    @Schema(description = "Work email address.", example = "hrishi@echno.xyz")
+    @Schema(nullable = true, description = "Work email address.", example = "hrishi@echno.xyz")
     private String emailAddress;
 
-    @Schema(description = "Date of birth.", example = "1998-04-12T00:00:00")
+    @Schema(nullable = true, description = "Date of birth.", example = "1998-04-12T00:00:00")
     private LocalDateTime dateOfBirth;
 
-    @Schema(description = "Id of the employee's manager. Must belong to the caller's organization, "
-            + "and may not introduce a cycle in the reporting line.", example = "7")
+    @Schema(nullable = true, description = "Id of the employee's manager. Must belong to the caller's organization, "
+            + "and may not introduce a cycle in the reporting line. Send null to detach the "
+            + "employee from their manager.", example = "7")
     private Long managerId;
 }

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -306,10 +306,7 @@ public class IssueService {
                     issue.setStatus(parseIssueStatus((String) value));
                     break;
                 case "assignedToId":
-                    Long assigneeId = ((Number) value).longValue();
-                    Employee assignee = employeeRepository.findByIdAndOrganizationId(assigneeId, TenantContext.getCurrentOrgId())
-                            .orElseThrow(() -> new ResourceNotFoundException("Assignee (employee) with ID " + assigneeId + " was not found in this organization"));
-                    issue.setAssignedTo(assignee);
+                    issue.setAssignedTo(resolveAssignee(value));
                     break;
                 default:
                     PartialUpdateKeys.reportUnknown(log, "issue", issue.getId(), key,
@@ -318,6 +315,33 @@ public class IssueService {
             }
         });
     }
+
+    /**
+     * Reads the {@code assignedToId} key of a partial issue update.
+     *
+     * <p>Null clears the assignment, which is what {@code assigned_to} being a nullable join
+     * column already allows and what unassigning an issue means. Before this branch existed the
+     * value went straight into {@code ((Number) value).longValue()} and a null answered 500, so
+     * there was no way to unassign. See #645.
+     *
+     * @param value The raw map value: an employee id, or null to unassign.
+     * @return The resolved employee, or null.
+     * @throws InvalidRequestException if the value is neither null nor a number.
+     * @throws ResourceNotFoundException if no such employee belongs to the caller's organization.
+     */
+    private Employee resolveAssignee(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Number number)) {
+            throw new InvalidRequestException("assignedToId must be a number");
+        }
+        Long assigneeId = number.longValue();
+        return employeeRepository.findByIdAndOrganizationId(assigneeId, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Assignee (employee) with ID " + assigneeId + " was not found in this organization"));
+    }
+
 
     @Transactional
     public void deleteAnIssue(Long id) {

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
@@ -14,25 +14,30 @@ import org.tornotron.echno_backend.issue.enums.IssueType;
  * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
  * {@code IssueService.partialUpdateAnIssue} actually accepts out of that method's source.
  */
-@Schema(description = "Fields a partial issue update may change. Every field is optional; only the "
-        + "fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial issue update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class IssueUpdateFieldsDto {
 
-    @Schema(description = "Short issue title.", example = "Rebar spacing off on grid C")
+    @Schema(nullable = true, description = "Short issue title.", example = "Rebar spacing off on grid C")
     private String title;
 
-    @Schema(description = "Longer description of the issue.",
+    @Schema(nullable = true, description = "Longer description of the issue.",
             example = "Spacing measured at 220 mm against a specified 200 mm across grid C.")
     private String description;
 
-    @Schema(description = "Category of the issue.")
+    @Schema(description = "Category of the issue. Cannot be cleared: a null or blank value is "
+            + "refused with a 400 rather than applied.")
     private IssueType type;
 
-    @Schema(description = "Lifecycle status of the issue.")
+    @Schema(description = "Lifecycle status of the issue. Cannot be cleared: a null or blank value "
+            + "is refused with a 400 rather than applied.")
     private IssueStatus status;
 
-    @Schema(description = "Id of the employee the issue is assigned to. The employee must belong to "
-            + "the caller's organization.", example = "17")
+    @Schema(nullable = true, description = "Id of the employee the issue is assigned to. The employee must belong to "
+            + "the caller's organization. Send null to unassign the issue.", example = "17")
     private Long assignedToId;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeavePolicyService.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.leave.dto.LeavePolicyDto;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.organization.OrganizationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -229,7 +230,7 @@ public class LeavePolicyService {
             switch (key) {
                 case "leaveTypeName" -> policy.setLeaveTypeName((String) value);
                 case "description" -> policy.setDescription((String) value);
-                case "annualQuota" -> policy.setAnnualQuota(((Number) value).doubleValue());
+                case "annualQuota" -> policy.setAnnualQuota(requireAnnualQuota(value));
                 case "accrualRatePerMonth" -> policy.setAccrualRatePerMonth(
                         value != null ? ((Number) value).doubleValue() : null);
                 case "carryForwardLimit" -> policy.setCarryForwardLimit(
@@ -263,6 +264,27 @@ public class LeavePolicyService {
         LeavePolicy saved = policyRepository.save(policy);
         return leavePolicyMapper.toDto(saved);
     }
+
+    /**
+     * Reads the {@code annualQuota} key of a partial leave-policy update.
+     *
+     * <p>Null is refused rather than applied. {@code annual_quota} is a {@code NOT NULL} column, so
+     * clearing it cannot be written; before this refusal existed the branch reached
+     * {@code ((Number) null).doubleValue()} and answered 500. Every other numeric key on this
+     * switch guards null and clears, because every other numeric column is nullable. See #645.
+     *
+     * @param value The raw map value.
+     * @return The quota.
+     * @throws InvalidRequestException if the value is null.
+     */
+    private Double requireAnnualQuota(Object value) {
+        if (value == null) {
+            throw new InvalidRequestException(
+                    "A leave policy must have an annual quota; annualQuota cannot be cleared");
+        }
+        return ((Number) value).doubleValue();
+    }
+
 
     /**
      * Marks a policy inactive, keeping it for historical reference.

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -22,6 +22,7 @@ import org.tornotron.echno_backend.leave.enums.LeaveStatus;
 import org.tornotron.echno_backend.organization.Organization;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -300,10 +301,10 @@ public class LeaveRequestService {
 
         updates.forEach((key, value) -> {
             switch (key) {
-                case "startDate" -> request.setStartDate(LocalDate.parse((String) value));
+                case "startDate" -> request.setStartDate(requireLeaveDate(value, "startDate"));
                 case "startHalfDayType" -> request.setStartHalfDayType(
                         value != null ? HalfDayType.valueOf((String) value) : null);
-                case "endDate" -> request.setEndDate(LocalDate.parse((String) value));
+                case "endDate" -> request.setEndDate(requireLeaveDate(value, "endDate"));
                 case "endHalfDayType" -> request.setEndHalfDayType(
                         value != null ? HalfDayType.valueOf((String) value) : null);
                 case "reason" -> request.setReason((String) value);
@@ -327,6 +328,42 @@ public class LeaveRequestService {
         LeaveRequest saved = requestRepository.save(request);
         return leaveRequestMapper.toDto(saved);
     }
+
+    /**
+     * Reads one of the two date keys of a partial leave-request update.
+     *
+     * <p>Null is refused rather than applied. Both columns are {@code NOT NULL}, and
+     * {@code calculateTotalDays} runs over both dates after the switch, so a cleared one could not
+     * be saved or counted. Before this refusal existed the branch reached
+     * {@code LocalDate.parse(null)} and answered 500, and an unparseable string answered 500 too,
+     * since {@code DateTimeParseException} is not an {@code IllegalArgumentException} and reached
+     * no handler. See #645.
+     *
+     * @param value The raw map value: an ISO date string, an already-typed date, or null.
+     * @param field The key's name, used in the message.
+     * @return The parsed date.
+     * @throws InvalidRequestException if the value is null, not a date, or unparseable.
+     */
+    private LocalDate requireLeaveDate(Object value, String field) {
+        if (value == null) {
+            throw new InvalidRequestException(
+                    "A leave request must have both dates; " + field + " cannot be cleared");
+        }
+        if (value instanceof LocalDate date) {
+            return date;
+        }
+        if (!(value instanceof String text)) {
+            throw new InvalidRequestException(
+                    field + " must be an ISO date, for example 2026-09-05");
+        }
+        try {
+            return LocalDate.parse(text);
+        } catch (DateTimeParseException e) {
+            throw new InvalidRequestException(
+                    field + " must be an ISO date, for example 2026-09-05, but got \"" + text + "\"");
+        }
+    }
+
 
     /**
      * Submits a draft request for approval, validating it and holding its days as pending.

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeavePolicyUpdateFieldsDto.java
@@ -14,66 +14,71 @@ import lombok.Data;
  * {@code leaveTypeCode} is deliberately absent: a policy's code is fixed at creation and the update
  * path does not accept it.
  */
-@Schema(description = "Fields a partial leave-policy update may change. Every field is optional; "
-        + "only the fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial leave-policy update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class LeavePolicyUpdateFieldsDto {
 
-    @Schema(description = "Display name of the leave type.", example = "Casual Leave")
+    @Schema(nullable = true, description = "Display name of the leave type.", example = "Casual Leave")
     private String leaveTypeName;
 
-    @Schema(description = "Description of the leave type and when it applies.",
+    @Schema(nullable = true, description = "Description of the leave type and when it applies.",
             example = "Short-notice leave for personal matters.")
     private String description;
 
-    @Schema(description = "Total days granted per year under this policy. Must be a number; null is "
-            + "rejected.", example = "12.0")
+    @Schema(description = "Total days granted per year under this policy. Cannot be cleared: the "
+            + "column is NOT NULL, so a null is refused with a 400 rather than applied. It is the "
+            + "one numeric field here that refuses a null; every other numeric column on a policy "
+            + "is nullable and clears.", example = "12.0")
     private Double annualQuota;
 
-    @Schema(description = "Days accrued per completed month.", example = "1.0")
+    @Schema(nullable = true, description = "Days accrued per completed month.", example = "1.0")
     private Double accrualRatePerMonth;
 
-    @Schema(description = "Maximum days that can be carried forward into the next year.", example = "5.0")
+    @Schema(nullable = true, description = "Maximum days that can be carried forward into the next year.", example = "5.0")
     private Double carryForwardLimit;
 
-    @Schema(description = "Months into the next year before carried-forward days expire.", example = "3")
+    @Schema(nullable = true, description = "Months into the next year before carried-forward days expire.", example = "3")
     private Integer carryForwardExpiryMonths;
 
-    @Schema(description = "Smallest number of days that can be requested at once.", example = "0.5")
+    @Schema(nullable = true, description = "Smallest number of days that can be requested at once.", example = "0.5")
     private Double minDaysPerRequest;
 
-    @Schema(description = "Largest number of days that can be requested at once.", example = "15.0")
+    @Schema(nullable = true, description = "Largest number of days that can be requested at once.", example = "15.0")
     private Double maxDaysPerRequest;
 
-    @Schema(description = "Minimum days of notice required before the leave starts.", example = "2")
+    @Schema(nullable = true, description = "Minimum days of notice required before the leave starts.", example = "2")
     private Integer advanceNoticeDays;
 
-    @Schema(description = "Whether a supporting attachment is required.", example = "false")
+    @Schema(nullable = true, description = "Whether a supporting attachment is required.", example = "false")
     private Boolean requiresAttachment;
 
-    @Schema(description = "Consecutive days after which an attachment becomes required.", example = "3")
+    @Schema(nullable = true, description = "Consecutive days after which an attachment becomes required.", example = "3")
     private Integer attachmentRequiredAfterDays;
 
-    @Schema(description = "Genders this policy applies to.", example = "ALL")
+    @Schema(nullable = true, description = "Genders this policy applies to.", example = "ALL")
     private String applicableGenders;
 
-    @Schema(description = "Months of service before an employee becomes eligible.", example = "6")
+    @Schema(nullable = true, description = "Months of service before an employee becomes eligible.", example = "6")
     private Integer minServiceMonths;
 
-    @Schema(description = "Whether requests under this policy can be for half a day.", example = "true")
+    @Schema(nullable = true, description = "Whether requests under this policy can be for half a day.", example = "true")
     private Boolean allowHalfDay;
 
-    @Schema(description = "Whether leave taken under this policy is paid.", example = "true")
+    @Schema(nullable = true, description = "Whether leave taken under this policy is paid.", example = "true")
     private Boolean isPaid;
 
-    @Schema(description = "Whether the policy is available for new requests.", example = "true")
+    @Schema(nullable = true, description = "Whether the policy is available for new requests.", example = "true")
     private Boolean isActive;
 
-    @Schema(description = "Whether requests go through the full multi-level approval chain.",
+    @Schema(nullable = true, description = "Whether requests go through the full multi-level approval chain.",
             example = "true")
     private Boolean multiLevelApprovalEnabled;
 
-    @Schema(description = "Order this policy is shown in, relative to the organization's others.",
+    @Schema(nullable = true, description = "Order this policy is shown in, relative to the organization's others.",
             example = "1")
     private Integer displayOrder;
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/dto/LeaveRequestUpdateFieldsDto.java
@@ -19,36 +19,41 @@ import java.time.LocalDate;
  * {@code LeaveRequestService.updateRequest} actually accepts out of that method's source.
  */
 @Schema(description = "Fields a partial leave-request update may change, accepted only while the "
-        + "request is a draft. Every field is optional; only the fields present in the request are "
-        + "applied. Keys not listed here are ignored.")
+        + "request is a draft. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class LeaveRequestUpdateFieldsDto {
 
-    @Schema(description = "First day of leave. Must be a date; null is rejected.",
-            example = "2026-09-14")
+    @Schema(description = "First day of leave. Cannot be cleared: the column is NOT NULL and the "
+            + "total-days figure is recomputed from both dates after every update, so a null is "
+            + "refused with a 400 rather than applied.", example = "2026-09-14")
     private LocalDate startDate;
 
-    @Schema(description = "Which half of the first day is taken, when the leave starts at midday.")
+    @Schema(nullable = true, description = "Which half of the first day is taken, when the leave starts at midday.")
     private HalfDayType startHalfDayType;
 
-    @Schema(description = "Last day of leave. Must be a date; null is rejected.",
-            example = "2026-09-18")
+    @Schema(description = "Last day of leave. Cannot be cleared: the column is NOT NULL and the "
+            + "total-days figure is recomputed from both dates after every update, so a null is "
+            + "refused with a 400 rather than applied.", example = "2026-09-18")
     private LocalDate endDate;
 
-    @Schema(description = "Which half of the last day is taken, when the leave ends at midday.")
+    @Schema(nullable = true, description = "Which half of the last day is taken, when the leave ends at midday.")
     private HalfDayType endHalfDayType;
 
-    @Schema(description = "Reason given for the leave.", example = "Family function")
+    @Schema(nullable = true, description = "Reason given for the leave.", example = "Family function")
     private String reason;
 
-    @Schema(description = "How to reach the employee during the leave.",
+    @Schema(nullable = true, description = "How to reach the employee during the leave.",
             example = "+91 99400 00000")
     private String contactDuringLeave;
 
-    @Schema(description = "Id of the employee taking over the work.", example = "7")
+    @Schema(nullable = true, description = "Id of the employee taking over the work.", example = "7")
     private Long handoverToId;
 
-    @Schema(description = "Notes for the person taking over.",
+    @Schema(nullable = true, description = "Notes for the person taking over.",
             example = "Block A pour is scheduled for the 16th; drawings are in the shared folder.")
     private String handoverNotes;
 }

--- a/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/organization/dto/OrganizationUpdateFieldsDto.java
@@ -13,28 +13,31 @@ import lombok.Data;
  * {@code OrganizationService.partialUpdateAnOrganization} actually accepts out of that method's
  * source.
  */
-@Schema(description = "Fields a partial organization update may change. Every field is optional; "
-        + "only the fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial organization update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class OrganizationUpdateFieldsDto {
 
-    @Schema(description = "Registered name of the organization.", example = "Asset Homes")
+    @Schema(nullable = true, description = "Registered name of the organization.", example = "Asset Homes")
     private String organizationName;
 
-    @Schema(description = "Postal address of the organization.",
+    @Schema(nullable = true, description = "Postal address of the organization.",
             example = "IIT Madras Research Park, Chennai 600113")
     private String organizationAddress;
 
-    @Schema(description = "Contact email for the organization.", example = "info@echno.xyz")
+    @Schema(nullable = true, description = "Contact email for the organization.", example = "info@echno.xyz")
     private String organizationEmail;
 
-    @Schema(description = "Contact phone number for the organization.", example = "+91 44 4000 0000")
+    @Schema(nullable = true, description = "Contact phone number for the organization.", example = "+91 44 4000 0000")
     private String organizationPhone;
 
-    @Schema(description = "Public website of the organization.", example = "https://echno.xyz")
+    @Schema(nullable = true, description = "Public website of the organization.", example = "https://echno.xyz")
     private String organizationWebsite;
 
-    @Schema(description = "Stored key or URL of the organization logo.",
+    @Schema(nullable = true, description = "Stored key or URL of the organization logo.",
             example = "organizations/2/logo.png")
     private String organizationLogo;
 }

--- a/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
+++ b/src/main/java/org/tornotron/echno_backend/project/ProjectService.java
@@ -382,7 +382,7 @@ public class ProjectService {
                     project.setProjectPostalCode(trimToNull((String) value));
                     break;
                 case "status":
-                    project.setStatus(ProjectCreationStatus.valueOf((String) value));
+                    project.setStatus(value != null ? ProjectCreationStatus.valueOf((String) value) : null);
                     break;
                 case "startDate":
                     project.setStartDate(DateConversion.parseLocalDateTime(value));
@@ -401,20 +401,10 @@ public class ProjectService {
                             : requireCustomerInTenant(UUID.fromString(customerId)));
                     break;
                 case "projectLongitude":
-                    float longitude = ((Number) value).floatValue();
-                    if(longitude >= -180 && longitude <= 180) {
-                        project.setProjectLongitude(longitude);
-                    } else {
-                        throw new IllegalArgumentException("Longitude must be between -180 and 180");
-                    }
+                    project.setProjectLongitude(coordinateWithin(value, -180, 180, "Longitude"));
                     break;
                 case "projectLatitude":
-                    float latitude = ((Number) value).floatValue();
-                    if (latitude >= -90 && latitude <= 90) {
-                        project.setProjectLatitude(latitude);
-                    } else {
-                        throw new IllegalArgumentException("Latitude must be between -90 and 90");
-                    }
+                    project.setProjectLatitude(coordinateWithin(value, -90, 90, "Latitude"));
                     break;
                 default:
                     PartialUpdateKeys.reportUnknown(log, "project", project.getId(), key,
@@ -431,6 +421,35 @@ public class ProjectService {
         recordStatusChange(project, previousStatus, actor);
         stampWrite(project, actor);
     }
+
+    /**
+     * Reads one of the two coordinate keys of a partial project update.
+     *
+     * <p>Null clears the coordinate: both columns are nullable and a project whose location is not
+     * known is the state every project starts in. Before this helper existed the value went
+     * straight into {@code ((Number) value).floatValue()} and a null answered 500. See #645.
+     *
+     * @param value The raw map value: a number, or null to clear the coordinate.
+     * @param minimum Lowest value the coordinate may take.
+     * @param maximum Highest value the coordinate may take.
+     * @param name The coordinate's name, used in the message.
+     * @return The coordinate, or null.
+     * @throws IllegalArgumentException if the value is not a number, or is out of range.
+     */
+    private Float coordinateWithin(Object value, int minimum, int maximum, String name) {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Number number)) {
+            throw new IllegalArgumentException(name + " must be a number");
+        }
+        float coordinate = number.floatValue();
+        if (coordinate < minimum || coordinate > maximum) {
+            throw new IllegalArgumentException(name + " must be between " + minimum + " and " + maximum);
+        }
+        return coordinate;
+    }
+
 
     /**
      * Appends a status change to the project's trail, if the patch was one.

--- a/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/project/dto/ProjectUpdateFieldsDto.java
@@ -17,53 +17,56 @@ import java.util.UUID;
  * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
  * {@code ProjectService.partialUpdateAProject} actually accepts out of that method's source.
  */
-@Schema(description = "Fields a partial project update may change. Every field is optional; only "
-        + "the fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial project update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class ProjectUpdateFieldsDto {
 
-    @Schema(description = "Name of the project.", example = "Marina Heights, phase 2")
+    @Schema(nullable = true, description = "Name of the project.", example = "Marina Heights, phase 2")
     private String projectName;
 
-    @Schema(description = "Free-text description of the project.",
+    @Schema(nullable = true, description = "Free-text description of the project.",
             maxLength = ProjectCreationDto.MAX_DESCRIPTION_LENGTH,
             example = "Twelve-storey residential tower, two basement levels, handover Q2 2027.")
     private String description;
 
-    @Schema(description = "Street address of the site.", example = "12 Kamaraj Salai")
+    @Schema(nullable = true, description = "Street address of the site.", example = "12 Kamaraj Salai")
     private String projectAddress;
 
-    @Schema(description = "City the site is in. Trimmed, and cleared when blank.", example = "Chennai")
+    @Schema(nullable = true, description = "City the site is in. Trimmed, and cleared when blank.", example = "Chennai")
     private String projectCity;
 
-    @Schema(description = "State the site is in. Recorded in the canonical spelling for the state.",
+    @Schema(nullable = true, description = "State the site is in. Recorded in the canonical spelling for the state.",
             example = "Tamil Nadu")
     private String projectState;
 
-    @Schema(description = "Postal code of the site. Trimmed, and cleared when blank.",
+    @Schema(nullable = true, description = "Postal code of the site. Trimmed, and cleared when blank.",
             example = "600113")
     private String projectPostalCode;
 
-    @Schema(description = "Lifecycle status of the project.")
+    @Schema(nullable = true, description = "Lifecycle status of the project.")
     private ProjectCreationStatus status;
 
-    @Schema(description = "Planned start of the project.", example = "2026-09-01T09:00:00")
+    @Schema(nullable = true, description = "Planned start of the project.", example = "2026-09-01T09:00:00")
     private LocalDateTime startDate;
 
-    @Schema(description = "Planned end of the project.", example = "2027-03-31T18:00:00")
+    @Schema(nullable = true, description = "Planned end of the project.", example = "2027-03-31T18:00:00")
     private LocalDateTime endDate;
 
-    @Schema(description = "Kind of work the project covers.")
+    @Schema(nullable = true, description = "Kind of work the project covers.")
     private ProjectType projectType;
 
-    @Schema(description = "Id of the finance customer the project bills to, as a UUID string. The "
+    @Schema(nullable = true, description = "Id of the finance customer the project bills to, as a UUID string. The "
             + "customer must belong to the caller's organization; null or blank clears the link.",
             example = "3f2a1c64-7b21-4d1e-9c8f-0a2b3c4d5e6f")
     private UUID customerId;
 
-    @Schema(description = "Site longitude, between -180 and 180.", example = "80.2412")
+    @Schema(nullable = true, description = "Site longitude, between -180 and 180.", example = "80.2412")
     private Float projectLongitude;
 
-    @Schema(description = "Site latitude, between -90 and 90.", example = "12.9915")
+    @Schema(nullable = true, description = "Site latitude, between -90 and 90.", example = "12.9915")
     private Float projectLatitude;
 }

--- a/src/main/java/org/tornotron/echno_backend/task/TaskService.java
+++ b/src/main/java/org/tornotron/echno_backend/task/TaskService.java
@@ -346,7 +346,7 @@ public class TaskService {
                     }
                     break;
                 case "status":
-                    task.setStatus(TaskStatus.valueOf((String) value));
+                    task.setStatus(requireStatus(value));
                     break;
                 case "tags":
                     updateTags(value, task);
@@ -364,6 +364,25 @@ public class TaskService {
             }
         });
     }
+
+    /**
+     * Reads the {@code status} key of a partial task update.
+     *
+     * <p>Null is refused rather than applied. {@code Task.status} is a {@code NOT NULL} column, so
+     * clearing it cannot be written; before this refusal existed the branch reached
+     * {@code TaskStatus.valueOf(null)} and answered 500. See #645.
+     *
+     * @param value The raw map value.
+     * @return The parsed status.
+     * @throws InvalidRequestException if the value is null.
+     */
+    private TaskStatus requireStatus(Object value) {
+        if (value == null) {
+            throw new InvalidRequestException("A task must have a status; status cannot be cleared");
+        }
+        return TaskStatus.valueOf((String) value);
+    }
+
 
     /**
      * Resolves the replacement assignee set for a task update.

--- a/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/task/dto/TaskUpdateFieldsDto.java
@@ -25,44 +25,48 @@ import java.util.List;
  * {@code TaskService.partialUpdateATask} actually accepts out of that method's source and fails
  * when they and these fields have drifted apart.
  */
-@Schema(description = "Fields a partial task update may change. Every field is optional; only the "
-        + "fields present in the request are applied, and a field sent as null is cleared. Keys not "
-        + "listed here are ignored.")
+@Schema(description = "Fields a partial task update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class TaskUpdateFieldsDto {
 
-    @Schema(description = "Short task title.", example = "Pour foundation slab, block A")
+    @Schema(nullable = true, description = "Short task title.", example = "Pour foundation slab, block A")
     private String title;
 
-    @Schema(description = "Longer description of the work to be done.",
+    @Schema(nullable = true, description = "Longer description of the work to be done.",
             example = "Complete formwork, reinforcement and concrete pour for the block A raft.")
     private String description;
 
-    @Schema(description = "Planned start of the task.", example = "2026-09-05T08:00:00")
+    @Schema(nullable = true, description = "Planned start of the task.", example = "2026-09-05T08:00:00")
     private LocalDateTime startDate;
 
-    @Schema(description = "Planned end of the task.", example = "2026-09-07T17:00:00")
+    @Schema(nullable = true, description = "Planned end of the task.", example = "2026-09-07T17:00:00")
     private LocalDateTime endDate;
 
-    @Schema(description = "Fraction of the task completed, between 0 and 1. A value that is neither "
+    @Schema(nullable = true, description = "Fraction of the task completed, between 0 and 1. A value that is neither "
             + "null nor a number is ignored.", example = "0.4")
     private Double progress;
 
-    @Schema(description = "Lifecycle status of the task.")
+    @Schema(description = "Lifecycle status of the task. Cannot be cleared: the column is NOT NULL, "
+            + "so a null is refused with a 400 rather than applied.")
     private TaskStatus status;
 
-    @Schema(description = "Free-form labels on the task. Replaces the existing labels rather than "
+    @Schema(nullable = true, description = "Free-form labels on the task. Replaces the existing labels rather than "
             + "adding to them, and must be a list of strings.", example = "[\"concrete\", \"block-a\"]")
     private List<String> tags;
 
-    @Schema(description = "Employees the task is assigned to. Replaces the existing assignees "
+    @Schema(nullable = true, description = "Employees the task is assigned to. Replaces the existing assignees "
             + "rather than adding to them, so a shorter list unassigns and an empty list or a null "
             + "clears the task. Every id must belong to an employee of the caller's organization.",
             example = "[12, 31]")
     private List<Long> assigneeIds;
 
     @Schema(description = "Work category the task belongs to. Cannot be cleared: a task is created "
-            + "with a category and a task without one is a state creation cannot produce.",
-            example = "4")
+            + "with a category and a task without one is a state creation cannot produce. This one "
+            + "is a product rule rather than a column rule, since the join column itself is "
+            + "nullable. A null is refused with a 400.", example = "4")
     private Long categoryId;
 }

--- a/src/main/java/org/tornotron/echno_backend/user/UserService.java
+++ b/src/main/java/org/tornotron/echno_backend/user/UserService.java
@@ -234,7 +234,7 @@ public class UserService {
                 case "experience" -> user.setExperience((Integer) value);
                 case "cvUrl" -> user.setCvUrl((String) value);
                 case "emergencyContact" -> user.setEmergencyContact((String) value);
-                case "role" -> user.setRole(UserRole.valueOf((String) value));
+                case "role" -> user.setRole(value != null ? UserRole.valueOf((String) value) : null);
                 case "profilePictureUrl" -> user.setProfilePictureUrl((String) value);
                 case "skills" -> user.setSkills(parseSkills(value));
                 case "certifications" -> user.setCertifications(parseCertifications(value));
@@ -247,6 +247,9 @@ public class UserService {
     }
 
     private Long parseDefaultOrganizationId(Object value) {
+        if (value == null) {
+            return null;
+        }
         if (value instanceof Number number) {
             return number.longValue();
         }

--- a/src/main/java/org/tornotron/echno_backend/user/dto/UserUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/user/dto/UserUpdateFieldsDto.java
@@ -16,61 +16,64 @@ import java.util.List;
  * <p>Its field list is kept honest by {@code PartialUpdateSchemaContractTest}, which reads the keys
  * {@code UserService.applyUpdates} actually accepts out of that method's source.
  */
-@Schema(description = "Fields a partial user update may change. Every field is optional; only the "
-        + "fields present in the request are applied. Keys not listed here are ignored.")
+@Schema(description = "Fields a partial user update may change. "
+        + "Every field is optional and an absent field is left untouched. A field this schema "
+        + "declares nullable is cleared by sending an explicit null; a field it does not declare "
+        + "nullable refuses a null with a 400 rather than clearing. Keys not listed here are "
+        + "ignored.")
 @Data
 public class UserUpdateFieldsDto {
 
-    @Schema(description = "Full name of the user.", example = "Hrishikesh R")
+    @Schema(nullable = true, description = "Full name of the user.", example = "Hrishikesh R")
     private String name;
 
-    @Schema(description = "Id of the organization the user lands in after signing in. Must be sent "
+    @Schema(nullable = true, description = "Id of the organization the user lands in after signing in. Must be sent "
             + "as a number.", example = "2")
     private Long defaultOrganizationId;
 
-    @Schema(description = "Gender recorded for the user.", example = "MALE")
+    @Schema(nullable = true, description = "Gender recorded for the user.", example = "MALE")
     private String gender;
 
-    @Schema(description = "Blood group recorded for the user.", example = "O+")
+    @Schema(nullable = true, description = "Blood group recorded for the user.", example = "O+")
     private String bloodGroup;
 
-    @Schema(description = "Contact email of the user.", example = "hrishi@echno.xyz")
+    @Schema(nullable = true, description = "Contact email of the user.", example = "hrishi@echno.xyz")
     private String email;
 
-    @Schema(description = "Contact phone number of the user.", example = "+91 99400 00000")
+    @Schema(nullable = true, description = "Contact phone number of the user.", example = "+91 99400 00000")
     private String phone;
 
-    @Schema(description = "Date of birth, sent as an ISO date-time string.",
+    @Schema(nullable = true, description = "Date of birth, sent as an ISO date-time string.",
             example = "1998-04-12T00:00:00")
     private LocalDateTime dateOfBirth;
 
-    @Schema(description = "Highest qualification held.", example = "B.Tech Civil Engineering")
+    @Schema(nullable = true, description = "Highest qualification held.", example = "B.Tech Civil Engineering")
     private String qualification;
 
-    @Schema(description = "Postal address of the user.", example = "18 Anna Nagar, Chennai 600040")
+    @Schema(nullable = true, description = "Postal address of the user.", example = "18 Anna Nagar, Chennai 600040")
     private String address;
 
-    @Schema(description = "Years of experience. Must be sent as a whole number.", example = "6")
+    @Schema(nullable = true, description = "Years of experience. Must be sent as a whole number.", example = "6")
     private Integer experience;
 
-    @Schema(description = "Stored key or URL of the uploaded CV.", example = "users/31/cv.pdf")
+    @Schema(nullable = true, description = "Stored key or URL of the uploaded CV.", example = "users/31/cv.pdf")
     private String cvUrl;
 
-    @Schema(description = "Emergency contact for the user.", example = "Anand, +91 88485 42511")
+    @Schema(nullable = true, description = "Emergency contact for the user.", example = "Anand, +91 88485 42511")
     private String emergencyContact;
 
-    @Schema(description = "Platform role held by the user.")
+    @Schema(nullable = true, description = "Platform role held by the user.")
     private UserRole role;
 
-    @Schema(description = "Stored key or URL of the profile picture.",
+    @Schema(nullable = true, description = "Stored key or URL of the profile picture.",
             example = "users/31/profile.jpg")
     private String profilePictureUrl;
 
-    @Schema(description = "Skills recorded for the user. Replaces the existing list rather than "
+    @Schema(nullable = true, description = "Skills recorded for the user. Replaces the existing list rather than "
             + "adding to it.", example = "[\"AutoCAD\", \"Site supervision\"]")
     private List<String> skills;
 
-    @Schema(description = "Certifications recorded for the user. Replaces the existing list rather "
+    @Schema(nullable = true, description = "Certifications recorded for the user. Replaces the existing list rather "
             + "than adding to it.", example = "[\"NEBOSH IGC\"]")
     private List<String> certifications;
 }

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullBehaviourTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullBehaviourTest.java
@@ -1,0 +1,581 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tornotron.echno_backend.architecture.PartialUpdateSurfaces.UpdateSurface;
+import org.tornotron.echno_backend.category.CategoryRepository;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.finance.ledger.repositories.CustomerRepository;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeHierarchyService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.employee.EmployeeService;
+import org.tornotron.echno_backend.employee.mapper.EmployeeMapper;
+import org.tornotron.echno_backend.issue.Issue;
+import org.tornotron.echno_backend.issue.IssueRepository;
+import org.tornotron.echno_backend.issue.IssueService;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.common.service.KeycloakGroupService;
+import org.tornotron.echno_backend.user.KeycloakUserProvisioningService;
+import org.tornotron.echno_backend.leave.LeaveApprovalService;
+import org.tornotron.echno_backend.leave.LeaveBalanceRepository;
+import org.tornotron.echno_backend.leave.LeavePolicy;
+import org.tornotron.echno_backend.leave.LeavePolicyRepository;
+import org.tornotron.echno_backend.leave.LeavePolicyService;
+import org.tornotron.echno_backend.leave.LeaveRequest;
+import org.tornotron.echno_backend.leave.LeaveRequestRepository;
+import org.tornotron.echno_backend.leave.LeaveRequestSequenceRepository;
+import org.tornotron.echno_backend.leave.LeaveRequestService;
+import org.tornotron.echno_backend.leave.LeaveRequestValidator;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeavePolicyMapper;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationOnboardingSeeder;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.organization.OrganizationService;
+import org.tornotron.echno_backend.organization.mapper.OrganizationMapper;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.project.ProjectService;
+import org.tornotron.echno_backend.project.enums.ProjectCreationStatus;
+import org.tornotron.echno_backend.project.mapper.ProjectMapper;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.billing.services.SubscriptionService;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.TaskRepository;
+import org.tornotron.echno_backend.task.TaskService;
+import org.tornotron.echno_backend.task.mapper.TaskMapper;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserRepository;
+import org.tornotron.echno_backend.user.UserService;
+import org.tornotron.echno_backend.user.enums.UserRole;
+import org.tornotron.echno_backend.user.mapper.UserMapper;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * What an explicit null actually does to every key of every partial-update surface.
+ *
+ * <p>This is the behavioural half of {@link PartialUpdateSurfaces#surfaces()}, and the reason that
+ * list can be trusted by {@link PartialUpdateNullContractTest} and, through it, by the published
+ * document. For each surface it sends {@code {key: null}} once per declared key and requires the
+ * outcome to be the one the list claims: a key not listed as refusing must be applied, and a key
+ * listed as refusing must come back as an {@code InvalidRequestException}, which the global handler
+ * answers 400 for.
+ *
+ * <p>Run against the tree before #645 the sweep reports eleven keys, on seven of the eight
+ * surfaces, that did neither: {@code TaskUpdateFieldsDto.status},
+ * {@code IssueUpdateFieldsDto.assignedToId}, {@code ProjectUpdateFieldsDto.status},
+ * {@code projectLatitude} and {@code projectLongitude}, {@code UserUpdateFieldsDto.role},
+ * {@code EmployeeUpdateFieldsDto.status} and {@code managerId},
+ * {@code LeavePolicyUpdateFieldsDto.annualQuota}, and {@code LeaveRequestUpdateFieldsDto.startDate}
+ * and {@code endDate}. Each reached an unguarded {@code Enum.valueOf(null)},
+ * {@code ((Number) null).longValue()} or {@code LocalDate.parse(null)} and threw a
+ * {@code NullPointerException}, which no handler names, so the endpoint answered 500 to a request
+ * whose shape the document said was fine.
+ *
+ * <p>The sweep is driven off the schema class rather than a written list of keys, so a field added
+ * to one of these DTOs is covered here the day it appears.
+ *
+ * <p>Plain Mockito, no Spring context, so this adds nothing to the cached-context heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PartialUpdateNullBehaviourTest {
+
+    private static final long ORG_ID = 1L;
+    private static final long ENTITY_ID = 7L;
+
+    /**
+     * Sends a null for every key of one surface and checks each outcome against the list.
+     *
+     * @param schema The surface's schema class, whose declared fields are the keys to sweep.
+     * @param apply Applies one single-key update, throwing whatever the service throws.
+     */
+    private static void sweep(Class<?> schema, Consumer<Map<String, Object>> apply) {
+        UpdateSurface surface = PartialUpdateSurfaces.surfaces().stream()
+                .filter(candidate -> candidate.schema().equals(schema))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        schema.getSimpleName() + " is not listed in PartialUpdateSurfaces"));
+
+        List<String> keys = Arrays.stream(schema.getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .map(Field::getName)
+                .toList();
+        assertThat(keys).as("%s declares no fields, so this sweep checks nothing", surface).isNotEmpty();
+
+        List<String> wrong = new ArrayList<>();
+        for (String key : keys) {
+            Map<String, Object> update = new HashMap<>();
+            update.put(key, null);
+            boolean refuses = surface.refusesNull().contains(key);
+            try {
+                apply.accept(update);
+                if (refuses) {
+                    wrong.add(key + ": listed as refusing a null, but the update was accepted");
+                }
+            } catch (InvalidRequestException e) {
+                if (!refuses) {
+                    wrong.add(key + ": refused the null with \"" + e.getMessage()
+                            + "\", but is not listed as refusing one");
+                }
+            } catch (RuntimeException e) {
+                wrong.add(key + ": threw " + e.getClass().getSimpleName() + " (\"" + e.getMessage()
+                        + "\"), which is neither clearing the field nor a 400. An unguarded null "
+                        + "reaching a cast or a parser answers 500");
+            }
+        }
+
+        assertThat(wrong)
+                .as("%s does not do to a null what PartialUpdateSurfaces says it does", surface)
+                .isEmpty();
+    }
+
+    @Nested
+    @DisplayName("task")
+    class TaskSurface {
+
+        @Mock private TaskRepository taskRepository;
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private ProjectRepository projectRepository;
+        @Mock private CategoryRepository categoryRepository;
+        @Mock private AttachmentService attachmentService;
+        @Mock private CurrentEmployeeService currentEmployeeService;
+        @Mock private TaskMapper taskMapper;
+        @Mock private PayloadValidator payloadValidator;
+
+        @InjectMocks private TaskService service;
+
+        private Task task;
+
+        private void apply(Map<String, Object> updates) {
+            Project project = new Project();
+            project.setId(3L);
+            task = new Task();
+            task.setProject(project);
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(taskRepository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(task));
+                when(taskRepository.save(any(Task.class))).thenAnswer(i -> i.getArgument(0));
+                when(taskRepository.findByProject_Id(any())).thenReturn(List.of());
+                service.partialUpdateATask(updates, ENTITY_ID, null, "TASK");
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.task.dto.TaskUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("status refuses a null rather than answering 500, since the column is NOT NULL")
+        void statusRefusesNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("status", null);
+
+            assertThatThrownBy(() -> apply(update))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("status cannot be cleared");
+        }
+    }
+
+    @Nested
+    @DisplayName("issue")
+    class IssueSurface {
+
+        @Mock private IssueRepository issueRepository;
+        @Mock private TaskRepository taskRepository;
+        @Mock private AttachmentService attachmentService;
+        @Mock private IssueMapper issueMapper;
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private CurrentEmployeeService currentEmployeeService;
+        @Mock private PayloadValidator payloadValidator;
+
+        @InjectMocks private IssueService service;
+
+        private Issue issue;
+
+        private void apply(Map<String, Object> updates) {
+            issue = new Issue();
+            issue.setAssignedTo(new Employee());
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(issueRepository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(issue));
+                when(issueRepository.save(any(Issue.class))).thenAnswer(i -> i.getArgument(0));
+                service.partialUpdateAnIssue(updates, ENTITY_ID, null, "ISSUE");
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.issue.dto.IssueUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("assignedToId unassigns on a null rather than answering 500")
+        void assignedToIdClearsOnNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("assignedToId", null);
+
+            apply(update);
+
+            assertThat(issue.getAssignedTo()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("project")
+    class ProjectSurface {
+
+        @Mock private ProjectRepository repository;
+        @Mock private OrganizationRepository organizationRepository;
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private AttachmentService attachmentService;
+        @Mock private ProjectMapper projectMapper;
+        @Mock private EmployeeMapper employeeMapper;
+        @Mock private ApplicationEventPublisher eventPublisher;
+        @Mock private CustomerRepository customerRepository;
+        @Mock private PayloadValidator payloadValidator;
+        @Mock private UserContextService userContextService;
+        @Mock private StatusTransitionRecorder statusTransitionRecorder;
+        @Mock private StatusTransitionRepository statusTransitionRepository;
+        @Mock private StatusTransitionMapper statusTransitionMapper;
+
+        @InjectMocks private ProjectService service;
+
+        private Project project;
+
+        private void apply(Map<String, Object> updates) {
+            project = new Project();
+            project.setId(ENTITY_ID);
+            project.setStatus(ProjectCreationStatus.open);
+            project.setProjectLatitude(12.9f);
+            project.setProjectLongitude(80.2f);
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(repository.findByIdAndOrganization_Id(any(), any())).thenReturn(Optional.of(project));
+                when(repository.save(any(Project.class))).thenAnswer(i -> i.getArgument(0));
+                when(userContextService.getCurrentUser()).thenReturn(new User());
+                service.partialUpdateAProject(updates, ENTITY_ID, null, "PROJECT");
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.project.dto.ProjectUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("both coordinates clear on a null rather than answering 500")
+        void coordinatesClearOnNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("projectLatitude", null);
+            update.put("projectLongitude", null);
+
+            apply(update);
+
+            assertThat(project.getProjectLatitude()).isNull();
+            assertThat(project.getProjectLongitude()).isNull();
+        }
+
+        @Test
+        @DisplayName("a coordinate still refuses a value outside its range")
+        void coordinateRangeIsStillEnforced() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("projectLatitude", 91);
+
+            assertThatThrownBy(() -> apply(update))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Latitude must be between -90 and 90");
+        }
+    }
+
+    @Nested
+    @DisplayName("organization")
+    class OrganizationSurface {
+
+        @Mock private OrganizationRepository repository;
+        @Mock private AttachmentService attachmentService;
+        @Mock private FileStorageService fileStorageService;
+        @Mock private KeycloakGroupService keycloakGroupService;
+        @Mock private SubscriptionService subscriptionService;
+        @Mock private UserContextService userContextService;
+        @Mock private EmployeeService employeeService;
+        @Mock private OrganizationMapper organizationMapper;
+        @Mock private OrganizationSecurityService orgSecurity;
+        @Mock private OrganizationOnboardingSeeder onboardingSeeder;
+        @Mock private PayloadValidator payloadValidator;
+
+        @InjectMocks private OrganizationService service;
+
+        private void apply(Map<String, Object> updates) {
+            Organization organization = new Organization();
+            organization.setId(ENTITY_ID);
+            when(repository.findById(any())).thenReturn(Optional.of(organization));
+            when(repository.save(any(Organization.class))).thenAnswer(i -> i.getArgument(0));
+            service.partialUpdateAnOrganization(updates, ENTITY_ID, null, "ORGANIZATION");
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.organization.dto.OrganizationUpdateFieldsDto.class, this::apply);
+        }
+    }
+
+    @Nested
+    @DisplayName("user")
+    class UserSurface {
+
+        @Mock private UserRepository userRepository;
+        @Mock private KeycloakUserProvisioningService keycloakUserProvisioningService;
+        @Mock private AttachmentService attachmentService;
+        @Mock private FileStorageService fileStorageService;
+        @Mock private EmployeeMapper employeeMapper;
+        @Mock private UserMapper userMapper;
+        @Mock private OrganizationMapper organizationMapper;
+
+        @InjectMocks private UserService service;
+
+        private User user;
+
+        private void apply(Map<String, Object> updates) {
+            user = new User();
+            user.setRole(UserRole.EMPLOYEE);
+            user.setDefaultOrganizationId(ORG_ID);
+            when(userRepository.findById(any())).thenReturn(Optional.of(user));
+            when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+            service.partialUpdateAnUser(updates, ENTITY_ID, null, null);
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.user.dto.UserUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("role clears on a null rather than answering 500")
+        void roleClearsOnNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("role", null);
+
+            apply(update);
+
+            assertThat(user.getRole()).isNull();
+        }
+
+        @Test
+        @DisplayName("defaultOrganizationId clears on a null rather than refusing it as a non-number")
+        void defaultOrganizationIdClearsOnNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("defaultOrganizationId", null);
+
+            apply(update);
+
+            assertThat(user.getDefaultOrganizationId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("employee")
+    class EmployeeSurface {
+
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private OrganizationRepository organizationRepository;
+        @Mock private UserRepository userRepository;
+        @Mock private KeycloakGroupService keycloakGroupService;
+        @Mock private EmployeeMapper employeeMapper;
+        @Mock private EmployeeHierarchyService employeeHierarchyService;
+        @Mock private ShiftTimingRepository shiftTimingRepository;
+
+        @InjectMocks private EmployeeService service;
+
+        private Employee employee;
+
+        private void apply(Map<String, Object> updates) {
+            employee = new Employee();
+            employee.setManager(new Employee());
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(employeeRepository.findByIdAndOrganizationId(any(), any()))
+                        .thenReturn(Optional.of(employee));
+                when(employeeRepository.save(any(Employee.class))).thenAnswer(i -> i.getArgument(0));
+                service.partialUpdateAnEmployee(updates, ENTITY_ID);
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.employee.dto.EmployeeUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("managerId detaches the manager on a null rather than answering 500")
+        void managerIdClearsOnNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("managerId", null);
+
+            apply(update);
+
+            assertThat(employee.getManager()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("leave policy")
+    class LeavePolicySurface {
+
+        @Mock private LeavePolicyRepository policyRepository;
+        @Mock private OrganizationRepository organizationRepository;
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private UserContextService userContextService;
+        @Mock private LeavePolicyMapper leavePolicyMapper;
+
+        @InjectMocks private LeavePolicyService service;
+
+        private void apply(Map<String, Object> updates) {
+            LeavePolicy policy = new LeavePolicy();
+            policy.setAnnualQuota(12.0);
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(policyRepository.findByIdAndOrganization_Id(any(), any()))
+                        .thenReturn(Optional.of(policy));
+                when(policyRepository.save(any(LeavePolicy.class))).thenAnswer(i -> i.getArgument(0));
+                service.updatePolicy(ENTITY_ID, updates);
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.leave.dto.LeavePolicyUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("annualQuota refuses a null rather than answering 500, since the column is NOT NULL")
+        void annualQuotaRefusesNull() {
+            Map<String, Object> update = new HashMap<>();
+            update.put("annualQuota", null);
+
+            assertThatThrownBy(() -> apply(update))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("annualQuota cannot be cleared");
+        }
+    }
+
+    @Nested
+    @DisplayName("leave request")
+    class LeaveRequestSurface {
+
+        @Mock private LeaveRequestRepository requestRepository;
+        @Mock private LeaveRequestSequenceRepository sequenceRepository;
+        @Mock private LeavePolicyRepository policyRepository;
+        @Mock private LeaveBalanceRepository balanceRepository;
+        @Mock private EmployeeRepository employeeRepository;
+        @Mock private LeaveApprovalService approvalService;
+        @Mock private LeaveRequestValidator leaveRequestValidator;
+        @Mock private LeaveRequestMapper leaveRequestMapper;
+        @Mock private OrganizationSecurityService orgSecurity;
+
+        @InjectMocks private LeaveRequestService service;
+
+        private void apply(Map<String, Object> updates) {
+            Employee employee = new Employee();
+            employee.setId(5L);
+            LeaveRequest request = new LeaveRequest();
+            request.setEmployee(employee);
+            request.setStatus(LeaveStatus.DRAFT);
+            request.setStartDate(LocalDate.of(2026, 9, 14));
+            request.setEndDate(LocalDate.of(2026, 9, 18));
+            TenantContext.setCurrentOrgId(ORG_ID);
+            try {
+                when(requestRepository.findByIdAndOrganization_Id(any(), any()))
+                        .thenReturn(Optional.of(request));
+                when(requestRepository.save(any(LeaveRequest.class))).thenAnswer(i -> i.getArgument(0));
+                when(orgSecurity.isSelfInCurrentTenant(any())).thenReturn(true);
+                service.updateRequest(ENTITY_ID, updates);
+            } finally {
+                TenantContext.clear();
+            }
+        }
+
+        @Test
+        @DisplayName("every key does to a null what PartialUpdateSurfaces says it does")
+        void nullBehaviourMatchesTheTable() {
+            sweep(org.tornotron.echno_backend.leave.dto.LeaveRequestUpdateFieldsDto.class, this::apply);
+        }
+
+        @Test
+        @DisplayName("both dates refuse a null rather than answering 500, since both columns are NOT NULL")
+        void datesRefuseNull() {
+            for (String key : List.of("startDate", "endDate")) {
+                Map<String, Object> update = new HashMap<>();
+                update.put(key, null);
+
+                assertThatThrownBy(() -> apply(update))
+                        .isInstanceOf(InvalidRequestException.class)
+                        .hasMessageContaining(key + " cannot be cleared");
+            }
+        }
+
+        @Test
+        @DisplayName("an unparseable date is a 400 rather than the 500 a DateTimeParseException gives")
+        void unparseableDateIsRefused() {
+            assertThatThrownBy(() -> apply(new HashMap<>(
+                    Collections.singletonMap("startDate", "14-09-2026"))))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("must be an ISO date");
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullContractTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateNullContractTest.java
@@ -1,0 +1,120 @@
+package org.tornotron.echno_backend.architecture;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.architecture.PartialUpdateSurfaces.UpdateSurface;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every partial-update field says in the schema what an explicit null does to it.
+ *
+ * <p>A partial update is the one place in this API where null and absent are different requests.
+ * Absence means the field is untouched. A null means either "clear this" or "no, and here is a
+ * 400", and which of the two it means was, before #645, undiscoverable from the document: the
+ * document declared nothing nullable at all, and the class-level description on
+ * {@code TaskUpdateFieldsDto} asserted a blanket "a field sent as null is cleared" that two of its
+ * own nine fields contradicted.
+ *
+ * <p>The two halves now compose. {@code required}, which #664 made accurate, says whether a field
+ * may be absent. The 3.1 type union, which #661 made reachable, says whether it may be null when
+ * present. Neither says anything about the other.
+ *
+ * <p>This test holds the annotations to {@link PartialUpdateSurfaces#surfaces()}: a field the
+ * surface does not list as refusing a null must be marked {@code @Schema(nullable = true)}, and a
+ * field it does list must not be. {@code OpenApiNullabilityTest} then carries the annotation into
+ * {@code docs/openapi.json}, and {@code PartialUpdateNullBehaviourTest} holds the service to the
+ * same list from the other side, so a field cannot be documented as clearing while the code
+ * refuses, or the reverse.
+ *
+ * <p>Plain reflection over eight named classes rather than an ArchUnit scan: the list is the point
+ * here, and a rule matching by package would quietly stop covering a DTO that moved.
+ */
+class PartialUpdateNullContractTest {
+
+    @Test
+    @DisplayName("a field that clears on null is declared nullable, and one that refuses is not")
+    void everyPartialUpdateFieldDeclaresWhatANullDoes() {
+        List<String> wrong = new ArrayList<>();
+
+        for (UpdateSurface surface : PartialUpdateSurfaces.surfaces()) {
+            Set<String> declared = fieldNames(surface);
+            Set<String> unknown = new LinkedHashSet<>(surface.refusesNull());
+            unknown.removeAll(declared);
+            assertThat(unknown)
+                    .as("%s lists these keys as refusing a null, but the schema class has no such "
+                            + "field. A renamed field, or a key removed from the switch without "
+                            + "being removed from PartialUpdateSurfaces", surface)
+                    .isEmpty();
+
+            for (Field field : schemaFields(surface)) {
+                boolean refuses = surface.refusesNull().contains(field.getName());
+                boolean marked = isMarkedNullable(field);
+                if (refuses && marked) {
+                    wrong.add(surface + "." + field.getName()
+                            + ": refuses a null, but is marked @Schema(nullable = true), so the "
+                            + "document invites a client to send one");
+                } else if (!refuses && !marked) {
+                    wrong.add(surface + "." + field.getName()
+                            + ": clears on null, but is not marked @Schema(nullable = true), so the "
+                            + "document says it may never be null and a client will not send one");
+                }
+            }
+        }
+
+        assertThat(wrong)
+                .as("the published schema and PartialUpdateSurfaces disagree about what an explicit "
+                        + "null does to these fields. Decide which is right, fix that one, and "
+                        + "regenerate with ./gradlew openApiSnapshot -PupdateOpenApiSnapshot")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("the table names a real key for every refusal, and no surface refuses everything")
+    void theTableIsNotVacuous() {
+        List<UpdateSurface> surfaces = PartialUpdateSurfaces.surfaces();
+
+        assertThat(surfaces)
+                .as("no partial-update surface is listed, so this test is checking nothing")
+                .isNotEmpty();
+        assertThat(surfaces.stream().anyMatch(surface -> !surface.refusesNull().isEmpty()))
+                .as("no surface refuses a null on any key, which would make the distinction this "
+                        + "test exists for meaningless. Either the table has been emptied or the "
+                        + "refusals have been removed from the services")
+                .isTrue();
+
+        for (UpdateSurface surface : surfaces) {
+            assertThat(surface.refusesNull())
+                    .as("%s refuses a null on every field it declares, which is a bean rather than "
+                            + "a partial update; it should not be taking a map", surface)
+                    .hasSizeLessThan(fieldNames(surface).size());
+        }
+    }
+
+    private static List<Field> schemaFields(UpdateSurface surface) {
+        return Arrays.stream(surface.schema().getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .toList();
+    }
+
+    private static Set<String> fieldNames(UpdateSurface surface) {
+        return schemaFields(surface).stream().map(Field::getName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static boolean isMarkedNullable(Field field) {
+        Schema schema = field.getAnnotation(Schema.class);
+        return schema != null && schema.nullable();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSurfaces.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/PartialUpdateSurfaces.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,48 +44,88 @@ final class PartialUpdateSurfaces {
      * @param serviceClass Fully qualified name of the service holding the update method.
      * @param methodSignature The opening text of the method declaration, used to find it in the
      *                        source. Must be unique within the file.
+     * @param refusesNull The keys that refuse an explicit null with a 400 instead of clearing the
+     *                    field. Every other key on the surface clears. See {@link #refusesNull()}
+     *                    for why this is written down here rather than read off the source.
      */
-    record UpdateSurface(Class<?> schema, String serviceClass, String methodSignature) {
+    record UpdateSurface(Class<?> schema, String serviceClass, String methodSignature,
+                         Set<String> refusesNull) {
         @Override
         public String toString() {
             return schema.getSimpleName();
         }
     }
 
+    /**
+     * The surfaces, and for each the keys that refuse a null.
+     *
+     * <p>A partial update has to tell "field absent" from "field explicitly null", which is why
+     * these endpoints take a map rather than a bean. Absence always means untouched. What an
+     * explicit null means was, until #645, three different things depending on the key: most
+     * cleared the field, two refused with a 400, and eleven reached an unguarded
+     * {@code Enum.valueOf(null)} or {@code ((Number) null).longValue()} and answered 500. The
+     * class-level schema on {@code TaskUpdateFieldsDto} meanwhile stated flatly that a null clears,
+     * which was true of seven of its nine fields.
+     *
+     * <p>The rule the eleven were settled by is not a matter of taste: <b>a null is refused where
+     * the column behind the field is {@code NOT NULL}, and clears where it is nullable</b>. The
+     * database already enforces that, so the alternative was a 500 now or a constraint violation
+     * at flush. Two keys refuse a null although their column is nullable, and both say so on their
+     * own schema: {@code TaskUpdateFieldsDto.categoryId} is a stated product rule, and
+     * {@code IssueUpdateFieldsDto.type} and {@code status} are required by the enum parser they
+     * share with creation.
+     *
+     * <p>This list is written down rather than derived from the source because the two facts that
+     * have to agree live in different places: what the service does with a null, and what the
+     * published schema says about it. {@code PartialUpdateNullBehaviourTest} holds the first to
+     * this list by calling each surface with each key set to null, and
+     * {@code PartialUpdateNullContractTest} holds the second to it by reading the annotations. A
+     * key added to a switch without a decision fails both.
+     *
+     * @return Every partial-update surface in the application.
+     */
     static List<UpdateSurface> surfaces() {
         return List.of(
                 new UpdateSurface(
                         TaskUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.task.TaskService",
-                        "private void partialUpdateATask(Map<String, Object> updates, Task task)"),
+                        "private void partialUpdateATask(Map<String, Object> updates, Task task)",
+                        Set.of("status", "categoryId")),
                 new UpdateSurface(
                         IssueUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.issue.IssueService",
-                        "private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue)"),
+                        "private void partialUpdateAnIssue(Map<String, Object> updates, Issue issue)",
+                        Set.of("type", "status")),
                 new UpdateSurface(
                         ProjectUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.project.ProjectService",
-                        "private void partialUpdateAProject(Map<String, Object> updates, Project project)"),
+                        "private void partialUpdateAProject(Map<String, Object> updates, Project project)",
+                        Set.of()),
                 new UpdateSurface(
                         OrganizationUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.organization.OrganizationService",
-                        "private void partialUpdateAnOrganization(Map<String, Object> updates, Organization organization)"),
+                        "private void partialUpdateAnOrganization(Map<String, Object> updates, Organization organization)",
+                        Set.of()),
                 new UpdateSurface(
                         UserUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.user.UserService",
-                        "private void applyUpdates(Map<String, Object> updates, User user)"),
+                        "private void applyUpdates(Map<String, Object> updates, User user)",
+                        Set.of()),
                 new UpdateSurface(
                         EmployeeUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.employee.EmployeeService",
-                        "private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee)"),
+                        "private void partialUpdateAnEmployee(Map<String, Object> updates, Employee employee)",
+                        Set.of()),
                 new UpdateSurface(
                         LeavePolicyUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.leave.LeavePolicyService",
-                        "public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates)"),
+                        "public LeavePolicyDto updatePolicy(Long policyId, Map<String, Object> updates)",
+                        Set.of("annualQuota")),
                 new UpdateSurface(
                         LeaveRequestUpdateFieldsDto.class,
                         "org.tornotron.echno_backend.leave.LeaveRequestService",
-                        "public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates)"));
+                        "public LeaveRequestDto updateRequest(Long requestId, Map<String, Object> updates)",
+                        Set.of("startDate", "endDate")));
     }
 
     /**


### PR DESCRIPTION
Closes the request half of #645 where the question is genuinely hard: the **eight partial-update surfaces, 87 properties**, where a null and an absent field are different requests. The remaining ~1000 request-side properties are specified at the bottom rather than left implied.

## Why this half is a different question

The response side (#661) needed one fact per property: may this be null. This side needs two, and until now the document could carry neither.

They now come from different halves of the document, and neither says anything about the other:

| | says | made accurate by |
|---|---|---|
| `required` | whether the field may be **absent** | #664 |
| the 3.1 type union | whether it may be **null when present** | #661 |

That composition is what makes the request side tractable at all. A partial-update property that is not in `required` and carries `["string", "null"]` means: you may omit this, and if you send it as null the field is cleared. One that is not in `required` and carries `"string"` means: you may omit this, but a null is refused.

## The disagreement, which was the actual work

`TaskUpdateFieldsDto` said at class level that "a field sent as null is cleared". `categoryId` on the same class said it cannot be cleared. `LeaveRequestUpdateFieldsDto.startDate` said "null is rejected". Three statements, one document, no convention.

Reading every branch of all eight switches found **three** behaviours, not two:

| what a null did | keys |
|---|---|
| cleared the field, 200 | 74 |
| refused with a 400 naming the field | 2 |
| **threw `NullPointerException`, which no handler names → 500** | **11** |

The eleven were not a decision anyone had taken. Each reached an unguarded `Enum.valueOf(null)`, `((Number) null).longValue()` or `LocalDate.parse(null)`:

`TaskUpdateFieldsDto.status`, `ProjectUpdateFieldsDto.status`, `projectLatitude`, `projectLongitude`, `IssueUpdateFieldsDto.assignedToId`, `EmployeeUpdateFieldsDto.status`, `managerId`, `UserUpdateFieldsDto.role`, `LeavePolicyUpdateFieldsDto.annualQuota`, `LeaveRequestUpdateFieldsDto.startDate` and `endDate`.

So the honest answer to "what does this class mean by null" was, for seven of the eight, "three different things depending on the key, and one of them is a 500."

## How the eleven were settled, which is not a matter of taste

**A null is refused where the column behind the field is `NOT NULL`, and clears where it is nullable.** The database already enforces that, so the alternative to a refusal was a 500 now or a `DataIntegrityViolation` at flush.

| | column | now |
|---|---|---|
| `Task.status` | `nullable = false` | **400**, "status cannot be cleared" |
| `LeavePolicy.annualQuota` | `nullable = false` | **400** |
| `LeaveRequest.startDate` / `endDate` | `nullable = false` | **400** |
| `Issue.assignedTo` | nullable join column | **clears** — this is what unassigning an issue is |
| `Employee.manager` | nullable join column | **clears** — this is what the top of a reporting line is |
| `Project.status`, `Employee.status`, `User.role` | nullable | **clears** |
| `Project.projectLatitude` / `projectLongitude` | nullable | **clears** |

Two of those were a user-visible gap rather than only a 500: there was no way to unassign an issue or detach an employee from their manager, because the only request that means it answered 500.

## Where the code contradicts itself, said rather than picked

Two keys refuse a null although their column is nullable. Both now say so on their own schema instead of by surprise.

- **`TaskUpdateFieldsDto.categoryId`** is a stated product rule ("a task without a category is a state creation cannot produce"), and the join column is nullable, so it is a rule the schema does not enforce. Kept, and the schema now says which kind of rule it is.
- **`UserUpdateFieldsDto.defaultOrganizationId`** was not a rule at all. It answered `"defaultOrganizationId must be a number"` to a null, which is a type-error message misapplied to a null by a `parseDefaultOrganizationId` that had no null branch. The column is nullable and rows already exist with it null, so it clears now like every other nullable column.

`IssueUpdateFieldsDto.type` and `status` refuse a null on a nullable column too, but deliberately and with their own message, from the enum parser they share with creation. Kept.

## What is published

**80 of the 87 properties marked `@Schema(nullable = true)`; 7 not.** The class-level descriptions no longer assert a blanket rule; each now says that an absent field is untouched, a field the schema declares nullable is cleared by an explicit null, and a field it does not declare nullable refuses one with a 400. The seven say why on themselves.

## Three tests, holding one list

`PartialUpdateSurfaces` gains the table: per surface, the keys that refuse a null. Everything else clears. Written down rather than derived, because the two facts that have to agree live in different places.

1. **`PartialUpdateNullBehaviourTest`** sends `{key: null}` for every declared key of every surface and requires the outcome the table claims. It is driven off the schema class, so a field added to one of these DTOs is covered the day it appears.
2. **`PartialUpdateNullContractTest`** requires the annotation to match the table in both directions: a clearing field must be marked, a refusing one must not.
3. **`OpenApiNullabilityTest`** (existing, from #661) carries the annotation into `docs/openapi.json`.

A key added to a switch without a decision fails all three.

## Proof, against the unfixed tree

Both new tests were run with the seven services and eight DTOs reverted to `development` and the tests and the table kept. **17 failures**, and they are exactly the eleven plus `defaultOrganizationId` plus the 80 undeclared:

```
employee  ["status: threw NullPointerException ("Name is null"), which is neither clearing
            the field nor a 400. An unguarded null reaching a cast or a parser answers 500",
           "managerId: threw NullPointerException ("Cannot invoke
            "java.lang.Number.longValue()" because "value" is null") …"]
project   ["status: …", "projectLongitude: …", "projectLatitude: …"]
task      ["status: threw NullPointerException ("Name is null") …"]
user      ["defaultOrganizationId: threw IllegalArgumentException
            ("defaultOrganizationId must be a number"), which is neither clearing the field
            nor a 400", "role: …"]
leave request ["startDate: threw NullPointerException ("text") …", "endDate: …"]
leave policy  ["annualQuota: threw NullPointerException …"]

PartialUpdateNullContractTest
  ["TaskUpdateFieldsDto.title: clears on null, but is not marked
    @Schema(nullable = true), so the document says it may never be null and a client
    will not send one", … 80 of them]
```

## The document diff, audited entry by entry

**95 changes and nothing else in the file.** No schema added or removed.

- 78 properties gaining `"null"` in a type union or an `anyOf` branch
- 2 more (`assignedToId`, `managerId`) that gained the union *and* a description saying a null unassigns or detaches
- 15 description-only changes: the 8 class descriptions and the 7 refusing fields

## Also fixed while there

An unparseable leave date threw `DateTimeParseException`, which is not an `IllegalArgumentException` and reached no handler either, so a mistyped date answered 500 as surely as a null did. It is a 400 now, pinned by its own test.

## Verified on lab `.116`

- `./gradlew test` **BUILD SUCCESSFUL** in 8m 53s; heap 574 MB live of the 2048 MB cap (28%), 8 Spring contexts cached of a maximum 8
- `./gradlew openApiSnapshot -PupdateOpenApiSnapshot` regenerated on a tree rebased onto `development`, and the diff audited as above

## Not in this change, and what it needs

**The bean-bound request DTOs, roughly a thousand properties.** These are a different and much easier question: they deserialize through Jackson into a typed bean, so absent and null both arrive as a null field and the endpoint cannot tell them apart. There is no "cleared by an explicit null" to describe, and `required` plus the validation constraints #664 published already carry most of what a client needs. The remaining work there is per-field reading — which optional fields the service tolerates as null on the way to the entity — and it is tractable module by module, in the same shape as the response-side pass #661 left open.

**The response-only schemas, 1975 properties**, remain as #661 left them.
