### PR TITLE
Give an issue somewhere to keep its priority

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7520,6 +7520,17 @@
             "minLength": 5,
             "type": "string"
           },
+          "priority": {
+            "description": "How urgently the issue wants attention. Optional: an issue raised without one has none, and none is inferred. Change it later through PATCH /issues/{id}.",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "example": "medium",
+            "type": "string"
+          },
           "status": {
             "description": "State the issue starts in. Optional, and open is the only value accepted, so leaving it out is the same as sending open. Every later state change goes through PATCH /issues/{id}, which only a system-admin or project-manager may call; being able to raise an issue that is already resolved or closed would hand every member the one move that endpoint exists to withhold.",
             "enum": [
@@ -7586,6 +7597,15 @@
               "$ref": "#/components/schemas/IssueCommentDto"
             },
             "type": "array"
+          },
+          "priority": {
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "type": "string"
           },
           "status": {
             "enum": [
@@ -7660,6 +7680,15 @@
             "format": "int64",
             "type": "integer"
           },
+          "priority": {
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "type": "string"
+          },
           "status": {
             "enum": [
               "open",
@@ -7730,6 +7759,20 @@
           "description": {
             "description": "Longer description of the issue.",
             "example": "Spacing measured at 220 mm against a specified 200 mm across grid C.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "priority": {
+            "description": "How urgently the issue wants attention. Send null to clear it, the way an issue is unassigned: no column constraint requires a value, and an issue can stop being ranked without stopping being an issue.",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "example": "high",
             "type": [
               "string",
               "null"

--- a/src/main/java/org/tornotron/echno_backend/issue/Issue.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/Issue.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.IssueComment.IssueComment;
 import org.tornotron.echno_backend.common.entity.Attachment;
 import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 import org.tornotron.echno_backend.task.Task;
@@ -22,9 +23,9 @@ import java.util.List;
 /**
  * An issue raised on site, such as a defect, safety concern, or query.
  *
- * <p>Carries a type and status, the employee who raised it and the one it is assigned to,
- * and an optional link to a task. Comments and file attachments hang off the issue. Scoped
- * to one organization by the {@code orgFilter} tenant filter.
+ * <p>Carries a type, a status, an optional priority, the employee who raised it and the one it is
+ * assigned to, and an optional link to a task. Comments and file attachments hang off the issue.
+ * Scoped to one organization by the {@code orgFilter} tenant filter.
  */
 @Entity
 @Data
@@ -55,6 +56,16 @@ public class Issue implements TenantScopedEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private IssueStatus status;
+
+    /**
+     * How urgently the issue wants attention. Nullable, and with no default: every issue raised
+     * before the column existed has no priority, and picking one for those rows would state
+     * something about them that nobody recorded. An issue raised without one has none until
+     * somebody sets it.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "priority")
+    private IssuePriority priority;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -25,6 +25,7 @@ import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
 import org.tornotron.echno_backend.issue.dto.IssueDto;
 import org.tornotron.echno_backend.issue.dto.IssueSimpleDto;
 import org.tornotron.echno_backend.issue.dto.IssueStatsDto;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 import org.tornotron.echno_backend.task.Task;
@@ -52,15 +53,15 @@ public class IssueService {
      * <p>{@code attachments} is the client telling the difference between "no upload" and
      * "untouched": it sets {@code attachments: []} on every update, and the files themselves
      * travel as their own multipart part, so the key in the JSON part carries nothing to apply.
-     * {@code priority} is a field the client's form offers and the {@code Issue} entity has no
-     * column for.
+     * It is the only one left. {@code priority} was here for the same reason until the entity
+     * grew the column, and the update now applies it.
      *
      * <p>Everything else falls to the {@code default} branch and is logged, because a key nobody
      * declared is how the {@code issueType} bug stayed invisible: the update answered 200 and
-     * changed nothing. Naming the two known ones here is what keeps that warning worth reading.
-     * Both are on the list in echno-core#57, and this set shrinks as that list is worked down.
+     * changed nothing. Naming the known one here is what keeps that warning worth reading. It is
+     * on the list in echno-core#57, and this set shrinks as that list is worked down.
      */
-    private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments", "priority");
+    private static final Set<String> DELIBERATELY_DROPPED_UPDATE_KEYS = Set.of("attachments");
 
     /**
      * The state an issue starts in, and the only one create accepts. It is what the web client's
@@ -132,6 +133,7 @@ public class IssueService {
         issue.setDescription(issueCreationDto.getDescription());
         issue.setType(parseIssueType(issueCreationDto.getType()));
         issue.setStatus(CREATION_STATUS);
+        issue.setPriority(issueCreationDto.getPriority());
         issue.setCreatedBy(creator);
         issue.setTask(task);
         issue.setOrganization(task.getOrganization());
@@ -238,6 +240,36 @@ public class IssueService {
         }
     }
 
+    /**
+     * Reads the {@code priority} key of a partial issue update.
+     *
+     * <p>Where {@link #parseIssueType} and {@link #parseIssueStatus} refuse a missing value,
+     * because their columns are not null, this one takes it as the caller clearing the field. That
+     * is what {@code assignedToId} already does, and what a nullable column with no default
+     * allows: an issue can stop being ranked without stopping being an issue.
+     *
+     * <p>The value comes out of the update map rather than a bound property, so it is taken as an
+     * {@code Object}. Anything that is neither absent nor a known member is a client error (400),
+     * not the class cast or {@code IllegalArgumentException} that would leave as a 500.
+     *
+     * @param value The raw map value: a priority name, or null to clear the priority.
+     * @return The parsed priority, or null.
+     * @throws InvalidRequestException if the value is not a known issue priority.
+     */
+    private static IssuePriority parseIssuePriority(Object value) {
+        if (value == null || (value instanceof String name && name.isBlank())) {
+            return null;
+        }
+        if (value instanceof String name) {
+            try {
+                return IssuePriority.valueOf(name);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidRequestException("'" + name + "' is not a valid issue priority");
+            }
+        }
+        throw new InvalidRequestException("'" + value + "' is not a valid issue priority");
+    }
+
     /** Parses a required issue status; see {@link #parseIssueType}. */
     private static IssueStatus parseIssueStatus(String status) {
         if (status == null || status.isBlank()) {
@@ -304,6 +336,9 @@ public class IssueService {
                     break;
                 case "status":
                     issue.setStatus(parseIssueStatus((String) value));
+                    break;
+                case "priority":
+                    issue.setPriority(parseIssuePriority(value));
                     break;
                 case "assignedToId":
                     issue.setAssignedTo(resolveAssignee(value));

--- a/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/IssueService.java
@@ -248,6 +248,10 @@ public class IssueService {
      * is what {@code assignedToId} already does, and what a nullable column with no default
      * allows: an issue can stop being ranked without stopping being an issue.
      *
+     * <p>Only an explicit null clears it, which is what the published schema says. A blank string
+     * is refused like any other value that names no member, so a client that sends {@code ""} is
+     * told so rather than quietly losing the field.
+     *
      * <p>The value comes out of the update map rather than a bound property, so it is taken as an
      * {@code Object}. Anything that is neither absent nor a known member is a client error (400),
      * not the class cast or {@code IllegalArgumentException} that would leave as a 500.
@@ -257,10 +261,10 @@ public class IssueService {
      * @throws InvalidRequestException if the value is not a known issue priority.
      */
     private static IssuePriority parseIssuePriority(Object value) {
-        if (value == null || (value instanceof String name && name.isBlank())) {
+        if (value == null) {
             return null;
         }
-        if (value instanceof String name) {
+        if (value instanceof String name && !name.isBlank()) {
             try {
                 return IssuePriority.valueOf(name);
             } catch (IllegalArgumentException e) {

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueCreationDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 
 @Data
@@ -53,6 +54,18 @@ public class IssueCreationDto {
             + "every member the one move that endpoint exists to withhold.",
             example = "open", allowableValues = {"open"})
     private IssueStatus status;
+
+    /**
+     * How urgently the issue wants attention. Optional: an issue raised without one has none, and
+     * no starting value is invented for it. The web form defaults its select to {@code medium} and
+     * sends that, so in practice most issues arrive with a priority; one raised by a client that
+     * offers no such control simply has none.
+     */
+    @Schema(description = "How urgently the issue wants attention. Optional: an issue raised "
+            + "without one has none, and none is inferred. Change it later through "
+            + "PATCH /issues/{id}.",
+            example = "medium")
+    private IssuePriority priority;
 
     /**
      * The assignee. Optional, and the only person on this payload the caller names: an issue may

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueDto.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.issue.dto;
 import lombok.Data;
 import org.tornotron.echno_backend.IssueComment.dto.IssueCommentDto;
 import org.tornotron.echno_backend.common.entity.AttachmentDto;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 
@@ -16,6 +17,7 @@ public class IssueDto {
     private String description;
     private IssueType type;
     private IssueStatus status;
+    private IssuePriority priority;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long createdById;

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueSimpleDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueSimpleDto.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.issue.dto;
 
 import lombok.Data;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 
@@ -13,6 +14,7 @@ public class IssueSimpleDto {
     private String description;
     private IssueType type;
     private IssueStatus status;
+    private IssuePriority priority;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long createdById;

--- a/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/dto/IssueUpdateFieldsDto.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.issue.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 
@@ -36,6 +37,12 @@ public class IssueUpdateFieldsDto {
     @Schema(description = "Lifecycle status of the issue. Cannot be cleared: a null or blank value "
             + "is refused with a 400 rather than applied.")
     private IssueStatus status;
+
+    @Schema(nullable = true, description = "How urgently the issue wants attention. Send null to "
+            + "clear it, the way an issue is unassigned: no column constraint requires a value, "
+            + "and an issue can stop being ranked without stopping being an issue.",
+            example = "high")
+    private IssuePriority priority;
 
     @Schema(nullable = true, description = "Id of the employee the issue is assigned to. The employee must belong to "
             + "the caller's organization. Send null to unassign the issue.", example = "17")

--- a/src/main/java/org/tornotron/echno_backend/issue/enums/IssuePriority.java
+++ b/src/main/java/org/tornotron/echno_backend/issue/enums/IssuePriority.java
@@ -1,0 +1,8 @@
+package org.tornotron.echno_backend.issue.enums;
+
+public enum IssuePriority {
+    low,
+    medium,
+    high,
+    critical
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -397,4 +397,7 @@
     <!-- v4.0 - Attendance: let a clock event say the geofence was never evaluated, and record an out-of-fence punch -->
     <include file="db/changelog/v4.0/087-clock-event-geofence-evaluation.xml"/>
 
+    <!-- v4.0 - Issues: keep the priority the issue form has been submitting all along -->
+    <include file="db/changelog/v4.0/088-add-issue-priority.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/088-add-issue-priority.xml
+++ b/src/main/resources/db/changelog/v4.0/088-add-issue-priority.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="088-add-issue-priority" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="issue" columnName="priority"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Give an issue somewhere to keep its priority. The issue form has rendered a required
+            Priority select (low, medium, high, critical) and submitted the choice on both create
+            and edit, and the form already colours a badge by it and warns on critical, but the
+            backend had the field at no layer, so the value was dropped on the way in and the issue
+            came back with the select reset to its default. VARCHAR(50) matches how type and status
+            are stored on this table,
+            since it is a string enum like both of them. Nullable and with no default: every issue
+            raised before this column has no priority, and choosing one for those rows would state
+            something about them that nobody recorded.
+        </comment>
+
+        <addColumn tableName="issue">
+            <column name="priority" type="VARCHAR(50)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePartialUpdateKeysTest.java
@@ -142,12 +142,12 @@ class IssuePartialUpdateKeysTest {
 
     @Test
     void update_acceptsTheKeysItHasNoFieldForRatherThanRefusingTheRequest() {
-        // echno-core puts attachments: [] in the JSON part of every issue update, and the form
-        // offers a priority the entity has no column for. Refusing an unrecognised key would turn
+        // echno-core puts attachments: [] in the JSON part of every issue update, and the files
+        // themselves travel as their own multipart part. Refusing an unrecognised key would turn
         // every update the deployed web app makes into a 400, so they are dropped and logged.
+        // The priority that used to sit on this list is applied now: see IssuePriorityTest.
         Map<String, Object> updates = new LinkedHashMap<>();
         updates.put("attachments", java.util.List.of());
-        updates.put("priority", "high");
         updates.put("somethingNobodyDeclared", "x");
         updates.put("type", "safety");
 

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePriorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePriorityTest.java
@@ -188,6 +188,22 @@ class IssuePriorityTest {
     }
 
     @Test
+    @DisplayName("partial update refuses a blank priority rather than treating it as a clear")
+    void partialUpdate_refusesABlankPriority() {
+        // An explicit null is the documented way to clear the field, and it is the only one. A
+        // blank string names no member, so letting it through would clear the priority on a
+        // payload the schema never described that way.
+        existing.setPriority(IssuePriority.high);
+
+        assertThatThrownBy(() -> service.partialUpdateAnIssue(Map.of("priority", "  "), 7L, null,
+                "ISSUE_ATTACHMENTS"))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("not a valid issue priority");
+
+        assertThat(existing.getPriority()).isEqualTo(IssuePriority.high);
+    }
+
+    @Test
     @DisplayName("partial update refuses a priority sent as something other than a name")
     void partialUpdate_refusesAPriorityThatIsNotAString() {
         // The value comes out of a map, so a number would be a class cast and a 500 if it were

--- a/src/test/java/org/tornotron/echno_backend/issue/IssuePriorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssuePriorityTest.java
@@ -1,0 +1,224 @@
+package org.tornotron.echno_backend.issue;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.issue.dto.IssueCreationDto;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
+import org.tornotron.echno_backend.issue.enums.IssueStatus;
+import org.tornotron.echno_backend.issue.enums.IssueType;
+import org.tornotron.echno_backend.issue.mapper.IssueMapper;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.task.Task;
+import org.tornotron.echno_backend.task.TaskRepository;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * An issue's priority, on the way in.
+ *
+ * <p>The issue form has rendered a Priority select (low, medium, high, critical) and submitted the
+ * choice on create and on edit, while the backend had the field at no layer: not on the entity,
+ * not on either payload, not as a case in the update switch and not as a column. The key was on
+ * the update's deliberately-dropped list, so the write was accepted with a 200 and the choice went
+ * nowhere. These pin both write paths, and the two ways the update can be asked for no priority at
+ * all.
+ *
+ * <p>Plain Mockito with a real validator and no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class IssuePriorityTest {
+
+    private static ValidatorFactory factory;
+
+    @Mock
+    private IssueRepository issueRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private AttachmentService attachmentService;
+    @Mock
+    private IssueMapper issueMapper;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private CurrentEmployeeService currentEmployeeService;
+
+    private IssueService service;
+    private Issue existing;
+
+    @BeforeEach
+    void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        service = new IssueService(issueRepository, taskRepository, attachmentService,
+                issueMapper, employeeRepository, currentEmployeeService,
+                new PayloadValidator(validator));
+
+        TenantContext.setCurrentOrgId(1L);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        Task task = new Task();
+        task.setOrganization(organization);
+        when(taskRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(task));
+        when(currentEmployeeService.requireCurrentEmployee(anyString())).thenReturn(new Employee());
+
+        existing = new Issue();
+        existing.setId(7L);
+        existing.setTitle("Honeycombing on the block A raft");
+        existing.setType(IssueType.quality);
+        existing.setStatus(IssueStatus.open);
+        existing.setOrganization(organization);
+
+        when(issueRepository.findByIdAndOrganization_Id(anyLong(), anyLong()))
+                .thenReturn(Optional.of(existing));
+        when(issueRepository.save(any(Issue.class))).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (factory != null) {
+            factory.close();
+        }
+    }
+
+    private IssueCreationDto validDto() {
+        IssueCreationDto dto = new IssueCreationDto();
+        dto.setTitle("Honeycombing on the block A raft");
+        dto.setDescription("Voids visible along the north edge of the pour after stripping.");
+        dto.setType("quality");
+        dto.setTaskId(11L);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("create stores the priority the form submitted")
+    void addIssue_storesThePriority() {
+        IssueCreationDto dto = validDto();
+        dto.setPriority(IssuePriority.critical);
+
+        service.addIssue(dto, null);
+
+        assertThat(savedIssue().getPriority()).isEqualTo(IssuePriority.critical);
+    }
+
+    @Test
+    @DisplayName("create leaves the priority unset when the payload names none")
+    void addIssue_leavesThePriorityUnsetWhenAbsent() {
+        // No default is invented here. An issue raised by a client with no such control has no
+        // priority, and saying it is medium would be a claim nobody made.
+        service.addIssue(validDto(), null);
+
+        assertThat(savedIssue().getPriority()).isNull();
+    }
+
+    @Test
+    @DisplayName("partial update applies the priority, which the switch used to drop")
+    void partialUpdate_appliesThePriority() {
+        service.partialUpdateAnIssue(Map.of("priority", "high"), 7L, null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getPriority()).isEqualTo(IssuePriority.high);
+    }
+
+    @Test
+    @DisplayName("partial update accepts every member the form's select offers")
+    void partialUpdate_acceptsEveryPriorityTheFormOffers() {
+        for (IssuePriority priority : IssuePriority.values()) {
+            service.partialUpdateAnIssue(Map.of("priority", priority.name()), 7L, null,
+                    "ISSUE_ATTACHMENTS");
+
+            assertThat(existing.getPriority()).isEqualTo(priority);
+        }
+    }
+
+    @Test
+    @DisplayName("partial update clears the priority when it is sent as an explicit null")
+    void partialUpdate_clearsThePriorityOnAnExplicitNull() {
+        existing.setPriority(IssuePriority.high);
+
+        service.partialUpdateAnIssue(singletonUpdate("priority", null), 7L, null,
+                "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getPriority()).isNull();
+    }
+
+    @Test
+    @DisplayName("partial update refuses a priority nobody defined with a 400, not a 500")
+    void partialUpdate_refusesAnUnknownPriority() {
+        assertThatThrownBy(() -> service.partialUpdateAnIssue(Map.of("priority", "urgent"), 7L,
+                null, "ISSUE_ATTACHMENTS"))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("not a valid issue priority");
+    }
+
+    @Test
+    @DisplayName("partial update refuses a priority sent as something other than a name")
+    void partialUpdate_refusesAPriorityThatIsNotAString() {
+        // The value comes out of a map, so a number would be a class cast and a 500 if it were
+        // read straight as a String the way type and status are.
+        assertThatThrownBy(() -> service.partialUpdateAnIssue(Map.of("priority", 2), 7L, null,
+                "ISSUE_ATTACHMENTS"))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("not a valid issue priority");
+    }
+
+    @Test
+    @DisplayName("partial update leaves the priority alone when the payload omits it")
+    void partialUpdate_leavesThePriorityAloneWhenAbsent() {
+        existing.setPriority(IssuePriority.low);
+
+        service.partialUpdateAnIssue(Map.of("title", "Honeycombing along the north edge"), 7L,
+                null, "ISSUE_ATTACHMENTS");
+
+        assertThat(existing.getPriority()).isEqualTo(IssuePriority.low);
+    }
+
+    /** {@link Map#of} refuses a null value, and an explicit null is what clears the priority. */
+    private Map<String, Object> singletonUpdate(String key, Object value) {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put(key, value);
+        return Collections.unmodifiableMap(updates);
+    }
+
+    private Issue savedIssue() {
+        ArgumentCaptor<Issue> captor = ArgumentCaptor.forClass(Issue.class);
+        verify(issueRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/issue/IssueRepositoryIT.java
+++ b/src/test/java/org/tornotron/echno_backend/issue/IssueRepositoryIT.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.issue.enums.IssuePriority;
 import org.tornotron.echno_backend.issue.enums.IssueStatus;
 import org.tornotron.echno_backend.issue.enums.IssueType;
 import org.tornotron.echno_backend.organization.Organization;
@@ -88,6 +89,28 @@ class IssueRepositoryIT extends AbstractIntegrationTest {
                 .contains("First unfiltered", "Second unfiltered");
     }
 
+    @Test
+    void issue_keepsThePriorityItWasSavedWith() {
+        // The column and the enum mapping, against the real schema Liquibase builds: a priority
+        // that survives a flush and a reload is the half a mocked repository cannot show.
+        Organization org = persistOrganization("Org D");
+        Employee frank = persistEmployee(org, "Frank");
+        persistIssue(org, "Raised as critical", frank, frank, IssuePriority.critical);
+        persistIssue(org, "Raised with no priority", frank, frank, null);
+        em.flush();
+        em.clear();
+
+        Page<Issue> result = issueRepository.search(
+                null, "%raised as critical%", null, null, null, null, PageRequest.of(0, 10));
+        assertThat(result.getContent()).singleElement()
+                .extracting(Issue::getPriority).isEqualTo(IssuePriority.critical);
+
+        Page<Issue> unranked = issueRepository.search(
+                null, "%raised with no priority%", null, null, null, null, PageRequest.of(0, 10));
+        assertThat(unranked.getContent()).singleElement()
+                .extracting(Issue::getPriority).isNull();
+    }
+
     private Organization persistOrganization(String name) {
         Organization org = new Organization();
         org.setOrganizationName(name);
@@ -117,7 +140,13 @@ class IssueRepositoryIT extends AbstractIntegrationTest {
     }
 
     private void persistIssue(Organization org, String title, Employee createdBy, Employee assignedTo) {
+        persistIssue(org, title, createdBy, assignedTo, null);
+    }
+
+    private void persistIssue(Organization org, String title, Employee createdBy,
+                              Employee assignedTo, IssuePriority priority) {
         Issue issue = new Issue();
+        issue.setPriority(priority);
         issue.setTitle(title);
         issue.setDescription(title + " description");
         issue.setType(IssueType.safety);


### PR DESCRIPTION
## What

The `issue` table grows a `priority` column, and the create and update paths read the field the client has been sending all along.

## Why

The issue form in `echno-web` (`features/issues/components/issue-form.tsx`) renders a required Priority select with `low`, `medium`, `high`, `critical`, defaults it to `medium`, colours a badge by it and warns when the choice is `critical`. It submits the value on `POST /issues/web` and on `PATCH /issues/web/{id}`. The backend had the field at no layer: not on the entity, not on either payload, not as a case in the update switch and not as a column, and `priority` was named on `IssueService.DELIBERATELY_DROPPED_UPDATE_KEYS`. Both writes answered 200 and the choice went nowhere, so reopening an issue showed the select back at its default.

This is two of the five remaining findings on echno-core#57, the register of request fields the client sends that no endpoint reads. The decision recorded there is that the backend grows the column rather than the client losing the field, because the control is real and half built, not decorative. Task `priority` went the other way for the opposite reason: no control existed there.

## What changed

- New `IssuePriority` enum (`low`, `medium`, `high`, `critical`), plain lowercase members like `IssueStatus` and `IssueType`, persisted as a string. The wire values are exactly what the select emits.
- `Issue.priority`, nullable, `@Enumerated(EnumType.STRING)`, no entity default. Every issue raised before this column has no priority and inventing one would state something nobody recorded.
- Changelog `087-add-issue-priority.xml`, a guarded `addColumn` of `VARCHAR(50)`, matching how `type` and `status` are stored on the same table.
- `IssueCreationDto.priority`, optional. `IssueUpdateFieldsDto.priority`, nullable, so it can be cleared the way an assignee can. Nothing on the column forces a value.
- `IssueService.addIssue` sets it; `partialUpdateAnIssue` gains a `case "priority"` reading it through a new `parseIssuePriority`. Null (or blank) clears it; anything else that is not a known member is a 400, not the class cast a bare `(String) value` would leave as a 500. `priority` comes off the deliberately-dropped set.
- `IssueDto` and `IssueSimpleDto` carry it back. MapStruct maps it by name, no explicit `@Mapping` needed. A field a client can set and can never read is the failure that got material `category`/`status`/`trend` deleted instead of built.
- `docs/openapi.json` regenerated, so echno-core's contract index picks the field up.

## Tests

New `IssuePriorityTest`: create stores it, create leaves it unset when the payload names none, the update applies it, accepts every member the select offers, clears it on an explicit null, refuses an unknown value and a non-string value with a 400, and leaves it alone when the payload omits it. `IssueRepositoryIT` gains a round trip through the real CockroachDB, which is what proves the column and the enum mapping agree with the schema Liquibase builds. `IssuePartialUpdateKeysTest` no longer claims `priority` is dropped.

`PartialUpdateSchemaContractTest`, `PartialUpdateNullBehaviourTest` and `PartialUpdateDefaultBranchTest` all pass unedited.

## Verification

Run on the lab build box: the issue and partial-update architecture suites pass with no failures, and `./gradlew openApiSnapshot -PupdateOpenApiSnapshot` regenerated the committed document, which then verifies clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue priority support with four levels: low, medium, high, and critical.
  * Priorities can be set when creating issues and changed or cleared during updates.
  * Issue responses now include priority information.
  * Existing issues may remain without a priority.

* **Documentation**
  * Updated the API specification to document priority fields, accepted values, and clearing behavior.

* **Tests**
  * Added coverage for priority creation, updates, clearing, validation, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->