### PR TITLE
Evaluate the attendance geofence, and let an employee mark from outside it with a reason

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1126,6 +1126,13 @@
             "format": "date-time",
             "type": "string"
           },
+          "geofenceExceptionReason": {
+            "description": "Why the employee is marking attendance from outside the project's geofence. Required only when they are marking their own attendance and the captured position falls outside the site boundary; the punch is accepted and the day is then held for their reporting manager to approve.",
+            "example": "Working from head office today for the client review",
+            "maxLength": 500,
+            "minLength": 0,
+            "type": "string"
+          },
           "gpsAccuracy": {
             "description": "GPS accuracy of the captured coordinates, in metres.",
             "example": 8.5,
@@ -1214,6 +1221,13 @@
               "EVENING_CLOCK_OUT"
             ],
             "example": "LUNCH_BREAK_START",
+            "type": "string"
+          },
+          "geofenceExceptionReason": {
+            "description": "Why the employee is marking attendance from outside the project's geofence. Required only when they are marking their own attendance and the captured position falls outside the site boundary; the punch is accepted and the day is then held for their reporting manager to approve.",
+            "example": "Working from head office today for the client review",
+            "maxLength": 500,
+            "minLength": 0,
             "type": "string"
           },
           "gpsAccuracy": {
@@ -1411,6 +1425,12 @@
             "example": "Ravi Kumar",
             "type": "string"
           },
+          "geofenceApproverId": {
+            "description": "Employee id of the person expected to decide the geofence exception: the employee's reporting manager, or a project manager assigned to the site. Null when neither could be resolved, in which case the attendance record managers decide as they do for every other record.",
+            "example": 42,
+            "format": "int64",
+            "type": "integer"
+          },
           "id": {
             "description": "Id of the attendance record.",
             "example": 781,
@@ -1485,6 +1505,11 @@
             "example": "Confirmed with site supervisor",
             "type": "string"
           },
+          "requiresGeofenceApproval": {
+            "description": "Whether this day contains a punch the employee marked themselves from outside the project's geofence, having given a reason. Such a record is held for a decision: it is still waiting while the approval status is PENDING.",
+            "example": false,
+            "type": "boolean"
+          },
           "shiftTiming": {
             "$ref": "#/components/schemas/ShiftTimingDto",
             "description": "Shift the employee was scheduled to work."
@@ -1553,7 +1578,7 @@
           },
           "geofenceRadiusMeters": {
             "description": "Radius in metres around the project within which a clock event is considered on site.",
-            "example": 200,
+            "example": 100,
             "format": "int32",
             "maximum": 5000,
             "minimum": 50,
@@ -1664,7 +1689,7 @@
           },
           "geofenceRadiusMeters": {
             "description": "Radius in metres around the project within which a clock event is considered on site.",
-            "example": 200,
+            "example": 100,
             "format": "int32",
             "type": "integer"
           },
@@ -1777,8 +1802,10 @@
           },
           "geofenceRadiusMeters": {
             "description": "Radius in metres around the project within which a clock event is considered on site.",
-            "example": 250,
+            "example": 100,
             "format": "int32",
+            "maximum": 5000,
+            "minimum": 50,
             "type": "integer"
           },
           "geolocationRequired": {
@@ -2832,7 +2859,7 @@
             "type": "string"
           },
           "distanceFromProject": {
-            "description": "Distance from the project site at the time of the event, in metres.",
+            "description": "Distance from the project site at the time of the event, in metres. Null when the geofence was not evaluated.",
             "example": 45.0,
             "format": "double",
             "type": "number"
@@ -2854,6 +2881,17 @@
             "example": "MORNING_CLOCK_IN",
             "type": "string"
           },
+          "geofenceExceptionReason": {
+            "description": "Why the employee marked their own attendance from outside the site boundary. Null when they did not.",
+            "example": "Working from head office today for the client review",
+            "type": "string"
+          },
+          "geofenceRadiusMeters": {
+            "description": "The geofence radius the verdict was reached against, in metres, as it stood at the time of the event. Null when the geofence was not evaluated.",
+            "example": 100,
+            "format": "int32",
+            "type": "integer"
+          },
           "gpsAccuracy": {
             "description": "GPS accuracy of the captured coordinates, in metres.",
             "example": 8.5,
@@ -2872,7 +2910,7 @@
             "type": "boolean"
           },
           "isWithinGeofence": {
-            "description": "Whether the event's coordinates fall within the project's geofence.",
+            "description": "Whether the event's coordinates fall within the project's geofence. Null when no verdict was reached, which is the case when the project has no coordinates, the event carries no position, or the event came from a regularization rather than a live punch. Null is not a violation and must not be shown as one.",
             "example": true,
             "type": "boolean"
           },
@@ -2903,6 +2941,12 @@
             "description": "Name of the project.",
             "example": "Asset Homes Kovilambakkam Phase 2",
             "type": "string"
+          },
+          "recordedById": {
+            "description": "Employee id of whoever submitted the punch. Differs from the employee the record belongs to when a supervisor marked attendance for their team, in which case the geofence is not evaluated because the position captured is the supervisor's.",
+            "example": 42,
+            "format": "int64",
+            "type": "integer"
           },
           "regularizationReason": {
             "description": "Reason given if this event was regularized.",
@@ -26465,7 +26509,7 @@
                 }
               }
             },
-            "description": "Caller lacks permission to manage attendance records"
+            "description": "Caller is neither an attendance record manager nor the approver the record names, or is the employee whose own geofence exception it is"
           },
           "404": {
             "content": {
@@ -26812,7 +26856,7 @@
                 }
               }
             },
-            "description": "Caller lacks permission to manage attendance records"
+            "description": "Caller is neither an attendance record manager nor the approver the record names, or is the employee whose own geofence exception it is"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/Attendance.java
@@ -128,6 +128,29 @@ public class Attendance implements TenantScopedEntity {
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
+    /**
+     * Whether this day is waiting on a decision about a punch taken outside the project's
+     * geofence.
+     *
+     * <p>Every record starts life with {@code approvalStatus} PENDING, so the status alone cannot
+     * say why a day needs a look. This flag is what separates a day held for a geofence exception
+     * from an ordinary one, and it is what an approver's queue filters on.
+     */
+    @Builder.Default
+    @Column(name = "requires_geofence_approval", nullable = false)
+    private Boolean requiresGeofenceApproval = false;
+
+    /**
+     * The employee expected to decide the geofence exception: the employee's reporting manager,
+     * or failing that a project manager assigned to the site being marked against.
+     *
+     * <p>Null when neither could be resolved, in which case the decision falls to the
+     * record-management roles that decide every other attendance record. Those roles can decide
+     * this one either way; the id widens who may approve, it does not narrow it.
+     */
+    @Column(name = "geofence_approver_id")
+    private Long geofenceApproverId;
+
     @Column(name = "remarks")
     private String remarks;
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceController.java
@@ -156,8 +156,13 @@ public class AttendanceController {
                 PageRequest.of(page, size, Sort.by("employeeName"))));
     }
 
+    // Tenant membership is all the annotation can check, because who may decide this record is a
+    // column on the record itself: a geofence exception names the employee's reporting manager,
+    // who is usually not one of the organization-wide record-management roles. Reading an approver
+    // id off the request would let a caller nominate themselves, so the real check runs in the
+    // service against the stored record, the way the check-in and clock-event guards already do.
     @PostMapping("/{id}/approve")
-    @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Approve or reject an attendance record",
             description = "Sets the approval status of an attendance record, with an optional remark, "
@@ -166,7 +171,7 @@ public class AttendanceController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval status updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "approvalStatus is missing or invalid"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither an attendance record manager nor the approver the record names, or is the employee whose own geofence exception it is"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> approve(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceControllerWeb.java
@@ -154,8 +154,13 @@ public class AttendanceControllerWeb {
                 PageRequest.of(page, size, Sort.by("employeeName"))));
     }
 
+    // Tenant membership is all the annotation can check, because who may decide this record is a
+    // column on the record itself: a geofence exception names the employee's reporting manager,
+    // who is usually not one of the organization-wide record-management roles. Reading an approver
+    // id off the request would let a caller nominate themselves, so the real check runs in the
+    // service against the stored record, the way the check-in and clock-event guards already do.
     @PostMapping("/{id}/approve")
-    @PreAuthorize("@attendanceSecurity.canManageRecords()")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Approve or reject an attendance record",
             description = "Sets the approval status of an attendance record, with an optional remark, "
@@ -164,7 +169,7 @@ public class AttendanceControllerWeb {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval status updated"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "approvalStatus is missing or invalid"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks permission to manage attendance records"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither an attendance record manager nor the approver the record names, or is the employee whose own geofence exception it is"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No attendance record with the given id")
     })
     public ResponseEntity<AttendanceResponseDto> approve(

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceService.java
@@ -15,9 +15,11 @@ import org.tornotron.echno_backend.attendance.enums.AttendanceStatus;
 import org.tornotron.echno_backend.attendance.enums.ClockEventType;
 import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
 import org.tornotron.echno_backend.attendance.service.AttendanceCalculationService;
+import org.tornotron.echno_backend.attendance.service.AttendanceGeofenceService;
 import org.tornotron.echno_backend.attendance.service.AttendanceSettingsService;
 import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
 import org.tornotron.echno_backend.common.entity.Attachment;
+import org.tornotron.echno_backend.common.exception.GeofenceExceptionReasonRequiredException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.AttachmentService;
@@ -43,7 +45,9 @@ import java.util.stream.Collectors;
  * <p>Check-in opens the day's record and its first clock event; later punches append to it. Each
  * change runs {@link AttendanceCalculationService} to recompute totals and status against the
  * shift. Enforces per-project photo and geolocation requirements from the effective settings, one
- * record per employee/date/project, and clock-event ordering. Uploaded photos are cleaned from
+ * record per employee/date/project, and clock-event ordering. Each punch is measured against the
+ * project's geofence, and a self-marked punch from outside it is recorded with the employee's
+ * reason and held for their reporting manager rather than refused. Uploaded photos are cleaned from
  * storage if the transaction rolls back. Also marks absence and leave days and builds monthly summaries.
  */
 @Service
@@ -68,6 +72,7 @@ public class AttendanceService {
     private final UserContextService userContextService;
     private final PayloadValidator payloadValidator;
     private final AttendanceSecurityService attendanceSecurity;
+    private final AttendanceGeofenceService geofenceService;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              ShiftTimingRepository shiftTimingRepository,
@@ -82,7 +87,8 @@ public class AttendanceService {
                              FileStorageService fileStorageService,
                              UserContextService userContextService,
                              PayloadValidator payloadValidator,
-                             AttendanceSecurityService attendanceSecurity) {
+                             AttendanceSecurityService attendanceSecurity,
+                             AttendanceGeofenceService geofenceService) {
         this.attendanceRepository = attendanceRepository;
         this.shiftTimingRepository = shiftTimingRepository;
         this.employeeRepository = employeeRepository;
@@ -97,6 +103,80 @@ public class AttendanceService {
         this.userContextService = userContextService;
         this.payloadValidator = payloadValidator;
         this.attendanceSecurity = attendanceSecurity;
+        this.geofenceService = geofenceService;
+    }
+
+    /**
+     * Records who took the punch, measures it against the project's geofence when that measurement
+     * means anything, and holds the day for a decision when a self-marked punch fell outside the
+     * site.
+     *
+     * <p>Only a punch an employee took on their own account is measured. The coordinates on a
+     * request are the submitting device's, so on the mark-for-team path they are the supervisor's
+     * position, not the employee's. Deriving "this employee was inside the site" from where their
+     * supervisor was standing would put a claim about the wrong person into the same column as real
+     * measurements, which is the defect this whole evaluation exists to remove. A punch entered for
+     * somebody else is therefore left unevaluated, the state the column now has words for, and
+     * {@code recordedById} says why.
+     *
+     * <p>Whether a supervisor marking their team should also have to satisfy the site's location
+     * and photo rules is an open product question and is deliberately not answered here: the
+     * mark-for-team path keeps exactly the requirements it has today.
+     *
+     * <p>Being outside the fence never refuses the punch. The employee supplies a reason, the
+     * reason is stored on the punch it explains, and the day waits on their reporting manager. A
+     * site engineer at head office marks attendance and says why.
+     *
+     * @param event The clock event being written, stamped in place.
+     * @param attendance The day's record the event belongs to.
+     * @param employee The employee the day belongs to, used to name the approver.
+     * @param project The project being marked against, or null when it cannot be resolved.
+     * @param settings The effective attendance settings for that project.
+     * @param latitude The latitude on the request.
+     * @param longitude The longitude on the request.
+     * @param exceptionReason The reason given for marking from outside the fence, if any.
+     * @param selfMarked Whether the caller is the employee the day belongs to.
+     * @throws GeofenceExceptionReasonRequiredException if a self-marked punch fell outside the
+     *     fence and carried no reason.
+     */
+    private void applyGeofence(ClockEvent event,
+                               Attendance attendance,
+                               Employee employee,
+                               Project project,
+                               AttendanceSettings settings,
+                               Double latitude,
+                               Double longitude,
+                               String exceptionReason,
+                               boolean selfMarked) {
+        Employee recorder = resolveCurrentEmployee();
+        event.setRecordedById(recorder == null ? null : recorder.getId());
+
+        AttendanceGeofenceService.Evaluation evaluation = selfMarked
+                ? geofenceService.evaluate(project, settings, latitude, longitude)
+                : AttendanceGeofenceService.Evaluation.notEvaluated();
+        geofenceService.applyTo(event, evaluation);
+
+        if (!evaluation.isOutsideFence()) {
+            return;
+        }
+
+        if (exceptionReason == null || exceptionReason.isBlank()) {
+            throw new GeofenceExceptionReasonRequiredException(
+                    evaluation.distanceMeters(), evaluation.radiusMeters());
+        }
+
+        event.setGeofenceExceptionReason(exceptionReason.trim());
+        attendance.setRequiresGeofenceApproval(true);
+        if (attendance.getGeofenceApproverId() == null) {
+            attendance.setGeofenceApproverId(geofenceService.resolveApprover(employee, project));
+        }
+        // A day that had already been decided is decided again, because the exception is new
+        // information. The punch keeps its own reason and distance, so what happened is still on
+        // the record; what is cleared is the standing decision, which no longer stands.
+        attendance.setApprovalStatus(ApprovalStatus.PENDING);
+        attendance.setApprovedBy(null);
+        attendance.setApprovedById(null);
+        attendance.setApprovedAt(null);
     }
 
     /**
@@ -223,12 +303,14 @@ public class AttendanceService {
                 .devicePlatform(dto.getDevicePlatform())
                 .deviceId(dto.getDeviceId())
                 .ipAddress(dto.getIpAddress())
-                .isWithinGeofence(false)
-                .distanceFromProject(0.0)
                 .isRegularized(false)
                 .remarks(dto.getRemarks())
                 .organization(org)
                 .build();
+
+        applyGeofence(clockEvent, attendance, employee, project, settings,
+                dto.getLatitude(), dto.getLongitude(), dto.getGeofenceExceptionReason(),
+                attendanceSecurity.isSelfMarking(dto.getEmployeeId()));
 
         attendance.getClockEvents().add(clockEvent);
         calculationService.recalculate(attendance, shift);
@@ -329,12 +411,24 @@ public class AttendanceService {
                 .devicePlatform(dto.getDevicePlatform())
                 .deviceId(dto.getDeviceId())
                 .ipAddress(dto.getIpAddress())
-                .isWithinGeofence(false)
-                .distanceFromProject(0.0)
                 .isRegularized(false)
                 .remarks(dto.getRemarks())
                 .organization(org)
                 .build();
+
+        // Both are looked up only to evaluate the geofence, and both are optional to it: the
+        // project supplies the centre and the employee names the approver, and a missing one
+        // leaves the punch unevaluated rather than failing a punch that is otherwise valid.
+        Project project = projectRepository
+                .findByIdAndOrganization_Id(attendance.getProjectId(), orgId)
+                .orElse(null);
+        Employee employee = employeeRepository
+                .findByIdAndOrganizationId(attendance.getEmployeeId(), orgId)
+                .orElse(null);
+
+        applyGeofence(clockEvent, attendance, employee, project, settings,
+                dto.getLatitude(), dto.getLongitude(), dto.getGeofenceExceptionReason(),
+                attendanceSecurity.isSelfMarking(attendance.getEmployeeId()));
 
         attendance.getClockEvents().add(clockEvent);
 
@@ -431,11 +525,15 @@ public class AttendanceService {
      * @param dto The approval status and optional remarks.
      * @return The updated attendance record.
      * @throws ResourceNotFoundException if no record with the given ID exists in this organization.
+     * @throws AccessDeniedException if the caller is neither a record manager nor the approver the
+     *     record names, or is the employee whose geofence exception is being decided.
      */
     @Transactional
     public AttendanceResponseDto approveAttendance(Long attendanceId, AttendanceApprovalDto dto) {
         Attendance attendance = attendanceRepository.findByIdAndOrganization_Id(attendanceId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException("Attendance record with ID " + attendanceId + " was not found"));
+
+        requireActorMayApprove(attendance);
 
         Employee approver = resolveCurrentEmployee();
 
@@ -453,6 +551,39 @@ public class AttendanceService {
         }
 
         return attendanceMapper.toResponseDto(attendanceRepository.save(attendance));
+    }
+
+    /**
+     * Refuses the call unless the caller may decide this record's approval.
+     *
+     * <p>The record-management roles decide every attendance record, as they did before, and the
+     * approver a geofence exception names is added to them. That addition is the reason the check
+     * lives here rather than in the {@code @PreAuthorize} guard, for the same reason
+     * {@link #requireActorMayRecordFor} does: the approver is a column on the stored record, which
+     * the annotation cannot see. Reading an approver id off the request instead would let any
+     * caller nominate themselves.
+     *
+     * <p>An employee never decides their own geofence exception, whatever roles they hold. The
+     * decision exists to have someone else vouch for the absence, and a self-approval is not that.
+     * This applies only to records flagged for a geofence decision; who may approve an ordinary
+     * record is unchanged.
+     *
+     * @param attendance The record being decided, read from the database.
+     * @throws AccessDeniedException if the caller may not decide it.
+     */
+    private void requireActorMayApprove(Attendance attendance) {
+        if (Boolean.TRUE.equals(attendance.getRequiresGeofenceApproval())
+                && attendanceSecurity.isSelfMarking(attendance.getEmployeeId())) {
+            throw new AccessDeniedException(
+                    "A geofence exception has to be approved by someone other than the employee it "
+                            + "belongs to");
+        }
+        if (attendanceSecurity.canDecideApproval(attendance.getGeofenceApproverId())) {
+            return;
+        }
+        throw new AccessDeniedException(
+                "Attendance can only be approved by an attendance record manager, or by the "
+                        + "approver the record names");
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsController.java
@@ -113,7 +113,7 @@ public class AttendanceSettingsController {
             @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
     })
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
-                                                         @RequestBody AttendanceSettingsPatchDto dto) {
+                                                         @Valid @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/AttendanceSettingsControllerWeb.java
@@ -114,7 +114,7 @@ public class AttendanceSettingsControllerWeb {
             @ApiResponse(responseCode = "404", description = "No attendance settings with the given id")
     })
     public ResponseEntity<AttendanceSettingsDto> update(@PathVariable Long id,
-                                                         @RequestBody AttendanceSettingsPatchDto dto) {
+                                                         @Valid @RequestBody AttendanceSettingsPatchDto dto) {
         return ResponseEntity.ok(settingsService.updateSettings(id, dto));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/ClockEvent.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/ClockEvent.java
@@ -23,6 +23,10 @@ import java.util.List;
  * longitude, accuracy, distance from the project, geofence flag), which the attendance calculation
  * reads to derive worked hours. May be flagged {@code isRegularized} when created or corrected
  * through a regularization rather than a live punch.
+ *
+ * <p>The geofence fields are nullable together: either a verdict was reached, in which case
+ * {@code isWithinGeofence}, {@code distanceFromProject} and {@code geofenceRadiusMeters} are all
+ * set, or none of them are.
  */
 @Entity
 @Table(name = "clock_event")
@@ -75,13 +79,49 @@ public class ClockEvent implements TenantScopedEntity {
     @Column(name = "ip_address")
     private String ipAddress;
 
-    @Builder.Default
-    @Column(name = "is_within_geofence", nullable = false)
-    private Boolean isWithinGeofence = false;
+    /**
+     * Whether the punch fell inside the project's geofence, or null when no verdict was reached.
+     *
+     * <p>Null is a real state and the common one: a project with no coordinates, an organization
+     * with no radius, a punch with no location, and an event written by a regularization rather
+     * than taken on a device all leave it unevaluated. It carried a {@code false} default until
+     * the evaluation was wired up, which made "nobody looked" read as "outside the site".
+     */
+    @Column(name = "is_within_geofence")
+    private Boolean isWithinGeofence;
 
-    @Builder.Default
+    /** How far the punch was from the project's marker, in metres, or null when not measured. */
     @Column(name = "distance_from_project")
-    private Double distanceFromProject = 0.0;
+    private Double distanceFromProject;
+
+    /**
+     * The geofence radius the verdict was reached against, in metres, or null when not evaluated.
+     *
+     * <p>Stamped here rather than read back from the settings because both the radius and the
+     * project's coordinates can change afterwards, and a verdict has to stay readable against the
+     * numbers that produced it.
+     */
+    @Column(name = "geofence_radius_meters")
+    private Integer geofenceRadiusMeters;
+
+    /**
+     * Why the employee marked their own attendance from outside the fence, or null when they did
+     * not. Set only on the self-marking path, which is the only one that asks for it.
+     */
+    @Column(name = "geofence_exception_reason", length = 500)
+    private String geofenceExceptionReason;
+
+    /**
+     * The employee who submitted this punch, which is not always the employee it belongs to: a
+     * supervisor can record attendance for their team.
+     *
+     * <p>It is what makes the geofence fields readable. A punch entered for somebody else carries
+     * the submitting device's position, so it is left unevaluated, and without this column a reader
+     * could not tell that absent verdict from one caused by a project with no coordinates. Null
+     * only when the caller resolves to no employee record in this tenant.
+     */
+    @Column(name = "recorded_by_id")
+    private Long recordedById;
 
     @Column(name = "remarks")
     private String remarks;

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceCheckInDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -59,4 +60,12 @@ public class AttendanceCheckInDto {
 
     @Schema(description = "Optional remarks about the check-in.", example = "Reported directly to the second floor slab pour")
     private String remarks;
+
+    @Schema(description = "Why the employee is marking attendance from outside the project's "
+            + "geofence. Required only when they are marking their own attendance and the captured "
+            + "position falls outside the site boundary; the punch is accepted and the day is then "
+            + "held for their reporting manager to approve.",
+            example = "Working from head office today for the client review")
+    @Size(max = 500)
+    private String geofenceExceptionReason;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceClockEventDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -58,4 +59,12 @@ public class AttendanceClockEventDto {
 
     @Schema(description = "Optional remarks about the event.", example = "Left site briefly for a material delivery")
     private String remarks;
+
+    @Schema(description = "Why the employee is marking attendance from outside the project's "
+            + "geofence. Required only when they are marking their own attendance and the captured "
+            + "position falls outside the site boundary; the punch is accepted and the day is then "
+            + "held for their reporting manager to approve.",
+            example = "Working from head office today for the client review")
+    @Size(max = 500)
+    private String geofenceExceptionReason;
 }

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceResponseDto.java
@@ -94,6 +94,19 @@ public class AttendanceResponseDto {
     @Schema(description = "Timestamp the record was approved or rejected.", example = "2026-01-16T10:15:00")
     private LocalDateTime approvedAt;
 
+    @Schema(description = "Whether this day contains a punch the employee marked themselves from "
+            + "outside the project's geofence, having given a reason. Such a record is held for a "
+            + "decision: it is still waiting while the approval status is PENDING.",
+            example = "false")
+    private Boolean requiresGeofenceApproval;
+
+    @Schema(description = "Employee id of the person expected to decide the geofence exception: "
+            + "the employee's reporting manager, or a project manager assigned to the site. Null "
+            + "when neither could be resolved, in which case the attendance record managers decide "
+            + "as they do for every other record.",
+            example = "42")
+    private Long geofenceApproverId;
+
     @Schema(description = "Remarks attached to the record, for example an approval or rejection note.", example = "Confirmed with site supervisor")
     private String remarks;
 

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsCreationDto.java
@@ -39,7 +39,7 @@ public class AttendanceSettingsCreationDto {
     @NotNull
     private Boolean geolocationRequired;
 
-    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "200")
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "100")
     @NotNull
     @Min(50) @Max(5000)
     private Integer geofenceRadiusMeters;

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsDto.java
@@ -39,7 +39,7 @@ public class AttendanceSettingsDto {
     @Schema(description = "Whether GPS coordinates are required on clock events.", example = "true")
     private Boolean geolocationRequired;
 
-    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "200")
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "100")
     private Integer geofenceRadiusMeters;
 
     @Schema(description = "Whether movements away from the checked-in location must be logged.", example = "true")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsPatchDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/AttendanceSettingsPatchDto.java
@@ -1,6 +1,8 @@
 package org.tornotron.echno_backend.attendance.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,7 +28,9 @@ public class AttendanceSettingsPatchDto {
     @Schema(description = "Whether GPS coordinates are required on clock events.", example = "true")
     private Boolean geolocationRequired;
 
-    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "250")
+    @Schema(description = "Radius in metres around the project within which a clock event is considered on site.", example = "100")
+    @Min(50)
+    @Max(5000)
     private Integer geofenceRadiusMeters;
 
     @Schema(description = "Whether movements away from the checked-in location must be logged.", example = "true")

--- a/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/dto/ClockEventDto.java
@@ -48,11 +48,33 @@ public class ClockEventDto {
     @Schema(description = "Platform the event was recorded from.", example = "android")
     private String devicePlatform;
 
-    @Schema(description = "Whether the event's coordinates fall within the project's geofence.", example = "true")
+    @Schema(description = "Whether the event's coordinates fall within the project's geofence. "
+            + "Null when no verdict was reached, which is the case when the project has no "
+            + "coordinates, the event carries no position, or the event came from a regularization "
+            + "rather than a live punch. Null is not a violation and must not be shown as one.",
+            example = "true")
     private Boolean isWithinGeofence;
 
-    @Schema(description = "Distance from the project site at the time of the event, in metres.", example = "45.0")
+    @Schema(description = "Distance from the project site at the time of the event, in metres. "
+            + "Null when the geofence was not evaluated.", example = "45.0")
     private Double distanceFromProject;
+
+    @Schema(description = "The geofence radius the verdict was reached against, in metres, as it "
+            + "stood at the time of the event. Null when the geofence was not evaluated.",
+            example = "100")
+    private Integer geofenceRadiusMeters;
+
+    @Schema(description = "Why the employee marked their own attendance from outside the site "
+            + "boundary. Null when they did not.",
+            example = "Working from head office today for the client review")
+    private String geofenceExceptionReason;
+
+    @Schema(description = "Employee id of whoever submitted the punch. Differs from the employee "
+            + "the record belongs to when a supervisor marked attendance for their team, in which "
+            + "case the geofence is not evaluated because the position captured is the "
+            + "supervisor's.",
+            example = "42")
+    private Long recordedById;
 
     @Schema(description = "Optional remarks about the event.", example = "Reported directly to the second floor slab pour")
     private String remarks;

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceService.java
@@ -1,0 +1,169 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.springframework.stereotype.Service;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.validator.GeofenceValidator;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.project.Project;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Evaluates a clock event against the project's geofence and works out who decides an exception.
+ *
+ * <p>The three inputs were all present long before anything joined them: the project's coordinates
+ * are the centre, the effective attendance settings carry the radius, and the punch carries the
+ * position captured on the device. {@link GeofenceValidator} has held the Haversine distance since
+ * March 2026 and was never called; this is what calls it.
+ *
+ * <p>An evaluation is either complete or absent. When any of the three inputs is missing the
+ * result is {@link Evaluation#notEvaluated()}, which the entity stores as nulls, and no verdict is
+ * implied. That matters more than it sounds: the columns spent months holding a hard-coded
+ * {@code false} and {@code 0.0} that a reader could not tell apart from a measurement.
+ */
+@Service
+public class AttendanceGeofenceService {
+
+    private final GeofenceValidator geofenceValidator;
+
+    public AttendanceGeofenceService(GeofenceValidator geofenceValidator) {
+        this.geofenceValidator = geofenceValidator;
+    }
+
+    /**
+     * The outcome of comparing one punch against one project's geofence.
+     *
+     * <p>All three components are set together or all three are null. {@code withinFence} is the
+     * verdict, {@code distanceMeters} the measured distance from the project's marker, and
+     * {@code radiusMeters} the radius the verdict was reached against, kept so the row still
+     * explains itself after the settings or the project's coordinates are edited.
+     *
+     * @param withinFence Whether the punch fell inside the radius, or null when not evaluated.
+     * @param distanceMeters Distance from the project marker in metres, or null when not measured.
+     * @param radiusMeters The radius applied, in metres, or null when not evaluated.
+     */
+    public record Evaluation(Boolean withinFence, Double distanceMeters, Integer radiusMeters) {
+
+        private static final Evaluation NOT_EVALUATED = new Evaluation(null, null, null);
+
+        /** No verdict was reached, because at least one of centre, radius or position was absent. */
+        public static Evaluation notEvaluated() {
+            return NOT_EVALUATED;
+        }
+
+        /** Whether a verdict was reached at all. */
+        public boolean isEvaluated() {
+            return withinFence != null;
+        }
+
+        /** Whether a verdict was reached and it puts the punch outside the fence. */
+        public boolean isOutsideFence() {
+            return Boolean.FALSE.equals(withinFence);
+        }
+    }
+
+    /**
+     * Compares a captured position against a project's geofence.
+     *
+     * <p>Returns {@link Evaluation#notEvaluated()} rather than guessing whenever the project has no
+     * coordinates, the settings carry no radius, or the punch carries no position. Roughly one
+     * project in six has no coordinates set, so an absent verdict is an ordinary outcome and not an
+     * error.
+     *
+     * <p>The distance is rounded to the centimetre. The project's coordinates are stored as
+     * {@code Float}, which holds about seven significant digits, so the metre is already the
+     * honest limit of this measurement and a full double's worth of decimals would read as
+     * precision that is not there.
+     *
+     * @param project The project being marked against, or null when it cannot be resolved.
+     * @param settings The effective attendance settings for that project, or null.
+     * @param latitude The latitude captured on the device, or null.
+     * @param longitude The longitude captured on the device, or null.
+     * @return The verdict, distance and radius, or an unevaluated result.
+     */
+    public Evaluation evaluate(Project project, AttendanceSettings settings,
+                               Double latitude, Double longitude) {
+        if (project == null || latitude == null || longitude == null
+                || project.getProjectLatitude() == null || project.getProjectLongitude() == null) {
+            return Evaluation.notEvaluated();
+        }
+        Integer radius = settings == null ? null : settings.getGeofenceRadiusMeters();
+        if (radius == null) {
+            return Evaluation.notEvaluated();
+        }
+
+        double distance = geofenceValidator.calculateDistance(
+                latitude, longitude,
+                project.getProjectLatitude(), project.getProjectLongitude());
+        double rounded = Math.round(distance * 100.0) / 100.0;
+        return new Evaluation(rounded <= radius, rounded, radius);
+    }
+
+    /**
+     * Writes an evaluation onto a clock event, including an unevaluated one.
+     *
+     * @param event The clock event to stamp.
+     * @param evaluation The evaluation to write.
+     */
+    public void applyTo(ClockEvent event, Evaluation evaluation) {
+        event.setIsWithinGeofence(evaluation.withinFence());
+        event.setDistanceFromProject(evaluation.distanceMeters());
+        event.setGeofenceRadiusMeters(evaluation.radiusMeters());
+    }
+
+    /**
+     * Names the employee expected to decide a geofence exception raised by this employee on this
+     * project.
+     *
+     * <p>The decision is the reporting manager's: an employee who is legitimately away from the
+     * site, at head office or between sites, is someone their own manager can vouch for. That
+     * relation exists on the employee as the self-referencing {@code manager}, which is what the
+     * leave module already walks to build an approval chain.
+     *
+     * <p>It is set on a minority of employees, so there is a fallback, and the fallback is
+     * deliberately the narrowest thing the schema can already answer rather than a new hierarchy: a
+     * project manager assigned to the project being marked against. A project has no manager
+     * pointer of its own, only membership plus the organization-wide {@code project-manager} role,
+     * so that is the intersection of the two. Where several qualify, the lowest employee id is
+     * taken, so the same exception always names the same approver.
+     *
+     * <p>Null when neither resolves. A null does not leave the record unapprovable: it falls to the
+     * record-management roles that already decide every attendance record.
+     *
+     * @param employee The employee whose punch fell outside the fence.
+     * @param project The project the punch was recorded against, or null when unresolved.
+     * @return The approver's employee id, or null when none could be named.
+     */
+    public Long resolveApprover(Employee employee, Project project) {
+        Long employeeId = employee == null ? null : employee.getId();
+
+        Employee manager = employee == null ? null : employee.getManager();
+        if (manager != null && manager.getId() != null && !manager.getId().equals(employeeId)) {
+            return manager.getId();
+        }
+        return projectManagerFor(project, employeeId);
+    }
+
+    /**
+     * The lowest-numbered employee assigned to the project who holds the project-manager role,
+     * never the employee raising the exception themselves.
+     */
+    private Long projectManagerFor(Project project, Long employeeId) {
+        List<Employee> members = project == null ? null : project.getEmployees();
+        if (members == null || members.isEmpty()) {
+            return null;
+        }
+        return members.stream()
+                .filter(Objects::nonNull)
+                .filter(member -> member.getId() != null && !member.getId().equals(employeeId))
+                .filter(member -> member.getOrgRoles() != null
+                        && member.getOrgRoles().contains(OrgRole.PROJECT_MANAGER))
+                .map(Employee::getId)
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
+++ b/src/main/java/org/tornotron/echno_backend/attendance/service/AttendanceRegularizationService.java
@@ -327,6 +327,13 @@ public class AttendanceRegularizationService {
      * missing, not to overwrite a real clock event, and skipping duplicates keeps the operation safe
      * to reach twice, for instance when a rejected request is resubmitted and then approved.
      *
+     * <p>The geofence fields are left unset, which is what the columns now mean by "not
+     * evaluated". A regularization supplies a punch that was never taken: its coordinates are what
+     * the employee says they were, remembered after the fact, and running them through the fence
+     * would produce a verdict about a recollection and store it in the same column as verdicts
+     * about measurements. The events written here used to carry a hard-coded "outside the fence,
+     * zero metres away", which claimed both at once.
+     *
      * <p>A correction let through under the break-glass role says so on every event it writes. The
      * request already records the requester and the approver side by side, but the clock event is
      * what a corrected day is read from, so a correction nobody independent agreed to says so where
@@ -365,8 +372,6 @@ public class AttendanceRegularizationService {
                     .projectName(attendance.getProjectName())
                     .isRegularized(true)
                     .regularizationReason("Self-regularized" + (selfApproved ? SELF_APPROVAL_NOTE : ""))
-                    .isWithinGeofence(false)
-                    .distanceFromProject(0.0)
                     .organization(org)
                     .build();
             attendance.getClockEvents().add(event);

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GeofenceExceptionReasonRequiredException.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GeofenceExceptionReasonRequiredException.java
@@ -1,0 +1,35 @@
+package org.tornotron.echno_backend.common.exception;
+
+/**
+ * Raised when an employee marks their own attendance from outside the project's geofence without
+ * saying why.
+ *
+ * <p>This is not a refusal. Being outside the fence is allowed and expected, for instance a site
+ * engineer punching in from head office; it needs a reason on the record and a manager's decision
+ * afterwards. The client is being asked for the reason, not turned away, which is why this carries
+ * the measured distance and the radius: the prompt should be able to tell the employee how far out
+ * they are rather than repeating a generic message.
+ */
+public class GeofenceExceptionReasonRequiredException extends RuntimeException {
+
+    private final double distanceMeters;
+    private final int radiusMeters;
+
+    public GeofenceExceptionReasonRequiredException(double distanceMeters, int radiusMeters) {
+        super("This location is " + Math.round(distanceMeters) + " m from the project site, outside "
+                + "the " + radiusMeters + " m site boundary. Give a reason to mark attendance from "
+                + "here; the record will be held for your reporting manager to approve.");
+        this.distanceMeters = distanceMeters;
+        this.radiusMeters = radiusMeters;
+    }
+
+    /** How far the punch was from the project marker, in metres. */
+    public double getDistanceMeters() {
+        return distanceMeters;
+    }
+
+    /** The geofence radius that applied, in metres. */
+    public int getRadiusMeters() {
+        return radiusMeters;
+    }
+}

--- a/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tornotron/echno_backend/common/exception/GlobalExceptionHandler.java
@@ -335,6 +335,18 @@ public class GlobalExceptionHandler {
         return problem(HttpStatus.CONFLICT, "Invalid Attendance Sequence", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(GeofenceExceptionReasonRequiredException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ProblemDetail handleGeofenceExceptionReasonRequiredException(
+            GeofenceExceptionReasonRequiredException ex, WebRequest request) {
+        logger.info("Attendance marked outside the geofence without a reason: {}", ex.getMessage());
+        ProblemDetail pd = problem(HttpStatus.UNPROCESSABLE_ENTITY,
+                "Geofence Exception Reason Required", ex.getMessage(), request);
+        pd.setProperty("distanceMeters", ex.getDistanceMeters());
+        pd.setProperty("geofenceRadiusMeters", ex.getRadiusMeters());
+        return pd;
+    }
+
     @ExceptionHandler(InsufficientStockException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ProblemDetail handleInsufficientStockException(InsufficientStockException ex, WebRequest request) {

--- a/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
+++ b/src/main/java/org/tornotron/echno_backend/common/service/AttendanceSecurityService.java
@@ -71,4 +71,42 @@ public class AttendanceSecurityService {
     public boolean canRecordFor(Long employeeId) {
         return orgSecurity.isSelfOrHasAnyOrgRole(employeeId, recordManagementRoles);
     }
+
+    /**
+     * Whether the caller is the employee whose attendance is being recorded, rather than someone
+     * recording it on their behalf.
+     *
+     * <p>{@link #canRecordFor} deliberately blurs the two, because both are allowed to write. The
+     * geofence rule needs them apart: a punch an employee takes on their own account is evaluated
+     * against the site they are marking against, and being outside it makes them explain
+     * themselves. A supervisor entering a team's attendance is sending their own device's position
+     * for somebody else's day, so the same demand would be asking the wrong person about the wrong
+     * location.
+     *
+     * @param employeeId The employee the record belongs to.
+     * @return Whether the caller is that employee.
+     */
+    public boolean isSelfMarking(Long employeeId) {
+        return orgSecurity.isSelfInCurrentTenant(employeeId);
+    }
+
+    /**
+     * Whether the caller may decide an attendance record's approval.
+     *
+     * <p>The record-management roles decide every attendance record and continue to. This adds the
+     * employee a geofence exception names as its approver, which is the reporting manager the
+     * decision is meant to rest with and who is often not a manager in the role sense: the role set
+     * is organization-wide, so gating on it alone would have sent every exception to HR and the
+     * project managers regardless of who the employee reports to.
+     *
+     * <p>The designated approver is read off the stored record, never off the request. Passing an
+     * id a caller supplied would let anyone nominate themselves.
+     *
+     * @param designatedApproverId The approver named on the record, or null when none is.
+     * @return Whether the caller may decide it.
+     */
+    public boolean canDecideApproval(Long designatedApproverId) {
+        return canManageRecords()
+                || (designatedApproverId != null && orgSecurity.isSelfInCurrentTenant(designatedApproverId));
+    }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -394,4 +394,7 @@
     <!-- v4.0 - Site transfers: record what arrived, and make existing rows agree with the ledger -->
     <include file="db/changelog/v4.0/086-site-transfer-two-step-receipt.xml"/>
 
+    <!-- v4.0 - Attendance: let a clock event say the geofence was never evaluated, and record an out-of-fence punch -->
+    <include file="db/changelog/v4.0/087-clock-event-geofence-evaluation.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/087-clock-event-geofence-evaluation.xml
+++ b/src/main/resources/db/changelog/v4.0/087-clock-event-geofence-evaluation.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        The order of the four changesets below is the point of this file, and it cannot be
+        rearranged.
+
+        clock_event.is_within_geofence has been NOT NULL with a false default since it was created,
+        and nothing ever computed a value for it: every row written since March 2026 carries a
+        false that means "nobody looked", written as a literal at the three places a clock event is
+        built. distance_from_project carries a 0.0 from the same literals, which reads as a
+        positive claim that the employee stood on the site marker.
+
+        Once the evaluation is wired up, a false will start meaning "measured, and outside the
+        fence". If real values were written before the column could hold a third state, the
+        placeholder rows would become indistinguishable from genuine violations, permanently: the
+        information needed to separate them exists only until the first real false lands.
+
+        So the column is widened first (087-01), the existing rows are moved to the unevaluated
+        state second (087-02), and only then do the new columns the evaluation writes appear
+        (087-03, 087-04).
+    -->
+
+    <changeSet id="087-01-clock-event-geofence-nullable" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="clock_event" columnName="is_within_geofence"/>
+        </preConditions>
+
+        <comment>
+            Give is_within_geofence a null state so "not evaluated" can be told apart from
+            "evaluated and outside the fence". A punch has no geofence verdict when the project
+            carries no coordinates, when the settings require no location, or when the event was
+            written by a regularization rather than taken on a device, and all three are ordinary.
+            The false default goes with the constraint: a default that is also a real verdict is
+            what made the placeholder rows unreadable in the first place.
+        </comment>
+
+        <dropDefaultValue tableName="clock_event" columnName="is_within_geofence" columnDataType="BOOLEAN"/>
+        <dropNotNullConstraint tableName="clock_event" columnName="is_within_geofence" columnDataType="BOOLEAN"/>
+    </changeSet>
+
+    <changeSet id="087-02-backfill-unevaluated-clock-events" author="echno">
+        <comment>
+            Move every existing row to the unevaluated state. None of them were evaluated: the two
+            values on them were literals, not measurements. Doing this before the evaluation ships
+            is what keeps the two kinds of false apart, because afterwards there is no way to tell
+            which rows were measured.
+
+            distance_from_project is set alongside it for the same reason and is the more
+            misleading of the two, since 0.0 asserts a measured position rather than an absent one.
+        </comment>
+
+        <update tableName="clock_event">
+            <column name="is_within_geofence" valueComputed="NULL"/>
+            <column name="distance_from_project" valueComputed="NULL"/>
+        </update>
+
+        <rollback>
+            <update tableName="clock_event">
+                <column name="is_within_geofence" valueBoolean="false"/>
+                <column name="distance_from_project" valueNumeric="0.0"/>
+            </update>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="087-03-add-clock-event-geofence-context" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="clock_event" columnName="geofence_radius_meters"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Stamp the radius the verdict was reached against. A project's coordinates and an
+            organization's radius can both be edited after the fact, so a distance recomputed later
+            is not necessarily the distance that applied at the time. Recording the radius next to
+            the measured distance makes the row explain itself: "240 m from a 100 m fence" stays
+            true whatever the settings say afterwards.
+        </comment>
+
+        <addColumn tableName="clock_event">
+            <column name="geofence_radius_meters" type="INT"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="087-04-add-geofence-exception-columns" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="clock_event" columnName="geofence_exception_reason"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            An employee marking their own attendance from outside the fence is not blocked. They
+            give a reason, the reason is stored on the punch that was outside, and the day's record
+            is held for a decision by their reporting manager.
+
+            recorded_by_id is who submitted the punch, which is not always whose day it is: a
+            supervisor can mark attendance for their team, and the coordinates on that request are
+            the supervisor's device, not the employee's. Those punches are therefore left
+            unevaluated rather than judged against a position that describes the wrong person, and
+            this column is what tells that absent verdict apart from one caused by a project with no
+            coordinates. It is also the only way to count how much attendance is entered this way,
+            which is the open question about what the mark-for-team path should require.
+
+            geofence_exception_reason is the reason, on the clock event because it belongs to the
+            punch it explains. requires_geofence_approval and geofence_approver_id are on the day's
+            attendance record because that is what gets approved: the flag is what separates a day
+            waiting on a geofence decision from every other pending day, and the approver id names
+            who is expected to make it. The id is nullable because not every employee has a
+            reporting manager and not every project has a manager assigned to it; a null there
+            means the existing record-management roles decide, which is who decides today.
+        </comment>
+
+        <addColumn tableName="clock_event">
+            <column name="geofence_exception_reason" type="VARCHAR(500)"/>
+            <column name="recorded_by_id" type="BIGINT"/>
+        </addColumn>
+
+        <addColumn tableName="attendance">
+            <column name="requires_geofence_approval" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="geofence_approver_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceActorAuthorizationTest.java
@@ -87,6 +87,7 @@ class AttendanceActorAuthorizationTest {
     @Mock private FileStorageService fileStorageService;
     @Mock private UserContextService userContextService;
     @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
     @Mock private MovementRecordRepository movementRecordRepository;
     @Mock private MovementRecordMapper movementRecordMapper;
 
@@ -106,7 +107,7 @@ class AttendanceActorAuthorizationTest {
                 sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
                 userContextService,
                 new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
-                attendanceSecurity);
+                attendanceSecurity, geofenceService);
     }
 
     private MovementRecordService movementRecordService() {

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceEnforcementTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceEnforcementTest.java
@@ -1,0 +1,303 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.ShiftTiming;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.dto.AttendanceCheckInDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.attendance.validator.GeofenceValidator;
+import org.tornotron.echno_backend.common.exception.GeofenceExceptionReasonRequiredException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.InstanceOfAssertFactories.throwable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What a clock event records about the geofence, and what happens when a self-marked punch falls
+ * outside it.
+ *
+ * <p>Before this, every clock event in the system was built with two literals: {@code
+ * isWithinGeofence(false)} and {@code distanceFromProject(0.0)}. Nothing measured anything. The
+ * browser blocked out-of-range clock-ins and the server then stored the opposite of what the
+ * browser had just verified, which is how the gap stayed invisible: the product visibly enforced a
+ * geofence while the two rows on staging said an employee standing nine metres from the site was
+ * outside it, and zero metres away, at the same time.
+ *
+ * <p>Each test below fails on the old code, and the first three fail by the assertion rather than
+ * by an error, which is the point: the old values were well-formed and wrong.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceGeofenceEnforcementTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long EMPLOYEE_ID = 7L;
+    private static final Long MANAGER_ID = 55L;
+    private static final Long PROJECT_ID = 12L;
+
+    private static final double PROJECT_LAT = 13.0827;
+    private static final double PROJECT_LON = 80.2707;
+    /** About eight metres from the marker: on site by any reading. */
+    private static final double ON_SITE_LAT = PROJECT_LAT + 0.00005;
+    private static final double ON_SITE_LON = PROJECT_LON + 0.00005;
+    /** About 256 metres from the marker: outside a hundred-metre fence. */
+    private static final double OFF_SITE_LAT = PROJECT_LAT + 0.0023;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity,
+                new AttendanceGeofenceService(new GeofenceValidator()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    /** The whole happy path up to the save, with the geofence inputs all present. */
+    private void givenACheckInIsPossible(Float projectLatitude, Float projectLongitude) {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+
+        Employee manager = new Employee();
+        manager.setId(MANAGER_ID);
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE_ID);
+        employee.setEmployeeName("Site engineer");
+        employee.setShiftTiming(new ShiftTiming());
+        employee.setManager(manager);
+
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setProjectName("Asset Homes Kovilambakkam Phase 2");
+        project.setProjectLatitude(projectLatitude);
+        project.setProjectLongitude(projectLongitude);
+        project.setEmployees(new ArrayList<>());
+
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization));
+        when(employeeRepository.findByIdAndOrganizationId(EMPLOYEE_ID, ORG_ID))
+                .thenReturn(Optional.of(employee));
+        when(projectRepository.findByIdAndOrganization_Id(PROJECT_ID, ORG_ID))
+                .thenReturn(Optional.of(project));
+        when(settingsService.resolveEffectiveSettings(ORG_ID, PROJECT_ID)).thenReturn(
+                AttendanceSettings.builder()
+                        .photoRequiredOnCheckIn(false)
+                        .geolocationRequired(true)
+                        .geofenceRadiusMeters(100)
+                        .build());
+        when(attendanceRepository.findByEmployeeIdAndAttendanceDateAndProjectId(
+                any(), any(), any())).thenReturn(Optional.empty());
+        lenient().when(attendanceRepository.save(any(Attendance.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(attendanceMapper.toResponseDto(any(Attendance.class)))
+                .thenReturn(AttendanceResponseDto.builder().build());
+        lenient().when(attendanceSecurity.canRecordFor(EMPLOYEE_ID)).thenReturn(true);
+    }
+
+    private void givenACheckInIsPossible() {
+        givenACheckInIsPossible((float) PROJECT_LAT, (float) PROJECT_LON);
+    }
+
+    private AttendanceCheckInDto checkInAt(Double latitude, Double longitude, String reason) {
+        AttendanceCheckInDto dto = new AttendanceCheckInDto();
+        dto.setEmployeeId(EMPLOYEE_ID);
+        dto.setProjectId(PROJECT_ID);
+        dto.setEventTimestamp(LocalDateTime.of(2026, 9, 6, 9, 2));
+        dto.setLatitude(latitude);
+        dto.setLongitude(longitude);
+        dto.setGeofenceExceptionReason(reason);
+        return dto;
+    }
+
+    private ClockEvent savedEvent() {
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        verify(attendanceRepository).save(captor.capture());
+        assertThat(captor.getValue().getClockEvents()).hasSize(1);
+        return captor.getValue().getClockEvents().get(0);
+    }
+
+    private Attendance savedAttendance() {
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        verify(attendanceRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void aPunchOnSiteIsRecordedAsInsideTheFence_withTheMeasuredDistance() {
+        // Fails on the old code by assertion: the event was built with isWithinGeofence(false) and
+        // distanceFromProject(0.0) whatever the coordinates said. This is the staging defect in
+        // miniature, where a punch nine metres from the site was filed as a violation.
+        givenACheckInIsPossible();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        service.checkIn(checkInAt(ON_SITE_LAT, ON_SITE_LON, null), null);
+
+        ClockEvent event = savedEvent();
+        assertThat(event.getIsWithinGeofence()).isTrue();
+        assertThat(event.getDistanceFromProject()).isCloseTo(7.8, within(2.0));
+        assertThat(event.getGeofenceRadiusMeters()).isEqualTo(100);
+        assertThat(event.getGeofenceExceptionReason()).isNull();
+        assertThat(savedAttendance().getRequiresGeofenceApproval()).isFalse();
+    }
+
+    @Test
+    void aProjectWithNoCoordinatesLeavesTheEventUnevaluated() {
+        // Fails on the old code by assertion, and this is the one that could not be fixed later:
+        // the old false and 0.0 were indistinguishable from a measured violation, so a null here
+        // is the only thing that keeps "nobody looked" readable.
+        givenACheckInIsPossible(null, null);
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        service.checkIn(checkInAt(ON_SITE_LAT, ON_SITE_LON, null), null);
+
+        ClockEvent event = savedEvent();
+        assertThat(event.getIsWithinGeofence()).isNull();
+        assertThat(event.getDistanceFromProject()).isNull();
+        assertThat(event.getGeofenceRadiusMeters()).isNull();
+    }
+
+    @Test
+    void aSelfMarkedPunchOutsideTheFence_withNoReason_asksForOne() {
+        // Fails on the old code by the check-in going through and storing a record.
+        givenACheckInIsPossible();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        // The distance and the radius travel with the exception so the prompt can tell the
+        // employee how far out they are rather than repeating a generic refusal.
+        assertThatThrownBy(() -> service.checkIn(checkInAt(OFF_SITE_LAT, PROJECT_LON, null), null))
+                .isInstanceOf(GeofenceExceptionReasonRequiredException.class)
+                .asInstanceOf(throwable(GeofenceExceptionReasonRequiredException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getDistanceMeters()).isCloseTo(256.0, within(5.0));
+                    assertThat(ex.getRadiusMeters()).isEqualTo(100);
+                });
+
+        verify(attendanceRepository, never()).save(any());
+    }
+
+    @Test
+    void aSelfMarkedPunchOutsideTheFence_withAReason_isAcceptedAndHeldForTheReportingManager() {
+        // The product decision: being outside the fence does not block the mark. A site engineer
+        // at head office marks attendance, says why, and their manager decides.
+        givenACheckInIsPossible();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        service.checkIn(checkInAt(OFF_SITE_LAT, PROJECT_LON,
+                "  At head office for the client review  "), null);
+
+        ClockEvent event = savedEvent();
+        assertThat(event.getIsWithinGeofence()).isFalse();
+        assertThat(event.getDistanceFromProject()).isCloseTo(256.0, within(5.0));
+        assertThat(event.getGeofenceExceptionReason())
+                .isEqualTo("At head office for the client review");
+
+        Attendance attendance = savedAttendance();
+        assertThat(attendance.getRequiresGeofenceApproval()).isTrue();
+        assertThat(attendance.getGeofenceApproverId()).isEqualTo(MANAGER_ID);
+        assertThat(attendance.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING);
+    }
+
+    @Test
+    void aBlankReasonIsNotAReason() {
+        givenACheckInIsPossible();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.checkIn(checkInAt(OFF_SITE_LAT, PROJECT_LON, "   "), null))
+                .isInstanceOf(GeofenceExceptionReasonRequiredException.class);
+    }
+
+    @Test
+    void aPunchEnteredForSomebodyElseIsLeftUnevaluated_andIsNotHeld() {
+        // A supervisor marking their team sends their own device's position for somebody else's
+        // day. Judging the employee by where their supervisor was standing would put a claim about
+        // the wrong person in the same column as real measurements, which is the defect this whole
+        // evaluation exists to remove. So the punch is recorded, unevaluated, and recordedById
+        // says why. Nothing about the mark-for-team path is gated.
+        givenACheckInIsPossible();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(false);
+
+        service.checkIn(checkInAt(OFF_SITE_LAT, PROJECT_LON, null), null);
+
+        ClockEvent event = savedEvent();
+        assertThat(event.getIsWithinGeofence()).isNull();
+        assertThat(event.getDistanceFromProject()).isNull();
+        assertThat(event.getGeofenceExceptionReason()).isNull();
+        assertThat(savedAttendance().getRequiresGeofenceApproval()).isFalse();
+        assertThat(savedAttendance().getGeofenceApproverId()).isNull();
+    }
+
+    @Test
+    void thePunchRecordsWhoSubmittedIt() {
+        // Without this the null verdict above is unreadable: a reader cannot tell a punch entered
+        // by a supervisor from one taken against a project that has no coordinates.
+        givenACheckInIsPossible();
+        Employee supervisor = new Employee();
+        supervisor.setId(31L);
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(false);
+        when(userContextService.getCurrentUserId()).thenReturn(900L);
+        when(employeeRepository.findByUserIdAndOrganizationId(900L, ORG_ID))
+                .thenReturn(Optional.of(supervisor));
+
+        service.checkIn(checkInAt(ON_SITE_LAT, ON_SITE_LON, null), null);
+
+        assertThat(savedEvent().getRecordedById()).isEqualTo(31L);
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceGeofenceServiceTest.java
@@ -1,0 +1,174 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import org.junit.jupiter.api.Test;
+import org.tornotron.echno_backend.attendance.AttendanceSettings;
+import org.tornotron.echno_backend.attendance.ClockEvent;
+import org.tornotron.echno_backend.attendance.validator.GeofenceValidator;
+import org.tornotron.echno_backend.common.enums.OrgRole;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.project.Project;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Evaluating a punch against a project's geofence, and naming who decides an exception.
+ *
+ * <p>The two halves are here for different reasons. The evaluation has to be able to say "no
+ * verdict", because roughly one project in six carries no coordinates and a punch can arrive
+ * without a position; the columns held a hard-coded {@code false} and {@code 0.0} for months
+ * precisely because there was nowhere to put that answer. The approver ladder has to fall back,
+ * because the reporting-manager relation exists but is set on a minority of employees.
+ */
+class AttendanceGeofenceServiceTest {
+
+    private static final double PROJECT_LAT = 13.0827;
+    private static final double PROJECT_LON = 80.2707;
+
+    private final AttendanceGeofenceService service =
+            new AttendanceGeofenceService(new GeofenceValidator());
+
+    private Project project(Float latitude, Float longitude) {
+        Project project = new Project();
+        project.setId(12L);
+        project.setProjectLatitude(latitude);
+        project.setProjectLongitude(longitude);
+        project.setEmployees(new ArrayList<>());
+        return project;
+    }
+
+    private Project locatedProject() {
+        return project((float) PROJECT_LAT, (float) PROJECT_LON);
+    }
+
+    private AttendanceSettings settings(Integer radius) {
+        return AttendanceSettings.builder().geofenceRadiusMeters(radius).build();
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        return employee;
+    }
+
+    @Test
+    void aPunchOnSiteIsInsideTheFence_withTheRealDistanceAndRadius() {
+        AttendanceGeofenceService.Evaluation evaluation = service.evaluate(
+                locatedProject(), settings(100), PROJECT_LAT + 0.00005, PROJECT_LON + 0.00005);
+
+        assertThat(evaluation.isEvaluated()).isTrue();
+        assertThat(evaluation.withinFence()).isTrue();
+        assertThat(evaluation.distanceMeters()).isCloseTo(7.8, within(2.0));
+        assertThat(evaluation.radiusMeters()).isEqualTo(100);
+    }
+
+    @Test
+    void aPunchAQuarterOfAKilometreAwayIsOutsideTheFence() {
+        AttendanceGeofenceService.Evaluation evaluation = service.evaluate(
+                locatedProject(), settings(100), PROJECT_LAT + 0.0023, PROJECT_LON);
+
+        assertThat(evaluation.isOutsideFence()).isTrue();
+        assertThat(evaluation.distanceMeters()).isCloseTo(256.0, within(5.0));
+    }
+
+    @Test
+    void aProjectWithNoCoordinatesLeavesThePunchUnevaluated() {
+        // Five of the twenty-eight projects on staging are in this state. An absent verdict here
+        // is ordinary, and it must not read as a violation.
+        AttendanceGeofenceService.Evaluation evaluation = service.evaluate(
+                project(null, null), settings(100), PROJECT_LAT, PROJECT_LON);
+
+        assertThat(evaluation.isEvaluated()).isFalse();
+        assertThat(evaluation.isOutsideFence()).isFalse();
+        assertThat(evaluation.withinFence()).isNull();
+        assertThat(evaluation.distanceMeters()).isNull();
+        assertThat(evaluation.radiusMeters()).isNull();
+    }
+
+    @Test
+    void aPunchWithNoPositionLeavesThePunchUnevaluated() {
+        assertThat(service.evaluate(locatedProject(), settings(100), null, null).isEvaluated())
+                .isFalse();
+    }
+
+    @Test
+    void noRadiusLeavesThePunchUnevaluated() {
+        assertThat(service.evaluate(locatedProject(), settings(null), PROJECT_LAT, PROJECT_LON)
+                .isEvaluated()).isFalse();
+    }
+
+    @Test
+    void applyingAnUnevaluatedResultClearsAllThreeFields() {
+        ClockEvent event = new ClockEvent();
+        event.setIsWithinGeofence(true);
+        event.setDistanceFromProject(12.0);
+        event.setGeofenceRadiusMeters(100);
+
+        service.applyTo(event, AttendanceGeofenceService.Evaluation.notEvaluated());
+
+        assertThat(event.getIsWithinGeofence()).isNull();
+        assertThat(event.getDistanceFromProject()).isNull();
+        assertThat(event.getGeofenceRadiusMeters()).isNull();
+    }
+
+    @Test
+    void theApproverIsTheEmployeesReportingManager() {
+        Employee employee = employee(7L);
+        employee.setManager(employee(55L));
+
+        assertThat(service.resolveApprover(employee, locatedProject())).isEqualTo(55L);
+    }
+
+    @Test
+    void withNoReportingManager_theApproverIsAProjectManagerOnTheSite() {
+        // The fallback is deliberately the narrowest thing the schema can already answer. A
+        // project has no manager pointer of its own, only membership plus the organization-wide
+        // project-manager role, so it is the intersection of the two.
+        Employee siteEngineer = employee(7L);
+        siteEngineer.setOrgRoles(Set.of(OrgRole.SITE_ENGINEER));
+        Employee projectManager = employee(31L);
+        projectManager.setOrgRoles(Set.of(OrgRole.PROJECT_MANAGER));
+
+        Project project = locatedProject();
+        project.setEmployees(List.of(siteEngineer, projectManager));
+
+        assertThat(service.resolveApprover(siteEngineer, project)).isEqualTo(31L);
+    }
+
+    @Test
+    void withSeveralProjectManagers_theSameOneIsAlwaysNamed() {
+        Employee first = employee(31L);
+        first.setOrgRoles(Set.of(OrgRole.PROJECT_MANAGER));
+        Employee second = employee(12L);
+        second.setOrgRoles(Set.of(OrgRole.PROJECT_MANAGER));
+
+        Project project = locatedProject();
+        project.setEmployees(List.of(first, second));
+
+        assertThat(service.resolveApprover(employee(7L), project)).isEqualTo(12L);
+    }
+
+    @Test
+    void anEmployeeIsNeverNamedAsTheirOwnApprover() {
+        // A project manager marking their own attendance from off site is the case this guards:
+        // the point of the decision is that somebody else vouches for the absence.
+        Employee projectManager = employee(31L);
+        projectManager.setOrgRoles(Set.of(OrgRole.PROJECT_MANAGER));
+
+        Project project = locatedProject();
+        project.setEmployees(List.of(projectManager));
+
+        assertThat(service.resolveApprover(projectManager, project)).isNull();
+    }
+
+    @Test
+    void withNeitherAManagerNorAProjectManager_noApproverIsNamed() {
+        // Null does not leave the record unapprovable: it falls to the record-management roles,
+        // which is who decides every attendance record today.
+        assertThat(service.resolveApprover(employee(7L), locatedProject())).isNull();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendancePayloadValidationTest.java
@@ -62,6 +62,7 @@ class AttendancePayloadValidationTest {
     @Mock private FileStorageService fileStorageService;
     @Mock private UserContextService userContextService;
     @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
 
     private AttendanceService service;
 
@@ -73,7 +74,7 @@ class AttendancePayloadValidationTest {
                 employeeRepository, organizationRepository, projectRepository, settingsService,
                 calculationService, sequenceValidator, attendanceMapper, attachmentService,
                 fileStorageService, userContextService, new PayloadValidator(validator),
-                attendanceSecurity);
+                attendanceSecurity, geofenceService);
         // Not the concern here: every payload test should fail on the payload, not on who is calling.
         lenient().when(attendanceSecurity.canRecordFor(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     }

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/AttendanceServiceApprovalTest.java
@@ -62,18 +62,23 @@ class AttendanceServiceApprovalTest {
     @Mock private FileStorageService fileStorageService;
     @Mock private UserContextService userContextService;
     @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
 
     private AttendanceService service;
 
     @BeforeEach
     void setUp() {
         TenantContext.setCurrentOrgId(ORG);
+        // These cases are about who the approval is attributed to, not who may give it. The
+        // authorization itself is covered in GeofenceApprovalAuthorizationTest.
+        org.mockito.Mockito.lenient().when(attendanceSecurity.canDecideApproval(any()))
+                .thenReturn(true);
         service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
                 organizationRepository, projectRepository, settingsService, calculationService,
                 sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
                 userContextService,
                 new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
-                attendanceSecurity);
+                attendanceSecurity, geofenceService);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/attendance/service/GeofenceApprovalAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/service/GeofenceApprovalAuthorizationTest.java
@@ -1,0 +1,197 @@
+package org.tornotron.echno_backend.attendance.service;
+
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.attendance.Attendance;
+import org.tornotron.echno_backend.attendance.AttendanceRepository;
+import org.tornotron.echno_backend.attendance.AttendanceService;
+import org.tornotron.echno_backend.attendance.ShiftTimingRepository;
+import org.tornotron.echno_backend.attendance.dto.AttendanceApprovalDto;
+import org.tornotron.echno_backend.attendance.dto.AttendanceResponseDto;
+import org.tornotron.echno_backend.attendance.enums.ApprovalStatus;
+import org.tornotron.echno_backend.attendance.mapper.AttendanceMapper;
+import org.tornotron.echno_backend.attendance.validator.ClockEventSequenceValidator;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.payload.PayloadValidator;
+import org.tornotron.echno_backend.common.service.AttachmentService;
+import org.tornotron.echno_backend.common.service.AttendanceSecurityService;
+import org.tornotron.echno_backend.common.service.FileStorageService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.organization.OrganizationRepository;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who may decide a geofence exception.
+ *
+ * <p>The product decision is that the employee's immediate reporting manager approves it. That
+ * manager is usually not one of the organization-wide record-management roles, which is what the
+ * approve endpoint was gated on, so gating on the role alone would have sent every exception to HR
+ * and the project managers regardless of who the employee actually reports to. The approver named
+ * on the record is added to the roles rather than replacing them, because the relation is set on a
+ * minority of employees and a record nobody can approve is worse than a broad one.
+ *
+ * <p>The one thing narrowed rather than widened: an employee does not decide their own exception,
+ * whatever roles they hold. The decision exists so that somebody else vouches for the absence.
+ */
+@ExtendWith(MockitoExtension.class)
+class GeofenceApprovalAuthorizationTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long ATTENDANCE_ID = 781L;
+    private static final Long EMPLOYEE_ID = 7L;
+    private static final Long MANAGER_ID = 55L;
+
+    @Mock private AttendanceRepository attendanceRepository;
+    @Mock private ShiftTimingRepository shiftTimingRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private AttendanceSettingsService settingsService;
+    @Mock private AttendanceCalculationService calculationService;
+    @Mock private ClockEventSequenceValidator sequenceValidator;
+    @Mock private AttendanceMapper attendanceMapper;
+    @Mock private AttachmentService attachmentService;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private UserContextService userContextService;
+    @Mock private AttendanceSecurityService attendanceSecurity;
+    @Mock private AttendanceGeofenceService geofenceService;
+
+    private AttendanceService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        service = new AttendanceService(attendanceRepository, shiftTimingRepository, employeeRepository,
+                organizationRepository, projectRepository, settingsService, calculationService,
+                sequenceValidator, attendanceMapper, attachmentService, fileStorageService,
+                userContextService,
+                new PayloadValidator(Validation.buildDefaultValidatorFactory().getValidator()),
+                attendanceSecurity, geofenceService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private Attendance heldForGeofenceApproval() {
+        Attendance attendance = new Attendance();
+        attendance.setId(ATTENDANCE_ID);
+        attendance.setEmployeeId(EMPLOYEE_ID);
+        attendance.setRequiresGeofenceApproval(true);
+        attendance.setGeofenceApproverId(MANAGER_ID);
+        return attendance;
+    }
+
+    private void givenTheRecordIsFound(Attendance attendance) {
+        when(attendanceRepository.findByIdAndOrganization_Id(ATTENDANCE_ID, ORG_ID))
+                .thenReturn(Optional.of(attendance));
+    }
+
+    private void givenTheDecisionIsSaved() {
+        lenient().when(attendanceRepository.save(any(Attendance.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(attendanceMapper.toResponseDto(any(Attendance.class)))
+                .thenReturn(AttendanceResponseDto.builder().build());
+    }
+
+    private AttendanceApprovalDto approval() {
+        AttendanceApprovalDto dto = new AttendanceApprovalDto();
+        dto.setApprovalStatus(ApprovalStatus.APPROVED);
+        return dto;
+    }
+
+    @Test
+    void theReportingManagerNamedOnTheRecordMayApprove_withoutAManagementRole() {
+        givenTheRecordIsFound(heldForGeofenceApproval());
+        givenTheDecisionIsSaved();
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(false);
+        when(attendanceSecurity.canDecideApproval(MANAGER_ID)).thenReturn(true);
+
+        service.approveAttendance(ATTENDANCE_ID, approval());
+
+        verify(attendanceRepository).save(any(Attendance.class));
+    }
+
+    @Test
+    void somebodyWhoIsNeitherTheNamedApproverNorARecordManagerIsRefused() {
+        givenTheRecordIsFound(heldForGeofenceApproval());
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(false);
+        when(attendanceSecurity.canDecideApproval(MANAGER_ID)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.approveAttendance(ATTENDANCE_ID, approval()))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendanceRepository, never()).save(any());
+    }
+
+    @Test
+    void theEmployeeDoesNotApproveTheirOwnGeofenceException() {
+        // Even a project manager or an HR admin, who may decide every other attendance record,
+        // does not sign off their own absence from the site.
+        givenTheRecordIsFound(heldForGeofenceApproval());
+        when(attendanceSecurity.isSelfMarking(EMPLOYEE_ID)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.approveAttendance(ATTENDANCE_ID, approval()))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("someone other than the employee");
+
+        verify(attendanceRepository, never()).save(any());
+    }
+
+    @Test
+    void anOrdinaryRecordIsStillDecidedByTheRecordManagementRoles() {
+        // Nothing about who approves a record with no geofence exception changes: the self-check
+        // is scoped to flagged records, and an unflagged one falls through to the role policy.
+        Attendance ordinary = new Attendance();
+        ordinary.setId(ATTENDANCE_ID);
+        ordinary.setEmployeeId(EMPLOYEE_ID);
+        givenTheRecordIsFound(ordinary);
+        givenTheDecisionIsSaved();
+        when(attendanceSecurity.canDecideApproval(null)).thenReturn(true);
+
+        service.approveAttendance(ATTENDANCE_ID, approval());
+
+        verify(attendanceRepository).save(any(Attendance.class));
+        verify(attendanceSecurity, never()).isSelfMarking(any());
+    }
+
+    /**
+     * The policy itself: the record managers, plus the approver the record names, and nobody else.
+     * An id of null must not open the decision to everyone.
+     */
+    @Test
+    void canDecideApproval_isTheRecordManagersPlusTheNamedApprover() {
+        OrganizationSecurityService orgSecurity =
+                org.mockito.Mockito.mock(OrganizationSecurityService.class);
+        AttendanceSecurityService security = new AttendanceSecurityService(
+                orgSecurity,
+                new String[] {"system-admin", "hr-admin"},
+                new String[] {"system-admin", "hr-admin", "project-manager"});
+
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant(
+                "system-admin", "hr-admin", "project-manager")).thenReturn(false);
+        when(orgSecurity.isSelfInCurrentTenant(MANAGER_ID)).thenReturn(true);
+
+        assertThat(security.canDecideApproval(MANAGER_ID)).isTrue();
+        assertThat(security.canDecideApproval(null)).isFalse();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/attendance/validator/GeofenceValidatorTest.java
+++ b/src/test/java/org/tornotron/echno_backend/attendance/validator/GeofenceValidatorTest.java
@@ -1,0 +1,63 @@
+package org.tornotron.echno_backend.attendance.validator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * The Haversine distance and the radius comparison behind the attendance geofence.
+ *
+ * <p>This class was added in March 2026 and had no test and no caller until the geofence was
+ * wired up: every clock event stored a hard-coded verdict instead. The distances below are checked
+ * against the two real clock events on staging, whose stored coordinates put them 9.66 m and
+ * 3.76 m from their project while both rows claimed they were outside a 100 m fence and zero
+ * metres away at the same time.
+ */
+class GeofenceValidatorTest {
+
+    private static final double PROJECT_LAT = 13.0827;
+    private static final double PROJECT_LON = 80.2707;
+
+    private final GeofenceValidator validator = new GeofenceValidator();
+
+    @Test
+    void distanceIsZeroAtTheProjectMarker() {
+        assertThat(validator.calculateDistance(PROJECT_LAT, PROJECT_LON, PROJECT_LAT, PROJECT_LON))
+                .isZero();
+    }
+
+    @Test
+    void aTenthOfADegreeOfLatitudeIsAboutElevenKilometres() {
+        // One degree of latitude is 111.32 km anywhere on the sphere, so this is the check that
+        // catches a radius, a unit or a radian conversion being wrong.
+        double distance = validator.calculateDistance(
+                PROJECT_LAT, PROJECT_LON, PROJECT_LAT + 0.1, PROJECT_LON);
+
+        assertThat(distance).isCloseTo(11_132.0, within(20.0));
+    }
+
+    @Test
+    void aPunchAFewMetresAwayIsInsideAHundredMetreFence() {
+        assertThat(validator.isWithinGeofence(
+                PROJECT_LAT + 0.00005, PROJECT_LON + 0.00005, PROJECT_LAT, PROJECT_LON, 100))
+                .isTrue();
+    }
+
+    @Test
+    void aPunchAQuarterOfAKilometreAwayIsOutsideAHundredMetreFence() {
+        assertThat(validator.isWithinGeofence(
+                PROJECT_LAT + 0.0023, PROJECT_LON, PROJECT_LAT, PROJECT_LON, 100))
+                .isFalse();
+    }
+
+    @Test
+    void theBoundaryItselfCounts_asInside() {
+        double radius = validator.calculateDistance(
+                PROJECT_LAT, PROJECT_LON, PROJECT_LAT + 0.0023, PROJECT_LON);
+
+        assertThat(validator.isWithinGeofence(
+                PROJECT_LAT + 0.0023, PROJECT_LON, PROJECT_LAT, PROJECT_LON, (int) Math.ceil(radius)))
+                .isTrue();
+    }
+}


### PR DESCRIPTION
Closes #646. Implements the product decision Anand gave on ClickUp 86d46he9e.

## What the code did before

The geofence was configured, the coordinates were captured, the browser enforced it, and the backend recorded the opposite of what the browser had just verified.

- `GeofenceValidator` has held a correct Haversine distance since March 2026 and had **zero call sites** anywhere in the repository, on any branch, in the whole history.
- All three `ClockEvent` construction sites wrote the same two literals: `.isWithinGeofence(false)` and `.distanceFromProject(0.0)`.
- `is_within_geofence` was `NOT NULL` with a `false` default, so the schema had no way to say "not evaluated".

The two clock events on staging were taken 9.66 m and 3.76 m from their project. Both rows say the employee was outside a 100 m fence and standing exactly on the site marker, at the same time.

On the issue's "two constants that contradict each other": they are those two literals, not two definitions of the radius. Every real radius default in all three repos is 100 and they agree (entity, four changelogs, core, two places in web). What does disagree is documentation: the OpenAPI `example` values were 200 on create, 200 on the response and 250 on patch, against an actual default of 100. Those are corrected here.

## The ordering constraint, which is the important part

The schema change had to land before any evaluation code, and 087 does it in that order:

1. `087-01` drops the NOT NULL and the false default, so null can mean "not evaluated".
2. `087-02` moves every existing row to null. None of them were evaluated.
3. `087-03` / `087-04` add the columns the evaluation writes.

Reversed, the first measured `false` would make the placeholder rows permanently indistinguishable from real violations.

## The behaviour

**Self-marked punch.** Measured against the project's coordinates and the effective radius. Inside the fence, nothing changes. Outside it, the punch is **not refused**: it needs a reason, the reason is stored on the punch it explains, and the day's record is held for a decision. Without a reason the call returns 422 carrying `distanceMeters` and `geofenceRadiusMeters`, so the client can say how far out the employee is rather than repeating a generic message.

**Who approves.** The employee's reporting manager. `Employee.manager` exists as a self-referencing FK, is validated by `EmployeeHierarchyService`, and is what `LeaveApprovalService` already walks. It is set on a minority of employees (4 of 30 on staging), so there is a ladder: reporting manager, else a project manager assigned to that site, else the record-management roles that decide every attendance record today.

There is no per-project manager relation in the schema. A project has only `project_employees` membership plus the organization-wide `project-manager` role, so the site-level fallback is the intersection of the two, deterministically the lowest employee id. This is a fallback within what the schema already answers, not a new hierarchy.

The named approver is **added** to the record-management roles rather than replacing them, because a record nobody can approve is worse than a broad one. The one thing narrowed: an employee never decides their own geofence exception, whatever roles they hold.

**Marked for somebody else.** Left unevaluated, and not gated. The coordinates on the request belong to the submitting device, so on the mark-for-team path they are the supervisor's position. Deriving "this employee was on site" from where their supervisor stood would put a claim about the wrong person into the same column as real measurements, which is exactly the defect being removed here. `recorded_by_id` is what tells that absent verdict apart from one caused by a project with no coordinates, and it is also the only way to measure how much attendance is entered this way.

Nothing about the mark-for-team path is gated, so #599's permission fix and the working behaviour on ClickUp 86d45jzpa are untouched. **Whether a supervisor marking their team should also have to satisfy the site's photo and location rules is still open** (raised on 86d45jzpa, unanswered) and is deliberately not answered here. The alternative considered was to evaluate that path too and route it into the same approval loop; it was rejected on the grounds above, and because `SelfApprovalPolicy` would reject the common case where the supervisor who marked is also the reporting manager who would approve, so the loop would block legitimate entries rather than add oversight.

**Regularizations.** Also left unevaluated. Their coordinates are a recollection, not a measurement, and they used to carry the same two literals.

## Adjacent hole closed

The radius was bounded 50-5000 on create and unbounded on PATCH, whose DTO had no `@Valid` on either controller. With the fence live, a patch setting the radius to 0 would have turned every punch into an exception.

## Tests

28 new tests across four classes. The seven in `AttendanceGeofenceEnforcementTest` were confirmed red against the pre-fix behaviour, and five of the seven fail by assertion rather than by error, which is the point: the old values were well-formed and wrong.

| Test | Asserts | Red before |
|---|---|---|
| `aPunchOnSiteIsRecordedAsInsideTheFence_withTheMeasuredDistance` | verdict true, real distance, radius stamped | `Expecting value to be true but was false` |
| `aProjectWithNoCoordinatesLeavesTheEventUnevaluated` | all three geofence fields null | `expected: null but was: false` |
| `aSelfMarkedPunchOutsideTheFence_withNoReason_asksForOne` | 422 carrying distance + radius, nothing saved | `Expecting code to raise a throwable` |
| `aSelfMarkedPunchOutsideTheFence_withAReason_isAcceptedAndHeldForTheReportingManager` | punch stored, reason trimmed, day held, approver = manager | `Expecting 0.0 to be close to 256.0` |
| `aBlankReasonIsNotAReason` | whitespace is not a reason | `Expecting code to raise a throwable` |
| `aPunchEnteredForSomebodyElseIsLeftUnevaluated_andIsNotHeld` | no verdict, no hold, no approver | `expected: null but was: false` |
| `thePunchRecordsWhoSubmittedIt` | `recordedById` stamped from the session | `Expecting actual not to be null` |

`GeofenceApprovalAuthorizationTest` (4 of 5 red with the service guard removed) covers the named approver approving without a management role, a stranger refused, an employee refused on their own exception, and an ordinary record still decided by the roles alone. `AttendanceGeofenceServiceTest` (11) covers the evaluation's three not-evaluated paths and the whole approver ladder. `GeofenceValidatorTest` (5) is the first test this class has ever had.

## Follow-on

`echno-core` and `echno-web` need the matching types and the reason field; those are separate PRs.