### PR TITLE
Wait for the lorry before saying the stock arrived

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15637,6 +15637,22 @@
         },
         "type": "object"
       },
+      "SiteTransferCancellationDto": {
+        "description": "Why a transfer that never arrived is being abandoned. Cancelling returns the stock to the sending project and location it was drawn from, which is a real movement on the ledger, so the reason is required and is kept on the transfer's status trail beside the movement it caused.",
+        "properties": {
+          "reason": {
+            "description": "Why the transfer is being cancelled.",
+            "example": "Lorry turned back at the gate, materials never left the yard",
+            "maxLength": 500,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "type": "object"
+      },
       "SiteTransferCreationDto": {
         "description": "Payload to create a site transfer moving materials from a sending project to a receiving project. The transfer number is allocated by the server and returned on the created transfer; it is not part of this payload. The two sides must differ: a transfer naming the same project and the same storage location on both sides moves nothing and is refused, while two storage locations inside one project is a real move and is accepted.",
         "properties": {
@@ -15685,7 +15701,7 @@
             "type": "integer"
           },
           "status": {
-            "description": "State the transfer starts in. Optional, and PENDING is the only value accepted, so leaving it out is the same as sending PENDING. PARTIALLY_TRANSFERRED and COMPLETED say the receiving site has taken delivery, which is recorded through PATCH /{id}/status; that endpoint wants a different authority from create, and a transfer issued as COMPLETED would stand as received with nobody having confirmed receipt.",
+            "description": "State the transfer starts in. Optional, and PENDING is the only value accepted, so leaving it out is the same as sending PENDING. A transfer between two projects is issued PENDING with only its outbound leg posted, and the quantity is in transit until somebody at the receiving site records what arrived with POST /{id}/receive. A transfer between two storage locations on one project is written COMPLETED by the server, because the material never leaves that site's custody and both legs are posted at once; that is the server's own finding and cannot be asked for here. PARTIALLY_TRANSFERRED and COMPLETED say the receiving site has taken delivery and CANCELLED says the stock came back, and each of those now follows from a movement rather than from a payload.",
             "enum": [
               "PENDING"
             ],
@@ -15773,13 +15789,14 @@
             "type": "string"
           },
           "status": {
-            "description": "Current status of the transfer.",
+            "description": "Current status of the transfer. PENDING means it has left the sending site and nothing has been recorded as arriving, so its quantity is in transit; PARTIALLY_TRANSFERRED and COMPLETED follow from what the receiving site confirmed; CANCELLED means it was abandoned in transit and its stock returned to the sender.",
             "enum": [
               "PENDING",
               "PARTIALLY_TRANSFERRED",
-              "COMPLETED"
+              "COMPLETED",
+              "CANCELLED"
             ],
-            "example": "IN_TRANSIT",
+            "example": "PENDING",
             "type": "string"
           },
           "transferNumber": {
@@ -15799,6 +15816,13 @@
             "format": "int64",
             "type": "integer"
           },
+          "inTransitQuantity": {
+            "description": "How much of this line is neither at the sending site nor recorded as having reached the receiving one: sent minus received, or the whole sent quantity while nothing has been received. On a transfer still in transit this is stock on a lorry. On one that has been received it is an open variance, closed by a stock adjustment naming this transfer rather than by the transfer writing a loss of its own. Zero once everything sent has arrived.",
+            "example": 0,
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          },
           "materialId": {
             "description": "Id of the material being transferred.",
             "example": 21,
@@ -15809,6 +15833,16 @@
             "description": "Name of the material being transferred.",
             "example": "TMT Bar 12mm",
             "type": "string"
+          },
+          "receivedQuantity": {
+            "description": "Quantity recorded as having arrived at the receiving site, in the material's unit. Null while the transfer is in transit and nobody has confirmed anything about this line yet, which is not the same as saying nothing arrived. A transfer between two stores on one project is received in full at creation, since the material never leaves that site's custody.",
+            "example": 18,
+            "format": "int32",
+            "readOnly": true,
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "remarks": {
             "description": "Optional remarks for this line item.",
@@ -15826,6 +15860,64 @@
         "required": [
           "materialId",
           "sentQuantity"
+        ],
+        "type": "object"
+      },
+      "SiteTransferReceiptDto": {
+        "description": "What arrived at the receiving site against a transfer that is in transit. Only the quantities are in this payload: who confirmed the delivery is taken from the session, not from the request, so a receipt is the caller's own statement and cannot be filed under a colleague's name.",
+        "properties": {
+          "allowOverReceipt": {
+            "description": "Set when the delivery really did carry more than the transfer sent. Without it an over-receipt is refused and the refusal names the line and the figures, which is enough to recognise a typed digit. With it the excess is recorded and the stock is posted, because material standing in the yard is there whether the system likes it or not and a receipt that cannot be filed leaves it outside the ledger. A short delivery needs no such flag: recording less than was sent puts nothing false into the ledger and leaves an open variance for a stock adjustment to close.",
+            "example": false,
+            "type": "boolean"
+          },
+          "items": {
+            "description": "One entry per transfer line being confirmed. Lines left out of the payload are untouched, so a delivery that answers only part of a transfer names only the lines it answers.",
+            "items": {
+              "$ref": "#/components/schemas/SiteTransferReceiptLineDto"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "receivedOn": {
+            "description": "Date and time the delivery was taken. Optional; the moment the receipt is filed is used when it is left out. It dates the inbound movements this receipt writes.",
+            "example": "2026-01-17T14:05:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "remarks": {
+            "description": "Optional note about the delivery, carried onto the inbound movements and the transfer's status trail.",
+            "example": "Two bags split in transit, driver informed",
+            "maxLength": 500,
+            "minLength": 0,
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "SiteTransferReceiptLineDto": {
+        "description": "How much of one transfer line arrived. The line is named by its own id rather than by its material, because a transfer may carry the same material on more than one line and a receipt has to say which of them it answers.",
+        "properties": {
+          "itemId": {
+            "description": "Id of the site transfer line this quantity is against.",
+            "example": 84,
+            "format": "int64",
+            "type": "integer"
+          },
+          "receivedQuantity": {
+            "description": "Quantity that arrived, in the material's unit. Zero is a legitimate answer and means this line's material did not arrive on this delivery; the quantity stays in transit and the transfer is not moved on by it.",
+            "example": 18,
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "itemId",
+          "receivedQuantity"
         ],
         "type": "object"
       },
@@ -82879,7 +82971,7 @@
     "/api/v1/project/web/{id}/status-history": {
       "get": {
         "description": "Returns a page of the project's status entries, newest first: what it moved from, what it moved to, when, by whom, and whether the status was set when the project was created or changed afterwards. Approval is the transition that carries behaviour, since it draws up the project's compliance inspections, so this is where to read who approved a project and when. Entries begin where recording began: a project created before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment, with no actor and no earlier status, because nothing else can truthfully be said about a history nobody recorded.",
-        "operationId": "readStatusHistory_1",
+        "operationId": "readStatusHistory_2",
         "parameters": [
           {
             "in": "path",
@@ -90209,7 +90301,7 @@
     "/api/v1/purchase-orders/web/{id}/status-history": {
       "get": {
         "description": "Returns a page of the order's status entries, newest first: what it moved from, what it moved to, when, and by whom. An entry sourced SYSTEM names no person because none decided it: the order reached PARTIALLY_RECEIVED or FULLY_RECEIVED because the quantities received against it said so, and the note on the entry names the goods receipt that last moved it. Follow that receipt to find who filed it. Entries begin where recording began, so an order raised before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment.",
-        "operationId": "readStatusHistory",
+        "operationId": "readStatusHistory_1",
         "parameters": [
           {
             "in": "path",
@@ -93116,7 +93208,8 @@
               "enum": [
                 "PENDING",
                 "PARTIALLY_TRANSFERRED",
-                "COMPLETED"
+                "COMPLETED",
+                "CANCELLED"
               ],
               "type": "string"
             }
@@ -93814,7 +93907,8 @@
               "enum": [
                 "PENDING",
                 "PARTIALLY_TRANSFERRED",
-                "COMPLETED"
+                "COMPLETED",
+                "CANCELLED"
               ],
               "type": "string"
             }
@@ -94034,9 +94128,256 @@
         ]
       }
     },
+    "/api/v1/site-transfers/web/{id}/cancel": {
+      "post": {
+        "description": "Abandons a PENDING transfer and returns the whole sent quantity to the sending project and location it was drawn from. Without the reversal a transfer written off in transit would leave the sending project permanently short with no way back. Only a PENDING transfer can be cancelled: once something has been received, part of the material is standing at the far site and what to do about the rest is a decision for a stock adjustment rather than a reversal.",
+        "operationId": "cancelSiteTransfer_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteTransferCancellationDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteTransferDto"
+                }
+              }
+            },
+            "description": "Transfer cancelled and its outbound leg reversed"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "The transfer is in any state but PENDING, or no reason was given"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No site transfer with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Cancel a transfer that never arrived",
+        "tags": [
+          "Site Transfers (Web)"
+        ]
+      }
+    },
+    "/api/v1/site-transfers/web/{id}/receive": {
+      "post": {
+        "description": "Posts the stock that actually arrived at the receiving project and location, writes each line's received quantity, and works the transfer's status out from the arithmetic: everything received is COMPLETED, some received is PARTIALLY_TRANSFERRED, nothing received leaves it PENDING. Who confirmed the delivery is taken from the session, never from the payload, so the receipt is that person's own statement. Receiving less than was sent is accepted and leaves an open variance on the transfer, visible as each line's in-transit quantity and closed by a stock adjustment naming the transfer; the transfer writes no loss movement of its own, because that would be a stock correction nobody authorised. Receiving more than was sent is refused unless the payload sets allowOverReceipt. Only a transfer that crosses a project boundary can be received: one between two stores on a single project had both of its legs written at creation, because the material never left that site's custody.",
+        "operationId": "receiveSiteTransfer_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteTransferReceiptDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteTransferDto"
+                }
+              }
+            },
+            "description": "Receipt recorded and the stock that arrived posted"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "The transfer never left one project, or it is already completed or cancelled, or a named line is not on it, or a line would be over-received without allowOverReceipt"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No site transfer with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Record what the receiving site took delivery of",
+        "tags": [
+          "Site Transfers (Web)"
+        ]
+      }
+    },
     "/api/v1/site-transfers/web/{id}/status": {
       "patch": {
-        "description": "Sets the status of an existing site transfer, for example moving it from PENDING to IN_TRANSIT or COMPLETED.",
+        "deprecated": true,
+        "description": "Always refuses, and names the endpoint that does what the caller wants. This used to assign whatever status it was handed and move no stock, which is how a transfer could read COMPLETED with nothing confirmed. Every state a transfer can hold now follows from a movement: record a delivery with POST /{id}/receive, or abandon one that never arrived with POST /{id}/cancel. The route is kept so an existing client gets an answer that names its replacement rather than a 404.",
         "operationId": "updateSiteTransferStatus_1",
         "parameters": [
           {
@@ -94056,7 +94397,8 @@
               "enum": [
                 "PENDING",
                 "PARTIALLY_TRANSFERRED",
-                "COMPLETED"
+                "COMPLETED",
+                "CANCELLED"
               ],
               "type": "string"
             }
@@ -94071,7 +94413,147 @@
                 }
               }
             },
-            "description": "Site transfer status updated"
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Always: the status is derived from movements and cannot be set"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No site transfer with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Deprecated: a transfer's status can no longer be set from a payload",
+        "tags": [
+          "Site Transfers (Web)"
+        ]
+      }
+    },
+    "/api/v1/site-transfers/web/{id}/status-history": {
+      "get": {
+        "description": "Returns a page of the transfer's status entries, newest first: what it moved from, what it moved to, when, and by whom. Unlike a purchase order's receipt-driven move, a transfer reaching PARTIALLY_TRANSFERRED or COMPLETED is somebody's act, so those entries name the person who confirmed the delivery. Entries begin where recording began, so a transfer raised before the trail existed carries a single BASELINE entry naming the status it was observed to hold at that moment, and one raised before the two-step document existed may carry a SYSTEM entry recording that its status was corrected to match movements that had already been posted.",
+        "operationId": "readStatusHistory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based page index.",
+            "in": "query",
+            "name": "pageNo",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based page index.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Rows per page.",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Rows per page.",
+              "format": "int32",
+              "maximum": 500,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageStatusTransitionDto"
+                }
+              }
+            },
+            "description": "Page of status entries returned"
           },
           "400": {
             "content": {
@@ -94154,7 +94636,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Update a site transfer's status",
+        "summary": "Read a site transfer's status trail",
         "tags": [
           "Site Transfers (Web)"
         ]
@@ -94273,10 +94755,10 @@
         ]
       }
     },
-    "/api/v1/site-transfers/{id}/status": {
-      "patch": {
-        "description": "Sets the status of an existing site transfer, for example moving it from PENDING to IN_TRANSIT or COMPLETED.",
-        "operationId": "updateSiteTransferStatus",
+    "/api/v1/site-transfers/{id}/cancel": {
+      "post": {
+        "description": "Abandons a PENDING transfer and returns the whole sent quantity to the sending project and location it was drawn from. Without the reversal a transfer written off in transit would leave the sending project permanently short with no way back. Only a PENDING transfer can be cancelled: once something has been received, part of the material is standing at the far site and what to do about the rest is a decision for a stock adjustment rather than a reversal.",
+        "operationId": "cancelSiteTransfer",
         "parameters": [
           {
             "in": "path",
@@ -94286,31 +94768,28 @@
               "format": "int64",
               "type": "integer"
             }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": true,
-            "schema": {
-              "enum": [
-                "PENDING",
-                "PARTIALLY_TRANSFERRED",
-                "COMPLETED"
-              ],
-              "type": "string"
-            }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteTransferCancellationDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "$ref": "#/components/schemas/SiteTransferDto"
                 }
               }
             },
-            "description": "Site transfer status updated"
+            "description": "Transfer cancelled and its outbound leg reversed"
           },
           "400": {
             "content": {
@@ -94320,7 +94799,7 @@
                 }
               }
             },
-            "description": "Bad Request"
+            "description": "The transfer is in any state but PENDING, or no reason was given"
           },
           "402": {
             "content": {
@@ -94393,7 +94872,258 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Update a site transfer's status",
+        "summary": "Cancel a transfer that never arrived",
+        "tags": [
+          "Site Transfers"
+        ]
+      }
+    },
+    "/api/v1/site-transfers/{id}/receive": {
+      "post": {
+        "description": "Posts the stock that actually arrived at the receiving project and location, writes each line's received quantity, and works the transfer's status out from the arithmetic: everything received is COMPLETED, some received is PARTIALLY_TRANSFERRED, nothing received leaves it PENDING. Who confirmed the delivery is taken from the session, never from the payload, so the receipt is that person's own statement. Receiving less than was sent is accepted and leaves an open variance on the transfer, visible as each line's in-transit quantity and closed by a stock adjustment naming the transfer; the transfer writes no loss movement of its own, because that would be a stock correction nobody authorised. Receiving more than was sent is refused unless the payload sets allowOverReceipt. Only a transfer that crosses a project boundary can be received: one between two stores on a single project had both of its legs written at creation, because the material never left that site's custody.",
+        "operationId": "receiveSiteTransfer",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteTransferReceiptDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteTransferDto"
+                }
+              }
+            },
+            "description": "Receipt recorded and the stock that arrived posted"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "The transfer never left one project, or it is already completed or cancelled, or a named line is not on it, or a line would be over-received without allowOverReceipt"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the site-transfer update or admin authority"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No site transfer with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Record what the receiving site took delivery of",
+        "tags": [
+          "Site Transfers"
+        ]
+      }
+    },
+    "/api/v1/site-transfers/{id}/status": {
+      "patch": {
+        "deprecated": true,
+        "description": "Always refuses, and names the endpoint that does what the caller wants. This used to assign whatever status it was handed and move no stock, which is how a transfer could read COMPLETED with nothing confirmed. Every state a transfer can hold now follows from a movement: record a delivery with POST /{id}/receive, or abandon one that never arrived with POST /{id}/cancel. The route is kept so an existing client gets an answer that names its replacement rather than a 404.",
+        "operationId": "updateSiteTransferStatus",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": true,
+            "schema": {
+              "enum": [
+                "PENDING",
+                "PARTIALLY_TRANSFERRED",
+                "COMPLETED",
+                "CANCELLED"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Always: the status is derived from movements and cannot be set"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the site-transfer update or admin authority"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No site transfer with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Deprecated: a transfer's status can no longer be set from a payload",
         "tags": [
           "Site Transfers"
         ]

--- a/src/main/java/org/tornotron/echno_backend/common/events/SiteTransferCancelledEvent.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/SiteTransferCancelledEvent.java
@@ -1,0 +1,51 @@
+package org.tornotron.echno_backend.common.events;
+
+import org.springframework.context.ApplicationEvent;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+
+import java.util.List;
+
+/**
+ * Raised when a transfer is abandoned before anything was received against it.
+ *
+ * <p>The listener returns each line's sent quantity to the sending project and location it was
+ * drawn from. Without that reversal the sending project would stay permanently short for a
+ * lorry that turned back, and the only way to correct it would be a stock adjustment reading as
+ * an unexplained count variance.
+ */
+public class SiteTransferCancelledEvent extends ApplicationEvent {
+
+    private final SiteTransfer siteTransfer;
+    private final List<SiteTransferItem> items;
+    private final Employee cancelledBy;
+    private final String reason;
+
+    public SiteTransferCancelledEvent(Object source, SiteTransfer siteTransfer,
+                                      List<SiteTransferItem> items, Employee cancelledBy,
+                                      String reason) {
+        super(source);
+        this.siteTransfer = siteTransfer;
+        this.items = List.copyOf(items);
+        this.cancelledBy = cancelledBy;
+        this.reason = reason;
+    }
+
+    public SiteTransfer getSiteTransfer() {
+        return siteTransfer;
+    }
+
+    public List<SiteTransferItem> getItems() {
+        return items;
+    }
+
+    /** The person who cancelled it, resolved from the session rather than the payload. */
+    public Employee getCancelledBy() {
+        return cancelledBy;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/events/SiteTransferReceivedEvent.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/SiteTransferReceivedEvent.java
@@ -1,0 +1,68 @@
+package org.tornotron.echno_backend.common.events;
+
+import org.springframework.context.ApplicationEvent;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Raised when somebody records what arrived against a transfer that was in transit.
+ *
+ * <p>Carries the quantity each line gained in this receipt, not the running total, because the
+ * listener writes one inbound movement per line for what arrived now. A second delivery against
+ * the same transfer raises a second event carrying only its own quantities, so the ledger reads
+ * as two arrivals rather than one restated total.
+ */
+public class SiteTransferReceivedEvent extends ApplicationEvent {
+
+    /**
+     * One line and how much of it arrived in this receipt.
+     *
+     * @param item     The transfer line, carrying its material.
+     * @param quantity How much arrived now. Always greater than zero; a line recorded as
+     *                 receiving nothing raises no movement and is left out.
+     */
+    public record ReceivedLine(SiteTransferItem item, int quantity) {
+    }
+
+    private final SiteTransfer siteTransfer;
+    private final List<ReceivedLine> receivedLines;
+    private final Employee receivedBy;
+    private final LocalDateTime receivedOn;
+    private final String remarks;
+
+    public SiteTransferReceivedEvent(Object source, SiteTransfer siteTransfer,
+                                     List<ReceivedLine> receivedLines, Employee receivedBy,
+                                     LocalDateTime receivedOn, String remarks) {
+        super(source);
+        this.siteTransfer = siteTransfer;
+        this.receivedLines = List.copyOf(receivedLines);
+        this.receivedBy = receivedBy;
+        this.receivedOn = receivedOn;
+        this.remarks = remarks;
+    }
+
+    public SiteTransfer getSiteTransfer() {
+        return siteTransfer;
+    }
+
+    public List<ReceivedLine> getReceivedLines() {
+        return receivedLines;
+    }
+
+    /** The person who confirmed the delivery, resolved from the session rather than the payload. */
+    public Employee getReceivedBy() {
+        return receivedBy;
+    }
+
+    public LocalDateTime getReceivedOn() {
+        return receivedOn;
+    }
+
+    public String getRemarks() {
+        return remarks;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
+++ b/src/main/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListener.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.common.events.listeners;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,7 +10,9 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
 import org.tornotron.echno_backend.common.events.MaterialConsumedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferCancelledEvent;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferReceivedEvent;
 import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
 import org.tornotron.echno_backend.grnItem.GrnItem;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
@@ -17,7 +20,11 @@ import org.tornotron.echno_backend.inventoryTransaction.InventoryTransaction;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 import org.tornotron.echno_backend.materialConsumption.MaterialConsumption;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferReceiptReconciler;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
 
 import java.math.BigDecimal;
@@ -132,102 +139,234 @@ public class InventoryEventListener {
                 consumption.getMaterial().getId(), consumption.getProject().getId(), quantityChanged, closingStock);
     }
 
+    /**
+     * Posts the legs a newly created site transfer writes.
+     *
+     * <p>The outbound leg is always written: the material has left the sending balance whichever
+     * kind of transfer this is. The inbound leg is written here only when the transfer stays
+     * inside one project, where the material is handed between two stores on a site whose
+     * storekeeper is accountable for it throughout and there is no window in which nobody is.
+     *
+     * <p>Across a project boundary the inbound leg waits for
+     * {@link #handleSiteTransferReceived}. Writing it here asserted that stock had arrived at a
+     * site where nobody had seen the lorry, which is the claim that made a receiving-site count
+     * unexplainable: the balance said twenty bags, the yard held none, and the ledger offered a
+     * TRANSFER_IN whose closing figure nobody could reconcile. Between the two legs the quantity
+     * is in transit, which is where it actually is.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSiteTransferCreated(SiteTransferCreatedEvent event) {
         SiteTransfer transfer = event.getSiteTransfer();
-        logger.info("Handling site transfer created event for transfer number: {}", transfer.getTransferNumber());
+        boolean crossesProjects = SiteTransferReceiptReconciler.crossesProjectBoundary(transfer);
+        logger.info("Handling site transfer created event for transfer number: {} ({})",
+                transfer.getTransferNumber(),
+                crossesProjects ? "outbound leg only, awaiting receipt" : "both legs, within one project");
 
         for (SiteTransferItem item : transfer.getItems()) {
-            // TRANSFER_OUT: Stock decreases at sending project.
-            // Read the balance this movement actually debits. With no sending storage location
-            // that is the sending project's unlocated row, not the project total: the total
-            // would put an opening and closing figure on the ledger entry that the row it
-            // moves never held, and it is a different quantity from the one updateCurrentStock
-            // goes on to write.
-            Double sendingOpeningStock;
-            if (transfer.getSendingStorageLocation() != null) {
-                sendingOpeningStock = inventoryService.getStockAtLocation(
-                        item.getMaterial().getId(), transfer.getSendingProject().getId(),
-                        transfer.getSendingStorageLocation().getId());
-            } else {
-                sendingOpeningStock = inventoryService.findUnlocatedStock(
-                        item.getMaterial().getId(), transfer.getSendingProject().getId()).orElse(0.0);
+            BigDecimal avgCost = writeTransferOut(transfer, item, item.getSentQuantity().doubleValue());
+
+            if (!crossesProjects) {
+                writeTransferIn(transfer, item, item.getSentQuantity().doubleValue(), avgCost,
+                        transfer.getIssueDate(), transfer.getSendingPerson(),
+                        "Transfer in from " + transfer.getSendingProject().getProjectName()
+                                + " by " + personName(transfer.getSendingPerson())
+                                + (item.getRemarks() != null ? " - " + item.getRemarks() : ""));
             }
-            Double sendingQuantityChanged = -item.getSentQuantity().doubleValue();
-            Double sendingClosingStock = sendingOpeningStock + sendingQuantityChanged;
+        }
+    }
 
-            // Compute avg cost from sending side before the outbound update
-            BigDecimal avgCost = inventoryService.getAverageCost(
-                    item.getMaterial().getId(), transfer.getSendingProject().getId(),
-                    transfer.getSendingStorageLocation() != null ? transfer.getSendingStorageLocation().getId() : null);
+    /**
+     * Raises stock at the receiving site for what somebody there confirmed had arrived.
+     *
+     * <p>The arrival is valued at the unit cost the outbound leg carried, not at the sending
+     * site's average cost as it stands now. By the time a lorry is unloaded the sending site may
+     * have moved or run out of the material entirely, and pricing the arrival off its current
+     * balance would value it at zero and silently destroy the stock value that left.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSiteTransferReceived(SiteTransferReceivedEvent event) {
+        SiteTransfer transfer = event.getSiteTransfer();
+        logger.info("Handling site transfer received event for transfer number: {}, {} line(s)",
+                transfer.getTransferNumber(), event.getReceivedLines().size());
 
-            InventoryTransaction outTransaction = new InventoryTransaction();
-            outTransaction.setTransactionDate(transfer.getIssueDate() != null ? transfer.getIssueDate() : LocalDateTime.now());
-            outTransaction.setMaterial(item.getMaterial());
-            outTransaction.setOpeningStock(sendingOpeningStock);
-            outTransaction.setQuantityChanged(sendingQuantityChanged);
-            outTransaction.setClosingStock(sendingClosingStock);
-            outTransaction.setTransactionType(InventoryTransactionType.TRANSFER_OUT);
-            outTransaction.setReferenceNumber(transfer.getTransferNumber());
-            outTransaction.setRemarks("Transfer out to " + transfer.getReceivingProject().getProjectName() +
-                    " by " + (transfer.getSendingPerson() != null ? transfer.getSendingPerson().getEmployeeName() : "employee") +
-                    (item.getRemarks() != null ? " - " + item.getRemarks() : ""));
-            outTransaction.setCreatedBy(transfer.getSendingPerson());
-            outTransaction.setProject(transfer.getSendingProject());
-            outTransaction.setStorageLocation(transfer.getSendingStorageLocation());
-            outTransaction.setOrganization(transfer.getOrganization());
-            outTransaction.setUnitCost(avgCost);
+        for (SiteTransferReceivedEvent.ReceivedLine line : event.getReceivedLines()) {
+            SiteTransferItem item = line.item();
+            BigDecimal avgCost = costThatLeftTheSendingSite(transfer, item);
+            writeTransferIn(transfer, item, (double) line.quantity(), avgCost,
+                    event.getReceivedOn(), event.getReceivedBy(),
+                    "Transfer in from " + transfer.getSendingProject().getProjectName()
+                            + ", received by " + personName(event.getReceivedBy())
+                            + (event.getRemarks() != null && !event.getRemarks().isBlank()
+                                    ? " - " + event.getRemarks() : ""));
+        }
+    }
 
-            inventoryTransactionRepository.save(outTransaction);
+    /**
+     * Returns a cancelled transfer's stock to the sending site.
+     *
+     * <p>A cancellation is only reachable while nothing has been received, so the whole sent
+     * quantity is still in transit and the whole of it comes back. Written as a TRANSFER_IN
+     * against the sending balance rather than as a new movement shape: the stock really is
+     * arriving back at that row, and the remark says why.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSiteTransferCancelled(SiteTransferCancelledEvent event) {
+        SiteTransfer transfer = event.getSiteTransfer();
+        logger.info("Handling site transfer cancelled event for transfer number: {}", transfer.getTransferNumber());
+
+        for (SiteTransferItem item : event.getItems()) {
+            BigDecimal avgCost = costThatLeftTheSendingSite(transfer, item);
+            Double quantityChanged = item.getSentQuantity().doubleValue();
+            Double openingStock = openingStockAt(item, transfer.getSendingProject(),
+                    transfer.getSendingStorageLocation());
+
+            InventoryTransaction reversal = new InventoryTransaction();
+            reversal.setTransactionDate(LocalDateTime.now());
+            reversal.setMaterial(item.getMaterial());
+            reversal.setOpeningStock(openingStock);
+            reversal.setQuantityChanged(quantityChanged);
+            reversal.setClosingStock(openingStock + quantityChanged);
+            reversal.setTransactionType(InventoryTransactionType.TRANSFER_IN);
+            reversal.setReferenceNumber(transfer.getTransferNumber());
+            reversal.setRemarks("Transfer cancelled in transit and returned to "
+                    + transfer.getSendingProject().getProjectName()
+                    + " by " + personName(event.getCancelledBy())
+                    + (event.getReason() != null ? " - " + event.getReason() : ""));
+            reversal.setCreatedBy(event.getCancelledBy());
+            reversal.setProject(transfer.getSendingProject());
+            reversal.setStorageLocation(transfer.getSendingStorageLocation());
+            reversal.setOrganization(transfer.getOrganization());
+            reversal.setUnitCost(avgCost);
+
+            inventoryTransactionRepository.save(reversal);
 
             inventoryService.updateCurrentStock(
                     item.getMaterial(), transfer.getSendingProject(), transfer.getSendingStorageLocation(),
-                    transfer.getOrganization(), sendingQuantityChanged, null);
+                    transfer.getOrganization(), quantityChanged, avgCost);
 
-            logger.debug("Created TRANSFER_OUT transaction for material ID: {}, sending project ID: {}, quantity: {}, closing stock: {}",
-                    item.getMaterial().getId(), transfer.getSendingProject().getId(), sendingQuantityChanged, sendingClosingStock);
-
-            // TRANSFER_IN: Stock increases at receiving project (carries avg cost from sender)
-            // Same on the receiving side: the row credited with no location is the receiving
-            // project's unlocated row.
-            Double receivingOpeningStock;
-            if (transfer.getReceivingStorageLocation() != null) {
-                receivingOpeningStock = inventoryService.getStockAtLocation(
-                        item.getMaterial().getId(), transfer.getReceivingProject().getId(),
-                        transfer.getReceivingStorageLocation().getId());
-            } else {
-                receivingOpeningStock = inventoryService.findUnlocatedStock(
-                        item.getMaterial().getId(), transfer.getReceivingProject().getId()).orElse(0.0);
-            }
-            Double receivingQuantityChanged = item.getSentQuantity().doubleValue();
-            Double receivingClosingStock = receivingOpeningStock + receivingQuantityChanged;
-
-            InventoryTransaction inTransaction = new InventoryTransaction();
-            inTransaction.setTransactionDate(transfer.getIssueDate() != null ? transfer.getIssueDate() : LocalDateTime.now());
-            inTransaction.setMaterial(item.getMaterial());
-            inTransaction.setOpeningStock(receivingOpeningStock);
-            inTransaction.setQuantityChanged(receivingQuantityChanged);
-            inTransaction.setClosingStock(receivingClosingStock);
-            inTransaction.setTransactionType(InventoryTransactionType.TRANSFER_IN);
-            inTransaction.setReferenceNumber(transfer.getTransferNumber());
-            inTransaction.setRemarks("Transfer in from " + transfer.getSendingProject().getProjectName() +
-                    " by " + (transfer.getSendingPerson() != null ? transfer.getSendingPerson().getEmployeeName() : "employee") +
-                    (item.getRemarks() != null ? " - " + item.getRemarks() : ""));
-            inTransaction.setCreatedBy(transfer.getSendingPerson());
-            inTransaction.setProject(transfer.getReceivingProject());
-            inTransaction.setStorageLocation(transfer.getReceivingStorageLocation());
-            inTransaction.setOrganization(transfer.getOrganization());
-            inTransaction.setUnitCost(avgCost);
-
-            inventoryTransactionRepository.save(inTransaction);
-
-            inventoryService.updateCurrentStock(
-                    item.getMaterial(), transfer.getReceivingProject(), transfer.getReceivingStorageLocation(),
-                    transfer.getOrganization(), receivingQuantityChanged, avgCost);
-
-            logger.debug("Created TRANSFER_IN transaction for material ID: {}, receiving project ID: {}, quantity: {}, closing stock: {}",
-                    item.getMaterial().getId(), transfer.getReceivingProject().getId(), receivingQuantityChanged, receivingClosingStock);
+            logger.debug("Reversed TRANSFER_OUT for material ID: {}, sending project ID: {}, quantity: {}",
+                    item.getMaterial().getId(), transfer.getSendingProject().getId(), quantityChanged);
         }
+    }
+
+    /**
+     * Draws a quantity down at the sending balance and returns the unit cost it left at.
+     *
+     * <p>The average cost is read before the balance is updated, so it prices the stock that is
+     * leaving rather than what remains behind it.
+     */
+    private BigDecimal writeTransferOut(SiteTransfer transfer, SiteTransferItem item, Double quantity) {
+        // Read the balance this movement actually debits. With no sending storage location
+        // that is the sending project's unlocated row, not the project total: the total
+        // would put an opening and closing figure on the ledger entry that the row it
+        // moves never held, and it is a different quantity from the one updateCurrentStock
+        // goes on to write.
+        Double openingStock = openingStockAt(item, transfer.getSendingProject(),
+                transfer.getSendingStorageLocation());
+        Double quantityChanged = -quantity;
+
+        // Compute avg cost from sending side before the outbound update
+        BigDecimal avgCost = inventoryService.getAverageCost(
+                item.getMaterial().getId(), transfer.getSendingProject().getId(),
+                transfer.getSendingStorageLocation() != null ? transfer.getSendingStorageLocation().getId() : null);
+
+        InventoryTransaction outTransaction = new InventoryTransaction();
+        outTransaction.setTransactionDate(transfer.getIssueDate() != null ? transfer.getIssueDate() : LocalDateTime.now());
+        outTransaction.setMaterial(item.getMaterial());
+        outTransaction.setOpeningStock(openingStock);
+        outTransaction.setQuantityChanged(quantityChanged);
+        outTransaction.setClosingStock(openingStock + quantityChanged);
+        outTransaction.setTransactionType(InventoryTransactionType.TRANSFER_OUT);
+        outTransaction.setReferenceNumber(transfer.getTransferNumber());
+        outTransaction.setRemarks("Transfer out to " + transfer.getReceivingProject().getProjectName() +
+                " by " + personName(transfer.getSendingPerson()) +
+                (item.getRemarks() != null ? " - " + item.getRemarks() : ""));
+        outTransaction.setCreatedBy(transfer.getSendingPerson());
+        outTransaction.setProject(transfer.getSendingProject());
+        outTransaction.setStorageLocation(transfer.getSendingStorageLocation());
+        outTransaction.setOrganization(transfer.getOrganization());
+        outTransaction.setUnitCost(avgCost);
+
+        inventoryTransactionRepository.save(outTransaction);
+
+        inventoryService.updateCurrentStock(
+                item.getMaterial(), transfer.getSendingProject(), transfer.getSendingStorageLocation(),
+                transfer.getOrganization(), quantityChanged, null);
+
+        logger.debug("Created TRANSFER_OUT transaction for material ID: {}, sending project ID: {}, quantity: {}",
+                item.getMaterial().getId(), transfer.getSendingProject().getId(), quantityChanged);
+        return avgCost;
+    }
+
+    /** Raises a quantity at the receiving balance, carrying the cost it left the sender at. */
+    private void writeTransferIn(SiteTransfer transfer, SiteTransferItem item, Double quantity,
+                                 BigDecimal avgCost, LocalDateTime movementDate,
+                                 Employee createdBy, String remarks) {
+        // The row credited with no location is the receiving project's unlocated row.
+        Double openingStock = openingStockAt(item, transfer.getReceivingProject(),
+                transfer.getReceivingStorageLocation());
+
+        InventoryTransaction inTransaction = new InventoryTransaction();
+        inTransaction.setTransactionDate(movementDate != null ? movementDate : LocalDateTime.now());
+        inTransaction.setMaterial(item.getMaterial());
+        inTransaction.setOpeningStock(openingStock);
+        inTransaction.setQuantityChanged(quantity);
+        inTransaction.setClosingStock(openingStock + quantity);
+        inTransaction.setTransactionType(InventoryTransactionType.TRANSFER_IN);
+        inTransaction.setReferenceNumber(transfer.getTransferNumber());
+        inTransaction.setRemarks(remarks);
+        inTransaction.setCreatedBy(createdBy);
+        inTransaction.setProject(transfer.getReceivingProject());
+        inTransaction.setStorageLocation(transfer.getReceivingStorageLocation());
+        inTransaction.setOrganization(transfer.getOrganization());
+        inTransaction.setUnitCost(avgCost);
+
+        inventoryTransactionRepository.save(inTransaction);
+
+        inventoryService.updateCurrentStock(
+                item.getMaterial(), transfer.getReceivingProject(), transfer.getReceivingStorageLocation(),
+                transfer.getOrganization(), quantity, avgCost);
+
+        logger.debug("Created TRANSFER_IN transaction for material ID: {}, receiving project ID: {}, quantity: {}",
+                item.getMaterial().getId(), transfer.getReceivingProject().getId(), quantity);
+    }
+
+    /**
+     * The unit cost this transfer's outbound leg carried for a material.
+     *
+     * <p>Read back off the ledger rather than recomputed, because the sending balance has moved
+     * on since the lorry left and may hold nothing at all. Falls back to the sending balance's
+     * current average cost when no outbound movement is found, which is the shape a transfer
+     * created before this ledger read existed would have.
+     *
+     * <p>The organization comes off the transfer rather than off the ambient tenant context, the
+     * same rule the status trail follows: the movement being looked for belongs to this document,
+     * so the document is what says whose it is.
+     */
+    private BigDecimal costThatLeftTheSendingSite(SiteTransfer transfer, SiteTransferItem item) {
+        return inventoryTransactionRepository
+                .findUnitCostsForReference(transfer.getTransferNumber(), item.getMaterial().getId(),
+                        InventoryTransactionType.TRANSFER_OUT, transfer.getOrganization().getId(),
+                        PageRequest.of(0, 1))
+                .stream().findFirst()
+                .orElseGet(() -> inventoryService.getAverageCost(
+                        item.getMaterial().getId(), transfer.getSendingProject().getId(),
+                        transfer.getSendingStorageLocation() != null
+                                ? transfer.getSendingStorageLocation().getId() : null));
+    }
+
+    /** The balance row a movement touches: the located row, or the project's unlocated one. */
+    private Double openingStockAt(SiteTransferItem item, Project project, StorageLocation location) {
+        if (location != null) {
+            return inventoryService.getStockAtLocation(item.getMaterial().getId(), project.getId(), location.getId());
+        }
+        return inventoryService.findUnlocatedStock(item.getMaterial().getId(), project.getId()).orElse(0.0);
+    }
+
+    private static String personName(Employee employee) {
+        return employee != null && employee.getEmployeeName() != null ? employee.getEmployeeName() : "employee";
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/InventoryTransactionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.tornotron.echno_backend.inventoryTransaction.enums.InventoryTransactionType;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -70,4 +71,31 @@ public interface InventoryTransactionRepository extends JpaRepository<InventoryT
            "FROM InventoryTransaction it WHERE it.storageLocation.id = :storageLocationId " +
            "GROUP BY it.material.id, it.material.materialName")
     List<Object[]> findStockGroupedByMaterialAtStorageLocation(@Param("storageLocationId") Long storageLocationId);
+
+    /**
+     * The unit cost the earliest movement of one type carried for a material against a document.
+     *
+     * <p>This exists so a movement that answers an earlier one can be priced at what the earlier
+     * one carried. A site transfer's inbound leg is written days after its outbound leg, by which
+     * time the sending balance has moved on and may hold nothing at all: pricing the arrival off
+     * that balance would value it at zero and silently destroy the stock value that left the site.
+     * The outbound movement is the only record of what the material was worth when it went, so it
+     * is read back rather than recomputed.
+     *
+     * <p>Ordered by id, with the caller passing a {@code Pageable} of one row, so a document that
+     * wrote more than one movement of the same type for the same material yields the first
+     * deterministically instead of raising a non-unique result. Deliberately not wrapped in a
+     * default method: a default method on a repository interface is mocked along with the rest of
+     * it, so a caller's stub of this query would be silently bypassed in tests.
+     */
+    @Query("SELECT it.unitCost FROM InventoryTransaction it "
+            + "WHERE it.referenceNumber = :referenceNumber AND it.material.id = :materialId "
+            + "AND it.transactionType = :transactionType AND it.organization.id = :organizationId "
+            + "AND it.unitCost IS NOT NULL ORDER BY it.id")
+    List<BigDecimal> findUnitCostsForReference(@Param("referenceNumber") String referenceNumber,
+                                               @Param("materialId") Long materialId,
+                                               @Param("transactionType") InventoryTransactionType transactionType,
+                                               @Param("organizationId") Long organizationId,
+                                               Pageable pageable);
+
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferController.java
@@ -13,7 +13,9 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCancellationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 
@@ -158,13 +160,20 @@ public class SiteTransferController {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasAuthority('site-transfer:update') or hasAuthority('site-transfer:admin')")
+    @Deprecated
     @Operation(
-            summary = "Update a site transfer's status",
-            description = "Sets the status of an existing site transfer, for example moving it from PENDING "
-                    + "to IN_TRANSIT or COMPLETED."
+            deprecated = true,
+            summary = "Deprecated: a transfer's status can no longer be set from a payload",
+            description = "Always refuses, and names the endpoint that does what the caller "
+                    + "wants. This used to assign whatever status it was handed and move no stock, "
+                    + "which is how a transfer could read COMPLETED with nothing confirmed. Every "
+                    + "state a transfer can hold now follows from a movement: record a delivery "
+                    + "with POST /{id}/receive, or abandon one that never arrived with POST "
+                    + "/{id}/cancel. The route is kept so an existing client gets an answer that "
+                    + "names its replacement rather than a 404."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Always: the status is derived from movements and cannot be set"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer update or admin authority"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
     })
@@ -174,5 +183,62 @@ public class SiteTransferController {
     ) {
         siteTransferService.updateSiteTransferStatus(id, status);
         return ResponseEntity.ok(new ApiResponse("Site transfer status updated successfully"));
+    }
+
+    @PostMapping("/{id}/receive")
+    @PreAuthorize("hasAuthority('site-transfer:update') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "Record what the receiving site took delivery of",
+            description = "Posts the stock that actually arrived at the receiving project and "
+                    + "location, writes each line's received quantity, and works the transfer's "
+                    + "status out from the arithmetic: everything received is COMPLETED, some "
+                    + "received is PARTIALLY_TRANSFERRED, nothing received leaves it PENDING. Who "
+                    + "confirmed the delivery is taken from the session, never from the payload, so "
+                    + "the receipt is that person's own statement. Receiving less than was sent is "
+                    + "accepted and leaves an open variance on the transfer, visible as each line's "
+                    + "in-transit quantity and closed by a stock adjustment naming the transfer; the "
+                    + "transfer writes no loss movement of its own, because that would be a stock "
+                    + "correction nobody authorised. Receiving more than was sent is refused unless "
+                    + "the payload sets allowOverReceipt. Only a transfer that crosses a project "
+                    + "boundary can be received: one between two stores on a single project had both "
+                    + "of its legs written at creation, because the material never left that site's "
+                    + "custody."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Receipt recorded and the stock that arrived posted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The transfer never left one project, or it is already completed or cancelled, or a named line is not on it, or a line would be over-received without allowOverReceipt"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
+    public ResponseEntity<SiteTransferDto> receiveSiteTransfer(
+            @PathVariable Long id,
+            @Valid @RequestBody SiteTransferReceiptDto receiptDto
+    ) {
+        return ResponseEntity.ok(siteTransferService.receiveSiteTransfer(id, receiptDto));
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('site-transfer:update') or hasAuthority('site-transfer:admin')")
+    @Operation(
+            summary = "Cancel a transfer that never arrived",
+            description = "Abandons a PENDING transfer and returns the whole sent quantity to the "
+                    + "sending project and location it was drawn from. Without the reversal a "
+                    + "transfer written off in transit would leave the sending project permanently "
+                    + "short with no way back. Only a PENDING transfer can be cancelled: once "
+                    + "something has been received, part of the material is standing at the far "
+                    + "site and what to do about the rest is a decision for a stock adjustment "
+                    + "rather than a reversal."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transfer cancelled and its outbound leg reversed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The transfer is in any state but PENDING, or no reason was given"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the site-transfer update or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
+    public ResponseEntity<SiteTransferDto> cancelSiteTransfer(
+            @PathVariable Long id,
+            @Valid @RequestBody SiteTransferCancellationDto cancellationDto
+    ) {
+        return ResponseEntity.ok(siteTransferService.cancelSiteTransfer(id, cancellationDto));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWeb.java
@@ -11,9 +11,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
 import org.tornotron.echno_backend.common.pagination.PageQuery;
 import org.tornotron.echno_backend.common.response.ApiResponse;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCancellationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
@@ -157,13 +160,20 @@ public class SiteTransferControllerWeb {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Deprecated
     @Operation(
-            summary = "Update a site transfer's status",
-            description = "Sets the status of an existing site transfer, for example moving it from PENDING "
-                    + "to IN_TRANSIT or COMPLETED."
+            deprecated = true,
+            summary = "Deprecated: a transfer's status can no longer be set from a payload",
+            description = "Always refuses, and names the endpoint that does what the caller "
+                    + "wants. This used to assign whatever status it was handed and move no stock, "
+                    + "which is how a transfer could read COMPLETED with nothing confirmed. Every "
+                    + "state a transfer can hold now follows from a movement: record a delivery "
+                    + "with POST /{id}/receive, or abandon one that never arrived with POST "
+                    + "/{id}/cancel. The route is kept so an existing client gets an answer that "
+                    + "names its replacement rather than a 404."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Site transfer status updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Always: the status is derived from movements and cannot be set"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
     })
@@ -173,5 +183,88 @@ public class SiteTransferControllerWeb {
     ) {
         siteTransferService.updateSiteTransferStatus(id, status);
         return ResponseEntity.ok(new ApiResponse("Site transfer status updated successfully"));
+    }
+
+    @PostMapping("/{id}/receive")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Record what the receiving site took delivery of",
+            description = "Posts the stock that actually arrived at the receiving project and "
+                    + "location, writes each line's received quantity, and works the transfer's "
+                    + "status out from the arithmetic: everything received is COMPLETED, some "
+                    + "received is PARTIALLY_TRANSFERRED, nothing received leaves it PENDING. Who "
+                    + "confirmed the delivery is taken from the session, never from the payload, so "
+                    + "the receipt is that person's own statement. Receiving less than was sent is "
+                    + "accepted and leaves an open variance on the transfer, visible as each line's "
+                    + "in-transit quantity and closed by a stock adjustment naming the transfer; the "
+                    + "transfer writes no loss movement of its own, because that would be a stock "
+                    + "correction nobody authorised. Receiving more than was sent is refused unless "
+                    + "the payload sets allowOverReceipt. Only a transfer that crosses a project "
+                    + "boundary can be received: one between two stores on a single project had both "
+                    + "of its legs written at creation, because the material never left that site's "
+                    + "custody."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Receipt recorded and the stock that arrived posted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The transfer never left one project, or it is already completed or cancelled, or a named line is not on it, or a line would be over-received without allowOverReceipt"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
+    public ResponseEntity<SiteTransferDto> receiveSiteTransfer(
+            @PathVariable Long id,
+            @Valid @RequestBody SiteTransferReceiptDto receiptDto
+    ) {
+        return ResponseEntity.ok(siteTransferService.receiveSiteTransfer(id, receiptDto));
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Cancel a transfer that never arrived",
+            description = "Abandons a PENDING transfer and returns the whole sent quantity to the "
+                    + "sending project and location it was drawn from. Without the reversal a "
+                    + "transfer written off in transit would leave the sending project permanently "
+                    + "short with no way back. Only a PENDING transfer can be cancelled: once "
+                    + "something has been received, part of the material is standing at the far "
+                    + "site and what to do about the rest is a decision for a stock adjustment "
+                    + "rather than a reversal."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Transfer cancelled and its outbound leg reversed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The transfer is in any state but PENDING, or no reason was given"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
+    public ResponseEntity<SiteTransferDto> cancelSiteTransfer(
+            @PathVariable Long id,
+            @Valid @RequestBody SiteTransferCancellationDto cancellationDto
+    ) {
+        return ResponseEntity.ok(siteTransferService.cancelSiteTransfer(id, cancellationDto));
+    }
+
+    @GetMapping("/{id}/status-history")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin')")
+    @Operation(
+            summary = "Read a site transfer's status trail",
+            description = "Returns a page of the transfer's status entries, newest first: what it "
+                    + "moved from, what it moved to, when, and by whom. Unlike a purchase order's "
+                    + "receipt-driven move, a transfer reaching PARTIALLY_TRANSFERRED or COMPLETED "
+                    + "is somebody's act, so those entries name the person who confirmed the "
+                    + "delivery. Entries begin where recording began, so a transfer raised before "
+                    + "the trail existed carries a single BASELINE entry naming the status it was "
+                    + "observed to hold at that moment, and one raised before the two-step document "
+                    + "existed may carry a SYSTEM entry recording that its status was corrected to "
+                    + "match movements that had already been posted."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of status entries returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No site transfer with the given id")
+    })
+    public ResponseEntity<Page<StatusTransitionDto>> readStatusHistory(
+            @PathVariable Long id,
+            @Valid @ParameterObject PageQuery pageQuery) {
+        return ResponseEntity.ok(
+                siteTransferService.getStatusHistory(id, pageQuery.getPageNo(), pageQuery.pageSizeOr(20)));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiptReconciler.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiptReconciler.java
@@ -1,0 +1,230 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.tornotron.echno_backend.common.events.SiteTransferReceivedEvent.ReceivedLine;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+import org.tornotron.echno_backend.user.User;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Works out what a receipt does to the transfer it answers, and moves the transfer's status.
+ *
+ * <p>A transfer used to write both of its inventory legs the moment it was created, so stock
+ * arrived at a site before anybody there had seen the lorry. That is right within one project,
+ * where the material never leaves the site's custody, and wrong between two, where there is a
+ * lorry and a road and a gap of hours or days. A transfer that crosses a project boundary now
+ * writes only its outbound leg at creation and gains its inbound leg here, when somebody at the
+ * receiving site says what turned up.
+ *
+ * <p>The arithmetic is deliberately separate from the loading, locking and event publishing in
+ * {@link SiteTransferService}, so the rules below can be read and tested without a transfer
+ * having to exist in a database.
+ */
+@Component
+public class SiteTransferReceiptReconciler {
+
+    private static final Logger logger = LoggerFactory.getLogger(SiteTransferReceiptReconciler.class);
+
+    private final StatusTransitionRecorder statusTransitionRecorder;
+
+    public SiteTransferReceiptReconciler(StatusTransitionRecorder statusTransitionRecorder) {
+        this.statusTransitionRecorder = statusTransitionRecorder;
+    }
+
+    /**
+     * What a receipt did to the transfer.
+     *
+     * @param received    One entry per line that gained a quantity, for the ledger to post.
+     * @param overReceipt Whether any line ended up received beyond what was sent.
+     * @param movedTo     The status the transfer was moved to, or null if it did not move.
+     */
+    public record ReceiptOutcome(List<ReceivedLine> received, boolean overReceipt,
+                                 SiteTransferStatus movedTo) {
+    }
+
+    /**
+     * Whether a transfer moves stock out of one project and into another.
+     *
+     * <p>This is the whole of the two-step decision. Between projects there is a lorry and a
+     * road, so the inbound leg waits for somebody to confirm it. Within one project the two
+     * sides are two stores on a site whose storekeeper hands the material from one to the other,
+     * with no window in which nobody is accountable for it, so both legs are written at creation
+     * and the transfer is complete from the moment it exists. A same-project transfer always
+     * names two different storage locations, because one that named the same location on both
+     * sides would move nothing and is refused at creation.
+     */
+    public static boolean crossesProjectBoundary(SiteTransfer transfer) {
+        Long sending = transfer.getSendingProject() != null ? transfer.getSendingProject().getId() : null;
+        Long receiving = transfer.getReceivingProject() != null ? transfer.getReceivingProject().getId() : null;
+        return !Objects.equals(sending, receiving);
+    }
+
+    /**
+     * Adds a receipt's quantities to a transfer's lines and moves the transfer's status.
+     *
+     * <p><strong>An over-receipt is refused by default and recorded on request</strong>, on the
+     * purchase order's reasoning and for the same reason: refusing outright would leave material
+     * that is standing in the yard outside the stock ledger, which is the condition that makes a
+     * later count unexplainable, while accepting it silently is the behaviour being replaced. So
+     * the refusal names the line, what was sent, what has already arrived and what this receipt
+     * adds, and a payload that acknowledges the excess records it.
+     *
+     * <p><strong>A shortfall is not refused and needs no acknowledgement</strong>, which is not
+     * an inconsistency with the rule above but the same rule applied to the other direction. The
+     * over-receipt guard exists because the document would otherwise assert stock the transfer
+     * never sent. Eight bags arriving against ten sent asserts nothing false: the ledger holds an
+     * honest outbound leg for ten and an honest inbound leg for eight, and the two missing bags
+     * are visible as the difference. Refusing the short receipt would force the storekeeper
+     * either to claim ten arrived or to leave the eight that did outside the ledger, which is the
+     * failure the over-receipt escape hatch exists to prevent. The gap is left as an open
+     * variance on the transfer and closed by a stock adjustment naming it. The transfer does not
+     * write a loss movement of its own: a loss written automatically is a stock correction
+     * nobody authorised, and putting an approver in front of stock corrections is what #651 is.
+     *
+     * @param transfer          The transfer being received.
+     * @param lines             The transfer's lines, already taken under a write lock.
+     * @param requested         How much each line id is being recorded as receiving now.
+     * @param overReceiptAllowed Whether the payload acknowledged an over-receipt in advance.
+     * @param actor             The user confirming the delivery, from the session.
+     * @param remarks           An optional note, carried onto the status trail.
+     * @return What the receipt did.
+     * @throws InvalidRequestException if a line would be over-received without acknowledgement,
+     *     or if the payload names a line that is not on this transfer.
+     */
+    public ReceiptOutcome applyReceipt(SiteTransfer transfer, List<SiteTransferItem> lines,
+                                       Map<Long, Integer> requested, boolean overReceiptAllowed,
+                                       User actor, String remarks) {
+        Map<Long, SiteTransferItem> linesById = new LinkedHashMap<>();
+        for (SiteTransferItem line : lines) {
+            linesById.put(line.getId(), line);
+        }
+
+        List<String> overReceipts = new ArrayList<>();
+        for (Map.Entry<Long, Integer> entry : requested.entrySet()) {
+            SiteTransferItem line = linesById.get(entry.getKey());
+            if (line == null) {
+                // Naming a line that is not on this transfer is a mistake about which document
+                // is being received, and guessing which line was meant would post stock against
+                // the wrong material.
+                throw new InvalidRequestException(
+                        "Site transfer " + transfer.getTransferNumber() + " has no line with id "
+                                + entry.getKey() + ". Read the transfer to see the line ids it "
+                                + "carries, and send a receipt against those.");
+            }
+            int sent = sentQuantity(line);
+            int already = receivedQuantity(line);
+            int total = already + entry.getValue();
+            if (total > sent) {
+                overReceipts.add(describeOverReceipt(transfer, line, sent, already, entry.getValue(), total));
+            }
+        }
+
+        boolean overReceipt = !overReceipts.isEmpty();
+        if (overReceipt && !overReceiptAllowed) {
+            throw new InvalidRequestException(String.join(" ", overReceipts)
+                    + " If more really did arrive than was sent, send the receipt again with "
+                    + "allowOverReceipt set, which records what arrived and posts it to the "
+                    + "receiving site. Receiving less than was sent needs no such flag: the "
+                    + "shortfall is left as an open variance for a stock adjustment to close.");
+        }
+
+        List<ReceivedLine> received = new ArrayList<>();
+        for (Map.Entry<Long, Integer> entry : requested.entrySet()) {
+            SiteTransferItem line = linesById.get(entry.getKey());
+            // A line recorded as receiving nothing still has its receivedQuantity written, so
+            // the transfer says the line was looked at and nothing came, rather than staying
+            // null and reading as never confirmed. It raises no movement.
+            line.setReceivedQuantity(receivedQuantity(line) + entry.getValue());
+            if (entry.getValue() > 0) {
+                received.add(new ReceivedLine(line, entry.getValue()));
+            }
+        }
+
+        SiteTransferStatus movedTo = moveStatus(transfer, lines, actor, remarks);
+        return new ReceiptOutcome(received, overReceipt, movedTo);
+    }
+
+    /**
+     * Works the transfer's status out from its lines and moves it if it has changed.
+     *
+     * <p>Unlike the purchase order's derived move, this transition is somebody's act: a person
+     * at the receiving site looked at what came off the lorry and said so. It is filed as an
+     * ordinary {@code UPDATE} against that person rather than as a {@code SYSTEM} transition,
+     * because there is an actor to name and naming them is the point of the two-step document.
+     *
+     * @return The status moved to, or null if it did not move.
+     */
+    private SiteTransferStatus moveStatus(SiteTransfer transfer, List<SiteTransferItem> lines,
+                                          User actor, String remarks) {
+        SiteTransferStatus current = transfer.getStatus();
+        SiteTransferStatus derived = derive(lines);
+        if (derived == null || derived == current) {
+            return null;
+        }
+
+        transfer.setStatus(derived);
+        String note = "Recorded from what the receiving site confirmed had arrived."
+                + (remarks != null && !remarks.isBlank() ? " " + remarks.trim() : "");
+        statusTransitionRecorder.recordChange(
+                SiteTransferService.HISTORY_ENTITY_TYPE,
+                transfer.getId(),
+                transfer.getOrganization(),
+                current != null ? current.name() : null,
+                derived.name(),
+                actor,
+                note);
+        logger.info("Site transfer {} moved from {} to {} on a recorded receipt",
+                transfer.getTransferNumber(), current, derived);
+        return derived;
+    }
+
+    /**
+     * The status a transfer's lines say it is in, or null while nothing has been received and
+     * the lines therefore say nothing about arrival at all.
+     */
+    private static SiteTransferStatus derive(List<SiteTransferItem> lines) {
+        boolean anyReceived = false;
+        boolean allMet = true;
+        for (SiteTransferItem line : lines) {
+            int received = receivedQuantity(line);
+            if (received > 0) {
+                anyReceived = true;
+            }
+            if (received < sentQuantity(line)) {
+                allMet = false;
+            }
+        }
+        if (!anyReceived) {
+            return null;
+        }
+        return allMet ? SiteTransferStatus.COMPLETED : SiteTransferStatus.PARTIALLY_TRANSFERRED;
+    }
+
+    private static String describeOverReceipt(SiteTransfer transfer, SiteTransferItem line,
+                                              int sent, int already, int arriving, int total) {
+        String material = line.getMaterial() != null && line.getMaterial().getMaterialName() != null
+                ? line.getMaterial().getMaterialName()
+                : "material " + (line.getMaterial() != null ? line.getMaterial().getId() : "unknown");
+        return "Site transfer " + transfer.getTransferNumber() + " sent " + sent + " of " + material
+                + ", " + already + " has already been received against it, and this receipt records "
+                + "a further " + arriving + ", which would take it to " + total + ".";
+    }
+
+    static int sentQuantity(SiteTransferItem line) {
+        return line.getSentQuantity() != null ? line.getSentQuantity() : 0;
+    }
+
+    static int receivedQuantity(SiteTransferItem line) {
+        return line.getReceivedQuantity() != null ? line.getReceivedQuantity() : 0;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/SiteTransferService.java
@@ -8,7 +8,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.common.events.SiteTransferCancelledEvent;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferReceivedEvent;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.dto.StatusTransitionDto;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
@@ -17,6 +23,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.retry.SqlStateDetector;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
@@ -24,9 +31,12 @@ import org.tornotron.echno_backend.material.Material;
 import org.tornotron.echno_backend.material.MaterialRepository;
 import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCancellationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCreationDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferDto;
 import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptLineDto;
 import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
@@ -34,13 +44,17 @@ import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocationScope;
 import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -60,16 +74,46 @@ import java.util.stream.Collectors;
  * leave an out and a matching in that cancel, sitting in the movement history looking like
  * real movement. Two locations inside one project are two rows, so a store-to-store move
  * within a project is a real transfer and is allowed.
+ *
+ * <p><strong>How many legs a creation writes depends on whether it crosses a project
+ * boundary.</strong> Within one project the material is handed between two stores on a site
+ * whose storekeeper is accountable for it throughout, so both legs are written at creation and
+ * the transfer is {@code COMPLETED} from the moment it exists: there is no arrival to confirm.
+ * Between two projects there is a lorry, a road and a gap of hours or days, so only the
+ * outbound leg is written, the transfer is {@code PENDING}, and the quantity is in transit until
+ * somebody at the receiving site records what arrived through {@link #receiveSiteTransfer}.
+ * Writing the inbound leg at creation asserted that stock had reached a site where nobody had
+ * seen it, which is the claim that made a receiving-site count unexplainable.
+ *
+ * <p>The reporting consequence is worth stating rather than leaving to be discovered: an
+ * organization-wide total of on-hand stock is short by everything in transit. That is the truth
+ * about material on a lorry, and each line reports its own in-transit quantity so a report
+ * summing stock across projects can show a labelled in-transit figure beside the total.
  */
 @Service
 public class SiteTransferService {
 
+    /** The kind this module files its status trail under. */
+    public static final String HISTORY_ENTITY_TYPE = "SITE_TRANSFER";
+
     /**
-     * The state a transfer starts in, and the only one create accepts. It is what the web
-     * client's transfer form already sends, and what {@code echno-core} documents as the
-     * typical initial value.
+     * The state a cross-project transfer starts in, and the only one create accepts from a
+     * payload. It is what the web client's transfer form already sends, and what
+     * {@code echno-core} documents as the typical initial value. A transfer that stays inside
+     * one project is written {@link SiteTransferStatus#COMPLETED} by the server instead, because
+     * both its legs are posted at creation.
      */
     private static final SiteTransferStatus CREATION_STATUS = SiteTransferStatus.PENDING;
+
+    /**
+     * The states a transfer can be received from.
+     *
+     * <p>A {@code COMPLETED} transfer has had everything it sent recorded as arriving, and a
+     * {@code CANCELLED} one has had its outbound leg reversed, so in both cases there is nothing
+     * left in transit for a receipt to be about.
+     */
+    private static final Set<SiteTransferStatus> RECEIVABLE = EnumSet.of(
+            SiteTransferStatus.PENDING, SiteTransferStatus.PARTIALLY_TRANSFERRED);
 
     private final SiteTransferRepository siteTransferRepository;
     private final SiteTransferItemRepository siteTransferItemRepository;
@@ -84,6 +128,12 @@ public class SiteTransferService {
     private final StorageLocationRepository storageLocationRepository;
     private final DocumentNumberAllocator documentNumberAllocator;
     private final TransactionRetryTemplate retryTemplate;
+    private final SiteTransferReceiptReconciler receiptReconciler;
+    private final CurrentEmployeeService currentEmployeeService;
+    private final UserContextService userContextService;
+    private final StatusTransitionRecorder statusTransitionRecorder;
+    private final StatusTransitionRepository statusTransitionRepository;
+    private final StatusTransitionMapper statusTransitionMapper;
 
     public SiteTransferService(SiteTransferRepository siteTransferRepository,
                                SiteTransferItemRepository siteTransferItemRepository,
@@ -97,7 +147,13 @@ public class SiteTransferService {
                                ProjectRepository projectRepository,
                                StorageLocationRepository storageLocationRepository,
                                DocumentNumberAllocator documentNumberAllocator,
-                               TransactionRetryTemplate retryTemplate) {
+                               TransactionRetryTemplate retryTemplate,
+                               SiteTransferReceiptReconciler receiptReconciler,
+                               CurrentEmployeeService currentEmployeeService,
+                               UserContextService userContextService,
+                               StatusTransitionRecorder statusTransitionRecorder,
+                               StatusTransitionRepository statusTransitionRepository,
+                               StatusTransitionMapper statusTransitionMapper) {
         this.siteTransferRepository = siteTransferRepository;
         this.siteTransferItemRepository = siteTransferItemRepository;
         this.userRepository = userRepository;
@@ -111,13 +167,22 @@ public class SiteTransferService {
         this.storageLocationRepository = storageLocationRepository;
         this.documentNumberAllocator = documentNumberAllocator;
         this.retryTemplate = retryTemplate;
+        this.receiptReconciler = receiptReconciler;
+        this.currentEmployeeService = currentEmployeeService;
+        this.userContextService = userContextService;
+        this.statusTransitionRecorder = statusTransitionRecorder;
+        this.statusTransitionRepository = statusTransitionRepository;
+        this.statusTransitionMapper = statusTransitionMapper;
     }
 
     /**
      * Creates a site transfer with its items after checking sending-side stock.
      *
-     * <p>The transfer starts {@link SiteTransferStatus#PENDING}, whether the payload says so or
-     * says nothing, and any other starting value is refused: see {@link #requireCreatableStatus}.
+     * <p>A transfer between two projects starts {@link SiteTransferStatus#PENDING} with only its
+     * outbound leg posted; one between two stores on a single project starts
+     * {@link SiteTransferStatus#COMPLETED} with both legs posted and every line received in
+     * full. The payload may ask for {@code PENDING} or for nothing at all, and any other value is
+     * refused: see {@link #requireCreatableStatus}.
      *
      * <p>Resolves the sending person, both projects and both optional storage locations,
      * refuses a pair of sides that resolve to the same balance row, then totals the requested
@@ -199,7 +264,11 @@ public class SiteTransferService {
         transfer.setSendingStorageLocation(sendingLocation);
         transfer.setReceivingStorageLocation(receivingLocation);
 
-        transfer.setStatus(CREATION_STATUS);
+        // A transfer that stays inside one project never leaves that site's custody, so both
+        // legs are written at creation and there is nothing left to confirm. One that crosses a
+        // project boundary is in transit until somebody at the far end says what arrived.
+        boolean crossesProjects = SiteTransferReceiptReconciler.crossesProjectBoundary(transfer);
+        transfer.setStatus(crossesProjects ? CREATION_STATUS : SiteTransferStatus.COMPLETED);
         transfer.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
         // Save transfer first
@@ -215,6 +284,10 @@ public class SiteTransferService {
             item.setSiteTransfer(transfer);
             item.setMaterial(material);
             item.setSentQuantity(itemDto.getSentQuantity());
+            // Within one project the inbound leg is written now, so the line records that the
+            // whole quantity arrived. Across projects it stays null: nobody has confirmed
+            // anything about this line, which is different from confirming that nothing came.
+            item.setReceivedQuantity(crossesProjects ? null : itemDto.getSentQuantity());
             item.setRemarks(itemDto.getRemarks());
             item.setOrganization(tenantEntityHelper.resolveCurrentOrganization());
 
@@ -223,6 +296,10 @@ public class SiteTransferService {
 
         siteTransferItemRepository.saveAll(items);
         transfer.setItems(items);
+
+        statusTransitionRecorder.recordCreation(HISTORY_ENTITY_TYPE, transfer.getId(),
+                transfer.getOrganization(), transfer.getStatus().name(),
+                userContextService.getCurrentUser());
 
         // Publish SiteTransferCreatedEvent for automatic inventory update
         eventPublisher.publishEvent(new SiteTransferCreatedEvent(this, transfer));
@@ -233,19 +310,18 @@ public class SiteTransferService {
     /**
      * Refuses a transfer asked to be created in any state but {@link #CREATION_STATUS}.
      *
-     * <p>The other two states both say the receiving site has taken delivery, and taking
-     * delivery is recorded through {@code PATCH /site-transfers/{id}/status}. That endpoint is
-     * held by a different authority from create on the token-authority controller
-     * ({@code site-transfer:update} against {@code site-transfer:create}), so a create that
-     * copied the payload's status let a caller who may only raise transfers record their own
-     * receipt of one. Stock moves on creation either way, through
-     * {@link SiteTransferCreatedEvent}, so what a transfer issued as {@code COMPLETED} leaves
-     * behind is a movement that stands as confirmed by nobody.
+     * <p>The other states all say something happened after the transfer was issued: two of them
+     * say the receiving site took delivery, and one says the transfer was abandoned and its stock
+     * returned. Each is now reached by an endpoint that moves stock, so a create that copied the
+     * payload's status would let a caller record their own receipt of a lorry nobody has seen, or
+     * mark a transfer cancelled while its outbound leg still stands.
      *
      * <p>This is the rule {@code ProjectService.addProject} and
      * {@code PurchaseOrderService.createPurchaseOrder} apply: a create may not reach a state
-     * whose transition carries a check or an event. Here the status endpoint gates both of the
-     * later states, so {@code PENDING} is all that is left.
+     * whose transition carries a check or a movement. That leaves {@code PENDING}. The server
+     * still writes {@code COMPLETED} itself for a transfer that stays inside one project, because
+     * there both legs are posted at creation and nothing is outstanding; what is refused is the
+     * caller claiming that state, not the state existing.
      *
      * @param status The status the create payload asked for, or null when it asked for none.
      * @throws InvalidRequestException if that status is anything but {@link #CREATION_STATUS}.
@@ -255,8 +331,10 @@ public class SiteTransferService {
             throw new InvalidRequestException(
                     "A site transfer is issued as " + CREATION_STATUS + " and cannot be created as "
                             + status + ". Issue it first, then record what the receiving site took "
-                            + "delivery of with PATCH /site-transfers/{id}/status, which is where "
-                            + "the authority to say a transfer has been received is checked.");
+                            + "delivery of with POST /site-transfers/{id}/receive, which posts the "
+                            + "stock that actually arrived and takes the person confirming it from "
+                            + "the session; a transfer that never arrived is closed with POST "
+                            + "/site-transfers/{id}/cancel, which returns the stock to the sender.");
         }
     }
 
@@ -391,18 +469,222 @@ public class SiteTransferService {
     }
 
     /**
-     * Sets the status of a site transfer.
+     * Refuses to set a transfer's status from a payload, and says where the status now comes from.
      *
-     * @param id The id of the site transfer to update.
-     * @param status The new status.
+     * <p>This endpoint used to assign whatever status it was handed and move no stock. That is
+     * how a transfer could read {@code COMPLETED} with nothing confirmed and how it could read
+     * {@code PENDING} with both legs already posted: the status was a label somebody typed rather
+     * than a claim the ledger supported. Every state a transfer can hold now follows from a
+     * movement, so there is no status left for a payload to set.
+     *
+     * <p>The route is kept rather than removed so an existing client gets an answer that names
+     * the endpoint it wants instead of a 404 it has to guess at.
+     *
+     * @param id The id of the site transfer the caller tried to move.
+     * @param status The status the caller asked for.
      * @throws ResourceNotFoundException if no site transfer with the given id exists in this organization.
+     * @throws InvalidRequestException always, once the transfer has been found.
      */
-    @Transactional
+    @Deprecated
+    @Transactional(readOnly = true)
     public void updateSiteTransferStatus(Long id, SiteTransferStatus status) {
         SiteTransfer transfer = siteTransferRepository.findByIdAndOrganization_Id(id,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Site transfer with ID " + id + " was not found in this organization"));
 
-        transfer.setStatus(status);
+        throw new InvalidRequestException(
+                "Site transfer " + transfer.getTransferNumber() + " is " + transfer.getStatus()
+                        + " and its status cannot be set to " + status + " from a payload. A status "
+                        + "that says stock arrived must not be settable by a request that moves no "
+                        + "stock. Record what the receiving site took delivery of with POST "
+                        + "/site-transfers/{id}/receive, which posts the inbound movements and "
+                        + "works the status out from them, or abandon a transfer that never "
+                        + "arrived with POST /site-transfers/{id}/cancel, which returns the stock "
+                        + "to the sending site.");
+    }
+
+    /**
+     * Records what the receiving site took delivery of, posts the stock that arrived, and moves
+     * the transfer's status to match.
+     *
+     * <p>This is the second step the two-step document exists for. Until it is called, a
+     * cross-project transfer's quantity is in transit: off the sending site's balance, not yet on
+     * the receiving site's, and visible as each line's in-transit quantity.
+     *
+     * <p>Who confirmed the delivery is taken from the session and never from the payload. A
+     * receipt is read as that person's own statement that they saw the material, and an id off
+     * the request body would be whatever the caller typed.
+     *
+     * <p>The lines are taken under a write lock, so two people confirming the same lorry at once
+     * queue rather than each judging themselves against the figure that stood before the other.
+     * The transaction is restarted on a serialization abort, as the create path is: the lock
+     * queues the second caller rather than aborting it on CockroachDB, but the transfer row and
+     * the status trail are written too, and a storekeeper standing at a gate should not be shown
+     * a failure for a conflict they did not cause. The work is safe to run again from the start,
+     * because the inbound movements are published as an event after the transaction commits,
+     * which is the same shape the outbound leg has used since the document existed, so an attempt
+     * that rolls back posts nothing.
+     *
+     * @param id The transfer being received.
+     * @param receiptDto The quantities that arrived, and whether an over-receipt was acknowledged.
+     * @return The transfer as it now stands.
+     * @throws ResourceNotFoundException if no site transfer with the given id exists in this organization.
+     * @throws InvalidRequestException if the transfer never went anywhere to be received from,
+     *     if it is already completed or cancelled, if the payload names a line that is not on it,
+     *     or if a line would be over-received without {@code allowOverReceipt}.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *     employee record in this organization, so there would be nobody to record as having
+     *     taken delivery.
+     */
+    public SiteTransferDto receiveSiteTransfer(Long id, SiteTransferReceiptDto receiptDto) {
+        return retryTemplate.execute(
+                "SiteTransferService.receiveSiteTransfer",
+                () -> receiveSiteTransferInTransaction(id, receiptDto));
+    }
+
+    private SiteTransferDto receiveSiteTransferInTransaction(Long id, SiteTransferReceiptDto receiptDto) {
+        SiteTransfer transfer = siteTransferRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Site transfer with ID " + id + " was not found in this organization"));
+
+        requireReceivable(transfer);
+        Employee receivedBy = currentEmployeeService.requireCurrentEmployee("record a site transfer as received");
+
+        List<SiteTransferItem> lines = siteTransferItemRepository
+                .lockBySiteTransferIdAndOrganizationId(transfer.getId(), TenantContext.getCurrentOrgId());
+        transfer.setItems(lines);
+
+        Map<Long, Integer> requested = new LinkedHashMap<>();
+        for (SiteTransferReceiptLineDto line : receiptDto.getItems()) {
+            // Merged rather than overwritten, so a payload naming the same line twice records
+            // both quantities instead of silently dropping the first.
+            requested.merge(line.getItemId(), line.getReceivedQuantity(), Integer::sum);
+        }
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome = receiptReconciler.applyReceipt(
+                transfer, lines, requested, Boolean.TRUE.equals(receiptDto.getAllowOverReceipt()),
+                userContextService.getCurrentUser(), receiptDto.getRemarks());
+
+        siteTransferItemRepository.saveAll(lines);
+        if (outcome.movedTo() != null) {
+            siteTransferRepository.save(transfer);
+        }
+
+        if (!outcome.received().isEmpty()) {
+            eventPublisher.publishEvent(new SiteTransferReceivedEvent(
+                    this, transfer, outcome.received(), receivedBy,
+                    receiptDto.getReceivedOn() != null ? receiptDto.getReceivedOn() : LocalDateTime.now(),
+                    receiptDto.getRemarks()));
+        }
+
+        return siteTransferMapper.toDto(transfer);
+    }
+
+    /**
+     * Abandons a transfer that never arrived, returning its stock to the sending site.
+     *
+     * <p>Without this the two-step document would be strictly worse than the one-step one it
+     * replaces: a transfer written off in transit would leave the sending project permanently
+     * short, with no way back except a stock adjustment reading as an unexplained count variance.
+     *
+     * <p>Only a {@link SiteTransferStatus#PENDING} transfer can be cancelled. Once something has
+     * been received, part of the material is standing at the far site and reversing the whole
+     * outbound leg would claim it came back. What to do about the rest is a decision rather than
+     * a reversal, and it belongs in a stock adjustment naming this transfer. A transfer inside
+     * one project is never {@code PENDING}, so it cannot be cancelled either: it was complete the
+     * moment it was written, and correcting it is an adjustment.
+     *
+     * @param id The transfer being cancelled.
+     * @param cancellationDto Why it is being cancelled.
+     * @return The transfer as it now stands.
+     * @throws ResourceNotFoundException if no site transfer with the given id exists in this organization.
+     * @throws InvalidRequestException if the transfer is in any state but {@code PENDING}.
+     * @throws org.springframework.security.access.AccessDeniedException if the caller has no
+     *     employee record in this organization.
+     */
+    public SiteTransferDto cancelSiteTransfer(Long id, SiteTransferCancellationDto cancellationDto) {
+        return retryTemplate.execute(
+                "SiteTransferService.cancelSiteTransfer",
+                () -> cancelSiteTransferInTransaction(id, cancellationDto));
+    }
+
+    private SiteTransferDto cancelSiteTransferInTransaction(Long id, SiteTransferCancellationDto cancellationDto) {
+        SiteTransfer transfer = siteTransferRepository.findByIdAndOrganization_Id(id, TenantContext.getCurrentOrgId())
+                .orElseThrow(() -> new ResourceNotFoundException("Site transfer with ID " + id + " was not found in this organization"));
+
+        if (transfer.getStatus() != SiteTransferStatus.PENDING) {
+            throw new InvalidRequestException(
+                    "Site transfer " + transfer.getTransferNumber() + " is " + transfer.getStatus()
+                            + " and cannot be cancelled. Cancelling returns the whole sent quantity "
+                            + "to the sending site, which would be untrue of a transfer that has "
+                            + "already had something received against it or that never left one "
+                            + "site. Correct it with a stock adjustment naming this transfer.");
+        }
+
+        Employee cancelledBy = currentEmployeeService.requireCurrentEmployee("cancel a site transfer");
+
+        List<SiteTransferItem> lines = siteTransferItemRepository
+                .lockBySiteTransferIdAndOrganizationId(transfer.getId(), TenantContext.getCurrentOrgId());
+        transfer.setItems(lines);
+
+        SiteTransferStatus previous = transfer.getStatus();
+        transfer.setStatus(SiteTransferStatus.CANCELLED);
         siteTransferRepository.save(transfer);
+        statusTransitionRecorder.recordChange(
+                HISTORY_ENTITY_TYPE, transfer.getId(), transfer.getOrganization(),
+                previous.name(), SiteTransferStatus.CANCELLED.name(),
+                userContextService.getCurrentUser(),
+                "Cancelled in transit and the sent quantity returned to the sending site. "
+                        + cancellationDto.getReason().trim());
+
+        eventPublisher.publishEvent(new SiteTransferCancelledEvent(
+                this, transfer, lines, cancelledBy, cancellationDto.getReason().trim()));
+
+        return siteTransferMapper.toDto(transfer);
+    }
+
+    /**
+     * Reads a site transfer's status trail.
+     *
+     * @param id The transfer whose trail to read.
+     * @param pageNo Zero-based page index.
+     * @param pageSize Entries per page.
+     * @return A page of trail entries, newest first.
+     * @throws ResourceNotFoundException if no site transfer with the given id exists in this organization.
+     */
+    @Transactional(readOnly = true)
+    public Page<StatusTransitionDto> getStatusHistory(Long id, int pageNo, int pageSize) {
+        Long orgId = TenantContext.getCurrentOrgId();
+        if (siteTransferRepository.findByIdAndOrganization_Id(id, orgId).isEmpty()) {
+            throw new ResourceNotFoundException(
+                    "Site transfer with ID " + id + " was not found in this organization");
+        }
+        return statusTransitionRepository
+                .findByEntityTypeAndEntityIdAndOrganization_IdOrderByOccurredAtDescIdDesc(
+                        HISTORY_ENTITY_TYPE, id, orgId, PageRequest.of(pageNo, pageSize))
+                .map(statusTransitionMapper::toDto);
+    }
+
+    /**
+     * Refuses a receipt against a transfer that has nothing in transit to be received.
+     *
+     * <p>A transfer inside one project is refused first and by name, because the answer a
+     * storekeeper needs there is not "it is already completed" but "there was never a lorry".
+     */
+    private void requireReceivable(SiteTransfer transfer) {
+        if (!SiteTransferReceiptReconciler.crossesProjectBoundary(transfer)) {
+            throw new InvalidRequestException(
+                    "Site transfer " + transfer.getTransferNumber() + " moves stock between two "
+                            + "storage locations on one project, so the material never left that "
+                            + "site's custody and both of its inventory legs were written when it "
+                            + "was created. There is no delivery to confirm. If the quantity that "
+                            + "reached the receiving store was not the quantity sent, correct it "
+                            + "with a stock adjustment.");
+        }
+        if (!RECEIVABLE.contains(transfer.getStatus())) {
+            throw new InvalidRequestException(
+                    "Site transfer " + transfer.getTransferNumber() + " is " + transfer.getStatus()
+                            + " and has nothing left in transit to receive. A further delivery "
+                            + "against it would be raising stock the transfer never sent; raise it "
+                            + "as its own transfer, or correct the balance with a stock adjustment.");
+        }
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCancellationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCancellationDto.java
@@ -1,0 +1,20 @@
+package org.tornotron.echno_backend.siteTransfer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Schema(description = "Why a transfer that never arrived is being abandoned. Cancelling returns "
+        + "the stock to the sending project and location it was drawn from, which is a real "
+        + "movement on the ledger, so the reason is required and is kept on the transfer's status "
+        + "trail beside the movement it caused.")
+@Data
+public class SiteTransferCancellationDto {
+
+    @Schema(description = "Why the transfer is being cancelled.",
+            example = "Lorry turned back at the gate, materials never left the yard")
+    @NotBlank(message = "cancellation reason is required")
+    @Size(max = 500, message = "cancellation reason cannot exceed 500 characters")
+    private String reason;
+}

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferCreationDto.java
@@ -50,16 +50,21 @@ public class SiteTransferCreationDto {
     private Long receivingStorageLocationId;
 
     /**
-     * The state the transfer starts in. Optional, and {@code PENDING} is the only value
-     * accepted: the other two say the far end has received the materials, and that is recorded
-     * through the transfer's own status endpoint. See {@code SiteTransferService.createSiteTransfer}.
+     * The state the transfer starts in. Optional, and {@code PENDING} is the only value a caller
+     * may ask for: the others all say something happened after the transfer was issued. The
+     * server writes {@code COMPLETED} itself for a transfer that stays inside one project, where
+     * both inventory legs are posted at creation. See {@code SiteTransferService.createSiteTransfer}.
      */
     @Schema(description = "State the transfer starts in. Optional, and PENDING is the only value "
-            + "accepted, so leaving it out is the same as sending PENDING. "
-            + "PARTIALLY_TRANSFERRED and COMPLETED say the receiving site has taken delivery, "
-            + "which is recorded through PATCH /{id}/status; that endpoint wants a different "
-            + "authority from create, and a transfer issued as COMPLETED would stand as received "
-            + "with nobody having confirmed receipt.",
+            + "accepted, so leaving it out is the same as sending PENDING. A transfer between two "
+            + "projects is issued PENDING with only its outbound leg posted, and the quantity is "
+            + "in transit until somebody at the receiving site records what arrived with POST "
+            + "/{id}/receive. A transfer between two storage locations on one project is written "
+            + "COMPLETED by the server, because the material never leaves that site's custody and "
+            + "both legs are posted at once; that is the server's own finding and cannot be asked "
+            + "for here. PARTIALLY_TRANSFERRED and COMPLETED say the receiving site has taken "
+            + "delivery and CANCELLED says the stock came back, and each of those now follows from "
+            + "a movement rather than from a payload.",
             example = "PENDING", allowableValues = {"PENDING"})
     private SiteTransferStatus status;
 

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferDto.java
@@ -48,7 +48,11 @@ public class SiteTransferDto {
     @Schema(description = "Name of the receiving storage location.", example = "Site B Yard")
     private String receivingStorageLocationName;
 
-    @Schema(description = "Current status of the transfer.", example = "IN_TRANSIT")
+    @Schema(description = "Current status of the transfer. PENDING means it has left the sending "
+            + "site and nothing has been recorded as arriving, so its quantity is in transit; "
+            + "PARTIALLY_TRANSFERRED and COMPLETED follow from what the receiving site confirmed; "
+            + "CANCELLED means it was abandoned in transit and its stock returned to the sender.",
+            example = "PENDING")
     private SiteTransferStatus status;
 
     @Schema(description = "Line items listing each material and quantity being transferred.")

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferItemDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferItemDto.java
@@ -24,6 +24,23 @@ public class SiteTransferItemDto {
     @Min(value = 1, message = "sent quantity must be at least 1")
     private Integer sentQuantity;
 
+    @Schema(description = "Quantity recorded as having arrived at the receiving site, in the "
+            + "material's unit. Null while the transfer is in transit and nobody has confirmed "
+            + "anything about this line yet, which is not the same as saying nothing arrived. A "
+            + "transfer between two stores on one project is received in full at creation, since "
+            + "the material never leaves that site's custody.",
+            example = "18", nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
+    private Integer receivedQuantity;
+
+    @Schema(description = "How much of this line is neither at the sending site nor recorded as "
+            + "having reached the receiving one: sent minus received, or the whole sent quantity "
+            + "while nothing has been received. On a transfer still in transit this is stock on a "
+            + "lorry. On one that has been received it is an open variance, closed by a stock "
+            + "adjustment naming this transfer rather than by the transfer writing a loss of its "
+            + "own. Zero once everything sent has arrived.",
+            example = "0", accessMode = Schema.AccessMode.READ_ONLY)
+    private Integer inTransitQuantity;
+
     @Schema(description = "Optional remarks for this line item.", example = "For column casting, Block C")
     private String remarks;
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferReceiptDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferReceiptDto.java
@@ -1,0 +1,45 @@
+package org.tornotron.echno_backend.siteTransfer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "What arrived at the receiving site against a transfer that is in transit. "
+        + "Only the quantities are in this payload: who confirmed the delivery is taken from the "
+        + "session, not from the request, so a receipt is the caller's own statement and cannot "
+        + "be filed under a colleague's name.")
+@Data
+public class SiteTransferReceiptDto {
+
+    @Schema(description = "Date and time the delivery was taken. Optional; the moment the receipt "
+            + "is filed is used when it is left out. It dates the inbound movements this receipt "
+            + "writes.", example = "2026-01-17T14:05:00")
+    private LocalDateTime receivedOn;
+
+    @Schema(description = "Set when the delivery really did carry more than the transfer sent. "
+            + "Without it an over-receipt is refused and the refusal names the line and the "
+            + "figures, which is enough to recognise a typed digit. With it the excess is "
+            + "recorded and the stock is posted, because material standing in the yard is there "
+            + "whether the system likes it or not and a receipt that cannot be filed leaves it "
+            + "outside the ledger. A short delivery needs no such flag: recording less than was "
+            + "sent puts nothing false into the ledger and leaves an open variance for a stock "
+            + "adjustment to close.", example = "false")
+    private Boolean allowOverReceipt;
+
+    @Schema(description = "Optional note about the delivery, carried onto the inbound movements "
+            + "and the transfer's status trail.", example = "Two bags split in transit, driver informed")
+    @Size(max = 500, message = "remarks cannot exceed 500 characters")
+    private String remarks;
+
+    @Schema(description = "One entry per transfer line being confirmed. Lines left out of the "
+            + "payload are untouched, so a delivery that answers only part of a transfer names "
+            + "only the lines it answers.")
+    @NotEmpty(message = "items list cannot be empty")
+    @Valid
+    private List<SiteTransferReceiptLineDto> items;
+}

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferReceiptLineDto.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/dto/SiteTransferReceiptLineDto.java
@@ -1,0 +1,25 @@
+package org.tornotron.echno_backend.siteTransfer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Schema(description = "How much of one transfer line arrived. The line is named by its own id "
+        + "rather than by its material, because a transfer may carry the same material on more "
+        + "than one line and a receipt has to say which of them it answers.")
+@Data
+public class SiteTransferReceiptLineDto {
+
+    @Schema(description = "Id of the site transfer line this quantity is against.", example = "84")
+    @NotNull(message = "transfer item id is required")
+    private Long itemId;
+
+    @Schema(description = "Quantity that arrived, in the material's unit. Zero is a legitimate "
+            + "answer and means this line's material did not arrive on this delivery; the "
+            + "quantity stays in transit and the transfer is not moved on by it.",
+            example = "18")
+    @NotNull(message = "received quantity is required")
+    @Min(value = 0, message = "received quantity cannot be negative")
+    private Integer receivedQuantity;
+}

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/enums/SiteTransferStatus.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/enums/SiteTransferStatus.java
@@ -1,7 +1,54 @@
 package org.tornotron.echno_backend.siteTransfer.enums;
 
+/**
+ * Where a site transfer stands between the material leaving one place and arriving at another.
+ *
+ * <p>Every one of these now follows from a movement rather than from a payload. A transfer that
+ * crosses a project boundary is issued {@link #PENDING} with only its outbound leg written, and
+ * reaches {@link #PARTIALLY_TRANSFERRED} or {@link #COMPLETED} when somebody at the receiving
+ * site records what arrived. A transfer between two stores on one project never leaves that
+ * site's custody, so it is written complete and is {@link #COMPLETED} from the moment it exists.
+ * {@link #CANCELLED} is a transfer abandoned in transit, and reaching it returns the stock to
+ * the sending site.
+ */
 public enum SiteTransferStatus {
+
+    /**
+     * Issued and not yet received. The material has left the sending site and nothing has been
+     * recorded as arriving.
+     *
+     * <p>The quantity is in transit: it is off the sending site's balance and not yet on the
+     * receiving site's, so an organization-wide total of on-hand stock is short by it. That is
+     * the truth about material sitting on a lorry, and a report summing stock across projects
+     * should show it as a labelled in-transit figure beside the total rather than pretending it
+     * is somewhere.
+     */
     PENDING,
+
+    /**
+     * Some of what was sent has been recorded as arriving and some has not.
+     *
+     * <p>The difference is an open variance: the sending project is down the full quantity
+     * against this transfer, the receiving project is up what arrived, and the rest is
+     * unaccounted for. The transfer does not write a loss movement of its own to close it. A
+     * loss written automatically is a stock correction nobody authorised, and a stock adjustment
+     * naming this transfer is where that decision belongs.
+     */
     PARTIALLY_TRANSFERRED,
-    COMPLETED
+
+    /** Everything that was sent has been recorded as arriving. */
+    COMPLETED,
+
+    /**
+     * Abandoned before it was received, with the outbound leg reversed.
+     *
+     * <p>Reachable only from {@link #PENDING}, and only through the cancel endpoint, which
+     * returns the stock to the sending project and location it was drawn from. Without the
+     * reversal a transfer abandoned in transit would leave the sending project permanently
+     * short with no way back, which would make the two-step document worse than the one-step
+     * one it replaces. A transfer that has already had something received against it cannot be
+     * cancelled: what arrived is at the far site, and deciding its fate is an adjustment rather
+     * than a reversal.
+     */
+    CANCELLED
 }

--- a/src/main/java/org/tornotron/echno_backend/siteTransfer/mapper/SiteTransferMapper.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransfer/mapper/SiteTransferMapper.java
@@ -34,7 +34,25 @@ public interface SiteTransferMapper {
 
     @Mapping(source = "material.id", target = "materialId")
     @Mapping(source = "material.materialName", target = "materialName")
+    @Mapping(target = "inTransitQuantity", ignore = true)
     SiteTransferItemDto toItemDto(SiteTransferItem item);
+
+    /**
+     * Fills in how much of a line is neither at the sending site nor recorded as having reached
+     * the receiving one.
+     *
+     * <p>Derived rather than stored, so it cannot drift from the two quantities it is the
+     * difference of. A line nobody has confirmed yet carries a null received quantity, and the
+     * whole sent quantity is in transit. It is floored at zero because an acknowledged
+     * over-receipt would otherwise report a negative amount on a lorry; that a receipt exceeded
+     * what was sent is visible from the two quantities themselves.
+     */
+    @AfterMapping
+    default void deriveInTransitQuantity(SiteTransferItem item, @MappingTarget SiteTransferItemDto dto) {
+        int sent = item.getSentQuantity() != null ? item.getSentQuantity() : 0;
+        int received = item.getReceivedQuantity() != null ? item.getReceivedQuantity() : 0;
+        dto.setInTransitQuantity(Math.max(0, sent - received));
+    }
 
     @AfterMapping
     default void nullifyEmptyItems(@MappingTarget SiteTransferDto dto) {

--- a/src/main/java/org/tornotron/echno_backend/siteTransferItem/SiteTransferItem.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransferItem/SiteTransferItem.java
@@ -28,6 +28,22 @@ public class SiteTransferItem implements TenantScopedEntity {
     @Column(name = "sent_quantity")
     private Integer sentQuantity;
 
+    /**
+     * How much of {@link #sentQuantity} has been recorded as arriving at the receiving site.
+     *
+     * <p>Null until somebody records a receipt, which is the state a transfer in transit is in:
+     * nothing has been said about this line yet, which is different from saying nothing arrived.
+     * A transfer between two stores on one project is written received in full at creation,
+     * because the material never leaves that site's custody and there is no arrival to confirm.
+     *
+     * <p>The gap between this and {@code sentQuantity} on a transfer that has been received is
+     * an open variance, not a loss: the transfer records the shortfall and leaves closing it to
+     * a stock adjustment, because writing a loss movement of its own would be a stock correction
+     * nobody authorised.
+     */
+    @Column(name = "received_quantity")
+    private Integer receivedQuantity;
+
     @Column(name = "remarks")
     private String remarks;
 

--- a/src/main/java/org/tornotron/echno_backend/siteTransferItem/SiteTransferItemRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/siteTransferItem/SiteTransferItemRepository.java
@@ -1,6 +1,10 @@
 package org.tornotron.echno_backend.siteTransferItem;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,4 +13,26 @@ public interface SiteTransferItemRepository extends JpaRepository<SiteTransferIt
     List<SiteTransferItem> findBySiteTransferId(Long siteTransferId);
 
     List<SiteTransferItem> findByMaterialId(Long materialId);
+
+    /**
+     * Loads a transfer's lines for a read-modify-write on {@code receivedQuantity} under a
+     * pessimistic write lock, ordered by id so two callers take the rows in the same sequence
+     * and cannot deadlock against each other.
+     *
+     * <p>Recording a receipt reads how much of a line has already arrived, decides whether the
+     * new quantity over-receives it, and writes the sum back. Two people confirming the same
+     * lorry at once would each read the figure as it stood before the other, so both would pass
+     * the over-receipt check and the second write would erase the first, leaving a transfer that
+     * reads as under-received while the ledger holds both inbound legs. On CockroachDB
+     * {@code SELECT … FOR UPDATE} queues the second caller rather than aborting it, so it reads
+     * the committed figure and is judged against the truth. The same lock is what stops a
+     * cancellation from reversing a transfer that is being received in the next connection.
+     *
+     * <p>Reads that only display a transfer keep {@link #findBySiteTransferId}.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sti FROM SiteTransferItem sti WHERE sti.siteTransfer.id = :siteTransferId "
+            + "AND sti.organization.id = :orgId ORDER BY sti.id")
+    List<SiteTransferItem> lockBySiteTransferIdAndOrganizationId(
+            @Param("siteTransferId") Long siteTransferId, @Param("orgId") Long orgId);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -391,4 +391,7 @@
     <!-- v4.0 - Payment vouchers: index the payee, verifier and raiser the listing can now filter on -->
     <include file="db/changelog/v4.0/085-index-construction-payment-people-columns.xml"/>
 
+    <!-- v4.0 - Site transfers: record what arrived, and make existing rows agree with the ledger -->
+    <include file="db/changelog/v4.0/086-site-transfer-two-step-receipt.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/086-site-transfer-two-step-receipt.xml
+++ b/src/main/resources/db/changelog/v4.0/086-site-transfer-two-step-receipt.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        A site transfer becomes a two-step document across a project boundary: the outbound leg is
+        written at creation and the inbound leg waits for somebody at the receiving site to record
+        what arrived.
+
+        Every transfer that already exists was written with both legs. The migration below makes
+        the documents agree with the ledger and not the other way round. Rewriting the ledger to
+        match the new model would break the property the whole materials module rests on, which is
+        that every balance is explainable from its movements: a TRANSFER_IN that was posted, that
+        a receiving site counted, and that later movements built on cannot be withdrawn because
+        the document that caused it has since changed shape. So the existing rows are made to
+        describe what actually happened, which is that the stock did arrive.
+
+        A note on timing. Liquibase runs at boot, before the instance serves traffic, so nothing
+        creates a transfer under the old rules between the backfill and the new code taking over
+        on that instance. A rolling deploy that leaves an older instance serving alongside is the
+        one window in which an old-style both-legs PENDING transfer could be written after the
+        backfill; it would then read as unreceived while its stock had moved, and be corrected by
+        a receipt naming what the ledger already holds. Staging and the compose environments
+        replace the single instance rather than rolling, so the window does not arise there.
+    -->
+
+    <changeSet id="086-01-add-site-transfer-item-received-quantity" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="site_transfer_item" columnName="received_quantity"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            How much of a transfer line has been recorded as arriving at the receiving site.
+
+            Nullable, and null is a meaningful state rather than a missing value: it says nobody
+            has confirmed anything about this line yet, which is different from confirming that
+            nothing came. A line that is confirmed as receiving nothing carries zero.
+
+            Until this column existed a short delivery could not be recorded even as a note, so
+            ten sent against eight arriving left two bags of stock at a site that did not have
+            them, and the only way to say so was a stock adjustment reading as an unexplained
+            count variance.
+        </comment>
+
+        <addColumn tableName="site_transfer_item">
+            <column name="received_quantity" type="BIGINT"/>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="site_transfer_item" columnName="received_quantity"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="086-02-backfill-site-transfer-received-quantity" author="echno">
+        <comment>
+            Every line of every transfer that already exists is received in full, whatever status
+            its transfer holds.
+
+            This is the truth about them rather than a convenience. Each of these transfers wrote
+            its inbound leg at creation for the whole sent quantity, so the stock reached the
+            receiving balance and every count taken there since has included it. Leaving a PENDING
+            transfer's lines unreceived would say the material is on a lorry when the receiving
+            site has been drawing it down for weeks, which is exactly the disagreement between
+            document and ledger this work exists to remove.
+
+            Scoped to rows whose received quantity is null, so re-running it cannot overwrite a
+            receipt recorded under the new rules.
+        </comment>
+
+        <sql>
+            UPDATE site_transfer_item
+            SET received_quantity = sent_quantity
+            WHERE received_quantity IS NULL;
+        </sql>
+
+        <rollback>
+            <sql>UPDATE site_transfer_item SET received_quantity = NULL;</sql>
+        </rollback>
+    </changeSet>
+
+    <!--
+        Where the trail begins for site transfers that already exist.
+
+        One BASELINE row each, naming the status the transfer is observed to hold at the moment
+        its trail is introduced, exactly as 073 did for projects and 084 for purchase orders. It
+        is not a transition and does not claim to be one.
+
+        It runs before the correction below, deliberately. A reader of a transfer that was PENDING
+        with its stock already moved then sees the trail it should: a BASELINE naming PENDING,
+        followed by a SYSTEM entry saying the status was corrected to match movements that had
+        already been posted. Seeding after the correction would leave a BASELINE of COMPLETED and
+        no record that anything was ever changed.
+    -->
+    <changeSet id="086-03-seed-site-transfer-status-baseline" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM status_transition WHERE entity_type = 'SITE_TRANSFER'
+            </sqlCheck>
+        </preConditions>
+
+        <sql>
+            INSERT INTO status_transition (
+                entity_type, entity_id, organization_id,
+                from_status, to_status, source, occurred_at, note
+            )
+            SELECT 'SITE_TRANSFER',
+                   st.id,
+                   st.organization_id,
+                   NULL,
+                   st.status,
+                   'BASELINE',
+                   CURRENT_TIMESTAMP,
+                   'The status this site transfer was observed to hold when its status trail began. What it was before that date, and who set it, was not recorded.'
+            FROM site_transfer st
+            WHERE st.status IS NOT NULL;
+        </sql>
+        <rollback>
+            <sql>DELETE FROM status_transition WHERE entity_type = 'SITE_TRANSFER' AND source = 'BASELINE';</sql>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="086-04-complete-transfers-whose-stock-already-moved" author="echno">
+        <comment>
+            Moves every existing PENDING and PARTIALLY_TRANSFERRED transfer to COMPLETED, and
+            records why.
+
+            Their stock has already moved: both legs were written when they were created. A
+            transfer left reading PENDING would say its material is in transit while the ledger
+            says it arrived, and the two-step document's whole point is that the status and the
+            movements agree. Under the new rules a transfer only holds one of those statuses while
+            something really is outstanding, so leaving these behind would also mean a receipt
+            could later be recorded against them and post the stock a second time.
+
+            The entry is SYSTEM rather than UPDATE because nobody decided it. It is not BASELINE
+            either: BASELINE is an observation of a status that was already held, and this is a
+            real change of status that the migration made, so it is recorded as one with a note
+            saying what it was and why it moved.
+
+            Nothing is written to the ledger here. The movements these transfers posted stand
+            exactly as they are.
+        </comment>
+
+        <sql>
+            INSERT INTO status_transition (
+                entity_type, entity_id, organization_id,
+                from_status, to_status, source, occurred_at, note
+            )
+            SELECT 'SITE_TRANSFER',
+                   st.id,
+                   st.organization_id,
+                   st.status,
+                   'COMPLETED',
+                   'SYSTEM',
+                   CURRENT_TIMESTAMP,
+                   'Status corrected to match movements that had already been posted. This transfer wrote both of its inventory legs when it was created, so its stock reached the receiving site whatever its status said; the status is moved to agree with the ledger rather than the ledger being changed to agree with the status.'
+            FROM site_transfer st
+            WHERE st.status IN ('PENDING', 'PARTIALLY_TRANSFERRED');
+        </sql>
+
+        <sql>
+            UPDATE site_transfer
+            SET status = 'COMPLETED'
+            WHERE status IN ('PENDING', 'PARTIALLY_TRANSFERRED');
+        </sql>
+
+        <!--
+            The entries written above are what makes this reversible: each one carries the status
+            its transfer held before the correction, so the rollback puts them back from the trail
+            rather than guessing, and only then removes the entries it read.
+        -->
+        <rollback>
+            <sql>
+                UPDATE site_transfer st
+                SET status = (
+                    SELECT stt.from_status FROM status_transition stt
+                    WHERE stt.entity_type = 'SITE_TRANSFER' AND stt.source = 'SYSTEM'
+                      AND stt.to_status = 'COMPLETED' AND stt.entity_id = st.id
+                    ORDER BY stt.id LIMIT 1)
+                WHERE EXISTS (
+                    SELECT 1 FROM status_transition stt
+                    WHERE stt.entity_type = 'SITE_TRANSFER' AND stt.source = 'SYSTEM'
+                      AND stt.to_status = 'COMPLETED' AND stt.entity_id = st.id);
+            </sql>
+            <sql>
+                DELETE FROM status_transition
+                WHERE entity_type = 'SITE_TRANSFER' AND source = 'SYSTEM' AND to_status = 'COMPLETED';
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerSiteTransferTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/events/listeners/InventoryEventListenerSiteTransferTest.java
@@ -7,7 +7,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.common.events.GrnCreatedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferCancelledEvent;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferReceivedEvent;
+import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.goodsReceivedNote.GoodsReceivedNote;
 import org.tornotron.echno_backend.grnItem.GrnItem;
 import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
@@ -28,6 +31,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -83,26 +88,31 @@ class InventoryEventListenerSiteTransferTest {
     }
 
     private SiteTransfer transfer(StorageLocation sending, StorageLocation receiving) {
+        return transfer(sending, receiving, receivingProject);
+    }
+
+    private SiteTransfer transfer(StorageLocation sending, StorageLocation receiving, Project into) {
         SiteTransfer transfer = new SiteTransfer();
         transfer.setId(51L);
         transfer.setTransferNumber("TRF-2026-000042");
         transfer.setIssueDate(LocalDateTime.now());
         transfer.setSendingProject(sendingProject);
-        transfer.setReceivingProject(receivingProject);
+        transfer.setReceivingProject(into);
         transfer.setSendingStorageLocation(sending);
         transfer.setReceivingStorageLocation(receiving);
         transfer.setOrganization(organization);
 
         SiteTransferItem item = new SiteTransferItem();
+        item.setId(84L);
         item.setMaterial(material);
         item.setSentQuantity(4);
         transfer.setItems(List.of(item));
         return transfer;
     }
 
-    private List<InventoryTransaction> savedTransactions() {
+    private List<InventoryTransaction> savedTransactions(int expected) {
         ArgumentCaptor<InventoryTransaction> captor = ArgumentCaptor.forClass(InventoryTransaction.class);
-        verify(inventoryTransactionRepository, times(2)).save(captor.capture());
+        verify(inventoryTransactionRepository, times(expected)).save(captor.capture());
         return captor.getAllValues();
     }
 
@@ -118,31 +128,152 @@ class InventoryEventListenerSiteTransferTest {
         lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
                 .thenReturn(BigDecimal.TEN);
         when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(10.0));
-        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(0.0));
 
         listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
 
-        InventoryTransaction out = of(savedTransactions(), InventoryTransactionType.TRANSFER_OUT);
+        InventoryTransaction out = of(savedTransactions(1), InventoryTransactionType.TRANSFER_OUT);
         assertThat(out.getOpeningStock()).isEqualTo(10.0);
         assertThat(out.getQuantityChanged()).isEqualTo(-4.0);
         assertThat(out.getClosingStock()).isEqualTo(6.0);
         verify(inventoryService, never()).getCurrentStock(any(), any());
     }
 
+    /**
+     * The claim that made a receiving-site count unexplainable: the balance said twenty bags, the
+     * yard held none, and the ledger offered a TRANSFER_IN whose closing figure nobody could
+     * reconcile. Creation now posts only what actually happened, which is that the stock left.
+     */
     @Test
-    void aTransferInWithNoReceivingLocationOpensFromTheReceivingProjectsUnlocatedBalance() {
+    void aTransferBetweenTwoProjectsPostsOnlyTheOutboundLegAtCreation() {
         lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
                 .thenReturn(BigDecimal.TEN);
         when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(10.0));
-        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(2.0));
 
         listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
 
-        InventoryTransaction in = of(savedTransactions(), InventoryTransactionType.TRANSFER_IN);
+        List<InventoryTransaction> saved = savedTransactions(1);
+        assertThat(saved).singleElement()
+                .extracting(InventoryTransaction::getTransactionType)
+                .isEqualTo(InventoryTransactionType.TRANSFER_OUT);
+        verify(inventoryService, never()).findUnlocatedStock(MATERIAL, RECEIVING_PROJECT);
+        verify(inventoryService, never()).updateCurrentStock(any(), eq(receivingProject), any(), any(), any(), any());
+    }
+
+    /**
+     * Within one project the storekeeper hands the material from one store to the other and is
+     * accountable for it throughout, so there is no window in which nobody is and nothing to
+     * confirm. Both legs are written at once.
+     */
+    @Test
+    void aTransferInsideOneProjectPostsBothLegsAtCreation() {
+        StorageLocation sending = location(SENDING_LOCATION);
+        StorageLocation receiving = location(RECEIVING_LOCATION);
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, SENDING_LOCATION))
+                .thenReturn(BigDecimal.TEN);
+        when(inventoryService.getStockAtLocation(MATERIAL, SENDING_PROJECT, SENDING_LOCATION)).thenReturn(10.0);
+        when(inventoryService.getStockAtLocation(MATERIAL, SENDING_PROJECT, RECEIVING_LOCATION)).thenReturn(2.0);
+
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(
+                this, transfer(sending, receiving, sendingProject)));
+
+        List<InventoryTransaction> saved = savedTransactions(2);
+        assertThat(of(saved, InventoryTransactionType.TRANSFER_OUT).getOpeningStock()).isEqualTo(10.0);
+        assertThat(of(saved, InventoryTransactionType.TRANSFER_IN).getOpeningStock()).isEqualTo(2.0);
+        assertThat(of(saved, InventoryTransactionType.TRANSFER_IN).getClosingStock()).isEqualTo(6.0);
+    }
+
+    @Test
+    void aTransferInWithNoReceivingLocationOpensFromTheReceivingProjectsUnlocatedBalance() {
+        SiteTransfer transfer = transfer(null, null);
+        SiteTransferItem item = transfer.getItems().get(0);
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(2.0));
+        when(inventoryTransactionRepository.findUnitCostsForReference(
+                eq("TRF-2026-000042"), eq(MATERIAL), eq(InventoryTransactionType.TRANSFER_OUT), eq(ORG), any()))
+                .thenReturn(List.of(BigDecimal.TEN));
+
+        listener.handleSiteTransferReceived(new SiteTransferReceivedEvent(
+                this, transfer, List.of(new SiteTransferReceivedEvent.ReceivedLine(item, 4)),
+                receiver(), LocalDateTime.now(), null));
+
+        InventoryTransaction in = of(savedTransactions(1), InventoryTransactionType.TRANSFER_IN);
         assertThat(in.getOpeningStock()).isEqualTo(2.0);
         assertThat(in.getQuantityChanged()).isEqualTo(4.0);
         assertThat(in.getClosingStock()).isEqualTo(6.0);
         verify(inventoryService, never()).getCurrentStock(any(), any());
+    }
+
+    /**
+     * A receipt posts only what arrived, so the two that never turned up are visible as the
+     * difference between the outbound leg and the inbound one rather than being invented into
+     * the receiving balance.
+     */
+    @Test
+    void aShortReceiptRaisesStockOnlyForWhatArrived() {
+        SiteTransfer transfer = transfer(null, null);
+        SiteTransferItem item = transfer.getItems().get(0);
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(0.0));
+        when(inventoryTransactionRepository.findUnitCostsForReference(
+                eq("TRF-2026-000042"), eq(MATERIAL), eq(InventoryTransactionType.TRANSFER_OUT), eq(ORG), any()))
+                .thenReturn(List.of(BigDecimal.TEN));
+
+        listener.handleSiteTransferReceived(new SiteTransferReceivedEvent(
+                this, transfer, List.of(new SiteTransferReceivedEvent.ReceivedLine(item, 2)),
+                receiver(), LocalDateTime.now(), null));
+
+        InventoryTransaction in = of(savedTransactions(1), InventoryTransactionType.TRANSFER_IN);
+        assertThat(in.getQuantityChanged()).isEqualTo(2.0);
+        verify(inventoryService).updateCurrentStock(any(), eq(receivingProject), any(), any(), eq(2.0), any());
+    }
+
+    /**
+     * By the time a lorry is unloaded the sending balance has moved on and may hold nothing at
+     * all. Pricing the arrival off it would value the material at zero and silently destroy the
+     * stock value that left the site, so the arrival takes the cost the outbound leg carried.
+     */
+    @Test
+    void aReceiptValuesTheArrivalAtWhatLeftTheSendingSiteNotAtWhatIsLeftThere() {
+        SiteTransfer transfer = transfer(null, null);
+        SiteTransferItem item = transfer.getItems().get(0);
+        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.of(0.0));
+        when(inventoryTransactionRepository.findUnitCostsForReference(
+                eq("TRF-2026-000042"), eq(MATERIAL), eq(InventoryTransactionType.TRANSFER_OUT), eq(ORG), any()))
+                .thenReturn(List.of(new BigDecimal("42.50")));
+        // The sending site has since run out, so its average cost is now zero.
+        lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null)).thenReturn(BigDecimal.ZERO);
+
+        listener.handleSiteTransferReceived(new SiteTransferReceivedEvent(
+                this, transfer, List.of(new SiteTransferReceivedEvent.ReceivedLine(item, 4)),
+                receiver(), LocalDateTime.now(), null));
+
+        InventoryTransaction in = of(savedTransactions(1), InventoryTransactionType.TRANSFER_IN);
+        assertThat(in.getUnitCost()).isEqualByComparingTo("42.50");
+        verify(inventoryService).updateCurrentStock(any(), eq(receivingProject), any(), any(), eq(4.0),
+                eq(new BigDecimal("42.50")));
+    }
+
+    /**
+     * Without this a transfer abandoned in transit would leave the sending project permanently
+     * short, which would make the two-step document worse than the one-step one it replaces.
+     */
+    @Test
+    void cancellingReturnsTheSentQuantityToTheSendingBalance() {
+        SiteTransfer transfer = transfer(null, null);
+        when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.of(6.0));
+        when(inventoryTransactionRepository.findUnitCostsForReference(
+                eq("TRF-2026-000042"), eq(MATERIAL), eq(InventoryTransactionType.TRANSFER_OUT), eq(ORG), any()))
+                .thenReturn(List.of(BigDecimal.TEN));
+
+        listener.handleSiteTransferCancelled(new SiteTransferCancelledEvent(
+                this, transfer, transfer.getItems(), receiver(), "Lorry turned back at the gate"));
+
+        InventoryTransaction reversal = of(savedTransactions(1), InventoryTransactionType.TRANSFER_IN);
+        assertThat(reversal.getProject()).isSameAs(sendingProject);
+        assertThat(reversal.getOpeningStock()).isEqualTo(6.0);
+        assertThat(reversal.getQuantityChanged()).isEqualTo(4.0);
+        assertThat(reversal.getClosingStock()).isEqualTo(10.0);
+        assertThat(reversal.getRemarks()).contains("cancelled in transit").contains("Lorry turned back");
+        verify(inventoryService).updateCurrentStock(any(), eq(sendingProject), any(), any(), eq(4.0), any());
+        verify(inventoryService, never()).updateCurrentStock(any(), eq(receivingProject), any(), any(), any(), any());
     }
 
     @Test
@@ -153,11 +284,10 @@ class InventoryEventListenerSiteTransferTest {
         lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, null))
                 .thenReturn(BigDecimal.ZERO);
         when(inventoryService.findUnlocatedStock(MATERIAL, SENDING_PROJECT)).thenReturn(Optional.empty());
-        when(inventoryService.findUnlocatedStock(MATERIAL, RECEIVING_PROJECT)).thenReturn(Optional.empty());
 
         listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(null, null)));
 
-        InventoryTransaction out = of(savedTransactions(), InventoryTransactionType.TRANSFER_OUT);
+        InventoryTransaction out = of(savedTransactions(1), InventoryTransactionType.TRANSFER_OUT);
         assertThat(out.getOpeningStock()).isZero();
         assertThat(out.getClosingStock()).isEqualTo(-4.0);
     }
@@ -166,17 +296,31 @@ class InventoryEventListenerSiteTransferTest {
     void aTransferBetweenTwoLocationsStillOpensFromEachLocationsOwnBalance() {
         StorageLocation sending = location(SENDING_LOCATION);
         StorageLocation receiving = location(RECEIVING_LOCATION);
+        SiteTransfer transfer = transfer(sending, receiving);
         lenient().when(inventoryService.getAverageCost(MATERIAL, SENDING_PROJECT, SENDING_LOCATION))
                 .thenReturn(BigDecimal.TEN);
         when(inventoryService.getStockAtLocation(MATERIAL, SENDING_PROJECT, SENDING_LOCATION)).thenReturn(10.0);
         when(inventoryService.getStockAtLocation(MATERIAL, RECEIVING_PROJECT, RECEIVING_LOCATION)).thenReturn(2.0);
+        when(inventoryTransactionRepository.findUnitCostsForReference(
+                eq("TRF-2026-000042"), eq(MATERIAL), eq(InventoryTransactionType.TRANSFER_OUT), eq(ORG), any()))
+                .thenReturn(List.of(BigDecimal.TEN));
 
-        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer(sending, receiving)));
+        listener.handleSiteTransferCreated(new SiteTransferCreatedEvent(this, transfer));
+        listener.handleSiteTransferReceived(new SiteTransferReceivedEvent(
+                this, transfer, List.of(new SiteTransferReceivedEvent.ReceivedLine(transfer.getItems().get(0), 4)),
+                receiver(), LocalDateTime.now(), null));
 
-        List<InventoryTransaction> saved = savedTransactions();
+        List<InventoryTransaction> saved = savedTransactions(2);
         assertThat(of(saved, InventoryTransactionType.TRANSFER_OUT).getOpeningStock()).isEqualTo(10.0);
         assertThat(of(saved, InventoryTransactionType.TRANSFER_IN).getOpeningStock()).isEqualTo(2.0);
-        verify(inventoryService, never()).findUnlocatedStock(any(), any());
+        verify(inventoryService, never()).findUnlocatedStock(any(), anyLong());
+    }
+
+    private Employee receiver() {
+        Employee employee = new Employee();
+        employee.setId(31L);
+        employee.setEmployeeName("Storekeeper");
+        return employee;
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferBackfillIT.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferBackfillIT.java
@@ -1,0 +1,225 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The backfill in changeset 086, run against a real CockroachDB over rows shaped the way the ones
+ * already in the database are shaped.
+ *
+ * <p>This is the part of the change whose correctness rests on facts about live data rather than
+ * on code, so it is worth a test that executes the migration's own SQL rather than a copy of it:
+ * the statements are read out of the changelog file itself, so editing the changeset and leaving
+ * this test passing is not possible.
+ *
+ * <p>What it pins is the direction of the correction. Every transfer that already exists wrote
+ * both of its inventory legs at creation, so its stock reached the receiving site whatever its
+ * status said. The documents are therefore made to agree with the ledger: the lines are received
+ * in full, and a transfer left reading PENDING or PARTIALLY_TRANSFERRED is moved to COMPLETED with
+ * an entry saying so. Doing it the other way round, rewriting the movements to match a document
+ * that has since changed shape, would break the property every balance in the system rests on,
+ * which is that it can be explained from the movements that produced it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SiteTransferBackfillIT extends AbstractIntegrationTest {
+
+    private static final String CHANGELOG = "db/changelog/v4.0/086-site-transfer-two-step-receipt.xml";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private long orgId;
+    private long projectA;
+    private long projectB;
+    private long materialId;
+
+    /**
+     * Reads the {@code <sql>} bodies out of one changeset, so the statements executed here are the
+     * migration's own and not a paraphrase of them.
+     */
+    private static List<String> statementsOf(String changeSetId) throws Exception {
+        try (InputStream in = SiteTransferBackfillIT.class.getClassLoader().getResourceAsStream(CHANGELOG)) {
+            assertThat(in).as("changelog %s is on the classpath", CHANGELOG).isNotNull();
+            var document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(in);
+            NodeList changeSets = document.getElementsByTagName("changeSet");
+            for (int i = 0; i < changeSets.getLength(); i++) {
+                Element changeSet = (Element) changeSets.item(i);
+                if (!changeSetId.equals(changeSet.getAttribute("id"))) {
+                    continue;
+                }
+                List<String> statements = new ArrayList<>();
+                NodeList children = changeSet.getChildNodes();
+                for (int j = 0; j < children.getLength(); j++) {
+                    Node child = children.item(j);
+                    if (child.getNodeType() == Node.ELEMENT_NODE && "sql".equals(child.getNodeName())) {
+                        statements.add(child.getTextContent().trim().replaceAll(";\\s*$", ""));
+                    }
+                }
+                return statements;
+            }
+        }
+        throw new AssertionError("No changeset " + changeSetId + " in " + CHANGELOG);
+    }
+
+    private long insert(String sql) {
+        return ((Number) entityManager.createNativeQuery(sql + " RETURNING id").getSingleResult()).longValue();
+    }
+
+    @BeforeEach
+    void seedTheShapeTheLiveRowsHave() {
+        orgId = insert("INSERT INTO organization (organization_name, organization_address, "
+                + "organization_email, organization_phone) VALUES ('Backfill Co', 'Chennai', "
+                + "'backfill@example.com', '0000000000')");
+        projectA = insert("INSERT INTO project (project_name, organization_id) VALUES ('Sending site', " + orgId + ")");
+        projectB = insert("INSERT INTO project (project_name, organization_id) VALUES ('Receiving site', " + orgId + ")");
+        materialId = insert("INSERT INTO material (material_name, unit, organization_id) "
+                + "VALUES ('TMT Bar 12mm', 'nos', " + orgId + ")");
+    }
+
+    private long transfer(String number, String status) {
+        return insert("INSERT INTO site_transfer (transfer_number, status, sending_project_id, "
+                + "receiving_project_id, organization_id) VALUES ('" + number + "', '" + status + "', "
+                + projectA + ", " + projectB + ", " + orgId + ")");
+    }
+
+    private long line(long transferId, int sent) {
+        return insert("INSERT INTO site_transfer_item (site_transfer_id, material_id, sent_quantity, "
+                + "organization_id) VALUES (" + transferId + ", " + materialId + ", " + sent + ", " + orgId + ")");
+    }
+
+    private void run(String changeSetId) throws Exception {
+        for (String statement : statementsOf(changeSetId)) {
+            entityManager.createNativeQuery(statement).executeUpdate();
+        }
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private Object scalar(String sql) {
+        return entityManager.createNativeQuery(sql).getSingleResult();
+    }
+
+    /**
+     * The inbound leg was written for the full quantity, so the full quantity is what arrived.
+     * Leaving these lines unreceived would say the material is on a lorry when the receiving site
+     * has been drawing it down for weeks.
+     */
+    @Test
+    void everyExistingLineIsBackfilledAsReceivedInFull() throws Exception {
+        long transferId = transfer("TRF-BACKFILL-001", "PENDING");
+        long lineId = line(transferId, 18);
+        entityManager.flush();
+
+        run("086-02-backfill-site-transfer-received-quantity");
+
+        assertThat(((Number) scalar("SELECT received_quantity FROM site_transfer_item WHERE id = " + lineId)).intValue())
+                .isEqualTo(18);
+    }
+
+    /** A receipt recorded under the new rules must not be overwritten by a re-run. */
+    @Test
+    void theBackfillLeavesALineThatHasAlreadyBeenReceivedAlone() throws Exception {
+        long transferId = transfer("TRF-BACKFILL-002", "PARTIALLY_TRANSFERRED");
+        long lineId = line(transferId, 10);
+        entityManager.createNativeQuery(
+                "UPDATE site_transfer_item SET received_quantity = 8 WHERE id = " + lineId).executeUpdate();
+        entityManager.flush();
+
+        run("086-02-backfill-site-transfer-received-quantity");
+
+        assertThat(((Number) scalar("SELECT received_quantity FROM site_transfer_item WHERE id = " + lineId)).intValue())
+                .isEqualTo(8);
+    }
+
+    /**
+     * A transfer left reading PENDING would say its material is in transit while the ledger says
+     * it arrived, and under the new rules a receipt could later be recorded against it and post
+     * the stock a second time.
+     */
+    @Test
+    void aTransferWhoseStockAlreadyMovedIsCorrectedToCompleted() throws Exception {
+        long pending = transfer("TRF-BACKFILL-003", "PENDING");
+        long partial = transfer("TRF-BACKFILL-004", "PARTIALLY_TRANSFERRED");
+        entityManager.flush();
+
+        run("086-04-complete-transfers-whose-stock-already-moved");
+
+        assertThat(scalar("SELECT status FROM site_transfer WHERE id = " + pending)).isEqualTo("COMPLETED");
+        assertThat(scalar("SELECT status FROM site_transfer WHERE id = " + partial)).isEqualTo("COMPLETED");
+        // Both halves of the changeset have to cover the same rows. If the entries were written
+        // for a narrower set than the update moves, a transfer would change status with nothing
+        // in its history saying it ever did, which is the silent change the trail exists to stop.
+        assertThat(scalar("SELECT from_status FROM status_transition WHERE entity_type = 'SITE_TRANSFER' "
+                + "AND entity_id = " + pending)).isEqualTo("PENDING");
+        assertThat(scalar("SELECT from_status FROM status_transition WHERE entity_type = 'SITE_TRANSFER' "
+                + "AND entity_id = " + partial)).isEqualTo("PARTIALLY_TRANSFERRED");
+    }
+
+    /**
+     * The correction is a real change of status that the migration made, so it is recorded as one.
+     * Making it silently would leave rows whose history says their status never moved.
+     */
+    @Test
+    void theCorrectionIsRecordedAsASystemTransitionSayingWhatItWasAndWhy() throws Exception {
+        long transferId = transfer("TRF-BACKFILL-005", "PENDING");
+        entityManager.flush();
+
+        run("086-04-complete-transfers-whose-stock-already-moved");
+
+        Object[] entry = (Object[]) scalar(
+                "SELECT from_status, to_status, source, note, changed_by FROM status_transition "
+                        + "WHERE entity_type = 'SITE_TRANSFER' AND entity_id = " + transferId);
+        assertThat(entry[0]).isEqualTo("PENDING");
+        assertThat(entry[1]).isEqualTo("COMPLETED");
+        assertThat(entry[2]).isEqualTo("SYSTEM");
+        assertThat((String) entry[3]).contains("already been posted");
+        // Nobody decided it, and inventing an actor would be worse than leaving the column empty.
+        assertThat(entry[4]).isNull();
+    }
+
+    /** A transfer that was already complete is not a transition and gets no entry. */
+    @Test
+    void aTransferThatWasAlreadyCompletedIsLeftUntouched() throws Exception {
+        long transferId = transfer("TRF-BACKFILL-006", "COMPLETED");
+        entityManager.flush();
+
+        run("086-04-complete-transfers-whose-stock-already-moved");
+
+        assertThat(((Number) scalar("SELECT count(*) FROM status_transition WHERE entity_type = 'SITE_TRANSFER' "
+                + "AND entity_id = " + transferId)).longValue()).isZero();
+    }
+
+    /**
+     * The baseline runs before the correction, so a reader sees the status the transfer was
+     * observed to hold and then the entry that moved it, rather than a baseline of the corrected
+     * value and no record that anything changed.
+     */
+    @Test
+    void theBaselineNamesTheStatusHeldBeforeTheCorrection() throws Exception {
+        long transferId = transfer("TRF-BACKFILL-007", "PENDING");
+        entityManager.flush();
+
+        run("086-03-seed-site-transfer-status-baseline");
+        run("086-04-complete-transfers-whose-stock-already-moved");
+
+        assertThat(scalar("SELECT to_status FROM status_transition WHERE entity_type = 'SITE_TRANSFER' "
+                + "AND source = 'BASELINE' AND entity_id = " + transferId)).isEqualTo("PENDING");
+        assertThat(scalar("SELECT status FROM site_transfer WHERE id = " + transferId)).isEqualTo("COMPLETED");
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferControllerWebAuthzTest.java
@@ -19,8 +19,11 @@ import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -77,6 +80,32 @@ class SiteTransferControllerWebAuthzTest {
         when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
 
         mockMvc.perform(get("/api/v1/site-transfers/web").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * The receive endpoint posts stock into a project, so a caller who cannot be trusted with the
+     * rest of this controller must not reach it either. It is gated on the same role rather than
+     * being left open because it is new.
+     */
+    @Test
+    void receive_isForbidden_forACallerWithNoElevatedRole() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/site-transfers/web/51/receive").with(jwt()).with(csrf())
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"items\":[{\"itemId\":84,\"receivedQuantity\":8}]}"))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Cancelling returns stock to the sending project, so it is gated the same way. */
+    @Test
+    void cancel_isForbidden_forACallerWithNoElevatedRole() throws Exception {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/site-transfers/web/51/cancel").with(jwt()).with(csrf())
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"reason\":\"Lorry turned back\"}"))
                 .andExpect(status().isForbidden());
     }
 

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferCreateStatusTest.java
@@ -12,7 +12,11 @@ import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.employee.Employee;
@@ -29,6 +33,7 @@ import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import java.time.LocalDateTime;
@@ -76,6 +81,11 @@ class SiteTransferCreateStatusTest {
     @Mock private StorageLocationRepository storageLocationRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private UserContextService userContextService;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
 
     private SiteTransferService service;
 
@@ -86,7 +96,9 @@ class SiteTransferCreateStatusTest {
         service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
                 materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
                 employeeRepository, projectRepository, storageLocationRepository,
-                documentNumberAllocator, retryTemplate);
+                documentNumberAllocator, retryTemplate, new SiteTransferReceiptReconciler(statusTransitionRecorder),
+                currentEmployeeService, userContextService, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper);
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
     }

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferInTransitMappingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferInTransitMappingTest.java
@@ -1,0 +1,63 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferItemDto;
+import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The reporting consequence of splitting a transfer into two steps, stated on the line itself.
+ *
+ * <p>An organization-wide total of on-hand stock is now short by everything in transit, because
+ * a quantity that has left one site and not been confirmed at another is on neither balance.
+ * That is the truth about material on a lorry, and it has to be visible somewhere rather than
+ * being discovered as a discrepancy: a report summing stock across projects reads this figure to
+ * show a labelled in-transit total beside the on-hand one. On a transfer that has been received
+ * the same figure is the open variance a stock adjustment closes.
+ */
+class SiteTransferInTransitMappingTest {
+
+    private final SiteTransferMapper mapper = Mappers.getMapper(SiteTransferMapper.class);
+
+    private SiteTransferItem line(int sent, Integer received) {
+        Material material = new Material();
+        material.setId(2L);
+        SiteTransferItem item = new SiteTransferItem();
+        item.setId(84L);
+        item.setMaterial(material);
+        item.setSentQuantity(sent);
+        item.setReceivedQuantity(received);
+        return item;
+    }
+
+    @Test
+    void aLineNobodyHasConfirmedReportsTheWholeSentQuantityAsInTransit() {
+        SiteTransferItemDto dto = mapper.toItemDto(line(10, null));
+
+        assertThat(dto.getReceivedQuantity()).isNull();
+        assertThat(dto.getInTransitQuantity()).isEqualTo(10);
+    }
+
+    @Test
+    void aShortDeliveryReportsTheGapThatIsStillUnaccountedFor() {
+        SiteTransferItemDto dto = mapper.toItemDto(line(10, 8));
+
+        assertThat(dto.getReceivedQuantity()).isEqualTo(8);
+        assertThat(dto.getInTransitQuantity()).isEqualTo(2);
+    }
+
+    @Test
+    void aLineReceivedInFullReportsNothingInTransit() {
+        assertThat(mapper.toItemDto(line(10, 10)).getInTransitQuantity()).isZero();
+    }
+
+    /** A negative amount on a lorry is not a thing, so an acknowledged excess floors at zero. */
+    @Test
+    void anAcknowledgedOverReceiptReportsNothingInTransitRatherThanANegativeAmount() {
+        assertThat(mapper.toItemDto(line(10, 12)).getInTransitQuantity()).isZero();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiptReconcilerTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiptReconcilerTest.java
@@ -1,0 +1,312 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+import org.tornotron.echno_backend.user.User;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The arithmetic a receipt performs on the transfer it answers, and the status that follows from
+ * it, with nothing loaded from a database.
+ *
+ * <p>The two directions of error are deliberately not symmetrical, and the tests below pin both.
+ * Receiving more than was sent is refused unless it is acknowledged, because the document would
+ * otherwise assert stock the transfer never sent. Receiving less is accepted without ceremony,
+ * because it asserts nothing false: refusing it would force the storekeeper either to claim the
+ * full quantity arrived or to leave the part that did outside the ledger.
+ */
+@ExtendWith(MockitoExtension.class)
+class SiteTransferReceiptReconcilerTest {
+
+    private static final Long ORG = 100L;
+    private static final Long SENDING_PROJECT = 7L;
+    private static final Long RECEIVING_PROJECT = 9L;
+
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+
+    private SiteTransferReceiptReconciler reconciler;
+    private Organization organization;
+    private User actor;
+
+    @BeforeEach
+    void setUp() {
+        reconciler = new SiteTransferReceiptReconciler(statusTransitionRecorder);
+        organization = new Organization();
+        organization.setId(ORG);
+        actor = new User();
+        actor.setId(5L);
+        actor.setName("Storekeeper");
+    }
+
+    private SiteTransfer transfer(SiteTransferStatus status, Long receivingProjectId) {
+        SiteTransfer transfer = new SiteTransfer();
+        transfer.setId(51L);
+        transfer.setTransferNumber("TRF-2026-000042");
+        transfer.setStatus(status);
+        Project sending = new Project();
+        sending.setId(SENDING_PROJECT);
+        Project receiving = new Project();
+        receiving.setId(receivingProjectId);
+        transfer.setSendingProject(sending);
+        transfer.setReceivingProject(receiving);
+        transfer.setOrganization(organization);
+        transfer.setItems(new ArrayList<>());
+        return transfer;
+    }
+
+    private SiteTransferItem line(SiteTransfer transfer, Long id, int sent, Integer received) {
+        Material material = new Material();
+        material.setId(2L);
+        material.setMaterialName("TMT Bar 12mm");
+        SiteTransferItem item = new SiteTransferItem();
+        item.setId(id);
+        item.setSiteTransfer(transfer);
+        item.setMaterial(material);
+        item.setSentQuantity(sent);
+        item.setReceivedQuantity(received);
+        transfer.getItems().add(item);
+        return item;
+    }
+
+    private Map<Long, Integer> receipt(Long itemId, int quantity) {
+        Map<Long, Integer> requested = new LinkedHashMap<>();
+        requested.put(itemId, quantity);
+        return requested;
+    }
+
+    /**
+     * Without this the line has no field to hold what came off the lorry, so ten sent against
+     * eight arriving is two bags of stock at a site that does not have them.
+     */
+    @Test
+    void writesWhatArrivedOntoTheLine() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+
+        reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 8), false, actor, null);
+
+        assertThat(line.getReceivedQuantity()).isEqualTo(8);
+    }
+
+    @Test
+    void addsToWhatHasAlreadyArrivedRatherThanReplacingIt() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PARTIALLY_TRANSFERRED, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, 6);
+
+        reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 3), false, actor, null);
+
+        assertThat(line.getReceivedQuantity()).isEqualTo(9);
+    }
+
+    @Test
+    void movesToCompletedWhenEveryLineIsMet() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 10), false, actor, null);
+
+        assertThat(outcome.movedTo()).isEqualTo(SiteTransferStatus.COMPLETED);
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.COMPLETED);
+    }
+
+    @Test
+    void movesToPartiallyTransferredWhileSomethingIsStillOutstanding() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 8), false, actor, null);
+
+        assertThat(outcome.movedTo()).isEqualTo(SiteTransferStatus.PARTIALLY_TRANSFERRED);
+    }
+
+    /**
+     * A receipt confirming that nothing came is a real answer and is recorded, but it moves
+     * nothing: the material is still on the road.
+     */
+    @Test
+    void staysPendingWhenNothingArrived() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 0), false, actor, null);
+
+        assertThat(outcome.movedTo()).isNull();
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+        assertThat(line.getReceivedQuantity()).isZero();
+        verify(statusTransitionRecorder, never())
+                .recordChange(anyString(), anyLong(), any(), any(), any(), any(), any());
+    }
+
+    /**
+     * The transition is somebody's act, not arithmetic nobody performed, so it is filed against
+     * the person who confirmed the delivery rather than as a SYSTEM entry with no actor.
+     */
+    @Test
+    void filesTheMoveAgainstThePersonWhoConfirmedTheDelivery() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+
+        reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 10), false, actor,
+                "Counted at the gate");
+
+        verify(statusTransitionRecorder).recordChange(
+                eq(SiteTransferService.HISTORY_ENTITY_TYPE), eq(51L), eq(organization),
+                eq("PENDING"), eq("COMPLETED"), eq(actor),
+                eq("Recorded from what the receiving site confirmed had arrived. Counted at the gate"));
+        verify(statusTransitionRecorder, never())
+                .recordSystemChange(anyString(), anyLong(), any(), any(), any(), any());
+    }
+
+    /** Twelve against ten sent is a typed digit until somebody says otherwise. */
+    @Test
+    void refusesAnOverReceiptThatWasNotAcknowledged() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> reconciler.applyReceipt(
+                        transfer, transfer.getItems(), receipt(84L, 12), false, actor, null))
+                .withMessageContaining("TRF-2026-000042")
+                .withMessageContaining("TMT Bar 12mm")
+                .withMessageContaining("sent 10")
+                .withMessageContaining("further 12")
+                .withMessageContaining("allowOverReceipt");
+
+        assertThat(line.getReceivedQuantity()).isNull();
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+    }
+
+    /**
+     * The check is cumulative. Two receipts of six against a transfer of ten would each pass a
+     * per-receipt check and leave the transfer holding twelve.
+     */
+    @Test
+    void countsWhatHasAlreadyArrivedWhenJudgingAnOverReceipt() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PARTIALLY_TRANSFERRED, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, 6);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> reconciler.applyReceipt(
+                        transfer, transfer.getItems(), receipt(84L, 6), false, actor, null))
+                .withMessageContaining("would take it to 12");
+    }
+
+    /**
+     * Refusing outright would leave material standing in the yard outside the ledger, which is
+     * the condition that makes a later count unexplainable.
+     */
+    @Test
+    void recordsAnOverReceiptThatWasAcknowledged() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 12), true, actor, null);
+
+        assertThat(outcome.overReceipt()).isTrue();
+        assertThat(line.getReceivedQuantity()).isEqualTo(12);
+        assertThat(outcome.movedTo()).isEqualTo(SiteTransferStatus.COMPLETED);
+    }
+
+    /**
+     * The asymmetry, stated as a test. A short delivery asserts nothing false, so it needs no
+     * flag and raises no refusal; the gap is left visible as an open variance for a stock
+     * adjustment to close, and the transfer writes no loss movement of its own.
+     */
+    @Test
+    void acceptsAShortDeliveryWithoutAnAcknowledgementAndLeavesTheGapOpen() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), receipt(84L, 8), false, actor, null);
+
+        assertThat(outcome.overReceipt()).isFalse();
+        assertThat(line.getSentQuantity() - line.getReceivedQuantity()).isEqualTo(2);
+        assertThat(outcome.received()).singleElement()
+                .extracting(l -> l.quantity()).isEqualTo(8);
+    }
+
+    /**
+     * Guessing which line was meant would post stock against the wrong material, so a line that
+     * is not on this transfer is refused rather than skipped.
+     */
+    @Test
+    void refusesAReceiptNamingALineThatIsNotOnThisTransfer() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> reconciler.applyReceipt(
+                        transfer, transfer.getItems(), receipt(999L, 4), false, actor, null))
+                .withMessageContaining("no line with id 999");
+    }
+
+    /** A line confirmed as receiving nothing raises no movement for the ledger to post. */
+    @Test
+    void reportsOnlyTheLinesThatActuallyGainedAQuantity() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+        line(transfer, 85L, 4, null);
+        Map<Long, Integer> requested = new LinkedHashMap<>();
+        requested.put(84L, 10);
+        requested.put(85L, 0);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome =
+                reconciler.applyReceipt(transfer, transfer.getItems(), requested, false, actor, null);
+
+        assertThat(outcome.received()).singleElement()
+                .extracting(l -> l.item().getId()).isEqualTo(84L);
+        assertThat(outcome.movedTo()).isEqualTo(SiteTransferStatus.PARTIALLY_TRANSFERRED);
+    }
+
+    /**
+     * The whole two-step decision in one line: between projects there is a lorry, within one
+     * project there is a storekeeper walking across the yard.
+     */
+    @Test
+    void crossesProjectBoundaryIsTrueOnlyWhenTheTwoProjectsDiffer() {
+        assertThat(SiteTransferReceiptReconciler.crossesProjectBoundary(
+                transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT))).isTrue();
+        assertThat(SiteTransferReceiptReconciler.crossesProjectBoundary(
+                transfer(SiteTransferStatus.COMPLETED, SENDING_PROJECT))).isFalse();
+    }
+
+    /** A transfer carrying no lines says nothing about arrival, so nothing moves. */
+    @Test
+    void aTransferWithNoLinesDoesNotMove() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+
+        SiteTransferReceiptReconciler.ReceiptOutcome outcome = reconciler.applyReceipt(
+                transfer, List.of(), Map.of(), false, actor, null);
+
+        assertThat(outcome.movedTo()).isNull();
+        assertThat(outcome.received()).isEmpty();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiveTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferReceiveTest.java
@@ -1,0 +1,386 @@
+package org.tornotron.echno_backend.siteTransfer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator;
+import org.tornotron.echno_backend.common.events.SiteTransferCancelledEvent;
+import org.tornotron.echno_backend.common.events.SiteTransferReceivedEvent;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferCancellationDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptDto;
+import org.tornotron.echno_backend.siteTransfer.dto.SiteTransferReceiptLineDto;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
+import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.User;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The second step of the two-step document: recording what the receiving site took delivery of,
+ * and abandoning a transfer that never arrived.
+ *
+ * <p>Repositories, the reconciler's collaborator and the event publisher are mocked; the real
+ * {@link SiteTransferReceiptReconciler} is used, because the point of most of these tests is the
+ * wiring between the two rather than the arithmetic, which has its own test.
+ */
+@ExtendWith(MockitoExtension.class)
+class SiteTransferReceiveTest {
+
+    private static final Long ORG = 100L;
+    private static final Long TRANSFER = 51L;
+    private static final Long SENDING_PROJECT = 7L;
+    private static final Long RECEIVING_PROJECT = 9L;
+
+    @Mock private SiteTransferRepository siteTransferRepository;
+    @Mock private SiteTransferItemRepository siteTransferItemRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private SiteTransferMapper siteTransferMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private DocumentNumberAllocator documentNumberAllocator;
+    @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private UserContextService userContextService;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
+
+    private SiteTransferService service;
+    private Organization organization;
+    private Employee storekeeper;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
+                materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
+                employeeRepository, projectRepository, storageLocationRepository,
+                documentNumberAllocator, retryTemplate,
+                new SiteTransferReceiptReconciler(statusTransitionRecorder),
+                currentEmployeeService, userContextService, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper);
+        // The template's own behaviour is covered by its own tests; here it just runs the work.
+        lenient().when(retryTemplate.execute(anyString(), any(Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(1, Supplier.class).get());
+        organization = new Organization();
+        organization.setId(ORG);
+        storekeeper = new Employee();
+        storekeeper.setId(31L);
+        storekeeper.setEmployeeName("Storekeeper");
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private SiteTransfer transfer(SiteTransferStatus status, Long receivingProjectId) {
+        SiteTransfer transfer = new SiteTransfer();
+        transfer.setId(TRANSFER);
+        transfer.setTransferNumber("TRF-2026-000042");
+        transfer.setStatus(status);
+        Project sending = new Project();
+        sending.setId(SENDING_PROJECT);
+        Project receiving = new Project();
+        receiving.setId(receivingProjectId);
+        transfer.setSendingProject(sending);
+        transfer.setReceivingProject(receiving);
+        transfer.setOrganization(organization);
+        transfer.setItems(new ArrayList<>());
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG)).thenReturn(Optional.of(transfer));
+        return transfer;
+    }
+
+    private SiteTransferItem line(SiteTransfer transfer, Long id, int sent, Integer received) {
+        Material material = new Material();
+        material.setId(2L);
+        material.setMaterialName("TMT Bar 12mm");
+        SiteTransferItem item = new SiteTransferItem();
+        item.setId(id);
+        item.setSiteTransfer(transfer);
+        item.setMaterial(material);
+        item.setSentQuantity(sent);
+        item.setReceivedQuantity(received);
+        transfer.getItems().add(item);
+        lenient().when(siteTransferItemRepository.lockBySiteTransferIdAndOrganizationId(TRANSFER, ORG))
+                .thenReturn(transfer.getItems());
+        return item;
+    }
+
+    private SiteTransferReceiptDto receipt(Long itemId, int quantity) {
+        SiteTransferReceiptLineDto line = new SiteTransferReceiptLineDto();
+        line.setItemId(itemId);
+        line.setReceivedQuantity(quantity);
+        SiteTransferReceiptDto dto = new SiteTransferReceiptDto();
+        dto.setItems(List.of(line));
+        return dto;
+    }
+
+    private void withSession() {
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(storekeeper);
+        User user = new User();
+        user.setId(5L);
+        lenient().when(userContextService.getCurrentUser()).thenReturn(user);
+    }
+
+    /**
+     * The whole point of the second step: the inbound leg is raised now, by an event carrying
+     * what arrived, rather than at creation when nobody had seen the lorry.
+     */
+    @Test
+    void recordingAReceiptPublishesTheInboundLegForWhatArrived() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+        withSession();
+
+        service.receiveSiteTransfer(TRANSFER, receipt(84L, 8));
+
+        ArgumentCaptor<SiteTransferReceivedEvent> captor =
+                ArgumentCaptor.forClass(SiteTransferReceivedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().getReceivedLines()).singleElement()
+                .satisfies(received -> {
+                    assertThat(received.item()).isSameAs(line);
+                    assertThat(received.quantity()).isEqualTo(8);
+                });
+        verify(siteTransferItemRepository).saveAll(transfer.getItems());
+    }
+
+    /**
+     * Five caller-supplied actors were closed across the codebase for the same reason: a field
+     * saying who did something is that person's statement, and an id off the payload is whatever
+     * the caller typed. The receipt payload carries no actor at all.
+     */
+    @Test
+    void takesThePersonConfirmingTheDeliveryFromTheSession() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+        withSession();
+
+        service.receiveSiteTransfer(TRANSFER, receipt(84L, 10));
+
+        ArgumentCaptor<SiteTransferReceivedEvent> captor =
+                ArgumentCaptor.forClass(SiteTransferReceivedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().getReceivedBy()).isSameAs(storekeeper);
+        verify(currentEmployeeService).requireCurrentEmployee("record a site transfer as received");
+    }
+
+    /** An account with no employee record has nobody to be recorded as having seen the lorry. */
+    @Test
+    void refusesACallerWithNoEmployeeRecordBeforeAnyStockMoves() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+        when(currentEmployeeService.requireCurrentEmployee(anyString()))
+                .thenThrow(new AccessDeniedException("no employee record"));
+
+        assertThatExceptionOfType(AccessDeniedException.class)
+                .isThrownBy(() -> service.receiveSiteTransfer(TRANSFER, receipt(84L, 10)));
+
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(siteTransferItemRepository, never()).saveAll(any());
+    }
+
+    /**
+     * Within one project both legs were posted at creation, so a receipt would raise the stock a
+     * second time. The refusal says there was never a lorry rather than that the transfer is
+     * already complete, which is the answer a storekeeper can act on.
+     */
+    @Test
+    void refusesToReceiveATransferThatNeverLeftOneProject() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.COMPLETED, SENDING_PROJECT);
+        line(transfer, 84L, 10, 10);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.receiveSiteTransfer(TRANSFER, receipt(84L, 10)))
+                .withMessageContaining("never left that site's custody")
+                .withMessageContaining("stock adjustment");
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void refusesASecondReceiptAgainstACompletedTransfer() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.COMPLETED, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, 10);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.receiveSiteTransfer(TRANSFER, receipt(84L, 1)))
+                .withMessageContaining("nothing left in transit");
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void refusesAReceiptAgainstACancelledTransfer() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.CANCELLED, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.receiveSiteTransfer(TRANSFER, receipt(84L, 10)));
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    /**
+     * Two people confirming the same lorry would otherwise each judge themselves against the
+     * figure that stood before the other, and the second write would erase the first.
+     */
+    @Test
+    void takesTheLinesUnderAWriteLock() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+        withSession();
+
+        service.receiveSiteTransfer(TRANSFER, receipt(84L, 10));
+
+        verify(siteTransferItemRepository).lockBySiteTransferIdAndOrganizationId(TRANSFER, ORG);
+        verify(siteTransferItemRepository, never()).findBySiteTransferId(anyLong());
+    }
+
+    /** A confirmation that nothing came is recorded on the line but posts no movement. */
+    @Test
+    void aReceiptOfNothingWritesNoInboundLeg() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+        withSession();
+
+        service.receiveSiteTransfer(TRANSFER, receipt(84L, 0));
+
+        assertThat(line.getReceivedQuantity()).isZero();
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void receivingAnUnknownTransferIsNotFound() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.receiveSiteTransfer(TRANSFER, receipt(84L, 1)));
+    }
+
+    /**
+     * Without the reversal a transfer abandoned in transit leaves the sending project
+     * permanently short with no way back, which makes the two-step document strictly worse than
+     * the one-step one it replaces.
+     */
+    @Test
+    void cancellingAPendingTransferReversesTheOutboundLeg() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        SiteTransferItem line = line(transfer, 84L, 10, null);
+        withSession();
+
+        SiteTransferCancellationDto dto = new SiteTransferCancellationDto();
+        dto.setReason("Lorry turned back at the gate");
+        service.cancelSiteTransfer(TRANSFER, dto);
+
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.CANCELLED);
+        ArgumentCaptor<SiteTransferCancelledEvent> captor =
+                ArgumentCaptor.forClass(SiteTransferCancelledEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().getItems()).containsExactly(line);
+        assertThat(captor.getValue().getCancelledBy()).isSameAs(storekeeper);
+        assertThat(captor.getValue().getReason()).isEqualTo("Lorry turned back at the gate");
+    }
+
+    @Test
+    void cancellingRecordsWhyOnTheStatusTrail() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PENDING, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, null);
+        withSession();
+
+        SiteTransferCancellationDto dto = new SiteTransferCancellationDto();
+        dto.setReason("Lorry turned back at the gate");
+        service.cancelSiteTransfer(TRANSFER, dto);
+
+        ArgumentCaptor<String> note = ArgumentCaptor.forClass(String.class);
+        verify(statusTransitionRecorder).recordChange(
+                eq(SiteTransferService.HISTORY_ENTITY_TYPE), eq(TRANSFER), eq(organization),
+                eq("PENDING"), eq("CANCELLED"), any(), note.capture());
+        assertThat(note.getValue()).contains("Lorry turned back at the gate");
+    }
+
+    /**
+     * Part of the material is standing at the far site, so reversing the whole outbound leg
+     * would claim it came back. What to do about the rest is a decision, not a reversal.
+     */
+    @Test
+    void refusesToCancelATransferThatHasAlreadyHadSomethingReceived() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.PARTIALLY_TRANSFERRED, RECEIVING_PROJECT);
+        line(transfer, 84L, 10, 8);
+
+        SiteTransferCancellationDto dto = new SiteTransferCancellationDto();
+        dto.setReason("Changed our minds");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.cancelSiteTransfer(TRANSFER, dto))
+                .withMessageContaining("cannot be cancelled")
+                .withMessageContaining("stock adjustment");
+
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.PARTIALLY_TRANSFERRED);
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    /** A transfer inside one project was complete when it was written; correcting it is an adjustment. */
+    @Test
+    void refusesToCancelATransferThatNeverLeftOneProject() {
+        SiteTransfer transfer = transfer(SiteTransferStatus.COMPLETED, SENDING_PROJECT);
+
+        SiteTransferCancellationDto dto = new SiteTransferCancellationDto();
+        dto.setReason("Changed our minds");
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.cancelSiteTransfer(TRANSFER, dto));
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferServiceTest.java
@@ -11,7 +11,11 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.tornotron.echno_backend.common.events.SiteTransferCreatedEvent;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -32,6 +36,7 @@ import org.tornotron.echno_backend.siteTransferItem.SiteTransferItem;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import java.time.LocalDateTime;
@@ -86,6 +91,11 @@ class SiteTransferServiceTest {
     @Mock private StorageLocationRepository storageLocationRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private UserContextService userContextService;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
 
     private SiteTransferService service;
 
@@ -96,7 +106,9 @@ class SiteTransferServiceTest {
         service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
                 materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
                 employeeRepository, projectRepository, storageLocationRepository,
-                documentNumberAllocator, retryTemplate);
+                documentNumberAllocator, retryTemplate, new SiteTransferReceiptReconciler(statusTransitionRecorder),
+                currentEmployeeService, userContextService, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper);
         // The template's own behaviour is covered by its own tests; here it just runs the work.
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
@@ -383,15 +395,74 @@ class SiteTransferServiceTest {
                 .isThrownBy(() -> service.updateSiteTransferStatus(5L, SiteTransferStatus.COMPLETED));
     }
 
+    /**
+     * Between projects there is a lorry and a road, so the transfer is issued in transit with
+     * nothing received: writing the inbound leg here asserted stock had reached a site where
+     * nobody had seen it.
+     */
     @Test
-    void updateStatus_setsAndSaves() {
+    void create_betweenTwoProjects_isPendingWithNothingReceived() {
+        stubMasterLookups();
+
+        service.createSiteTransfer(baseDto());
+
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<SiteTransferItem>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(siteTransferItemRepository).saveAll(itemsCaptor.capture());
+        assertThat(itemsCaptor.getValue().get(0).getReceivedQuantity()).isNull();
+    }
+
+    /**
+     * Within one project the material never leaves that site's custody, so both legs are posted
+     * at creation and there is nothing to confirm. Leaving it PENDING would have it waiting on a
+     * confirmation that has nothing to confirm.
+     */
+    @Test
+    void create_betweenTwoStoresOnOneProject_isCompletedAndReceivedInFull() {
+        stubMasterLookups();
+        location(SENDING_LOCATION, SENDING_PROJECT);
+        location(RECEIVING_LOCATION, SENDING_PROJECT);
+
+        SiteTransferCreationDto dto = baseDto();
+        dto.setReceivingProjectId(SENDING_PROJECT);
+        dto.setSendingStorageLocationId(SENDING_LOCATION);
+        dto.setReceivingStorageLocationId(RECEIVING_LOCATION);
+
+        service.createSiteTransfer(dto);
+
+        ArgumentCaptor<SiteTransfer> captor = ArgumentCaptor.forClass(SiteTransfer.class);
+        verify(siteTransferRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(SiteTransferStatus.COMPLETED);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<SiteTransferItem>> itemsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(siteTransferItemRepository).saveAll(itemsCaptor.capture());
+        assertThat(itemsCaptor.getValue().get(0).getReceivedQuantity()).isEqualTo(4);
+    }
+
+    /**
+     * The endpoint used to write whatever status it was handed and move no stock, which is how a
+     * transfer could read COMPLETED with nothing confirmed. Every state now follows from a
+     * movement, so a status cannot be claimed by a payload; the refusal names the endpoint that
+     * does what the caller wanted rather than leaving them at a 404.
+     */
+    @Test
+    void updateStatus_refusesToClaimAStatusThatSaysStockMoved() {
         SiteTransfer transfer = new SiteTransfer();
+        transfer.setTransferNumber("TRF-2026-000042");
         transfer.setStatus(SiteTransferStatus.PENDING);
         when(siteTransferRepository.findByIdAndOrganization_Id(5L, ORG)).thenReturn(Optional.of(transfer));
 
-        service.updateSiteTransferStatus(5L, SiteTransferStatus.COMPLETED);
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.updateSiteTransferStatus(5L, SiteTransferStatus.COMPLETED))
+                .withMessageContaining("/receive")
+                .withMessageContaining("/cancel");
 
-        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.COMPLETED);
-        verify(siteTransferRepository).save(transfer);
+        assertThat(transfer.getStatus()).isEqualTo(SiteTransferStatus.PENDING);
+        verify(siteTransferRepository, never()).save(any());
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
+++ b/src/test/java/org/tornotron/echno_backend/siteTransfer/SiteTransferStockScopeTest.java
@@ -11,7 +11,11 @@ import org.tornotron.echno_backend.common.documentnumber.DocumentNumberAllocator
 import org.tornotron.echno_backend.common.documentnumber.DocumentNumberType;
 import org.tornotron.echno_backend.common.exception.InsufficientStockException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.history.StatusTransitionRecorder;
+import org.tornotron.echno_backend.common.history.StatusTransitionRepository;
+import org.tornotron.echno_backend.common.history.mapper.StatusTransitionMapper;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
 import org.tornotron.echno_backend.common.retry.TransactionRetryTemplate;
 import org.tornotron.echno_backend.employee.Employee;
@@ -32,6 +36,7 @@ import org.tornotron.echno_backend.siteTransfer.mapper.SiteTransferMapper;
 import org.tornotron.echno_backend.siteTransferItem.SiteTransferItemRepository;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserRepository;
 
 import java.time.LocalDateTime;
@@ -86,6 +91,11 @@ class SiteTransferStockScopeTest {
     @Mock private StorageLocationRepository storageLocationRepository;
     @Mock private DocumentNumberAllocator documentNumberAllocator;
     @Mock private TransactionRetryTemplate retryTemplate;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private UserContextService userContextService;
+    @Mock private StatusTransitionRecorder statusTransitionRecorder;
+    @Mock private StatusTransitionRepository statusTransitionRepository;
+    @Mock private StatusTransitionMapper statusTransitionMapper;
 
     private SiteTransferService service;
 
@@ -98,7 +108,9 @@ class SiteTransferStockScopeTest {
         service = new SiteTransferService(siteTransferRepository, siteTransferItemRepository, userRepository,
                 materialRepository, inventoryService, eventPublisher, siteTransferMapper, tenantEntityHelper,
                 employeeRepository, projectRepository, storageLocationRepository,
-                documentNumberAllocator, retryTemplate);
+                documentNumberAllocator, retryTemplate, new SiteTransferReceiptReconciler(statusTransitionRecorder),
+                currentEmployeeService, userContextService, statusTransitionRecorder,
+                statusTransitionRepository, statusTransitionMapper);
         lenient().when(retryTemplate.execute(anyString(), any(Predicate.class), any(Supplier.class)))
                 .thenAnswer(invocation -> invocation.getArgument(2, Supplier.class).get());
 


### PR DESCRIPTION
Closes #660, and with it the site-transfer half of #648. The goods-receipt half landed in #659; this follows its precedent on every question the two share.

## What was wrong

`InventoryEventListener.handleSiteTransferCreated` wrote both legs in one loop: a `TRANSFER_OUT` at the sending project and a `TRANSFER_IN` at the receiving one, before anybody at the receiving site had seen the lorry. `SiteTransferItem` had no received quantity, so a short delivery could not be recorded even as a note. And `PATCH .../status` assigned whatever it was handed and moved no stock, so `COMPLETED` was a label somebody typed.

## The decision the design follows

Whether both legs at creation is wrong depends entirely on whether the transfer crosses a site boundary.

**Within one project it is right.** The material is handed from one store to another on a site whose storekeeper is accountable for it throughout. There is no window in which nobody is. Both legs are written, every line is received in full, and the transfer is `COMPLETED` from the moment it exists rather than sitting in `PENDING` waiting for a confirmation that has nothing to confirm.

**Between two projects it is wrong.** There is a lorry, a road and a gap of hours or days. Creation writes only the outbound leg, the transfer is `PENDING`, and the quantity is in transit until somebody at the far end records what arrived.

## What a between-sites transfer became

- **`SiteTransferItem.receivedQuantity`**, nullable. Null says nobody has confirmed anything about the line yet, which is different from confirming that nothing came.
- **`POST /{id}/receive`** and its `/web` twin, carrying per-line quantities. It posts the inbound legs for what actually arrived and derives the status: every line met is `COMPLETED`, some received is `PARTIALLY_TRANSFERRED`, nothing received stays `PENDING`. Unlike the purchase order's derived move this transition *is* somebody's act, so the actor comes from the session (`CurrentEmployeeService.requireCurrentEmployee`) and it is filed in the shared trail as an ordinary `UPDATE` against that person, not as `SYSTEM`. No actor field on the payload, so this is not a sixth caller-supplied actor after #589, #599, #607, #631 and #635.
- **`POST /{id}/cancel`** with a required reason, reversing the outbound leg back onto the sending balance. In scope, not a follow-up: without it a transfer abandoned in transit leaves the sending project permanently short with no way back, which would make the two-step document strictly worse than the one-step one it replaces. Only reachable from `PENDING`; once something has been received, part of the material is at the far site and its fate is a decision rather than a reversal.
- **`PATCH .../status` now refuses every status** and names the endpoint the caller wanted. The route is kept so an existing client gets an answer rather than a 404.
- **`GET /web/{id}/status-history`**, the same shape the project and purchase order trails use.

## The shortfall policy, and why it does not mirror the over-receipt one

Over-receipt follows #659 exactly: refused by default with the line and the figures named, recorded when the payload sets `allowOverReceipt`.

A shortfall is accepted with no acknowledgement, and that is the same rule applied to the other direction rather than an inconsistency. The over-receipt guard exists because the document would otherwise assert stock the transfer never sent. Eight arriving against ten sent asserts nothing false: the ledger holds an honest outbound leg for ten and an honest inbound leg for eight, and the two missing bags are the difference. Refusing the short receipt would force the storekeeper either to claim ten came or to leave the eight that did outside the ledger, which is the SA-563 failure the over-receipt escape hatch exists to prevent.

The gap is left as an **open variance**, reported per line as `inTransitQuantity`, and closed by a stock adjustment naming the transfer. The transfer writes no loss movement of its own: a loss written automatically is a stock correction nobody authorised, and #651 exists to put an approver in front of those.

## Reporting consequence, stated rather than discovered

An organization-wide total of on-hand stock is now short by everything in transit. That is the truth about material on a lorry. Each line reports its own in-transit figure so a report summing stock across projects can show a labelled in-transit total beside the on-hand one. The alternative, a transit storage location per transfer, is cleaner for reporting and more machinery; not built, per the issue's recommendation.

## Ledger safety

No new movement shapes. A cancellation's reversal is a `TRANSFER_IN` against the sending balance, which is where the stock really is arriving back, with the remark saying why.

One correctness fix the split forced: **the arrival is valued at the unit cost the outbound leg carried**, read back off the ledger, not at the sending balance's average cost as it stands at receive time. By the time a lorry is unloaded the sender may hold none of the material, and `getAverageCost` would return zero and silently destroy the stock value that left. Falls back to the current average only when no outbound movement is found.

The lines are taken with `SELECT ... FOR UPDATE` ordered by id, so two people confirming the same lorry queue rather than each judging themselves against the figure that stood before the other. Receive and cancel run under the house `TransactionRetryTemplate`, as create does; the inbound movements publish after commit, so an attempt that rolls back posts nothing.

## Live data, checked read-only before the migration was written

Staging holds **one transfer and one line**: `TRF-2026-000001`, `COMPLETED`, project 2 to project 6 (so cross-project), 18 of TNT Steel, with both legs posted (`TRANSFER_OUT` -18 opening 50 closing 32, `TRANSFER_IN` +18 opening 0 closing 18). No `PENDING` or `PARTIALLY_TRANSFERRED` rows, so 086-04 touches nothing there but is needed for other tenants. `site_transfer.status` is `VARCHAR` with no check constraint, so `CANCELLED` needs no schema change. `status_transition` holds 28 `PROJECT` and 1 `PURCHASE_ORDER` row and no `SITE_TRANSFER` rows, so 086-03's precondition passes. **No row resists the new model**: the one that exists is exactly what the backfill describes.

## The backfill makes the documents agree with the ledger, not the reverse

Every existing transfer wrote both legs, so its stock reached the receiving site whatever its status said. Rewriting the movements to match a document that has since changed shape would break the property `SA-563` depended on, which is that every balance is explainable from its movements.

- `086-01` adds the nullable column.
- `086-02` sets `received_quantity = sent_quantity` on every existing line, scoped to nulls so a re-run cannot overwrite a real receipt.
- `086-03` seeds one `BASELINE` per transfer, **before** the correction, so a reader sees the status the transfer was observed to hold and then the entry that moved it.
- `086-04` moves `PENDING` and `PARTIALLY_TRANSFERRED` to `COMPLETED` and writes a `SYSTEM` entry saying the status was corrected to match movements already posted. `SYSTEM` and not `BASELINE`, because this is a real change the migration made rather than an observation of a status already held, and nobody decided it.

The one window the changeset names in its own comment: a rolling deploy that leaves an older instance serving could write an old-style both-legs `PENDING` transfer after the backfill. Staging and the compose environments replace the single instance rather than rolling.

## Tests

46 new. Every one was checked by mutation: each mutant below was applied to `development` plus this change, the suite run, and the failures recorded. All 17 were caught.

| Mutation | Caught by |
|---|---|
| over-receipt refusal removed | `refusesAnOverReceiptThatWasNotAcknowledged`, `countsWhatHasAlreadyArrivedWhenJudgingAnOverReceipt` |
| inbound leg written at creation again | `aTransferBetweenTwoProjectsPostsOnlyTheOutboundLegAtCreation` + 3 |
| creation never completes a within-project transfer | `create_betweenTwoStoresOnOneProject_isCompletedAndReceivedInFull` |
| receivable guard removed | the three refusal tests |
| arrival priced off the sending balance now | `aReceiptValuesTheArrivalAtWhatLeftTheSendingSiteNotAtWhatIsLeftThere` + 4 |
| status patch sets and saves again | `updateStatus_refusesToClaimAStatusThatSaysStockMoved` |
| cancellation publishes no reversal | `cancellingAPendingTransferReversesTheOutboundLeg` |
| received quantity never written to the line | 10 tests |
| the move filed as SYSTEM with no actor | `filesTheMoveAgainstThePersonWhoConfirmedTheDelivery` |
| lines read without a write lock | `takesTheLinesUnderAWriteLock` + 3 |
| shortfall raises stock for the full sent quantity | `acceptsAShortDeliveryWithoutAnAcknowledgementAndLeavesTheGapOpen` + 1 |
| unmatched receipt line skipped instead of refused | `refusesAReceiptNamingALineThatIsNotOnThisTransfer` |
| actor taken leniently instead of fail-closed | `refusesACallerWithNoEmployeeRecordBeforeAnyStockMoves` + 4 |
| every transfer treated as crossing a boundary | `crossesProjectBoundaryIsTrueOnlyWhenTheTwoProjectsDiffer` + 3 |
| cancel guard removed | `refusesToCancelATransferThatHasAlreadyHadSomethingReceived` + 1 |
| cancellation records nothing on the trail | `cancellingRecordsWhyOnTheStatusTrail` |
| in-transit quantity always zero | `aLineNobodyHasConfirmedReportsTheWholeSentQuantityAsInTransit` + 1 |

`SiteTransferBackfillIT` runs the changeset's own `<sql>`, read out of the XML rather than copied, against a real CockroachDB over rows shaped like the live one. Its five mutants were checked the same way. One of them found a gap worth naming: making the changeset write its trail entries for a narrower set of rows than its `UPDATE` moves passed at first, because the transition assertion only covered a `PENDING` transfer. A `PARTIALLY_TRANSFERRED` row would then have changed status with nothing in its history saying it ever did, which is the silent change the trail exists to prevent. The test now asserts both rows carry an entry naming their own prior status.

## Contract

Additive apart from one break. New: `receivedQuantity` and `inTransitQuantity` (both read-only) on `SiteTransferItemDto`, `CANCELLED` on `SiteTransferStatus`, `SiteTransferReceiptDto`, `SiteTransferReceiptLineDto`, `SiteTransferCancellationDto`, and three endpoints on each controller. The break is `PATCH .../status`, which now always returns 400. Filed for the web app as tornotron/echno-web#387, the sibling of #380.

`docs/openapi.json` regenerated with `-PupdateOpenApiSnapshot`.
