### PR TITLE
Total the stock value across the organization, not across a page

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10448,6 +10448,44 @@
         },
         "type": "object"
       },
+      "MaterialStockSummaryDto": {
+        "description": "The figures a materials dashboard strip is built from, totalled in the database over the whole scope rather than over the rows a client happens to hold. Every figure is for the same scope: the organization, or one project when projectId is given.",
+        "properties": {
+          "distinctUnits": {
+            "description": "How many distinct units of measure those materials are held in.",
+            "example": 9,
+            "format": "int64",
+            "type": "integer"
+          },
+          "materialCount": {
+            "description": "How many materials the figures cover. At organization scope this is the catalogue size. At project scope it is how many materials the project carries a balance row for, which is the same set the value is summed over.",
+            "example": 743,
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "description": "The project these figures were totalled within, null when the whole organization was totalled.",
+            "example": 5,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "totalStockValue": {
+            "description": "The value of the stock on hand, summed over every balance row in scope at its running weighted-average cost. Zero when nothing is held.",
+            "example": 5.01483E7,
+            "type": "number"
+          },
+          "unvaluedHoldingCount": {
+            "description": "How many balance rows hold a quantity the total could not price, because the receipts behind them carried no unit cost and so added quantity at no value. Those rows are in the total at the zero they actually hold, so a non-zero count here means the total is an understatement and says by how many holdings. Zero means every holding in scope is priced and the total is complete.",
+            "example": 0,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "MaterialUpdateDto": {
         "description": "Payload to partially update a material. Fields left null are left unchanged.",
         "properties": {
@@ -73769,6 +73807,119 @@
           }
         },
         "summary": "Search materials by name",
+        "tags": [
+          "Materials (Web)"
+        ]
+      }
+    },
+    "/api/v1/materials/web/summary": {
+      "get": {
+        "description": "Returns the figures a materials dashboard strip is built from, totalled in the database: the value of the stock on hand, how many materials the figures cover, and how many distinct units of measure those materials are held in. None of them is derivable from a page of materials, which is why they are here: the listing serves at most 500 rows, so a client adding up what it holds describes 500 materials however large the catalogue is. With projectId the figures cover that project's balance rows instead of the whole catalogue, matching the scopes the low-stock read offers. unvaluedHoldingCount reports how many holdings the value could not price, because stock received with no unit cost carries none; those holdings are in the total at the zero they hold, so a non-zero count means the total understates and says by how many.",
+        "operationId": "getStockSummary",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaterialStockSummaryDto"
+                }
+              }
+            },
+            "description": "Summary returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the required role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "No project with the given id"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Total the catalogue and the value of the stock on hand",
         "tags": [
           "Materials (Web)"
         ]

--- a/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/inventoryTransaction/CurrentStockRepository.java
@@ -80,6 +80,82 @@ public interface CurrentStockRepository extends JpaRepository<CurrentStock, Long
     BigDecimal sumStockValueByMaterial(@Param("materialId") Long materialId);
 
     /**
+     * The value of every holding in the organization, in one aggregate.
+     *
+     * <p>The organization-wide counterpart of {@link #sumStockValueByMaterial}, which is the same
+     * aggregate with the material predicate dropped. It exists because a total over a catalogue is
+     * not derivable from a page of it: the console used to add up whatever rows one capped listing
+     * returned and label the answer "current inventory value", which was two thirds of the truth at
+     * 500 rows of a 743-row catalogue and read like a fact.
+     *
+     * <p>The organization is a predicate here rather than only the Hibernate {@code orgFilter},
+     * which is not the ordinary convention on this repository and is deliberate. The filter is off
+     * for a bypassed request, and on a sum that is invisible: a total spanning every tenant is
+     * still a number, and nobody reading it can tell. The filter still applies on top, which is
+     * what {@code MaterialStockSummaryIT} pins.
+     *
+     * @param organizationId The tenant to total within.
+     * @return The value on hand across every project and storage location, zero when nothing is held.
+     */
+    @Query("SELECT COALESCE(SUM(cs.stockValue), 0) FROM CurrentStock cs "
+            + "WHERE cs.organization.id = :organizationId")
+    BigDecimal sumStockValueForOrganization(@Param("organizationId") Long organizationId);
+
+    /** {@link #sumStockValueForOrganization} narrowed to one project's balance rows. */
+    @Query("SELECT COALESCE(SUM(cs.stockValue), 0) FROM CurrentStock cs "
+            + "WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId")
+    BigDecimal sumStockValueForProject(@Param("organizationId") Long organizationId,
+                                       @Param("projectId") Long projectId);
+
+    /**
+     * How many holdings the value total cannot price.
+     *
+     * <p>A receipt posted with no unit cost adds quantity and no value, so the balance row it
+     * lands on carries stock at a value of zero. That zero is written by the posting path, not
+     * chosen by the sum, so the sum has nothing to exclude and no reason to refuse: it counts the
+     * row at the value the row holds. What it must not do is stay quiet about it, because a total
+     * that silently understates is the failure this whole read exists to correct. This is the
+     * count that lets the caller say so.
+     *
+     * @param organizationId The tenant to count within.
+     * @return How many balance rows hold a positive quantity at no value.
+     */
+    @Query("SELECT COUNT(cs.id) FROM CurrentStock cs WHERE cs.organization.id = :organizationId "
+            + "AND cs.currentQuantity > 0 AND cs.stockValue <= 0")
+    long countUnvaluedHoldingsForOrganization(@Param("organizationId") Long organizationId);
+
+    /** {@link #countUnvaluedHoldingsForOrganization} narrowed to one project's balance rows. */
+    @Query("SELECT COUNT(cs.id) FROM CurrentStock cs WHERE cs.organization.id = :organizationId "
+            + "AND cs.project.id = :projectId AND cs.currentQuantity > 0 AND cs.stockValue <= 0")
+    long countUnvaluedHoldingsForProject(@Param("organizationId") Long organizationId,
+                                         @Param("projectId") Long projectId);
+
+    /**
+     * How many distinct materials a project carries a balance row for.
+     *
+     * <p>The project-scope candidate set, matching the one
+     * {@code LowStockRepository.findLowStockForProject} uses: at project scope the materials that
+     * count are the ones held there, not the whole catalogue, because every catalogue material
+     * would otherwise be reported against a project that has never carried it. A row sitting at
+     * zero still counts, because the project carries the material and the value total sums that
+     * same row.
+     *
+     * @param organizationId The tenant to count within.
+     * @param projectId The project to count at.
+     * @return How many materials have a balance row on the project.
+     */
+    @Query("SELECT COUNT(DISTINCT cs.material.id) FROM CurrentStock cs "
+            + "WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId")
+    long countDistinctMaterialsForProject(@Param("organizationId") Long organizationId,
+                                          @Param("projectId") Long projectId);
+
+    /** The distinct units of measure across the materials {@link #countDistinctMaterialsForProject} counts. */
+    @Query("SELECT COUNT(DISTINCT cs.material.unit) FROM CurrentStock cs "
+            + "WHERE cs.organization.id = :organizationId AND cs.project.id = :projectId")
+    long countDistinctUnitsForProject(@Param("organizationId") Long organizationId,
+                                      @Param("projectId") Long projectId);
+
+    /**
      * Totals quantity and value for many materials in one grouped read.
      *
      * <p>The batched form of {@link #sumCurrentQuantityByMaterial} and

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialControllerWeb.java
@@ -17,8 +17,10 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.material.dto.LowStockMaterialDto;
 import org.tornotron.echno_backend.material.dto.MaterialCreationDto;
 import org.tornotron.echno_backend.material.dto.MaterialDto;
+import org.tornotron.echno_backend.material.dto.MaterialStockSummaryDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
 import org.tornotron.echno_backend.material.lowstock.LowStockService;
+import org.tornotron.echno_backend.material.summary.MaterialStockSummaryService;
 import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdDto;
 import org.tornotron.echno_backend.material.threshold.dto.MaterialLocationThresholdUpsertDto;
@@ -44,13 +46,16 @@ public class MaterialControllerWeb {
     private final MaterialService materialService;
     private final MaterialLocationThresholdService thresholdService;
     private final LowStockService lowStockService;
+    private final MaterialStockSummaryService stockSummaryService;
 
     public MaterialControllerWeb(MaterialService materialService,
                                 MaterialLocationThresholdService thresholdService,
-                                LowStockService lowStockService) {
+                                LowStockService lowStockService,
+                                MaterialStockSummaryService stockSummaryService) {
         this.materialService = materialService;
         this.thresholdService = thresholdService;
         this.lowStockService = lowStockService;
+        this.stockSummaryService = stockSummaryService;
     }
 
     @PostMapping
@@ -148,6 +153,33 @@ public class MaterialControllerWeb {
             @Valid @ParameterObject PageQuery pageQuery) {
         return ResponseEntity.ok(lowStockService.findLowStock(projectId, storageLocationId,
                 PageRequest.of(pageQuery.getPageNo(), pageQuery.getPageSize())));
+    }
+
+    @GetMapping("/summary")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "Total the catalogue and the value of the stock on hand",
+            description = "Returns the figures a materials dashboard strip is built from, totalled "
+                    + "in the database: the value of the stock on hand, how many materials the "
+                    + "figures cover, and how many distinct units of measure those materials are "
+                    + "held in. None of them is derivable from a page of materials, which is why "
+                    + "they are here: the listing serves at most 500 rows, so a client adding up "
+                    + "what it holds describes 500 materials however large the catalogue is. With "
+                    + "projectId the figures cover that project's balance rows instead of the "
+                    + "whole catalogue, matching the scopes the low-stock read offers. "
+                    + "unvaluedHoldingCount reports how many holdings the value could not price, "
+                    + "because stock received with no unit cost carries none; those holdings are "
+                    + "in the total at the zero they hold, so a non-zero count means the total "
+                    + "understates and says by how many."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Summary returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No project with the given id")
+    })
+    public ResponseEntity<MaterialStockSummaryDto> getStockSummary(
+            @RequestParam(required = false) Long projectId) {
+        return ResponseEntity.ok(stockSummaryService.summarize(projectId));
     }
 
     @GetMapping("/search")

--- a/src/main/java/org/tornotron/echno_backend/material/MaterialRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/material/MaterialRepository.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.material;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +20,37 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
     boolean existsByIdAndOrganization_Id(Long id, Long organizationId);
 
     void deleteByIdAndOrganization_Id(Long id, Long organizationId);
+
+    /**
+     * The catalogue size, as a count rather than a page.
+     *
+     * <p>{@code /materials/web/all} already carries this on a page's {@code totalElements}, but
+     * getting it that way costs a request whose only purpose is to be thrown away, and it cannot
+     * travel on the same payload as the aggregates it is read beside. Counted here so the summary
+     * answers with one call.
+     *
+     * <p>Written as JPQL with an explicit predicate rather than a derived
+     * {@code countByOrganization_Id}, for the reason given on
+     * {@code CurrentStockRepository.sumStockValueForOrganization}: these figures are read together
+     * and must be scoped the same way as each other, including for a bypassed request.
+     *
+     * @param organizationId The tenant to count within.
+     * @return How many materials the catalogue holds.
+     */
+    @Query("SELECT COUNT(m.id) FROM Material m WHERE m.organization.id = :organizationId")
+    long countForOrganization(@Param("organizationId") Long organizationId);
+
+    /**
+     * How many distinct units of measure the catalogue uses.
+     *
+     * <p>The console counted these over the same capped array the stock value was summed over, so
+     * it under-reported for the same reason. Unlike the value it is a count and could have been
+     * fixed on the client, but only by loading the catalogue to count it, which is what the cap
+     * exists to stop.
+     *
+     * @param organizationId The tenant to count within.
+     * @return How many distinct units the catalogue's materials are measured in.
+     */
+    @Query("SELECT COUNT(DISTINCT m.unit) FROM Material m WHERE m.organization.id = :organizationId")
+    long countDistinctUnitsForOrganization(@Param("organizationId") Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/material/dto/MaterialStockSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/material/dto/MaterialStockSummaryDto.java
@@ -1,0 +1,44 @@
+package org.tornotron.echno_backend.material.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Schema(description = "The figures a materials dashboard strip is built from, totalled in the "
+        + "database over the whole scope rather than over the rows a client happens to hold. "
+        + "Every figure is for the same scope: the organization, or one project when projectId "
+        + "is given.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MaterialStockSummaryDto {
+
+    @Schema(description = "The project these figures were totalled within, null when the whole "
+            + "organization was totalled.", example = "5", nullable = true)
+    private Long projectId;
+
+    @Schema(description = "How many materials the figures cover. At organization scope this is "
+            + "the catalogue size. At project scope it is how many materials the project carries "
+            + "a balance row for, which is the same set the value is summed over.", example = "743")
+    private long materialCount;
+
+    @Schema(description = "How many distinct units of measure those materials are held in.",
+            example = "9")
+    private long distinctUnits;
+
+    @Schema(description = "The value of the stock on hand, summed over every balance row in "
+            + "scope at its running weighted-average cost. Zero when nothing is held.",
+            example = "50148300.00")
+    private BigDecimal totalStockValue;
+
+    @Schema(description = "How many balance rows hold a quantity the total could not price, "
+            + "because the receipts behind them carried no unit cost and so added quantity at no "
+            + "value. Those rows are in the total at the zero they actually hold, so a non-zero "
+            + "count here means the total is an understatement and says by how many holdings. "
+            + "Zero means every holding in scope is priced and the total is complete.",
+            example = "0")
+    private long unvaluedHoldingCount;
+}

--- a/src/main/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryService.java
+++ b/src/main/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryService.java
@@ -1,0 +1,103 @@
+package org.tornotron.echno_backend.material.summary;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.material.dto.MaterialStockSummaryDto;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+/**
+ * The materials dashboard strip, totalled where the data is.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * <p>Three tiles on the materials console are aggregates over the whole catalogue: the value of
+ * the stock on hand, how many materials there are, and how many units of measure they are held in.
+ * All three were computed in the browser over the array one capped listing returned, which is at
+ * most 500 rows. Past that the tiles described 500 materials and were captioned as describing the
+ * inventory. The money one was the dangerous one, because a caption does not travel with a figure
+ * once somebody repeats it: a catalogue of 743 materials rendered a confident five crore that was
+ * two thirds of the truth.
+ *
+ * <p>The count could have been fixed in the browser and was, from a page's {@code totalElements}.
+ * The sum could not: totalling 743 rows means holding 743 rows, and not holding them is what the
+ * cap is for. So the console stopped showing the figure. This is what lets it show one again.
+ *
+ * <h2>Scope</h2>
+ *
+ * <p>Two, matching the first two the low-stock read offers, because a project's material view
+ * showing an organization-wide total would be the same class of misleading figure this replaced.
+ * The scopes differ in what they count as a material, and deliberately:
+ *
+ * <ul>
+ *   <li><b>Organization.</b> The catalogue. Every material is counted whether or not it has ever
+ *       been stocked, because that is what the catalogue is.
+ *   <li><b>Project.</b> What the project carries a balance row for. Counting the catalogue here
+ *       would report every material against a project that has never held one, and the count would
+ *       no longer describe the same rows the value was summed over.
+ * </ul>
+ *
+ * <h2>Stock with no cost behind it</h2>
+ *
+ * <p>A receipt posted with no unit cost adds quantity at no value, so its balance row holds stock
+ * worth zero. The sum counts that row at the zero it holds, which is the only figure anybody has
+ * for it, and reports how many such rows it counted. Excluding them would understate silently;
+ * refusing the whole total over one of them would throw away a figure that is right about
+ * everything else. Naming them lets the console decide, which is the same judgement the tile
+ * already makes about the cap.
+ */
+@Service
+public class MaterialStockSummaryService {
+
+    private final MaterialRepository materialRepository;
+    private final CurrentStockRepository currentStockRepository;
+    private final ProjectRepository projectRepository;
+
+    public MaterialStockSummaryService(MaterialRepository materialRepository,
+                                       CurrentStockRepository currentStockRepository,
+                                       ProjectRepository projectRepository) {
+        this.materialRepository = materialRepository;
+        this.currentStockRepository = currentStockRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    /**
+     * The catalogue and stock-value figures for the current tenant, or for one of its projects.
+     *
+     * <p>A project that does not exist in this tenant is a 404 rather than a summary of zeroes,
+     * for the reason the low-stock read gives: zeroes are an answer, and they must not be the
+     * answer to a question that was never asked of any real project.
+     *
+     * @param projectId The project to total within, or null for the whole organization.
+     * @return The four figures, all at the same scope.
+     * @throws ResourceNotFoundException if the project is not in this tenant.
+     */
+    @Transactional(readOnly = true)
+    public MaterialStockSummaryDto summarize(Long projectId) {
+        Long orgId = TenantContext.getCurrentOrgId();
+
+        if (projectId == null) {
+            return new MaterialStockSummaryDto(
+                    null,
+                    materialRepository.countForOrganization(orgId),
+                    materialRepository.countDistinctUnitsForOrganization(orgId),
+                    currentStockRepository.sumStockValueForOrganization(orgId),
+                    currentStockRepository.countUnvaluedHoldingsForOrganization(orgId));
+        }
+
+        if (!projectRepository.existsByIdAndOrganization_Id(projectId, orgId)) {
+            throw new ResourceNotFoundException(
+                    "Project with ID " + projectId + " was not found in this organization");
+        }
+
+        return new MaterialStockSummaryDto(
+                projectId,
+                currentStockRepository.countDistinctMaterialsForProject(orgId, projectId),
+                currentStockRepository.countDistinctUnitsForProject(orgId, projectId),
+                currentStockRepository.sumStockValueForProject(orgId, projectId),
+                currentStockRepository.countUnvaluedHoldingsForProject(orgId, projectId));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
+++ b/src/test/java/org/tornotron/echno_backend/common/pagination/CappedWebListingTest.java
@@ -191,7 +191,7 @@ class CappedWebListingTest {
     void materialsReadTheFirstCappedPage() {
         when(materialService.getAllMaterials(anyInt(), anyInt())).thenReturn(Page.empty());
 
-        new MaterialControllerWeb(materialService, null, null).getAllMaterials();
+        new MaterialControllerWeb(materialService, null, null, null).getAllMaterials();
 
         verify(materialService).getAllMaterials(0, UnpagedResultCap.MAX_ROWS);
     }

--- a/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/MaterialControllerWebAuthzTest.java
@@ -18,8 +18,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
 import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.material.dto.MaterialStockSummaryDto;
 import org.tornotron.echno_backend.material.dto.MaterialWithStockDto;
 import org.tornotron.echno_backend.material.lowstock.LowStockService;
+import org.tornotron.echno_backend.material.summary.MaterialStockSummaryService;
 import org.tornotron.echno_backend.material.threshold.MaterialLocationThresholdService;
 
 import java.util.List;
@@ -75,6 +77,9 @@ class MaterialControllerWebAuthzTest {
     @MockitoBean
     private LowStockService lowStockService;
 
+    @MockitoBean
+    private MaterialStockSummaryService stockSummaryService;
+
     @MockitoBean(name = "orgSecurity")
     private OrganizationSecurityService orgSecurity;
 
@@ -104,6 +109,7 @@ class MaterialControllerWebAuthzTest {
                 .thenReturn(new MaterialWithStockDto());
         when(materialService.getMaterialWithAggregateStock(anyLong()))
                 .thenReturn(new MaterialWithStockDto());
+        when(stockSummaryService.summarize(any())).thenReturn(new MaterialStockSummaryDto());
     }
 
     /**
@@ -117,6 +123,8 @@ class MaterialControllerWebAuthzTest {
             "/api/v1/materials/web/1",
             "/api/v1/materials/web/search?name=Cement",
             "/api/v1/materials/web/low-stock",
+            "/api/v1/materials/web/summary",
+            "/api/v1/materials/web/summary?projectId=4",
             "/api/v1/materials/web/1/location-thresholds",
             "/api/v1/materials/web/1/stock",
             "/api/v1/materials/web/1/stock?projectId=4",
@@ -133,6 +141,7 @@ class MaterialControllerWebAuthzTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "/api/v1/materials/web",
+            "/api/v1/materials/web/summary",
             "/api/v1/materials/web/1/stock?projectId=4&storageLocationId=7"
     })
     void aMemberHoldingNeitherRoleIsStillRefusedTheRead(String path) throws Exception {

--- a/src/test/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryIT.java
@@ -1,0 +1,294 @@
+package org.tornotron.echno_backend.material.summary;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStock;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.material.Material;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.storageLocation.StorageLocation;
+import org.tornotron.echno_backend.storageLocation.enums.StorageLocationType;
+import org.tornotron.echno_backend.support.AbstractIntegrationTest;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The organization-wide aggregates against a real CockroachDB.
+ *
+ * <p>These are money figures totalled over rows nobody looked at, which makes them the shape of
+ * read where a mistake is least visible: a total that quietly leaves out a third of the catalogue,
+ * or quietly takes in another tenant's, is still a number, and the person quoting it cannot tell.
+ * So the cases here are the ones where a wrong answer would still look like an answer.
+ *
+ * <h2>Two organizations, on purpose</h2>
+ *
+ * <p>Every aggregate is checked with a second organization holding stock alongside, because that
+ * is the only way a cross-tenant sum shows up at all. Two of the tests go further and enable the
+ * Hibernate {@code orgFilter} for the wrong organization while asking for the right one: the
+ * queries carry their own organization predicate, so those two are what prove the filter clause
+ * genuinely reaches an aggregate query rather than only an entity one. Without it they would come
+ * back with the figure the predicate alone selects, which is the whole point of running them.
+ *
+ * <p>Runs on the plain {@code @DataJpaTest} configuration the other material repository tests use,
+ * so it shares their Spring context rather than adding one to a cache the suite is tight on.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MaterialStockSummaryIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MaterialRepository materialRepository;
+
+    @Autowired
+    private CurrentStockRepository currentStockRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("the value total leaves out another organization's stock")
+    void valueTotal_excludesAnotherOrganizationsStock() {
+        Organization ours = persistOrganization("value-ours");
+        Organization theirs = persistOrganization("value-theirs");
+        holding(ours, "Cement", "bags", 100.0, new BigDecimal("40000.00"));
+        holding(ours, "Steel", "kg", 2000.0, new BigDecimal("150000.00"));
+        holding(theirs, "Sand", "cft", 500.0, new BigDecimal("999999.00"));
+        em.flush();
+        em.clear();
+
+        BigDecimal total = currentStockRepository.sumStockValueForOrganization(ours.getId());
+
+        // A sum is the one read where a leaked row does not look like a leak. Drop the
+        // organization predicate and this returns 1,189,999 and reads as our inventory.
+        assertThat(total).isEqualByComparingTo("190000.00");
+    }
+
+    @Test
+    @DisplayName("the value total runs under the tenant filter, not only its own predicate")
+    void valueTotal_runsUnderTheTenantFilter() {
+        Organization ours = persistOrganization("filter-value-ours");
+        Organization theirs = persistOrganization("filter-value-theirs");
+        holding(ours, "Cement", "bags", 100.0, new BigDecimal("40000.00"));
+        em.flush();
+        em.clear();
+
+        // Ask for our organization while the session filter is set to somebody else's. The two
+        // scopings intersect to nothing, so a zero here is only possible if the filter clause was
+        // actually appended to the aggregate. If Hibernate applied filters to entity queries but
+        // not to this one, the query's own predicate would still hand back our 40,000.
+        enableOrgFilterFor(theirs);
+
+        assertThat(currentStockRepository.sumStockValueForOrganization(ours.getId()))
+                .isEqualByComparingTo("0");
+        assertThat(currentStockRepository.countUnvaluedHoldingsForOrganization(ours.getId()))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("the catalogue count and unit count leave out another organization's materials")
+    void catalogueCounts_excludeAnotherOrganization() {
+        Organization ours = persistOrganization("catalogue-ours");
+        Organization theirs = persistOrganization("catalogue-theirs");
+        persistMaterial(ours, "Cement", "bags");
+        persistMaterial(ours, "Fly ash", "bags");
+        persistMaterial(ours, "Steel", "kg");
+        persistMaterial(theirs, "Sand", "cft");
+        persistMaterial(theirs, "Paint", "litre");
+        em.flush();
+        em.clear();
+
+        assertThat(materialRepository.countForOrganization(ours.getId())).isEqualTo(3);
+        // Three materials, two units. A count that forgot the DISTINCT would say three, and the
+        // tile is captioned "Unique Units".
+        assertThat(materialRepository.countDistinctUnitsForOrganization(ours.getId())).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("the catalogue count runs under the tenant filter, not only its own predicate")
+    void catalogueCount_runsUnderTheTenantFilter() {
+        Organization ours = persistOrganization("filter-catalogue-ours");
+        Organization theirs = persistOrganization("filter-catalogue-theirs");
+        persistMaterial(ours, "Cement", "bags");
+        em.flush();
+        em.clear();
+
+        enableOrgFilterFor(theirs);
+
+        assertThat(materialRepository.countForOrganization(ours.getId())).isZero();
+        assertThat(materialRepository.countDistinctUnitsForOrganization(ours.getId())).isZero();
+    }
+
+    @Test
+    @DisplayName("stock received with no unit cost is totalled at the zero it holds and reported")
+    void unpricedStock_isCountedAtZeroAndReported() {
+        Organization org = persistOrganization("unpriced");
+        holding(org, "Cement", "bags", 100.0, new BigDecimal("40000.00"));
+        // Received with no unit cost, so the posting path added the quantity and no value. The
+        // zero was written there, not decided here.
+        holding(org, "Rubble", "cft", 250.0, BigDecimal.ZERO);
+        em.flush();
+        em.clear();
+
+        assertThat(currentStockRepository.sumStockValueForOrganization(org.getId()))
+                .isEqualByComparingTo("40000.00");
+        // The total understates by whatever the rubble is worth, and this is what says so. Without
+        // it the figure is complete-looking and short, which is the failure this endpoint replaces.
+        assertThat(currentStockRepository.countUnvaluedHoldingsForOrganization(org.getId()))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a holding that has run down to nothing is not reported as unpriced")
+    void emptyHolding_isNotReportedAsUnpriced() {
+        Organization org = persistOrganization("run-down");
+        // Quantity zero and value zero: the location has run out, which is a complete and correct
+        // answer. Counting it as unpriced would caption an accurate total as an understatement,
+        // and every seeded balance row starts in exactly this state.
+        holding(org, "Cement", "bags", 0.0, BigDecimal.ZERO);
+        em.flush();
+        em.clear();
+
+        assertThat(currentStockRepository.countUnvaluedHoldingsForOrganization(org.getId()))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("project scope covers what the project carries, not the whole catalogue")
+    void projectScope_coversWhatTheProjectCarries() {
+        Organization org = persistOrganization("project-scope");
+        Project site = persistProject(org, "Site A");
+        Project other = persistProject(org, "Site B");
+        StorageLocation store = persistLocation(org, "Store");
+
+        Material cement = persistMaterial(org, "Cement", "bags");
+        Material flyAsh = persistMaterial(org, "Fly ash", "bags");
+        Material steel = persistMaterial(org, "Steel", "kg");
+        persistMaterial(org, "Never stocked", "nos");
+
+        persistStock(org, cement, site, store, 100.0, new BigDecimal("40000.00"));
+        persistStock(org, flyAsh, site, store, 60.0, new BigDecimal("12000.00"));
+        persistStock(org, steel, other, store, 2000.0, new BigDecimal("150000.00"));
+        em.flush();
+        em.clear();
+
+        assertThat(currentStockRepository.sumStockValueForProject(org.getId(), site.getId()))
+                .isEqualByComparingTo("52000.00");
+        // Two materials at this site, both in bags. The organization holds four materials in
+        // three units, which is the figure a project view must not be shown.
+        assertThat(currentStockRepository.countDistinctMaterialsForProject(org.getId(), site.getId()))
+                .isEqualTo(2);
+        assertThat(currentStockRepository.countDistinctUnitsForProject(org.getId(), site.getId()))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("project scope leaves out another organization even when handed its project id")
+    void projectScope_excludesAnotherOrganization() {
+        Organization ours = persistOrganization("project-ours");
+        Organization theirs = persistOrganization("project-theirs");
+        Project theirSite = persistProject(theirs, "Their site");
+        StorageLocation theirStore = persistLocation(theirs, "Their store");
+        Material sand = persistMaterial(theirs, "Sand", "cft");
+        persistStock(theirs, sand, theirSite, theirStore, 500.0, new BigDecimal("999999.00"));
+        em.flush();
+        em.clear();
+
+        // Project ids are unique across the installation, so nothing but the organization
+        // predicate stands between a guessed id and another tenant's site total.
+        assertThat(currentStockRepository.sumStockValueForProject(ours.getId(), theirSite.getId()))
+                .isEqualByComparingTo("0");
+        assertThat(currentStockRepository.countDistinctMaterialsForProject(ours.getId(), theirSite.getId()))
+                .isZero();
+        assertThat(currentStockRepository.countDistinctUnitsForProject(ours.getId(), theirSite.getId()))
+                .isZero();
+        assertThat(currentStockRepository.countUnvaluedHoldingsForProject(ours.getId(), theirSite.getId()))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("an organization holding nothing totals to zero rather than to null")
+    void emptyOrganization_totalsToZero() {
+        Organization org = persistOrganization("empty");
+        em.flush();
+        em.clear();
+
+        // SUM over no rows is null in SQL, and a null money figure reaching the console is a
+        // blank tile for a reason nobody can diagnose.
+        assertThat(currentStockRepository.sumStockValueForOrganization(org.getId()))
+                .isEqualByComparingTo("0");
+        assertThat(materialRepository.countForOrganization(org.getId())).isZero();
+        assertThat(materialRepository.countDistinctUnitsForOrganization(org.getId())).isZero();
+    }
+
+    private void enableOrgFilterFor(Organization org) {
+        em.getEntityManager().unwrap(Session.class)
+                .enableFilter("orgFilter")
+                .setParameter("organizationId", org.getId());
+    }
+
+    /** A material with one balance row against a project and location of its own. */
+    private void holding(Organization org, String name, String unit, Double quantity, BigDecimal value) {
+        Material material = persistMaterial(org, name, unit);
+        Project project = persistProject(org, name + " site");
+        StorageLocation location = persistLocation(org, name + " store");
+        persistStock(org, material, project, location, quantity, value);
+    }
+
+    private Organization persistOrganization(String name) {
+        Organization org = new Organization();
+        org.setOrganizationName("Stock summary " + name);
+        org.setOrganizationAddress(name + " address");
+        org.setOrganizationEmail(name + "@example.test");
+        org.setOrganizationPhone("0000000000");
+        em.persist(org);
+        return org;
+    }
+
+    private Project persistProject(Organization org, String name) {
+        Project project = new Project();
+        project.setProjectName(name);
+        project.setProjectAddress(name + " road");
+        project.setOrganization(org);
+        em.persist(project);
+        return project;
+    }
+
+    private StorageLocation persistLocation(Organization org, String name) {
+        StorageLocation location = new StorageLocation();
+        location.setLocationName(name);
+        location.setLocationType(StorageLocationType.WAREHOUSE);
+        location.setOrganization(org);
+        em.persist(location);
+        return location;
+    }
+
+    private Material persistMaterial(Organization org, String name, String unit) {
+        Material material = new Material();
+        material.setMaterialName(name);
+        material.setUnit(unit);
+        material.setOrganization(org);
+        em.persist(material);
+        return material;
+    }
+
+    private void persistStock(Organization org, Material material, Project project,
+                              StorageLocation location, Double quantity, BigDecimal value) {
+        CurrentStock stock = new CurrentStock();
+        stock.setOrganization(org);
+        stock.setMaterial(material);
+        stock.setProject(project);
+        stock.setStorageLocation(location);
+        stock.setCurrentQuantity(quantity);
+        stock.setStockValue(value);
+        em.persist(stock);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/material/summary/MaterialStockSummaryServiceTest.java
@@ -1,0 +1,119 @@
+package org.tornotron.echno_backend.material.summary;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.inventoryTransaction.CurrentStockRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.material.dto.MaterialStockSummaryDto;
+import org.tornotron.echno_backend.project.ProjectRepository;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Which set of figures each scope answers with, and what an unknown project gets.
+ *
+ * <p>The arithmetic is checked against a real database in {@link MaterialStockSummaryIT}. What is
+ * checked here is the choice between the two scopes, because the two count different things on
+ * purpose and picking the wrong one is a mistake that produces a plausible number rather than an
+ * error: an organization count on a project view says the site carries the whole catalogue.
+ */
+@ExtendWith(MockitoExtension.class)
+class MaterialStockSummaryServiceTest {
+
+    private static final long ORG_ID = 7L;
+    private static final long PROJECT_ID = 42L;
+
+    @Mock
+    private MaterialRepository materialRepository;
+
+    @Mock
+    private CurrentStockRepository currentStockRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private MaterialStockSummaryService service;
+
+    @BeforeEach
+    void scopeToATenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearContext() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("organization scope counts the catalogue and never asks about a project")
+    void organizationScope_countsTheCatalogue() {
+        when(materialRepository.countForOrganization(ORG_ID)).thenReturn(743L);
+        when(materialRepository.countDistinctUnitsForOrganization(ORG_ID)).thenReturn(9L);
+        when(currentStockRepository.sumStockValueForOrganization(ORG_ID))
+                .thenReturn(new BigDecimal("50148300.00"));
+        when(currentStockRepository.countUnvaluedHoldingsForOrganization(ORG_ID)).thenReturn(0L);
+
+        MaterialStockSummaryDto summary = service.summarize(null);
+
+        assertThat(summary.getProjectId()).isNull();
+        assertThat(summary.getMaterialCount()).isEqualTo(743);
+        assertThat(summary.getDistinctUnits()).isEqualTo(9);
+        assertThat(summary.getTotalStockValue()).isEqualByComparingTo("50148300.00");
+        assertThat(summary.getUnvaluedHoldingCount()).isZero();
+        verifyNoInteractions(projectRepository);
+    }
+
+    @Test
+    @DisplayName("project scope counts what the project carries, not the catalogue")
+    void projectScope_countsWhatTheProjectCarries() {
+        when(projectRepository.existsByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(true);
+        when(currentStockRepository.countDistinctMaterialsForProject(ORG_ID, PROJECT_ID)).thenReturn(12L);
+        when(currentStockRepository.countDistinctUnitsForProject(ORG_ID, PROJECT_ID)).thenReturn(4L);
+        when(currentStockRepository.sumStockValueForProject(ORG_ID, PROJECT_ID))
+                .thenReturn(new BigDecimal("620000.00"));
+        when(currentStockRepository.countUnvaluedHoldingsForProject(ORG_ID, PROJECT_ID)).thenReturn(2L);
+
+        MaterialStockSummaryDto summary = service.summarize(PROJECT_ID);
+
+        assertThat(summary.getProjectId()).isEqualTo(PROJECT_ID);
+        assertThat(summary.getMaterialCount()).isEqualTo(12);
+        assertThat(summary.getDistinctUnits()).isEqualTo(4);
+        assertThat(summary.getTotalStockValue()).isEqualByComparingTo("620000.00");
+        assertThat(summary.getUnvaluedHoldingCount()).isEqualTo(2);
+        // The catalogue counts describe the organization. On a project view they would say the
+        // site carries every material the company has ever listed.
+        verify(materialRepository, never()).countForOrganization(ORG_ID);
+        verify(materialRepository, never()).countDistinctUnitsForOrganization(ORG_ID);
+    }
+
+    @Test
+    @DisplayName("a project that is not this tenant's is refused rather than summarised as zero")
+    void unknownProject_isRefused() {
+        when(projectRepository.existsByIdAndOrganization_Id(PROJECT_ID, ORG_ID)).thenReturn(false);
+
+        // Zeroes are an answer, and "this site holds nothing worth anything" must never be the
+        // answer to a question asked of a project that is not there. The same reason the
+        // low-stock read gives for its 404.
+        assertThatThrownBy(() -> service.summarize(PROJECT_ID))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining(String.valueOf(PROJECT_ID));
+
+        verifyNoInteractions(currentStockRepository);
+    }
+}


### PR DESCRIPTION
Closes #673.

`GET /api/v1/materials/web/summary` returns the four figures a materials dashboard strip is built from, totalled in the database:

```json
{ "projectId": null, "materialCount": 743, "distinctUnits": 9,
  "totalStockValue": 50148300.00, "unvaluedHoldingCount": 0 }
```

`?projectId=` narrows every figure to one project. Read is `system-admin` or `project-manager`, matching the listing it feeds (widened in #669). Writes are untouched.

## The shape, and why one endpoint

The strip is three tiles over the same scope, and the console asks for them together. A `Page` cannot carry them: `totalElements` gives the count and there is nowhere on the envelope for a sum. Putting the value on `MaterialDto` would put a catalogue-wide figure on every row of a page of the catalogue. So one read, four figures, one scope for all four.

Two scopes, matching the first two the low-stock read offers, because a project's material view showing an organization-wide total would be the same class of misleading figure this replaces. They count different things and the difference is the point: at organization scope `materialCount` is the catalogue, whether or not a material has ever been stocked; at project scope it is what the project carries a balance row for, which is the same set the value is summed over. Counting the catalogue at project scope would report every material against a site that has never held one.

A project that is not this tenant's is a 404, not a summary of zeroes, for the reason `LowStockService` gives: zeroes are an answer, and they must not be the answer to a question asked of a project that is not there.

## Stock with no cost behind it

`updateCurrentStock` adds value only when the movement carries a unit cost:

```java
if (quantityChanged > 0 && unitCost != null) {
    stock.setStockValue(stock.getStockValue().add(incomingValue));
}
```

So a receipt posted with no unit cost adds quantity at no value, and the balance row holds stock worth zero. `stock_value` is `NOT NULL`, so nothing is null by the time a sum sees it: the zero was written by the posting path, not chosen here.

**The sum counts those rows at the zero they hold, and reports how many it counted.** Excluding them would understate silently, which is the failure this issue exists to fix. Refusing the whole total over one of them would throw away a figure that is right about everything else. `unvaluedHoldingCount` is what lets the console say the total understates and by how many holdings, which is the same judgement the tile already makes about the 500-row cap.

A row at zero quantity and zero value is not counted: that is a location that has run out, which is a complete and correct answer, and every seeded balance row starts in exactly that state.

## Tenant scope

Both aggregates carry an explicit `organization_id` predicate **as well as** running under the Hibernate `orgFilter`. That is not the convention on the surrounding per-material reads and is deliberate: the filter is off for a bypassed request, and on a sum that is invisible. A total spanning every tenant is still a number, and nobody reading it can tell.

The filter is proved to reach the aggregate rather than assumed. `valueTotal_runsUnderTheTenantFilter` and `catalogueCount_runsUnderTheTenantFilter` enable `orgFilter` for one organization and ask for another's total: the two scopings intersect to nothing, so the zero they assert is only reachable if the filter clause was appended to the aggregate SQL. Had Hibernate applied filters to entity queries but not to these, the query's own predicate would have handed back the figure. Both tests fail when the `@Filter` is taken off the entity.

## Tests

Twelve new, plus two existing files updated for the new endpoint. Each was run with the code it pins broken, and each failed:

| Test | Broken by | Then |
|---|---|---|
| `valueTotal_excludesAnotherOrganizationsStock` | value total loses its organization predicate | fails |
| `valueTotal_runsUnderTheTenantFilter` | `@Filter` off `CurrentStock` | fails |
| `catalogueCount_runsUnderTheTenantFilter` | `@Filter` off `Material` | fails |
| `catalogueCounts_excludeAnotherOrganization` | unit count loses its `DISTINCT` | fails |
| `emptyHolding_isNotReportedAsUnpriced` | unpriced count stops requiring a quantity on hand | fails |
| `unpricedStock_isCountedAtZeroAndReported` | unpriced count looks for a negative value instead of no value | fails |
| `projectScope_coversWhatTheProjectCarries` | project figures lose their project predicate | fails |
| `projectScope_excludesAnotherOrganization` | project figures lose their organization predicate | fails |
| `emptyOrganization_totalsToZero` | the empty total is no longer coalesced | fails |
| `unknownProject_isRefused` | the project existence check is removed | fails |
| `projectScope_countsWhatTheProjectCarries` | project scope answers with the catalogue counts | fails |
| `EndpointAuthorizationTest`, `MaterialControllerWebAuthzTest` | `@PreAuthorize` off `/summary` | fails |

`MaterialStockSummaryIT` runs on the plain `@DataJpaTest` configuration the other material repository tests use, so it shares their Spring context rather than adding one.

## Not done

No index on `current_stock(organization_id)`. The organization-scope sum reads essentially the whole tenant's balance rows whether or not one exists, and on the per-client production model that is the table. The project-scope variant is bounded by one project. Worth revisiting with a measurement rather than ahead of one.

`docs/openapi.json` was regenerated with `-PupdateOpenApiSnapshot` on the rebased tree and came back byte-identical to the committed file: 151 insertions, no deletions, the new path and schema only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a materials stock summary endpoint for dashboard metrics.
  * View total stock value, material count, distinct units of measure, and unvalued holdings.
  * Optionally filter summaries by project.
  * Summaries are scoped to the current organization, with validation for inaccessible projects.

* **Tests**
  * Added coverage for organization and project summaries, authorization, tenant isolation, empty data, and stock valuation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->