### PR TITLE
Say which vendor response fields are null, and which never are

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19272,7 +19272,11 @@
       "VendorBankAccountDto": {
         "properties": {
           "accountHolderName": {
-            "type": "string"
+            "description": "Name the account is held in, where it differs from the vendor's own name. Null where it was not recorded.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "accountNumber": {
             "type": "string"
@@ -19288,10 +19292,18 @@
             "type": "integer"
           },
           "ifscCode": {
-            "type": "string"
+            "description": "IFSC code, which only an Indian domestic account has. Null on a foreign account, which carries a SWIFT code instead.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "swift": {
-            "type": "string"
+            "description": "SWIFT code, which only an account reachable internationally has. Null on a domestic account.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -19328,7 +19340,11 @@
       "VendorContactDto": {
         "properties": {
           "alternatePhone": {
-            "type": "string"
+            "description": "Second number for this contact. Null where only one was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contactPerson": {
             "type": "string"
@@ -19435,7 +19451,11 @@
             "type": "array"
           },
           "city": {
-            "type": "string"
+            "description": "City. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "contacts": {
             "items": {
@@ -19444,7 +19464,11 @@
             "type": "array"
           },
           "country": {
-            "type": "string"
+            "description": "Country. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "goodsReceivedNotes": {
             "items": {
@@ -19457,7 +19481,11 @@
             "type": "integer"
           },
           "notes": {
-            "type": "string"
+            "description": "Free-text notes about the vendor. Null where none were written.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "payables": {
             "items": {
@@ -19466,10 +19494,22 @@
             "type": "array"
           },
           "paymentTerms": {
-            "$ref": "#/components/schemas/VendorPaymentTermsDto"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VendorPaymentTermsDto"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The vendor's single payment-terms record. Null until terms are set, and null again once they are deleted."
           },
           "pinCode": {
-            "type": "string"
+            "description": "Postal code. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "purchaseOrders": {
             "items": {
@@ -19478,7 +19518,11 @@
             "type": "array"
           },
           "state": {
-            "type": "string"
+            "description": "State. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "enum": [
@@ -19506,7 +19550,11 @@
             "type": "string"
           },
           "vendorAddress": {
-            "type": "string"
+            "description": "Street address. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vendorEmail": {
             "type": "string"
@@ -19515,7 +19563,11 @@
             "type": "string"
           },
           "website": {
-            "type": "string"
+            "description": "Website. Optional on creation, so null where none was given.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -19541,11 +19593,19 @@
       "VendorPaymentTermsDto": {
         "properties": {
           "creditDays": {
+            "description": "Days allowed before payment falls due. Null where no period was agreed, leaving the due date to whatever the invoice states.",
             "format": "int32",
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "creditLimit": {
-            "type": "number"
+            "description": "Ceiling on what may be outstanding with this vendor. Null where no limit was agreed, which is not the same as a limit of zero.",
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "id": {
             "format": "int64",

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorBankAccountDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorBankAccountDto.java
@@ -1,14 +1,32 @@
 package org.tornotron.echno_backend.vendor.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * A vendor bank account, as it is served. A field without {@code nullable = true} is one the
+ * schema behind it makes {@code NOT NULL}; see {@code ReviewedResponseSchemas}.
+ */
 @Data
 public class VendorBankAccountDto {
+
     private Long id;
+
     private String bankName;
+
     private String accountNumber;
+
+    @Schema(description = "IFSC code, which only an Indian domestic account has. Null on a "
+            + "foreign account, which carries a SWIFT code instead.", nullable = true)
     private String ifscCode;
+
+    @Schema(description = "Name the account is held in, where it differs from the vendor's own "
+            + "name. Null where it was not recorded.", nullable = true)
     private String accountHolderName;
+
+    @Schema(description = "SWIFT code, which only an account reachable internationally has. Null "
+            + "on a domestic account.", nullable = true)
     private String swift;
+
     private boolean isDefault;
 }

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorContactDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorContactDto.java
@@ -1,13 +1,26 @@
 package org.tornotron.echno_backend.vendor.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * A contact person at a vendor, as it is served. A field without {@code nullable = true} is one
+ * the schema behind it makes {@code NOT NULL}; see {@code ReviewedResponseSchemas}.
+ */
 @Data
 public class VendorContactDto {
+
     private Long id;
+
     private String contactPerson;
+
     private String email;
+
     private String phone;
+
+    @Schema(description = "Second number for this contact. Null where only one was given.",
+            nullable = true)
     private String alternatePhone;
+
     private boolean isPrimary;
 }

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorDto.java
@@ -1,5 +1,6 @@
 package org.tornotron.echno_backend.vendor.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.tornotron.echno_backend.goodsReceivedNote.dto.GoodsReceivedNoteDto;
 import org.tornotron.echno_backend.payable.dto.PayableDto;
@@ -9,26 +10,65 @@ import org.tornotron.echno_backend.vendor.enums.VendorType;
 
 import java.util.List;
 
+/**
+ * A vendor as it is served. Every optional field carries {@code nullable = true}, and a field
+ * without it is one the schema behind it makes {@code NOT NULL}; see
+ * {@code ReviewedResponseSchemas} for the field-by-field record and what holds it.
+ */
 @Data
 public class VendorDto {
 
     private Long id;
+
     private String vendorName;
+
+    @Schema(description = "Street address. Optional on creation, so null where none was given.",
+            nullable = true)
     private String vendorAddress;
+
     private String vendorEmail;
+
+    @Schema(description = "City. Optional on creation, so null where none was given.",
+            nullable = true)
     private String city;
+
+    @Schema(description = "State. Optional on creation, so null where none was given.",
+            nullable = true)
     private String state;
+
+    @Schema(description = "Postal code. Optional on creation, so null where none was given.",
+            nullable = true)
     private String pinCode;
+
+    @Schema(description = "Country. Optional on creation, so null where none was given.",
+            nullable = true)
     private String country;
+
+    @Schema(description = "Website. Optional on creation, so null where none was given.",
+            nullable = true)
     private String website;
+
     private VendorType type;
+
     private VendorStatus status;
+
+    @Schema(description = "Free-text notes about the vendor. Null where none were written.",
+            nullable = true)
     private String notes;
+
     private List<GoodsReceivedNoteDto> goodsReceivedNotes;
+
     private List<PurchaseOrderDto> purchaseOrders;
+
     private List<PayableDto> payables;
+
     private List<VendorContactDto> contacts;
+
     private List<VendorTaxIdentifierDto> taxIdentifiers;
+
     private List<VendorBankAccountDto> bankAccounts;
+
+    @Schema(description = "The vendor's single payment-terms record. Null until terms are set, "
+            + "and null again once they are deleted.", nullable = true)
     private VendorPaymentTermsDto paymentTerms;
 }

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorPaymentTermsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorPaymentTermsDto.java
@@ -1,13 +1,27 @@
 package org.tornotron.echno_backend.vendor.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
+/**
+ * The payment terms agreed with a vendor, as they are served. A field without
+ * {@code nullable = true} is one the schema behind it makes {@code NOT NULL}; see
+ * {@code ReviewedResponseSchemas}.
+ */
 @Data
 public class VendorPaymentTermsDto {
+
     private Long id;
+
     private String paymentTerms;
+
+    @Schema(description = "Ceiling on what may be outstanding with this vendor. Null where no "
+            + "limit was agreed, which is not the same as a limit of zero.", nullable = true)
     private BigDecimal creditLimit;
+
+    @Schema(description = "Days allowed before payment falls due. Null where no period was "
+            + "agreed, leaving the due date to whatever the invoice states.", nullable = true)
     private Integer creditDays;
 }

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorSummaryDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorSummaryDto.java
@@ -6,6 +6,15 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+/**
+ * Purchase, payable and receipt totals for one vendor.
+ *
+ * <p>No field here admits null. The counts are {@code COUNT}, which is zero over no rows, and
+ * every money total is summed under a {@code COALESCE(..., 0)} in
+ * {@link org.tornotron.echno_backend.vendor.VendorSummaryService}, so a vendor with no purchase
+ * orders reports zero rather than the null a bare {@code SUM} would return. See
+ * {@code ReviewedResponseSchemas}.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorTaxIdentifierDto.java
+++ b/src/main/java/org/tornotron/echno_backend/vendor/dto/VendorTaxIdentifierDto.java
@@ -3,6 +3,10 @@ package org.tornotron.echno_backend.vendor.dto;
 import lombok.Data;
 import org.tornotron.echno_backend.vendor.enums.TaxIdentifierType;
 
+/**
+ * A tax registration held by a vendor, as it is served. Every column behind this schema is
+ * {@code NOT NULL}, so no field here admits null; see {@code ReviewedResponseSchemas}.
+ */
 @Data
 public class VendorTaxIdentifierDto {
     private Long id;

--- a/src/test/java/org/tornotron/echno_backend/architecture/ResponseNullabilityRatchetTest.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ResponseNullabilityRatchetTest.java
@@ -1,0 +1,252 @@
+package org.tornotron.echno_backend.architecture;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.architecture.ReviewedResponseSchemas.ReviewedSchema;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * On a reviewed response schema, an unmarked property is a claim that the server never sends null
+ * there.
+ *
+ * <p>{@code OpenApiNullabilityTest} checks one direction: a field marked
+ * {@code @Schema(nullable = true)} says so in the published document. That is what keeps the #661
+ * customizer working, and it is all it can do, because across the rest of the document an
+ * unmarked property means nothing at all. 1987 response-only properties say nothing about null,
+ * and a reader cannot tell the ones nobody has looked at from the ones that are genuinely never
+ * null.
+ *
+ * <p>This test is the other direction, over the schemas in
+ * {@link ReviewedResponseSchemas#schemas()} only. For those it requires the three places the
+ * answer is written to agree: the table, the annotation on the field, and the type union in
+ * {@code docs/openapi.json}. Two things follow that the one-directional test cannot give:
+ *
+ * <ul>
+ *   <li>a property on a reviewed schema that admits null without being listed fails, so silence
+ *       on a reviewed schema is a decision rather than an omission;
+ *   <li>a property added to a reviewed schema fails until it is classified, because the table
+ *       names the non-null half explicitly and the union of the two halves has to be the
+ *       published property list exactly. A field that arrives with no thought given to it cannot
+ *       drift into the non-null half by being the complement of the marked one.
+ * </ul>
+ *
+ * <p>Reads the committed document rather than booting an application, as
+ * {@code OpenApiNullabilityTest} does and for the same reason: {@code OpenApiSnapshotTest} already
+ * holds that file to the document the code serves, in a task of its own.
+ */
+class ResponseNullabilityRatchetTest {
+
+    /** The committed contract, relative to the project directory the test task runs in. */
+    private static final Path DOCUMENT = Path.of("docs", "openapi.json");
+
+    /** The JSON Schema type that admits only null. */
+    private static final String NULL_TYPE = "null";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("a reviewed schema accounts for every property it publishes")
+    void everyPublishedPropertyIsClassified() {
+        JsonNode schemas = readSchemas();
+        List<String> wrong = new ArrayList<>();
+
+        for (ReviewedSchema reviewed : ReviewedResponseSchemas.schemas()) {
+            Set<String> published = publishedProperties(schemas, reviewed);
+
+            Set<String> both = new LinkedHashSet<>(reviewed.nullable());
+            both.retainAll(reviewed.nonNull());
+            if (!both.isEmpty()) {
+                wrong.add(reviewed + ": " + both + " are listed as both nullable and non-null");
+            }
+
+            Set<String> unclassified = new TreeSet<>(published);
+            unclassified.removeAll(reviewed.nullable());
+            unclassified.removeAll(reviewed.nonNull());
+            if (!unclassified.isEmpty()) {
+                wrong.add(reviewed + ": " + unclassified + " are published but not classified. "
+                        + "Read what the schema, the mapper or the query behind each one can "
+                        + "produce, then add it to the nullable or the non-null half");
+            }
+
+            Set<String> stale = new TreeSet<>(reviewed.nullable());
+            stale.addAll(reviewed.nonNull());
+            stale.removeAll(published);
+            if (!stale.isEmpty()) {
+                wrong.add(reviewed + ": " + stale + " are classified but the document publishes "
+                        + "no such property. A renamed or removed field");
+            }
+        }
+
+        assertThat(wrong)
+                .as("ReviewedResponseSchemas and the published document disagree about which "
+                        + "properties exist. Until they agree, an unmarked property on these "
+                        + "schemas cannot be read as a claim that it is never null")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("a reviewed property admits null in the document exactly when the table says so")
+    void theDocumentAgreesWithTheTable() {
+        JsonNode schemas = readSchemas();
+        List<String> wrong = new ArrayList<>();
+
+        for (ReviewedSchema reviewed : ReviewedResponseSchemas.schemas()) {
+            JsonNode properties = schemas.path(reviewed.dto().getSimpleName()).path("properties");
+            for (String property : publishedProperties(schemas, reviewed)) {
+                boolean listed = reviewed.nullable().contains(property);
+                boolean admits = admitsNull(properties.path(property));
+                if (listed && !admits) {
+                    wrong.add(reviewed + "." + property + ": listed as nullable, but the document "
+                            + "says " + properties.path(property));
+                } else if (!listed && admits) {
+                    wrong.add(reviewed + "." + property + ": the document says it admits null, but "
+                            + "it is listed as non-null. Either the field was marked without the "
+                            + "table being updated, or the table is now wrong");
+                }
+            }
+        }
+
+        assertThat(wrong)
+                .as("the published document does not describe these properties the way "
+                        + "ReviewedResponseSchemas does. Fix whichever is wrong, then regenerate "
+                        + "with ./gradlew openApiSnapshot -PupdateOpenApiSnapshot")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("a reviewed property carries the annotation exactly when the table says so")
+    void theAnnotationAgreesWithTheTable() {
+        List<String> wrong = new ArrayList<>();
+
+        for (ReviewedSchema reviewed : ReviewedResponseSchemas.schemas()) {
+            for (BeanPropertyDefinition property : serializedProperties(reviewed.dto())) {
+                boolean listed = reviewed.nullable().contains(property.getName());
+                boolean marked = isMarkedNullable(property);
+                if (listed && !marked) {
+                    wrong.add(reviewed + "." + property.getName() + ": listed as nullable, but the "
+                            + "field does not carry @Schema(nullable = true), so nothing carries "
+                            + "it into the document");
+                } else if (!listed && marked) {
+                    wrong.add(reviewed + "." + property.getName() + ": marked "
+                            + "@Schema(nullable = true), but listed as non-null");
+                }
+            }
+        }
+
+        assertThat(wrong)
+                .as("the annotations on these fields do not match ReviewedResponseSchemas")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("the table is not empty and does not claim everything is nullable")
+    void theTableIsNotVacuous() {
+        List<ReviewedSchema> reviewed = ReviewedResponseSchemas.schemas();
+
+        assertThat(reviewed)
+                .as("no response schema is listed as reviewed, so this test is checking nothing")
+                .isNotEmpty();
+        assertThat(reviewed.stream().anyMatch(schema -> !schema.nullable().isEmpty()))
+                .as("no reviewed schema declares a single nullable property, which would mean "
+                        + "either the marking has been removed or nothing genuinely optional has "
+                        + "been reviewed yet")
+                .isTrue();
+        assertThat(reviewed.stream().anyMatch(schema -> !schema.nonNull().isEmpty()))
+                .as("no reviewed schema declares a single non-null property, which is the half "
+                        + "that makes an unmarked field mean something")
+                .isTrue();
+    }
+
+    /**
+     * The property names the document publishes for a reviewed schema, failing if it publishes
+     * none, since every check here would then pass over an empty set.
+     */
+    private static Set<String> publishedProperties(JsonNode schemas, ReviewedSchema reviewed) {
+        JsonNode properties = schemas.path(reviewed.dto().getSimpleName()).path("properties");
+        assertThat(properties.isObject())
+                .as("the document has no schema named %s with properties. A renamed class, a "
+                        + "schema springdoc names differently, or a DTO no endpoint returns any "
+                        + "more; if the last, take it out of ReviewedResponseSchemas", reviewed)
+                .isTrue();
+        Set<String> names = new LinkedHashSet<>();
+        properties.fieldNames().forEachRemaining(names::add);
+        return names;
+    }
+
+    /**
+     * The properties a DTO serializes, under the same Jackson naming the document is generated
+     * through. Needed because a property name is not always the field name: Jackson strips the
+     * {@code is} prefix from a primitive boolean, so {@code isPrimary} publishes as
+     * {@code primary}.
+     */
+    private static List<BeanPropertyDefinition> serializedProperties(Class<?> dto) {
+        BeanDescription description = MAPPER.getSerializationConfig()
+                .introspect(MAPPER.getTypeFactory().constructType(dto));
+        return description.findProperties();
+    }
+
+    private static boolean isMarkedNullable(BeanPropertyDefinition property) {
+        AnnotatedField field = property.getField();
+        if (field == null) {
+            return false;
+        }
+        Schema schema = field.getAnnotated().getAnnotation(Schema.class);
+        return schema != null && schema.nullable();
+    }
+
+    /**
+     * Whether a property schema admits null: either as a member of its type union, or as a branch
+     * of the {@code anyOf} a reference has to be wrapped in to say the same thing.
+     */
+    private static boolean admitsNull(JsonNode property) {
+        JsonNode type = property.path("type");
+        if (type.isArray()) {
+            for (JsonNode member : type) {
+                if (NULL_TYPE.equals(member.asText())) {
+                    return true;
+                }
+            }
+        }
+        if (NULL_TYPE.equals(type.asText())) {
+            return true;
+        }
+        for (String composition : List.of("anyOf", "oneOf")) {
+            for (JsonNode branch : property.path(composition)) {
+                if (admitsNull(branch)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static JsonNode readSchemas() {
+        assertThat(DOCUMENT)
+                .as("the committed OpenAPI document is missing; run ./gradlew openApiSnapshot "
+                        + "-PupdateOpenApiSnapshot")
+                .exists();
+        try {
+            return MAPPER.readTree(Files.readString(DOCUMENT))
+                    .path("components").path("schemas");
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot read " + DOCUMENT.toAbsolutePath(), e);
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
+++ b/src/test/java/org/tornotron/echno_backend/architecture/ReviewedResponseSchemas.java
@@ -1,0 +1,150 @@
+package org.tornotron.echno_backend.architecture;
+
+import org.tornotron.echno_backend.vendor.dto.VendorBankAccountDto;
+import org.tornotron.echno_backend.vendor.dto.VendorContactDto;
+import org.tornotron.echno_backend.vendor.dto.VendorDto;
+import org.tornotron.echno_backend.vendor.dto.VendorPaymentTermsDto;
+import org.tornotron.echno_backend.vendor.dto.VendorSummaryDto;
+import org.tornotron.echno_backend.vendor.dto.VendorTaxIdentifierDto;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The response schemas whose nullability has been read field by field, and the answer for each
+ * field.
+ *
+ * <h2>What this list is for</h2>
+ *
+ * <p>#661 made {@code @Schema(nullable = true)} reach the published document, which under
+ * OpenAPI 3.1 it never had. What it could not do is say anything about a field nobody has marked.
+ * An unmarked property means "no one has looked", and a reader has no way to tell that from
+ * "someone looked and it is never null". Across 1987 response-only properties that silence is
+ * uniform, so the document is honest but useless on the question.
+ *
+ * <p>A schema listed here is one where the silence has been made into a claim. Every one of its
+ * properties is named below as either nullable or non-null, from the schema, the mapper or the
+ * query behind it, so an unmarked field on a listed schema now means the server does not send
+ * null there. {@link ResponseNullabilityRatchetTest} holds all three representations to this list:
+ * the annotation on the field, the union in {@code docs/openapi.json}, and this table. A property
+ * added to a listed schema fails the build until it is classified here, which is the whole point
+ * of writing the non-null half down rather than leaving it as the complement.
+ *
+ * <p>The claim is deliberately narrow. It says the field is not null in a response, and nothing
+ * about whether a client may send null in a request: that is the other axis, and the eight
+ * partial-update surfaces in {@link PartialUpdateSurfaces} are where it is written down.
+ *
+ * <h2>How a schema gets added</h2>
+ *
+ * <p>Per property, in this order, and none of the three is guesswork:
+ *
+ * <ol>
+ *   <li>where the field maps straight through from an entity, the Liquibase column behind it.
+ *       Note that the entity's own {@code @Column(nullable = ...)} is not the authority:
+ *       {@code ddl-auto} is {@code validate}, and Hibernate's validation does not compare
+ *       nullability, so an entity can disagree with the table and nothing will say so;
+ *   <li>where the mapper does something other than copy, the mapper;
+ *   <li>where the value is computed, the query or service that computes it. A bare SQL
+ *       {@code SUM} over no rows is null, so an aggregate is non-null only if something makes it
+ *       so.
+ * </ol>
+ *
+ * <p>The vendor module is the first through this, chosen because its five tables are the whole of
+ * it and its mappers copy by name, so every answer is checkable rather than argued. Adding a
+ * module is per-field reading work with no shortcut, and is worth doing a module at a time so
+ * each pass arrives as a diff someone can actually review.
+ */
+final class ReviewedResponseSchemas {
+
+    private ReviewedResponseSchemas() {
+    }
+
+    /**
+     * One reviewed schema, split into the two halves that together must account for every
+     * property it publishes.
+     *
+     * <p>Names here are the property names the document uses, which are not always the Java field
+     * names: Jackson strips the {@code is} prefix from a primitive boolean, so
+     * {@code VendorContactDto.isPrimary} publishes as {@code primary}.
+     *
+     * @param dto The response DTO class.
+     * @param nullable Properties the server may send as null.
+     * @param nonNull Properties the server always sends with a value.
+     */
+    record ReviewedSchema(Class<?> dto, Set<String> nullable, Set<String> nonNull) {
+        @Override
+        public String toString() {
+            return dto.getSimpleName();
+        }
+    }
+
+    /**
+     * Every reviewed response schema.
+     *
+     * <p><b>Vendor.</b> The five vendor tables are defined in
+     * {@code db/changelog/v4.0/baseline-001-level0-tables.xml} and
+     * {@code baseline-002-level1-tables.xml} and are not altered afterwards, so the column list
+     * there is the whole answer for everything that maps straight through. The mappers copy by
+     * name and add nothing.
+     *
+     * <ul>
+     *   <li>{@code VendorDto}: seven optional columns on the {@code vendor} table
+     *       ({@code vendor_address}, {@code city}, {@code state}, {@code pin_code},
+     *       {@code country}, {@code website}, {@code notes}), plus {@code paymentTerms}, which is
+     *       the inverse side of a {@code @OneToOne} the service only populates when the creation
+     *       request carried terms and which {@code deletePaymentTerms} removes again. The six
+     *       collections are non-null because the entity initialises each to an empty list, so
+     *       there is no null for MapStruct to carry across.
+     *   <li>{@code VendorContactDto}: {@code alternate_phone} is the one nullable column.
+     *   <li>{@code VendorBankAccountDto}: {@code ifsc_code}, {@code account_holder_name} and
+     *       {@code swift} are nullable, which matches the domain, since an account is reachable
+     *       domestically or internationally and rarely carries codes for both.
+     *       {@code account_number} is {@code NOT NULL}; it is stored encrypted through a
+     *       converter, and the converter is symmetric, so nothing there can produce a null on the
+     *       way out.
+     *   <li>{@code VendorPaymentTermsDto}: {@code credit_limit} and {@code credit_days} are
+     *       nullable. Both are the case the issue was raised over, where a client writing
+     *       {@code ?? 0} on the strength of the document turns "no limit agreed" into "a limit of
+     *       zero".
+     *   <li>{@code VendorTaxIdentifierDto}: every column is {@code NOT NULL}.
+     *   <li>{@code VendorSummaryDto}: computed rather than mapped. Both counts are
+     *       {@code COUNT}, and all five money totals are summed inside a
+     *       {@code COALESCE(..., 0)}, so none of them can come back null.
+     * </ul>
+     *
+     * @return The reviewed schemas.
+     */
+    static List<ReviewedSchema> schemas() {
+        return List.of(
+                new ReviewedSchema(
+                        VendorDto.class,
+                        Set.of("vendorAddress", "city", "state", "pinCode", "country", "website",
+                                "notes", "paymentTerms"),
+                        Set.of("id", "vendorName", "vendorEmail", "type", "status",
+                                "goodsReceivedNotes", "purchaseOrders", "payables", "contacts",
+                                "taxIdentifiers", "bankAccounts")),
+                new ReviewedSchema(
+                        VendorContactDto.class,
+                        Set.of("alternatePhone"),
+                        Set.of("id", "contactPerson", "email", "phone", "primary")),
+                new ReviewedSchema(
+                        VendorBankAccountDto.class,
+                        Set.of("ifscCode", "accountHolderName", "swift"),
+                        Set.of("id", "bankName", "accountNumber", "default")),
+                new ReviewedSchema(
+                        VendorPaymentTermsDto.class,
+                        Set.of("creditLimit", "creditDays"),
+                        Set.of("id", "paymentTerms")),
+                new ReviewedSchema(
+                        VendorTaxIdentifierDto.class,
+                        Set.of(),
+                        Set.of("id", "type", "value")),
+                new ReviewedSchema(
+                        VendorSummaryDto.class,
+                        Set.of(),
+                        Set.of("vendorId", "vendorName", "purchaseOrderCount",
+                                "totalPurchaseOrderValue", "totalAmountRecorded",
+                                "totalAmountPaid", "outstandingAmount", "grnCount",
+                                "totalInvoiceAmount")));
+    }
+}


### PR DESCRIPTION
Advances #645. Not a fix for the mechanism, which #661 already built: this is the first module through the pass that issue was left open for.

## What I found before building anything

The brief I picked this up from described the document as declaring nothing nullable across 3069 properties, with `@Schema(nullable = true)` silently discarded by swagger-core's `Schema31Mixin`, and asked for a customizer, a mixin override or a pin to 3.0. All of that is already done and merged, so it is worth saying plainly rather than rebuilding it:

- `NullableSchemaCustomizer` (#661, `8a3164c`) already converts the flag into the 3.1 form: a type union for a typed property, an `anyOf` with `{"type": "null"}` for a bare `$ref`. The `OpenApiCustomizer` was the right choice over a `ModelConverter` and I would not change it.
- `docs/openapi.json` on `development` already carries **139** properties admitting null (136 type unions, 3 `anyOf`), not 0.
- The `@Size` overwriting `@NotBlank`'s `minLength: 1` finding was a separate ticket, #657, fixed in #664 by `ValidationConstraintsModelConverter`.
- The eight partial-update surfaces were done in #670.

So the mechanism works and is held by `OpenApiNullabilityTest`. What #645 stayed open for is the per-field reading work, and that is what this is.

## The gap this closes

`OpenApiNullabilityTest` checks one direction: an annotated field says so in the document. It cannot say anything about a field nobody marked, and across the other **1987** response-only properties nothing does. A reader cannot tell a property nobody has looked at from one that is genuinely never null, so the uniform silence carries no information either way.

This makes the silence mean something on one module. Every property of the six vendor response schemas is classified, from the Liquibase column, the mapper, or the query behind it.

| schema | nullable | of | notable |
|---|---|---|---|
| `VendorDto` | 8 | 19 | `paymentTerms` is the inverse side of a `@OneToOne` the service populates only when terms were supplied, and `deletePaymentTerms` removes again |
| `VendorContactDto` | 1 | 6 | `alternatePhone` |
| `VendorBankAccountDto` | 3 | 7 | `ifscCode` / `swift`, since an account is domestic or international and rarely carries both |
| `VendorPaymentTermsDto` | 2 | 4 | `creditLimit` and `creditDays`, where a client writing `?? 0` turns "no limit agreed" into a limit of zero |
| `VendorTaxIdentifierDto` | 0 | 3 | every column `NOT NULL` |
| `VendorSummaryDto` | 0 | 9 | every money total summed under `COALESCE(..., 0)`, so none can come back null the way a bare `SUM` would |

**One thing worth carrying to the next module: the entity's own `@Column(nullable = ...)` is not the authority.** `ddl-auto` is `validate`, and Hibernate's schema validation does not compare nullability, so an entity can disagree with its table and nothing in the build will say so. The Liquibase changelog is what I read. For vendor the two happen to agree, but that was checked rather than assumed.

## What holds it

`ReviewedResponseSchemas` records both halves per schema, and `ResponseNullabilityRatchetTest` requires the table, the annotation on the field and the union in `docs/openapi.json` to agree. Writing the **non-null** half down explicitly, rather than leaving it as the complement of the marked one, is what makes it a ratchet: a property added to a reviewed schema fails the build until someone classifies it, instead of drifting into "non-null" by being unmarked.

Property names in the table are the document's, not the field's. Jackson strips the `is` prefix from a primitive boolean, so `VendorContactDto.isPrimary` publishes as `primary`; the test resolves this through Jackson's own introspection, which is what the document is generated through.

### Failing-test table

Same tests, three trees. Run on `lab-node-116-f`.

| test | unfixed tree | one name removed from the table | this PR |
|---|---|---|---|
| `theAnnotationAgreesWithTheTable` | FAIL, all 14 listed as nullable but unannotated | FAIL, `VendorDto.notes` marked but listed non-null | PASS |
| `theDocumentAgreesWithTheTable` | FAIL, all 14, eg `paymentTerms` still a bare `$ref` | FAIL, `VendorDto.notes` admits null but listed non-null | PASS |
| `everyPublishedPropertyIsClassified` | PASS, property names did not change | FAIL, `VendorDto: [notes] are published but not classified` | PASS |
| `theTableIsNotVacuous` | PASS | PASS | PASS |

The middle column is the drift case demonstrated rather than asserted: it is the code path a newly added property takes.

`OpenApiNullabilityTest`, `PartialUpdateNullContractTest` and `PartialUpdateNullBehaviourTest` stay green, and the full `./gradlew test` suite passes (8m 46s, heap 610 MB live of the 2048 MB cap, 30%).

## Document diff

Audited semantically, not by line count: **14 properties changed, 0 added, 0 removed, `paths` byte-identical.**

```
VendorBankAccountDto: accountHolderName, ifscCode, swift
VendorContactDto:     alternatePhone
VendorDto:            city, country, notes, paymentTerms, pinCode, state, vendorAddress, website
VendorPaymentTermsDto: creditDays, creditLimit
```

## Scoped out, still open on #645

- The request-side properties that are not on a partial-update surface. Lower value: absent and null are the same thing to a bean-bound DTO, and `required` plus the #664 constraints already carry it.
- The response schemas of every other module, about 1930 properties. Per-field reading work with no shortcut, worth taking a module at a time so each pass arrives as a diff someone can review. Vendor went first because its five tables are the whole of it and its mappers copy by name, so every answer is checkable.
- Adding descriptions to the non-null vendor properties. That is the documentation gap, not this one, and doing it here would have buried 14 real changes in 48.

Closes nothing; #645 stays open for the modules above.