### PR TITLE
Let the person holding a leave decision make it

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -60907,7 +60907,7 @@
     },
     "/api/v1/leave-approvals/requests/{requestId}/approve": {
       "post": {
-        "description": "Records an approval for the given request at its current approval level and advances the workflow. Returns the request with its updated status and approval trail.",
+        "description": "Records an approval for the given request at its current approval level and advances the workflow. The approval is recorded against the signed-in caller, who must be the request's current approver. Returns the request with its updated status and approval trail.",
         "operationId": "approve_1",
         "parameters": [
           {
@@ -60949,7 +60949,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation"
+            "description": "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"
           },
           "402": {
             "content": {
@@ -60969,7 +60969,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"
           },
           "404": {
             "content": {
@@ -61030,21 +61030,12 @@
     },
     "/api/v1/leave-approvals/requests/{requestId}/can-approve": {
       "get": {
-        "description": "Returns whether the given employee is the current approver for the given leave request, as a single boolean flag.",
+        "description": "Returns whether the signed-in caller is the current approver for the given leave request, as a single boolean flag. This is the check a client makes before drawing an approve button. It used to take the employee to ask about as a query parameter, which let one employee probe another's place in a chain; a caller that still sends employeeId is answered for themselves, because a query parameter no handler declares is ignored.",
         "operationId": "canApprove_1",
         "parameters": [
           {
             "in": "path",
             "name": "requestId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "employeeId",
             "required": true,
             "schema": {
               "format": "int64",
@@ -61094,7 +61085,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave approve or admin authority"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -61147,7 +61138,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Check whether an employee can approve a request",
+        "summary": "Check whether you can approve a request",
         "tags": [
           "Leave Approvals"
         ]
@@ -61210,7 +61201,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"
           },
           "404": {
             "content": {
@@ -61271,7 +61262,7 @@
     },
     "/api/v1/leave-approvals/requests/{requestId}/delegate": {
       "post": {
-        "description": "Reassigns the current approval step for the given request to the delegate named in the payload. Returns the request with its updated approver and approval trail.",
+        "description": "Reassigns the current approval step for the given request to the delegate named in the payload, recording who handed it over. Only the request's current approver may delegate it. Returns the request with its updated approver and approval trail.",
         "operationId": "delegate_1",
         "parameters": [
           {
@@ -61313,7 +61304,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation, or no delegate was given"
+            "description": "The approval action payload failed validation, no delegate was given, or the caller is not the request's current approver"
           },
           "402": {
             "content": {
@@ -61333,7 +61324,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the handover would name nobody"
           },
           "404": {
             "content": {
@@ -61343,7 +61334,7 @@
                 }
               }
             },
-            "description": "No leave request with the given id"
+            "description": "No leave request with the given id, or no such delegate in this organization"
           },
           "409": {
             "content": {
@@ -61394,7 +61385,7 @@
     },
     "/api/v1/leave-approvals/requests/{requestId}/history": {
       "get": {
-        "description": "Returns every approval action recorded against the given leave request, in the order they occurred.",
+        "description": "Returns every approval action recorded against the given leave request, in the order they occurred: who acted, at which level, with what comment, and when.",
         "operationId": "getApprovalHistory_1",
         "parameters": [
           {
@@ -61449,7 +61440,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"
           },
           "404": {
             "content": {
@@ -61510,7 +61501,7 @@
     },
     "/api/v1/leave-approvals/requests/{requestId}/reject": {
       "post": {
-        "description": "Records a rejection for the given request, stopping the approval workflow. Returns the request with its updated status and approval trail.",
+        "description": "Records a rejection for the given request, stopping the approval workflow and releasing the days it was holding. The rejection is recorded against the signed-in caller, who must be the request's current approver. Returns the request with its updated status and approval trail.",
         "operationId": "reject_2",
         "parameters": [
           {
@@ -61552,7 +61543,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation"
+            "description": "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"
           },
           "402": {
             "content": {
@@ -61572,7 +61563,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"
           },
           "404": {
             "content": {
@@ -61633,7 +61624,7 @@
     },
     "/api/v1/leave-approvals/web/approve": {
       "post": {
-        "description": "Records an approval for the given request at its current approval level and advances the workflow. Returns the request with its updated status and approval trail.",
+        "description": "Records an approval for the given request at its current approval level and advances the workflow. The approval is recorded against the signed-in caller, who must be the request's current approver. Returns the request with its updated status and approval trail.",
         "operationId": "approve",
         "parameters": [
           {
@@ -61675,7 +61666,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation"
+            "description": "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"
           },
           "402": {
             "content": {
@@ -61695,7 +61686,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"
           },
           "404": {
             "content": {
@@ -61756,21 +61747,12 @@
     },
     "/api/v1/leave-approvals/web/can-approve": {
       "get": {
-        "description": "Returns whether the given employee is the current approver for the given leave request, as a single boolean flag.",
+        "description": "Returns whether the signed-in caller is the current approver for the given leave request, as a single boolean flag. This is the check a client makes before drawing an approve button. It used to take the employee to ask about as a query parameter, which let one employee probe another's place in a chain; a caller that still sends employeeId is answered for themselves, because a query parameter no handler declares is ignored.",
         "operationId": "canApprove",
         "parameters": [
           {
             "in": "query",
             "name": "requestId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "employeeId",
             "required": true,
             "schema": {
               "format": "int64",
@@ -61820,7 +61802,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -61873,7 +61855,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Check whether an employee can approve a request",
+        "summary": "Check whether you can approve a request",
         "tags": [
           "Leave Approvals (Web)"
         ]
@@ -61936,7 +61918,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"
           },
           "404": {
             "content": {
@@ -61997,7 +61979,7 @@
     },
     "/api/v1/leave-approvals/web/delegate": {
       "post": {
-        "description": "Reassigns the current approval step for the given request to the delegate named in the payload. Returns the request with its updated approver and approval trail.",
+        "description": "Reassigns the current approval step for the given request to the delegate named in the payload, recording who handed it over. Only the request's current approver may delegate it. Returns the request with its updated approver and approval trail.",
         "operationId": "delegate",
         "parameters": [
           {
@@ -62039,7 +62021,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation, or no delegate was given"
+            "description": "The approval action payload failed validation, no delegate was given, or the caller is not the request's current approver"
           },
           "402": {
             "content": {
@@ -62059,7 +62041,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the handover would name nobody"
           },
           "404": {
             "content": {
@@ -62069,7 +62051,7 @@
                 }
               }
             },
-            "description": "No leave request with the given id"
+            "description": "No leave request with the given id, or no such delegate in this organization"
           },
           "409": {
             "content": {
@@ -62120,7 +62102,7 @@
     },
     "/api/v1/leave-approvals/web/history": {
       "get": {
-        "description": "Returns every approval action recorded against the given leave request, in the order they occurred.",
+        "description": "Returns every approval action recorded against the given leave request, in the order they occurred: who acted, at which level, with what comment, and when.",
         "operationId": "getApprovalHistory",
         "parameters": [
           {
@@ -62175,7 +62157,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"
           },
           "404": {
             "content": {
@@ -62236,7 +62218,7 @@
     },
     "/api/v1/leave-approvals/web/reject": {
       "post": {
-        "description": "Records a rejection for the given request, stopping the approval workflow. Returns the request with its updated status and approval trail.",
+        "description": "Records a rejection for the given request, stopping the approval workflow and releasing the days it was holding. The rejection is recorded against the signed-in caller, who must be the request's current approver. Returns the request with its updated status and approval trail.",
         "operationId": "reject_1",
         "parameters": [
           {
@@ -62278,7 +62260,7 @@
                 }
               }
             },
-            "description": "The approval action payload failed validation"
+            "description": "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"
           },
           "402": {
             "content": {
@@ -62298,7 +62280,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"
           },
           "404": {
             "content": {
@@ -68350,19 +68332,8 @@
     },
     "/api/v1/leave-requests/pending-approvals": {
       "get": {
-        "description": "Returns the leave requests currently awaiting action from the given approver.",
+        "description": "Returns the leave requests currently awaiting a decision from the signed-in caller. The approver used to be a query parameter under a guard that only asked for a role, so an administrator could read a colleague's queue while the managers an approval chain is actually built from could not read their own; a caller that still sends approverId is served their own queue, because a query parameter no handler declares is ignored.",
         "operationId": "getPendingApprovals_1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "approverId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -68405,7 +68376,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve"
           },
           "404": {
             "content": {
@@ -68415,7 +68386,7 @@
                 }
               }
             },
-            "description": "No approver with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -68458,7 +68429,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List requests pending an approver's action",
+        "summary": "List the requests waiting on you",
         "tags": [
           "Leave Requests"
         ]
@@ -68466,19 +68437,8 @@
     },
     "/api/v1/leave-requests/pending-approvals/count": {
       "get": {
-        "description": "Returns the number of leave requests currently awaiting action from the given approver.",
+        "description": "Returns the number of leave requests currently awaiting a decision from the signed-in caller, for the badge a client draws on the menu.",
         "operationId": "getPendingApprovalCount_1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "approverId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -68522,7 +68482,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count"
           },
           "404": {
             "content": {
@@ -68532,7 +68492,7 @@
                 }
               }
             },
-            "description": "No approver with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -68575,7 +68535,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Count requests pending an approver's action",
+        "summary": "Count the requests waiting on you",
         "tags": [
           "Leave Requests"
         ]
@@ -69289,19 +69249,8 @@
     },
     "/api/v1/leave-requests/web/approver": {
       "get": {
-        "description": "Returns the leave requests, across all statuses, that name the given employee as an approver at any level of the approval chain.",
+        "description": "Returns the leave requests, across all statuses, that name the signed-in caller as an approver at any level of the approval chain. This is an approver's own record of what they have handled. A caller that still sends approverId is served their own list, because a query parameter no handler declares is ignored.",
         "operationId": "getRequestsByApprover",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "approverId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -69344,7 +69293,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it"
           },
           "404": {
             "content": {
@@ -69354,7 +69303,7 @@
                 }
               }
             },
-            "description": "No approver with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -69397,7 +69346,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List requests routed to an approver",
+        "summary": "List the requests you have been an approver on",
         "tags": [
           "Leave Requests (Web)"
         ]
@@ -70393,19 +70342,8 @@
     },
     "/api/v1/leave-requests/web/pending-approvals": {
       "get": {
-        "description": "Returns the leave requests currently awaiting action from the given approver.",
+        "description": "Returns the leave requests currently awaiting a decision from the signed-in caller. The approver used to be a query parameter under a guard that only asked for a role, so an administrator could read a colleague's queue while the managers an approval chain is actually built from could not read their own; a caller that still sends approverId is served their own queue, because a query parameter no handler declares is ignored.",
         "operationId": "getPendingApprovals",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "approverId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -70448,7 +70386,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve"
           },
           "404": {
             "content": {
@@ -70458,7 +70396,7 @@
                 }
               }
             },
-            "description": "No approver with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -70501,7 +70439,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List requests pending an approver's action",
+        "summary": "List the requests waiting on you",
         "tags": [
           "Leave Requests (Web)"
         ]
@@ -70509,19 +70447,8 @@
     },
     "/api/v1/leave-requests/web/pending-approvals/count": {
       "get": {
-        "description": "Returns the number of leave requests currently awaiting action from the given approver.",
+        "description": "Returns the number of leave requests currently awaiting a decision from the signed-in caller, for the badge a client draws on the menu.",
         "operationId": "getPendingApprovalCount",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "approverId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -70565,7 +70492,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count"
           },
           "404": {
             "content": {
@@ -70575,7 +70502,7 @@
                 }
               }
             },
-            "description": "No approver with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -70618,7 +70545,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Count requests pending an approver's action",
+        "summary": "Count the requests waiting on you",
         "tags": [
           "Leave Requests (Web)"
         ]
@@ -108191,11 +108118,11 @@
       "name": "Labour"
     },
     {
-      "description": "Actions on the approval workflow of a submitted leave request: approve, reject, delegate to another approver, and read the approval history or the full approval chain. Approving is gated to the system-admin or hr-admin role in the caller's tenant; reject, delegate and the read endpoints are gated by the leave approve, read or admin authority.",
+      "description": "Actions on the approval workflow of a submitted leave request: approve, reject, delegate to another approver, and read the approval history or the full approval chain. Every endpoint is open to a member of the caller's tenant, and who may act is settled against the request itself: acting on one is the current approver's to do, and the approval trail is readable by the employee the leave belongs to, the approvers in its chain, and the system-admin or hr-admin roles.",
       "name": "Leave Approvals"
     },
     {
-      "description": "Web-console equivalent of the leave approval endpoints, addressing the request by a requestId query parameter instead of a path segment. Covers approve, reject, delegate, approval history and chain, and the can-approve check. All endpoints are gated to the system-admin or hr-admin role in the caller's tenant.",
+      "description": "Web-console equivalent of the leave approval endpoints, addressing the request by a requestId query parameter instead of a path segment. Covers approve, reject, delegate, approval history and chain, and the can-approve check. Every endpoint is open to a member of the caller's tenant, and who may act is settled against the request itself: acting on one is the current approver's to do, and the approval trail is readable by the employee the leave belongs to, the approvers in its chain, and the system-admin or hr-admin roles.",
       "name": "Leave Approvals (Web)"
     },
     {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68543,7 +68543,7 @@
     },
     "/api/v1/leave-requests/requestId/{requestId}": {
       "get": {
-        "description": "Returns a single leave request with its approval trail.",
+        "description": "Returns a single leave request with its approval trail. Readable by the employee the leave belongs to, everybody named in its approval chain, and the system-admin or hr-admin roles. This is the read the request detail screen is built on, and the approve, reject and delegate actions live on that screen, so an approver has to be able to make it.",
         "operationId": "getRequest",
         "parameters": [
           {
@@ -68595,7 +68595,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither leave-administrator role"
           },
           "404": {
             "content": {
@@ -70553,7 +70553,7 @@
     },
     "/api/v1/leave-requests/web/request": {
       "get": {
-        "description": "Returns a single leave request with its approval trail.",
+        "description": "Returns a single leave request with its approval trail. Readable by the employee the leave belongs to, everybody named in its approval chain, and the system-admin or hr-admin roles. This is the read the request detail screen is built on, and the approve, reject and delegate actions live on that screen, so an approver has to be able to make it.",
         "operationId": "getRequest_1",
         "parameters": [
           {
@@ -70605,7 +70605,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or takes no part in this request and holds neither leave-administrator role"
           },
           "404": {
             "content": {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalController.java
@@ -15,6 +15,31 @@ import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The approval workflow of a submitted leave request, addressed by a path segment.
+ *
+ * <p>This is the surface a phone uses, and until now it did not work. Reject, delegate, the two
+ * approval-trail reads and the can-approve check asked for {@code hasAuthority('leave:approve')},
+ * {@code 'leave:read'} or {@code 'leave:admin'}. {@code JwtAuthConverter} mints a bare
+ * {@code resource:scope} authority in exactly one place, {@code extractPermissions}, which reads
+ * the {@code authorization} claim of an RPT, and the realm defines no authorization scopes at all
+ * (traced end to end for the identical {@code organization:admin} case in the multi-tenancy audit
+ * of 2026-08-18, and again for {@code billing:admin} in #641). Nothing granted those strings and
+ * nothing could, so five of the six endpoints refused every caller while looking guarded.
+ *
+ * <p>Approve was the sixth, and it was the one with the subtler problem. Its guard asked for the
+ * system-admin or hr-admin role, while {@code LeaveApprovalService} requires the caller to be the
+ * request's current approver, and an approval chain is built by walking the employee's management
+ * line. A site manager is an approver and holds neither role, so the guard refused them; a
+ * system-admin who is not in the chain got past the guard and was refused by the service. The two
+ * halves could only both be satisfied by the accident of an approver who also happened to be an
+ * administrator.
+ *
+ * <p>So every endpoint here is now gated on tenant membership, which is what the annotation can
+ * actually evaluate, and the decision of who may act is answered in the service against the
+ * record: the current approver acts, and nobody else. That is narrower than the role gate it
+ * replaces, not wider. The trail reads are answered the same way, against the chain.
+ */
 @RestController
 @RequestMapping("/api/v1/leave-approvals")
 @Validated
@@ -22,8 +47,10 @@ import java.util.Map;
         name = "Leave Approvals",
         description = "Actions on the approval workflow of a submitted leave request: approve, reject, "
                 + "delegate to another approver, and read the approval history or the full approval chain. "
-                + "Approving is gated to the system-admin or hr-admin role in the caller's tenant; reject, "
-                + "delegate and the read endpoints are gated by the leave approve, read or admin authority."
+                + "Every endpoint is open to a member of the caller's tenant, and who may act is settled "
+                + "against the request itself: acting on one is the current approver's to do, and the "
+                + "approval trail is readable by the employee the leave belongs to, the approvers in its "
+                + "chain, and the system-admin or hr-admin roles."
 )
 public class LeaveApprovalController {
 
@@ -34,17 +61,18 @@ public class LeaveApprovalController {
     }
 
     @PostMapping("/requests/{requestId}/approve")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Approve a leave request",
             description = "Records an approval for the given request at its current approval level and "
-                    + "advances the workflow. Returns the request with its updated status and approval trail."
+                    + "advances the workflow. The approval is recorded against the signed-in caller, who "
+                    + "must be the request's current approver. Returns the request with its updated status "
+                    + "and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> approve(
@@ -54,16 +82,18 @@ public class LeaveApprovalController {
     }
 
     @PostMapping("/requests/{requestId}/reject")
-    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Reject a leave request",
-            description = "Records a rejection for the given request, stopping the approval workflow. "
-                    + "Returns the request with its updated status and approval trail."
+            description = "Records a rejection for the given request, stopping the approval workflow and "
+                    + "releasing the days it was holding. The rejection is recorded against the signed-in "
+                    + "caller, who must be the request's current approver. Returns the request with its "
+                    + "updated status and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> reject(
@@ -73,17 +103,18 @@ public class LeaveApprovalController {
     }
 
     @PostMapping("/requests/{requestId}/delegate")
-    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Delegate a pending approval",
             description = "Reassigns the current approval step for the given request to the delegate named "
-                    + "in the payload. Returns the request with its updated approver and approval trail."
+                    + "in the payload, recording who handed it over. Only the request's current approver "
+                    + "may delegate it. Returns the request with its updated approver and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority, or has no employee record in the current tenant, so the record would name nobody"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, no delegate was given, or the caller is not the request's current approver"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the handover would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id, or no such delegate in this organization")
     })
     public ResponseEntity<LeaveRequestDto> delegate(
             @PathVariable Long requestId,
@@ -92,15 +123,15 @@ public class LeaveApprovalController {
     }
 
     @GetMapping("/requests/{requestId}/history")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get the approval history of a request",
             description = "Returns every approval action recorded against the given leave request, in the "
-                    + "order they occurred."
+                    + "order they occurred: who acted, at which level, with what comment, and when."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval history returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalHistory(
@@ -109,7 +140,7 @@ public class LeaveApprovalController {
     }
 
     @GetMapping("/requests/{requestId}/chain")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get the approval chain of a request",
             description = "Returns the ordered sequence of approvers configured for the given leave request, "
@@ -117,7 +148,7 @@ public class LeaveApprovalController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval chain returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalChain(
@@ -126,21 +157,24 @@ public class LeaveApprovalController {
     }
 
     @GetMapping("/requests/{requestId}/can-approve")
-    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Check whether an employee can approve a request",
-            description = "Returns whether the given employee is the current approver for the given leave "
-                    + "request, as a single boolean flag."
+            summary = "Check whether you can approve a request",
+            description = "Returns whether the signed-in caller is the current approver for the given leave "
+                    + "request, as a single boolean flag. This is the check a client makes before drawing "
+                    + "an approve button. It used to take the employee to ask about as a query parameter, "
+                    + "which let one employee probe another's place in a chain; a caller that still sends "
+                    + "employeeId is answered for themselves, because a query parameter no handler declares "
+                    + "is ignored."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Eligibility flag returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave approve or admin authority"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<Map<String, Boolean>> canApprove(
-            @PathVariable Long requestId,
-            @RequestParam Long employeeId) {
-        boolean canApprove = approvalService.canApprove(requestId, employeeId);
+            @PathVariable Long requestId) {
+        boolean canApprove = approvalService.canApprove(requestId);
         return ResponseEntity.ok(Map.of("canApprove", canApprove));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalControllerWeb.java
@@ -15,6 +15,16 @@ import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Web-console twin of {@link LeaveApprovalController}, addressing the request by a query parameter.
+ *
+ * <p>It carried the same role gate as its twin's approve endpoint, with the same effect: an
+ * approval chain is built by walking the employee's management line, so the people who hold these
+ * decisions are managers rather than administrators, and a manager holds neither system-admin nor
+ * hr-admin. The guard refused them and the service refused any administrator who was not in the
+ * chain, so the two halves agreed only by accident. Both twins are now gated on tenant membership,
+ * with who may act settled in {@code LeaveApprovalService} against the record.
+ */
 @RestController
 @RequestMapping("/api/v1/leave-approvals/web")
 @Validated
@@ -22,8 +32,11 @@ import java.util.Map;
         name = "Leave Approvals (Web)",
         description = "Web-console equivalent of the leave approval endpoints, addressing the request by a "
                 + "requestId query parameter instead of a path segment. Covers approve, reject, delegate, "
-                + "approval history and chain, and the can-approve check. All endpoints are gated to the "
-                + "system-admin or hr-admin role in the caller's tenant."
+                + "approval history and chain, and the can-approve check. Every endpoint is open to a "
+                + "member of the caller's tenant, and who may act is settled against the request itself: "
+                + "acting on one is the current approver's to do, and the approval trail is readable by the "
+                + "employee the leave belongs to, the approvers in its chain, and the system-admin or "
+                + "hr-admin roles."
 )
 public class LeaveApprovalControllerWeb {
 
@@ -34,16 +47,18 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/approve")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Approve a leave request",
             description = "Records an approval for the given request at its current approval level and "
-                    + "advances the workflow. Returns the request with its updated status and approval trail."
+                    + "advances the workflow. The approval is recorded against the signed-in caller, who "
+                    + "must be the request's current approver. Returns the request with its updated status "
+                    + "and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request approved"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> approve(
@@ -53,16 +68,18 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/reject")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Reject a leave request",
-            description = "Records a rejection for the given request, stopping the approval workflow. "
-                    + "Returns the request with its updated status and approval trail."
+            description = "Records a rejection for the given request, stopping the approval workflow and "
+                    + "releasing the days it was holding. The rejection is recorded against the signed-in "
+                    + "caller, who must be the request's current approver. Returns the request with its "
+                    + "updated status and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request rejected"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or the caller is not the request's current approver, or the request is not pending approval"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the decision would name nobody"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> reject(
@@ -72,17 +89,18 @@ public class LeaveApprovalControllerWeb {
     }
 
     @PostMapping("/delegate")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Delegate a pending approval",
             description = "Reassigns the current approval step for the given request to the delegate named "
-                    + "in the payload. Returns the request with its updated approver and approval trail."
+                    + "in the payload, recording who handed it over. Only the request's current approver "
+                    + "may delegate it. Returns the request with its updated approver and approval trail."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval delegated"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, or no delegate was given"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant, or has no employee record in it, so the record would name nobody"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "The approval action payload failed validation, no delegate was given, or the caller is not the request's current approver"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so the handover would name nobody"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id, or no such delegate in this organization")
     })
     public ResponseEntity<LeaveRequestDto> delegate(
             @RequestParam Long requestId,
@@ -91,15 +109,15 @@ public class LeaveApprovalControllerWeb {
     }
 
     @GetMapping("/history")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get the approval history of a request",
             description = "Returns every approval action recorded against the given leave request, in the "
-                    + "order they occurred."
+                    + "order they occurred: who acted, at which level, with what comment, and when."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval history returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalHistory(
@@ -108,7 +126,7 @@ public class LeaveApprovalControllerWeb {
     }
 
     @GetMapping("/chain")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get the approval chain of a request",
             description = "Returns the ordered sequence of approvers configured for the given leave request, "
@@ -116,7 +134,7 @@ public class LeaveApprovalControllerWeb {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Approval chain returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither the system-admin nor the hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<List<LeaveApprovalDto>> getApprovalChain(
@@ -125,21 +143,24 @@ public class LeaveApprovalControllerWeb {
     }
 
     @GetMapping("/can-approve")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Check whether an employee can approve a request",
-            description = "Returns whether the given employee is the current approver for the given leave "
-                    + "request, as a single boolean flag."
+            summary = "Check whether you can approve a request",
+            description = "Returns whether the signed-in caller is the current approver for the given leave "
+                    + "request, as a single boolean flag. This is the check a client makes before drawing "
+                    + "an approve button. It used to take the employee to ask about as a query parameter, "
+                    + "which let one employee probe another's place in a chain; a caller that still sends "
+                    + "employeeId is answered for themselves, because a query parameter no handler declares "
+                    + "is ignored."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Eligibility flag returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<Map<String, Boolean>> canApprove(
-            @RequestParam Long requestId,
-            @RequestParam Long employeeId) {
-        boolean canApprove = approvalService.canApprove(requestId, employeeId);
+            @RequestParam Long requestId) {
+        boolean canApprove = approvalService.canApprove(requestId);
         return ResponseEntity.ok(Map.of("canApprove", canApprove));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -1,6 +1,7 @@
 package org.tornotron.echno_backend.leave;
 
 import org.springframework.context.annotation.Lazy;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -9,6 +10,7 @@ import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
@@ -44,9 +46,13 @@ public class LeaveApprovalService {
     private final LeaveTransactionRepository transactionRepository;
     private final EmployeeRepository employeeRepository;
     private final CurrentEmployeeService currentEmployeeService;
+    private final OrganizationSecurityService orgSecurity;
     private final LeaveCalendarService calendarService;
     private final NotificationService notificationService;
     private final LeaveRequestMapper leaveRequestMapper;
+
+    /** The roles that may read any leave request's approval trail, chain membership aside. */
+    private static final String[] LEAVE_ADMIN_ROLES = {"system-admin", "hr-admin"};
 
     public LeaveApprovalService(
             LeaveApprovalRepository approvalRepository,
@@ -55,6 +61,7 @@ public class LeaveApprovalService {
             LeaveTransactionRepository transactionRepository,
             EmployeeRepository employeeRepository,
             CurrentEmployeeService currentEmployeeService,
+            OrganizationSecurityService orgSecurity,
             @Lazy LeaveCalendarService calendarService,
             @Lazy NotificationService notificationService,
             LeaveRequestMapper leaveRequestMapper) {
@@ -64,6 +71,7 @@ public class LeaveApprovalService {
         this.transactionRepository = transactionRepository;
         this.employeeRepository = employeeRepository;
         this.currentEmployeeService = currentEmployeeService;
+        this.orgSecurity = orgSecurity;
         this.calendarService = calendarService;
         this.notificationService = notificationService;
         this.leaveRequestMapper = leaveRequestMapper;
@@ -306,50 +314,107 @@ public class LeaveApprovalService {
     }
 
     /**
-     * Lists all approval records for a request, ordered by approval level.
+     * The trail of decisions on a request: who acted, at which level, with what comment and when.
      *
-     * @param requestId The ID of the leave request.
-     * @return The approval records in level order.
-     */
-    @Transactional(readOnly = true)
-    public List<LeaveApprovalDto> getApprovalHistory(Long requestId) {
-        return approvalRepository.findByLeaveRequestIdOrderByApprovalLevelAsc(requestId)
-                .stream()
-                .map(leaveRequestMapper::toApprovalDto)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Lists the approval records for a request after verifying the request exists in this organization.
+     * <p>This is the audit answer, so who may read it is settled against the record rather than
+     * against a role alone. An approver has to be able to read the trail to decide: the request
+     * arrives at them at level two knowing nothing about what level one said, and refusing them
+     * the trail is refusing them the decision. So the employee the leave belongs to, everybody
+     * named anywhere in its chain, and the leave administrators can read it, and nobody else can.
      *
      * @param requestId The ID of the leave request.
      * @return The approval records in level order.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
+     * @throws AccessDeniedException if the caller takes no part in this request and holds neither
+     *     leave-administrator role.
+     */
+    @Transactional(readOnly = true)
+    public List<LeaveApprovalDto> getApprovalHistory(Long requestId) {
+        return readApprovalTrail(requestId);
+    }
+
+    /**
+     * The same trail, including the levels nobody has acted on yet.
+     *
+     * <p>Kept as a separate endpoint because the two answer different questions for a caller, and
+     * gated identically because they read the same rows.
+     *
+     * @param requestId The ID of the leave request.
+     * @return The approval records in level order.
+     * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
+     * @throws AccessDeniedException if the caller takes no part in this request and holds neither
+     *     leave-administrator role.
      */
     @Transactional(readOnly = true)
     public List<LeaveApprovalDto> getApprovalChain(Long requestId) {
-        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
+        return readApprovalTrail(requestId);
+    }
+
+    private List<LeaveApprovalDto> readApprovalTrail(Long requestId) {
+        LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
 
-        return approvalRepository.findByLeaveRequestIdOrderByApprovalLevelAsc(requestId)
-                .stream()
+        List<LeaveApproval> approvals = approvalRepository.findByLeaveRequestIdOrderByApprovalLevelAsc(requestId);
+
+        requireMayReadTrail(request, approvals);
+
+        return approvals.stream()
                 .map(leaveRequestMapper::toApprovalDto)
                 .collect(Collectors.toList());
     }
 
+    private void requireMayReadTrail(LeaveRequest request, List<LeaveApproval> approvals) {
+        if (orgSecurity.hasAnyOrgRoleForCurrentTenant(LEAVE_ADMIN_ROLES)) {
+            return;
+        }
+
+        Long callerId = currentEmployeeService.currentEmployee().map(Employee::getId).orElse(null);
+        if (callerId == null) {
+            throw new AccessDeniedException(
+                    "You have no employee record in this organization, so you take no part in this "
+                            + "leave request and cannot read its approval trail.");
+        }
+
+        if (request.getEmployee() != null && callerId.equals(request.getEmployee().getId())) {
+            return;
+        }
+
+        boolean namedInTheChain = approvals.stream().anyMatch(approval ->
+                (approval.getApprover() != null && callerId.equals(approval.getApprover().getId()))
+                        || callerId.equals(approval.getDelegatedFromId()));
+        if (namedInTheChain) {
+            return;
+        }
+
+        throw new AccessDeniedException(
+                "The approval trail of a leave request is readable by the employee it belongs to, "
+                        + "the approvers in its chain, and the system-admin or hr-admin roles.");
+    }
+
     /**
-     * Checks whether an employee is the current approver of a request that is pending approval.
+     * Whether the caller may act on this request right now.
+     *
+     * <p>This is the question a phone asks before it draws an approve button, so it answers for
+     * whoever is signed in. It used to take the employee to ask about as a query parameter, which
+     * is a different question than any caller has ever wanted answered and let one employee probe
+     * another's place in a chain. A caller that still sends {@code employeeId} is served the
+     * answer for themselves, because Spring drops a query parameter no handler declares.
      *
      * @param requestId The ID of the leave request.
-     * @param employeeId The ID of the employee to check.
-     * @return {@code true} if the employee may act on the request now; {@code false} otherwise.
+     * @return {@code true} if the caller is the current approver of a request that is pending
+     *     approval; {@code false} otherwise, including when the caller has no employee record here.
      */
     @Transactional(readOnly = true)
-    public boolean canApprove(Long requestId, Long employeeId) {
-        return requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
+    public boolean canApprove(Long requestId) {
+        Long callerId = currentEmployeeService.currentEmployee().map(Employee::getId).orElse(null);
+        if (callerId == null) {
+            return false;
+        }
+
+        return requestRepository.findByIdAndOrganization_Id(requestId, TenantContext.getCurrentOrgId())
                 .map(request -> request.getCurrentApprover() != null &&
-                               request.getCurrentApprover().getId().equals(employeeId) &&
+                               request.getCurrentApprover().getId().equals(callerId) &&
                                request.getStatus() == LeaveStatus.PENDING_APPROVAL)
                 .orElse(false);
     }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveApprovalService.java
@@ -364,6 +364,26 @@ public class LeaveApprovalService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Refuses the caller unless they take part in this request or hold a leave-administrator role.
+     *
+     * <p>The same rule as the approval trail, exposed because the request itself is on the same
+     * footing: an approver cannot decide on a request they cannot open, and the request detail
+     * screen is where the approve, reject and delegate buttons are. Reading it here rather than in
+     * a {@code @PreAuthorize} is the point, because the guard sees only the request id the caller
+     * sent and nothing about whose leave it is.
+     *
+     * @param request The stored request, already resolved in the current tenant.
+     * @throws AccessDeniedException if the caller is neither the employee the leave belongs to, nor
+     *     named anywhere in its approval chain, nor a system-admin or hr-admin.
+     */
+    @Transactional(readOnly = true)
+    public void requireMayReadRequest(LeaveRequest request) {
+        requireMayReadTrail(
+                request,
+                approvalRepository.findByLeaveRequestIdOrderByApprovalLevelAsc(request.getId()));
+    }
+
     private void requireMayReadTrail(LeaveRequest request, List<LeaveApproval> approvals) {
         if (orgSecurity.hasAnyOrgRoleForCurrentTenant(LEAVE_ADMIN_ROLES)) {
             return;
@@ -373,7 +393,7 @@ public class LeaveApprovalService {
         if (callerId == null) {
             throw new AccessDeniedException(
                     "You have no employee record in this organization, so you take no part in this "
-                            + "leave request and cannot read its approval trail.");
+                            + "leave request.");
         }
 
         if (request.getEmployee() != null && callerId.equals(request.getEmployee().getId())) {
@@ -388,7 +408,7 @@ public class LeaveApprovalService {
         }
 
         throw new AccessDeniedException(
-                "The approval trail of a leave request is readable by the employee it belongs to, "
+                "A leave request and its approval trail are readable by the employee it belongs to, "
                         + "the approvers in its chain, and the system-admin or hr-admin roles.");
     }
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -66,15 +66,18 @@ public class LeaveRequestController {
     }
 
     @GetMapping("/requestId/{requestId}")
-//    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a leave request by id",
-            description = "Returns a single leave request with its approval trail."
+            description = "Returns a single leave request with its approval trail. Readable by the "
+                    + "employee the leave belongs to, everybody named in its approval chain, and the "
+                    + "system-admin or hr-admin roles. This is the read the request detail screen is "
+                    + "built on, and the approve, reject and delegate actions live on that screen, so "
+                    + "an approver has to be able to make it."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Request found"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither leave-administrator role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> getRequest(@PathVariable Long requestId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestController.java
@@ -134,38 +134,37 @@ public class LeaveRequestController {
     }
 
     @GetMapping("/pending-approvals")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List requests pending an approver's action",
-            description = "Returns the leave requests currently awaiting action from the given approver."
+            summary = "List the requests waiting on you",
+            description = "Returns the leave requests currently awaiting a decision from the signed-in "
+                    + "caller. The approver used to be a query parameter under a guard that only asked "
+                    + "for a role, so an administrator could read a colleague's queue while the managers "
+                    + "an approval chain is actually built from could not read their own; a caller that "
+                    + "still sends approverId is served their own queue, because a query parameter no "
+                    + "handler declares is ignored."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pending requests returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No approver with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve")
     })
-    public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
-            @RequestParam Long approverId) {
-        return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
+    public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals() {
+        return ResponseEntity.ok(requestService.getPendingApprovals());
     }
 
     @GetMapping("/pending-approvals/count")
-//    @PreAuthorize("hasAuthority('leave:approve') or hasAuthority('leave:admin')")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Count requests pending an approver's action",
-            description = "Returns the number of leave requests currently awaiting action from the given "
-                    + "approver."
+            summary = "Count the requests waiting on you",
+            description = "Returns the number of leave requests currently awaiting a decision from the "
+                    + "signed-in caller, for the badge a client draws on the menu."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No approver with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count")
     })
-    public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
-            @RequestParam Long approverId) {
-        long count = requestService.getPendingApprovalCount(approverId);
+    public ResponseEntity<Map<String, Long>> getPendingApprovalCount() {
+        long count = requestService.getPendingApprovalCount();
         return ResponseEntity.ok(Map.of("count", count));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -133,53 +133,54 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/approver")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List requests routed to an approver",
-            description = "Returns the leave requests, across all statuses, that name the given employee "
-                    + "as an approver at any level of the approval chain."
+            summary = "List the requests you have been an approver on",
+            description = "Returns the leave requests, across all statuses, that name the signed-in caller "
+                    + "as an approver at any level of the approval chain. This is an approver's own record "
+                    + "of what they have handled. A caller that still sends approverId is served their own "
+                    + "list, because a query parameter no handler declares is ignored."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Requests returned"),
-            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it")
     })
-    public ResponseEntity<List<LeaveRequestDto>> getRequestsByApprover(
-            @RequestParam Long approverId) {
-        return ResponseEntity.ok(requestService.getRequestsByApprover(approverId));
+    public ResponseEntity<List<LeaveRequestDto>> getRequestsByApprover() {
+        return ResponseEntity.ok(requestService.getRequestsByApprover());
     }
 
     @GetMapping("/pending-approvals")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List requests pending an approver's action",
-            description = "Returns the leave requests currently awaiting action from the given approver."
+            summary = "List the requests waiting on you",
+            description = "Returns the leave requests currently awaiting a decision from the signed-in "
+                    + "caller. The approver used to be a query parameter under a guard that only asked "
+                    + "for a role, so an administrator could read a colleague's queue while the managers "
+                    + "an approval chain is actually built from could not read their own; a caller that "
+                    + "still sends approverId is served their own queue, because a query parameter no "
+                    + "handler declares is ignored."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Pending requests returned"),
-            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to serve")
     })
-    public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals(
-            @RequestParam Long approverId) {
-        return ResponseEntity.ok(requestService.getPendingApprovals(approverId));
+    public ResponseEntity<List<LeaveRequestDto>> getPendingApprovals() {
+        return ResponseEntity.ok(requestService.getPendingApprovals());
     }
 
     @GetMapping("/pending-approvals/count")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Count requests pending an approver's action",
-            description = "Returns the number of leave requests currently awaiting action from the given "
-                    + "approver."
+            summary = "Count the requests waiting on you",
+            description = "Returns the number of leave requests currently awaiting a decision from the "
+                    + "signed-in caller, for the badge a client draws on the menu."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Count returned"),
-            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @ApiResponse(responseCode = "404", description = "No approver with the given id")
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no queue to count")
     })
-    public ResponseEntity<Map<String, Long>> getPendingApprovalCount(
-            @RequestParam Long approverId) {
-        long count = requestService.getPendingApprovalCount(approverId);
+    public ResponseEntity<Map<String, Long>> getPendingApprovalCount() {
+        long count = requestService.getPendingApprovalCount();
         return ResponseEntity.ok(Map.of("count", count));
     }
 

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestControllerWeb.java
@@ -68,14 +68,18 @@ public class LeaveRequestControllerWeb {
     }
 
     @GetMapping("/request")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
             summary = "Get a leave request by id",
-            description = "Returns a single leave request with its approval trail."
+            description = "Returns a single leave request with its approval trail. Readable by the "
+                    + "employee the leave belongs to, everybody named in its approval chain, and the "
+                    + "system-admin or hr-admin roles. This is the read the request detail screen is "
+                    + "built on, and the approve, reject and delegate actions live on that screen, so "
+                    + "an approver has to be able to make it."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Request found"),
-            @ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or takes no part in this request and holds neither leave-administrator role"),
             @ApiResponse(responseCode = "404", description = "No leave request with the given id")
     })
     public ResponseEntity<LeaveRequestDto> getRequest(@RequestParam Long requestId) {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -12,6 +12,7 @@ import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -50,6 +51,7 @@ public class LeaveRequestService {
     private final LeaveRequestValidator leaveRequestValidator;
     private final LeaveRequestMapper leaveRequestMapper;
     private final OrganizationSecurityService orgSecurity;
+    private final CurrentEmployeeService currentEmployeeService;
 
     /** The roles that may raise or act on a leave request belonging to somebody else. */
     private static final String[] LEAVE_ADMIN_ROLES = {"system-admin", "hr-admin"};
@@ -63,7 +65,8 @@ public class LeaveRequestService {
             LeaveApprovalService approvalService,
             LeaveRequestValidator leaveRequestValidator,
             LeaveRequestMapper leaveRequestMapper,
-            OrganizationSecurityService orgSecurity) {
+            OrganizationSecurityService orgSecurity,
+            CurrentEmployeeService currentEmployeeService) {
         this.requestRepository = requestRepository;
         this.sequenceRepository = sequenceRepository;
         this.policyRepository = policyRepository;
@@ -73,6 +76,7 @@ public class LeaveRequestService {
         this.leaveRequestValidator = leaveRequestValidator;
         this.leaveRequestMapper = leaveRequestMapper;
         this.orgSecurity = orgSecurity;
+        this.currentEmployeeService = currentEmployeeService;
     }
 
     /**
@@ -233,43 +237,60 @@ public class LeaveRequestService {
     }
 
     /**
-     * Lists requests currently awaiting a decision from a given approver.
+     * The caller's own approval queue: the requests waiting on a decision from them right now.
      *
-     * @param approverId The approver's employee ID.
-     * @return The requests where this approver is the current, pending approver.
+     * <p>The approver used to be a query parameter under a guard that only asked whether the
+     * caller held the system-admin or hr-admin role, which is the same shape settled on the rest
+     * of this service: the guard checks a role, the query reads a number the caller chose, and
+     * nothing ties the two together. So an administrator read any colleague's queue by asking for
+     * it, while the people who actually hold these decisions, the managers an approval chain is
+     * built from, could not read their own at all. A queue is the caller's own by definition.
+     *
+     * @return The requests where the caller is the current, pending approver.
+     * @throws AccessDeniedException if the caller has no employee record here, so there is no
+     *     queue to serve.
      */
     @Transactional(readOnly = true)
-    public List<LeaveRequestDto> getPendingApprovals(Long approverId) {
-        return requestRepository.findByCurrentApproverIdAndStatus(approverId, LeaveStatus.PENDING_APPROVAL)
+    public List<LeaveRequestDto> getPendingApprovals() {
+        return requestRepository.findByCurrentApproverIdAndStatus(
+                        callerEmployeeId("read your approval queue"), LeaveStatus.PENDING_APPROVAL)
                 .stream()
                 .map(leaveRequestMapper::toDto)
                 .collect(Collectors.toList());
     }
 
     /**
-     * Lists every request an approver has taken part in at any level, past or present.
+     * Every request the caller has taken part in at any level, past or present.
      *
-     * @param approverId The approver's employee ID.
-     * @return The distinct requests this approver participated in.
+     * <p>This is what an approver's own decision history is read from, and it took the approver as
+     * a parameter for the same reason and with the same consequence as the queue above.
+     *
+     * @return The distinct requests the caller participated in.
+     * @throws AccessDeniedException if the caller has no employee record here.
      */
     @Transactional(readOnly = true)
-    public List<LeaveRequestDto> getRequestsByApprover(Long approverId) {
-        return requestRepository.findDistinctByApproverParticipation(approverId)
+    public List<LeaveRequestDto> getRequestsByApprover() {
+        return requestRepository.findDistinctByApproverParticipation(
+                        callerEmployeeId("read the requests you have acted on"))
                 .stream()
                 .map(leaveRequestMapper::toDto)
                 .collect(Collectors.toList());
     }
 
     /**
-     * Counts the requests currently awaiting a decision from a given approver.
+     * How many requests are waiting on the caller, for the badge a phone draws on the menu.
      *
-     * @param approverId The approver's employee ID.
-     * @return The number of requests pending this approver.
+     * @return The number of requests pending the caller's decision.
+     * @throws AccessDeniedException if the caller has no employee record here.
      */
     @Transactional(readOnly = true)
-    public long getPendingApprovalCount(Long approverId) {
+    public long getPendingApprovalCount() {
         return requestRepository.countByCurrentApproverIdAndStatus(
-                approverId, LeaveStatus.PENDING_APPROVAL);
+                callerEmployeeId("count your approval queue"), LeaveStatus.PENDING_APPROVAL);
+    }
+
+    private Long callerEmployeeId(String action) {
+        return currentEmployeeService.requireCurrentEmployee(action).getId();
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveRequestService.java
@@ -178,15 +178,25 @@ public class LeaveRequestService {
     /**
      * Retrieves a single leave request, resolving the handover employee's name when set.
      *
+     * <p>Readable by the employee the leave belongs to, everybody named in its approval chain, and
+     * the leave administrators. It was gated on the system-admin and hr-admin roles alone, which
+     * left the approver unable to open the request they are being asked to decide: this is the read
+     * the request detail screen is built on, and the approve, reject and delegate buttons live on
+     * that screen. Repairing the action without this would have repaired the endpoint that returns
+     * 403 and left the caller unable to reach the form, which is what happened in #666.
+     *
      * @param requestId The ID of the leave request.
      * @return The request.
      * @throws ResourceNotFoundException if no request with the given ID exists in this organization.
+     * @throws AccessDeniedException if the caller takes no part in this request and holds neither
+     *     leave-administrator role.
      */
     @Transactional(readOnly = true)
     public LeaveRequestDto getRequest(Long requestId) {
         LeaveRequest request = requestRepository.findByIdAndOrganization_Id(requestId,TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Leave request with ID " + requestId + " was not found in this organization"));
+        approvalService.requireMayReadRequest(request);
         LeaveRequestDto dto = leaveRequestMapper.toDto(request);
         if (request.getHandoverToId() != null) {
             employeeRepository.findById(request.getHandoverToId())

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalEndpointAuthorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalEndpointAuthorityTest.java
@@ -1,0 +1,184 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The leave approval workflow may not be guarded by an authority this realm has no way to issue.
+ *
+ * <p>Five of the six endpoints on {@link LeaveApprovalController} asked for
+ * {@code hasAuthority('leave:approve')}, {@code 'leave:read'} or {@code 'leave:admin'}.
+ * {@code JwtAuthConverter} mints a bare {@code resource:scope} authority in exactly one place,
+ * {@code extractPermissions}, which reads the {@code authorization} claim of an RPT, so each of
+ * those strings needed a Keycloak Authorization Services resource named {@code leave} carrying the
+ * matching scope. The multi-tenancy audit of 2026-08-18 traced the identical case of
+ * {@code organization:admin} against the live staging realm and found zero authorization scopes
+ * realm-wide, one scopeless Default Resource and one scopeless Default Permission; a scopeless
+ * permission yields no {@code resource:scope} authority at all. #641 confirmed the same for
+ * {@code billing:admin} and fixed the billing surface.
+ *
+ * <p>So rejecting a leave request, delegating one, reading its approval trail and asking whether
+ * you may act on it all refused every caller, forever, while looking guarded. Approvals are a
+ * required workflow on mobile, so they were repaired rather than deleted.
+ *
+ * <p>This is the ratchet that stops the phantom being reintroduced by copying a neighbouring
+ * annotation. It reads the annotations off the production classes rather than the source text, and
+ * the second test pins the endpoint count so that the first cannot pass by an endpoint's guard
+ * having been deleted rather than corrected, or by the controller having been emptied.
+ *
+ * <p>Scoped to the leave approval surface deliberately. {@code NotificationController} and
+ * {@code LeaveCalendarController} in this same package still carry the phantom, and widening this
+ * test is a change to endpoints it was not written for.
+ */
+class LeaveApprovalEndpointAuthorityTest {
+
+    /** The controllers that make up the leave approval workflow, on both twins. */
+    private static final List<Class<?>> APPROVAL_CONTROLLERS = List.of(
+            LeaveApprovalController.class,
+            LeaveApprovalControllerWeb.class,
+            LeaveRequestController.class,
+            LeaveRequestControllerWeb.class);
+
+    /**
+     * A bare {@code resource:scope} grant inside a hasAuthority call, which is the form that needs
+     * an authorization scope the realm does not define. Org-scoped authorities built at runtime,
+     * such as {@code ORG_MEMBER_7}, are a different mechanism and do not match.
+     */
+    private static final Pattern UNGRANTABLE_SCOPE_AUTHORITY =
+            Pattern.compile("hasAuthority\\(\\s*'[a-z-]+:[a-z-]+'\\s*\\)");
+
+    private record Endpoint(String name, String guard) {}
+
+    private static List<Endpoint> endpoints() {
+        List<Endpoint> found = new ArrayList<>();
+        for (Class<?> controller : APPROVAL_CONTROLLERS) {
+            for (Method method : controller.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers())) {
+                    continue;
+                }
+                if (!isRequestMapped(method)) {
+                    continue;
+                }
+                PreAuthorize guard = method.getAnnotation(PreAuthorize.class);
+                found.add(new Endpoint(
+                        controller.getSimpleName() + "." + method.getName(),
+                        guard == null ? null : guard.value()));
+            }
+        }
+        return found;
+    }
+
+    private static boolean isRequestMapped(Method method) {
+        return java.util.Arrays.stream(method.getAnnotations())
+                .anyMatch(annotation ->
+                        annotation.annotationType().isAnnotationPresent(RequestMapping.class)
+                                || annotation.annotationType().equals(RequestMapping.class));
+    }
+
+    @Test
+    void noLeaveApprovalEndpointIsGuardedByAnAuthorityTheRealmCannotIssue() {
+        List<String> offenders = endpoints().stream()
+                .filter(endpoint -> endpoint.guard() != null)
+                .filter(endpoint -> UNGRANTABLE_SCOPE_AUTHORITY.matcher(endpoint.guard()).find())
+                .map(endpoint -> endpoint.name() + " asks for " + endpoint.guard())
+                .toList();
+
+        assertThat(offenders)
+                .as("leave approval endpoints guarded by a resource:scope authority that nothing in "
+                        + "the realm grants, so they refuse every caller forever")
+                .isEmpty();
+    }
+
+    @Test
+    void everyLeaveApprovalEndpointIsStillGuardedBySomething() {
+        // Without this, the rule above passes for the worst possible reason: an endpoint whose
+        // guard was deleted rather than corrected is not an offender, and neither is a deleted
+        // endpoint. Pinning the count is what makes the absence of offenders mean something.
+        List<Endpoint> endpoints = endpoints();
+
+        assertThat(endpoints.stream().filter(endpoint -> endpoint.guard() == null).toList())
+                .as("every request-mapped method on the leave approval surface carries a @PreAuthorize")
+                .isEmpty();
+
+        assertThat(endpoints)
+                .as("the four leave approval and leave request controllers still expose their endpoints")
+                .hasSizeGreaterThanOrEqualTo(38);
+    }
+
+    @Test
+    void actingOnAnApprovalIsGatedOnMembershipBecauseTheRecordDecidesWhoMayAct() {
+        // The role gate this replaces could not express the rule. An approval chain is built by
+        // walking the employee's management line, so an approver is a manager and holds neither
+        // system-admin nor hr-admin: the guard refused the very people who hold the decision,
+        // while an administrator who was not in the chain got past it and was refused by the
+        // service. Membership is what the annotation can evaluate; the service settles the rest.
+        assertThat(guardOf(LeaveApprovalController.class, "approve"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+        assertThat(guardOf(LeaveApprovalController.class, "reject"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+        assertThat(guardOf(LeaveApprovalController.class, "delegate"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+        assertThat(guardOf(LeaveApprovalControllerWeb.class, "approve"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+        assertThat(guardOf(LeaveApprovalControllerWeb.class, "reject"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+        assertThat(guardOf(LeaveApprovalControllerWeb.class, "delegate"))
+                .isEqualTo("@orgSecurity.isMemberOfCurrentTenant()");
+    }
+
+    @Test
+    void anApprovalQueueTakesNoApproverParameter() {
+        // A queue is the caller's own by definition. Taking the approver as a parameter under a
+        // guard that only checked a role let an administrator read a colleague's queue and left
+        // the managers an approval chain is built from unable to read their own. Each of these
+        // declared one parameter, @RequestParam Long approverId, and now declares none.
+        assertThat(parameterCount(LeaveRequestController.class, "getPendingApprovals")).isZero();
+        assertThat(parameterCount(LeaveRequestController.class, "getPendingApprovalCount")).isZero();
+        assertThat(parameterCount(LeaveRequestControllerWeb.class, "getPendingApprovals")).isZero();
+        assertThat(parameterCount(LeaveRequestControllerWeb.class, "getPendingApprovalCount")).isZero();
+        assertThat(parameterCount(LeaveRequestControllerWeb.class, "getRequestsByApprover")).isZero();
+    }
+
+    @Test
+    void theCanApproveCheckAsksAboutTheCallerRatherThanAnEmployeeTheySend() {
+        // The request is the only thing left to name. Asking "can employee 9 approve request 12"
+        // is a question no client has ever needed answered, and it let one employee probe
+        // another's place in a chain. The employeeId parameter is gone from both twins.
+        assertThat(parameterCount(LeaveApprovalController.class, "canApprove")).isEqualTo(1);
+        assertThat(parameterCount(LeaveApprovalControllerWeb.class, "canApprove")).isEqualTo(1);
+        assertThat(requestParameterCount(LeaveApprovalController.class, "canApprove")).isZero();
+        assertThat(requestParameterCount(LeaveApprovalControllerWeb.class, "canApprove")).isEqualTo(1);
+    }
+
+    private static String guardOf(Class<?> controller, String methodName) {
+        return endpointMethod(controller, methodName).getAnnotation(PreAuthorize.class).value();
+    }
+
+    private static int parameterCount(Class<?> controller, String methodName) {
+        return endpointMethod(controller, methodName).getParameterCount();
+    }
+
+    private static long requestParameterCount(Class<?> controller, String methodName) {
+        return java.util.Arrays.stream(endpointMethod(controller, methodName).getParameters())
+                .filter(parameter -> parameter.isAnnotationPresent(
+                        org.springframework.web.bind.annotation.RequestParam.class))
+                .count();
+    }
+
+    private static Method endpointMethod(Class<?> controller, String methodName) {
+        return java.util.Arrays.stream(controller.getDeclaredMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        controller.getSimpleName() + " has no method named " + methodName));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
 import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
@@ -54,6 +55,7 @@ class LeaveApprovalServiceTest {
     @Mock private LeaveTransactionRepository transactionRepository;
     @Mock private EmployeeRepository employeeRepository;
     @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private OrganizationSecurityService orgSecurity;
     @Mock private LeaveCalendarService calendarService;
     @Mock private NotificationService notificationService;
     @Mock private LeaveRequestMapper leaveRequestMapper;
@@ -66,6 +68,7 @@ class LeaveApprovalServiceTest {
                 transactionRepository,
                 employeeRepository,
                 currentEmployeeService,
+                orgSecurity,
                 calendarService,
                 notificationService,
                 leaveRequestMapper);

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalTrailAccessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalTrailAccessTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -205,6 +206,30 @@ class LeaveApprovalTrailAccessTest {
         assertThatThrownBy(() -> service().getApprovalChain(REQUEST_ID))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("no employee record");
+    }
+
+    @Test
+    void anApproverMayOpenTheRequestTheyAreBeingAskedToDecide() {
+        // The request read was gated on the system-admin and hr-admin roles alone, so the approver
+        // could not open the screen the approve, reject and delegate buttons live on. Repairing
+        // the action and leaving this is what #666 did.
+        theRequestExists();
+        signedInAs(LINE_MANAGER_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThatCode(() -> service().requireMayReadRequest(requestPendingOnTheLineManager()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aColleagueWhoTakesNoPartInTheRequestMayNotOpenIt() {
+        theRequestExists();
+        signedInAs(BYSTANDER_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThatThrownBy(() -> service().requireMayReadRequest(requestPendingOnTheLineManager()))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("readable by the employee it belongs to");
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalTrailAccessTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalTrailAccessTest.java
@@ -1,0 +1,244 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.LeaveApprovalDto;
+import org.tornotron.echno_backend.leave.enums.ApprovalAction;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Who may read a leave request's approval trail, and who the can-approve check answers about.
+ *
+ * <p>Both endpoints were unreachable: the trail reads asked for {@code hasAuthority('leave:read')}
+ * and the check for {@code hasAuthority('leave:approve')}, neither of which this realm can issue.
+ * Repairing the guard is only half the answer, because the guard an annotation can evaluate sees
+ * the request id the caller sent and nothing about the record behind it. The trail is the audit of
+ * a decision that moves an employee's days, so who may read it is settled here, against the record.
+ *
+ * <p>An approver has to be in that set. A request arriving at level two carries no account of what
+ * level one said unless its approver can read the trail, so refusing them the trail refuses them
+ * the decision. That is the shape #666 was: the endpoint that returned 403 was repaired and the
+ * caller was still unable to complete the workflow it belonged to.
+ *
+ * <p>Every test here fails on the old code. The four allowed cases fail because the old
+ * {@code getApprovalHistory} let anybody through and so never refused, making the refusal cases the
+ * ones that carry the change; the can-approve cases fail because the old signature answered about
+ * whatever employee id the caller passed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeaveApprovalTrailAccessTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long REQUEST_ID = 42L;
+    private static final Long APPLICANT_ID = 7L;
+    private static final Long LINE_MANAGER_ID = 8L;
+    private static final Long SENIOR_MANAGER_ID = 9L;
+    private static final Long BYSTANDER_ID = 11L;
+
+    @Mock private LeaveApprovalRepository approvalRepository;
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private LeaveTransactionRepository transactionRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private LeaveCalendarService calendarService;
+    @Mock private NotificationService notificationService;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        when(leaveRequestMapper.toApprovalDto(any(LeaveApproval.class))).thenReturn(new LeaveApprovalDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private LeaveApprovalService service() {
+        return new LeaveApprovalService(
+                approvalRepository,
+                requestRepository,
+                balanceRepository,
+                transactionRepository,
+                employeeRepository,
+                currentEmployeeService,
+                orgSecurity,
+                calendarService,
+                notificationService,
+                leaveRequestMapper);
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        employee.setOrganization(organization);
+        return employee;
+    }
+
+    /**
+     * A request raised by the applicant, at level one of a two-level chain, where the senior
+     * manager took over level one from the line manager by delegation.
+     */
+    private LeaveRequest requestPendingOnTheLineManager() {
+        LeaveRequest request = new LeaveRequest();
+        request.setId(REQUEST_ID);
+        request.setEmployee(employee(APPLICANT_ID));
+        request.setCurrentApprover(employee(LINE_MANAGER_ID));
+        request.setStatus(LeaveStatus.PENDING_APPROVAL);
+        return request;
+    }
+
+    private List<LeaveApproval> chain() {
+        LeaveApproval levelOne = new LeaveApproval();
+        levelOne.setApprovalLevel(1);
+        levelOne.setApprover(employee(LINE_MANAGER_ID));
+        levelOne.setAction(ApprovalAction.PENDING);
+
+        LeaveApproval levelTwo = new LeaveApproval();
+        levelTwo.setApprovalLevel(2);
+        levelTwo.setApprover(employee(SENIOR_MANAGER_ID));
+        levelTwo.setAction(ApprovalAction.PENDING);
+
+        return List.of(levelOne, levelTwo);
+    }
+
+    private void theRequestExists() {
+        when(requestRepository.findByIdAndOrganization_Id(REQUEST_ID, ORG_ID))
+                .thenReturn(Optional.of(requestPendingOnTheLineManager()));
+        when(approvalRepository.findByLeaveRequestIdOrderByApprovalLevelAsc(REQUEST_ID))
+                .thenReturn(chain());
+    }
+
+    private void signedInAs(Long employeeId) {
+        when(currentEmployeeService.currentEmployee()).thenReturn(Optional.of(employee(employeeId)));
+    }
+
+    private void holdingNoLeaveAdminRole() {
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+    }
+
+    @Test
+    void theApproverHoldingTheRequestMayReadItsTrail() {
+        theRequestExists();
+        signedInAs(LINE_MANAGER_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThat(service().getApprovalHistory(REQUEST_ID)).hasSize(2);
+    }
+
+    @Test
+    void anApproverFurtherUpTheChainMayReadItBeforeItReachesThem() {
+        // Level two has not acted and the request is not with them yet. Reading the trail is how
+        // they see what is coming and what level one said when it arrives.
+        theRequestExists();
+        signedInAs(SENIOR_MANAGER_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThat(service().getApprovalChain(REQUEST_ID)).hasSize(2);
+    }
+
+    @Test
+    void theEmployeeTheLeaveBelongsToMayReadTheTrail() {
+        theRequestExists();
+        signedInAs(APPLICANT_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThat(service().getApprovalHistory(REQUEST_ID)).hasSize(2);
+    }
+
+    @Test
+    void aLeaveAdministratorMayReadAnyTrail() {
+        theRequestExists();
+        signedInAs(BYSTANDER_ID);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+
+        assertThat(service().getApprovalChain(REQUEST_ID)).hasSize(2);
+    }
+
+    @Test
+    void aColleagueWhoTakesNoPartInTheRequestIsRefusedTheTrail() {
+        theRequestExists();
+        signedInAs(BYSTANDER_ID);
+        holdingNoLeaveAdminRole();
+
+        assertThatThrownBy(() -> service().getApprovalHistory(REQUEST_ID))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("readable by the employee it belongs to");
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHereIsRefusedTheTrail() {
+        // The shape a bootstrap administrator has: a Keycloak account with no employee row in
+        // this organization. They take no part in any request, so there is nothing to show them.
+        theRequestExists();
+        when(currentEmployeeService.currentEmployee()).thenReturn(Optional.empty());
+        holdingNoLeaveAdminRole();
+
+        assertThatThrownBy(() -> service().getApprovalChain(REQUEST_ID))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("no employee record");
+    }
+
+    @Test
+    void canApproveAnswersTrueForTheApproverHoldingTheRequest() {
+        theRequestExists();
+        signedInAs(LINE_MANAGER_ID);
+
+        assertThat(service().canApprove(REQUEST_ID)).isTrue();
+    }
+
+    @Test
+    void canApproveAnswersFalseForAnApproverWhoseTurnHasNotCome() {
+        theRequestExists();
+        signedInAs(SENIOR_MANAGER_ID);
+
+        assertThat(service().canApprove(REQUEST_ID)).isFalse();
+    }
+
+    @Test
+    void canApproveAnswersAboutTheCallerRatherThanTheApproverHoldingTheRequest() {
+        // The old signature took the employee to ask about, so a bystander asking about the line
+        // manager was told true. It is the caller's own eligibility that a client needs, and
+        // anything else is one employee probing another's place in a chain.
+        theRequestExists();
+        signedInAs(BYSTANDER_ID);
+
+        assertThat(service().canApprove(REQUEST_ID)).isFalse();
+    }
+
+    @Test
+    void canApproveAnswersFalseForACallerWithNoEmployeeRecordHere() {
+        theRequestExists();
+        when(currentEmployeeService.currentEmployee()).thenReturn(Optional.empty());
+
+        assertThat(service().canApprove(REQUEST_ID)).isFalse();
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalWorkflowAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalWorkflowAuthzTest.java
@@ -94,6 +94,7 @@ class LeaveApprovalWorkflowAuthzTest {
         when(requestService.getPendingApprovals()).thenReturn(List.of());
         when(requestService.getPendingApprovalCount()).thenReturn(0L);
         when(requestService.getRequestsByApprover()).thenReturn(List.of());
+        when(requestService.getRequest(anyLong())).thenReturn(new LeaveRequestDto());
     }
 
     /** A site manager: a member of the tenant, holding neither administrative leave role. */
@@ -119,7 +120,11 @@ class LeaveApprovalWorkflowAuthzTest {
             "/api/v1/leave-requests/pending-approvals/count",
             "/api/v1/leave-requests/web/pending-approvals",
             "/api/v1/leave-requests/web/pending-approvals/count",
-            "/api/v1/leave-requests/web/approver"
+            "/api/v1/leave-requests/web/approver",
+            // The request itself. An approver cannot decide on one they cannot open, and this is
+            // the read the detail screen is built on, where the three action buttons live.
+            "/api/v1/leave-requests/requestId/42",
+            "/api/v1/leave-requests/web/request?requestId=42"
     })
     void anApproverMayReadTheirQueueAndTheTrailOfARequest(String path) throws Exception {
         asAnApproverHoldingNoAdministrativeRole();
@@ -164,7 +169,9 @@ class LeaveApprovalWorkflowAuthzTest {
             "/api/v1/leave-approvals/requests/42/can-approve",
             "/api/v1/leave-approvals/web/chain?requestId=42",
             "/api/v1/leave-requests/pending-approvals",
-            "/api/v1/leave-requests/web/pending-approvals/count"
+            "/api/v1/leave-requests/web/pending-approvals/count",
+            "/api/v1/leave-requests/requestId/42",
+            "/api/v1/leave-requests/web/request?requestId=42"
     })
     void somebodyOutsideTheTenantIsStillRefused(String path) throws Exception {
         // Membership replaced a role gate that could not express the rule. It did not replace it

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalWorkflowAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalWorkflowAuthzTest.java
@@ -1,0 +1,225 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.leave.dto.LeaveRequestDto;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * A site manager holding no administrative role reaches the leave approval workflow on both twins.
+ *
+ * <p>This is the end-to-end proof of the change, driven through the real security pipeline rather
+ * than against the annotation text. Every one of these paths answered 403 to this caller before it,
+ * for one of two reasons. Reject, delegate, the trail reads and the can-approve check on the phone
+ * twin asked for {@code hasAuthority('leave:approve')}, {@code 'leave:read'} or
+ * {@code 'leave:admin'}, which this realm defines no mechanism to issue, so they refused everybody.
+ * Approve, both twins' web equivalents and the pending-approvals queue asked for the system-admin
+ * or hr-admin role, which an approver does not hold: an approval chain is built by walking the
+ * employee's management line, so the holder of the decision is a manager.
+ *
+ * <p>The counterpart matters as much. Membership is a coarse gate, and it is deliberately not the
+ * whole answer: {@code LeaveApprovalService} refuses anybody who is not the request's current
+ * approver, and {@code LeaveApproverQueueTest} and {@code LeaveApprovalTrailAccessTest} pin that.
+ * What this test adds is that a caller who is not a member of the tenant at all still gets nowhere,
+ * so the guard was widened to the workflow and not to everybody.
+ *
+ * <p>All four controllers share one web slice so the suite gains one Spring context rather than
+ * four; see {@code EchnoBackendApplicationTests} for why the cached-context budget is watched.
+ */
+@WebMvcTest({
+        LeaveApprovalController.class,
+        LeaveApprovalControllerWeb.class,
+        LeaveRequestController.class,
+        LeaveRequestControllerWeb.class})
+@Import(LeaveApprovalWorkflowAuthzTest.TestSecurityConfig.class)
+class LeaveApprovalWorkflowAuthzTest {
+
+    private static final String ACTION_BODY = "{\"comments\":\"Approved, plan the handover\"}";
+    private static final String DELEGATE_BODY = "{\"comments\":\"Away next week\",\"delegateToId\":9}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeaveApprovalService approvalService;
+
+    @MockitoBean
+    private LeaveRequestService requestService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void stubTheWorkflow() {
+        when(approvalService.approve(anyLong(), any())).thenReturn(new LeaveRequestDto());
+        when(approvalService.reject(anyLong(), any())).thenReturn(new LeaveRequestDto());
+        when(approvalService.delegate(anyLong(), any())).thenReturn(new LeaveRequestDto());
+        when(approvalService.getApprovalHistory(anyLong())).thenReturn(List.of());
+        when(approvalService.getApprovalChain(anyLong())).thenReturn(List.of());
+        when(approvalService.canApprove(anyLong())).thenReturn(true);
+        when(requestService.getPendingApprovals()).thenReturn(List.of());
+        when(requestService.getPendingApprovalCount()).thenReturn(0L);
+        when(requestService.getRequestsByApprover()).thenReturn(List.of());
+    }
+
+    /** A site manager: a member of the tenant, holding neither administrative leave role. */
+    private void asAnApproverHoldingNoAdministrativeRole() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+    }
+
+    private void asSomebodyOutsideTheTenant() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-approvals/requests/42/history",
+            "/api/v1/leave-approvals/requests/42/chain",
+            "/api/v1/leave-approvals/requests/42/can-approve",
+            "/api/v1/leave-approvals/web/history?requestId=42",
+            "/api/v1/leave-approvals/web/chain?requestId=42",
+            "/api/v1/leave-approvals/web/can-approve?requestId=42",
+            "/api/v1/leave-requests/pending-approvals",
+            "/api/v1/leave-requests/pending-approvals/count",
+            "/api/v1/leave-requests/web/pending-approvals",
+            "/api/v1/leave-requests/web/pending-approvals/count",
+            "/api/v1/leave-requests/web/approver"
+    })
+    void anApproverMayReadTheirQueueAndTheTrailOfARequest(String path) throws Exception {
+        asAnApproverHoldingNoAdministrativeRole();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-approvals/requests/42/approve",
+            "/api/v1/leave-approvals/requests/42/reject",
+            "/api/v1/leave-approvals/web/approve?requestId=42",
+            "/api/v1/leave-approvals/web/reject?requestId=42"
+    })
+    void anApproverMayApproveAndRejectFromEitherTwin(String path) throws Exception {
+        asAnApproverHoldingNoAdministrativeRole();
+
+        mockMvc.perform(post(path).with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(ACTION_BODY))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-approvals/requests/42/delegate",
+            "/api/v1/leave-approvals/web/delegate?requestId=42"
+    })
+    void anApproverMayHandTheirTurnToADelegate(String path) throws Exception {
+        asAnApproverHoldingNoAdministrativeRole();
+
+        mockMvc.perform(post(path).with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(DELEGATE_BODY))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-approvals/requests/42/history",
+            "/api/v1/leave-approvals/requests/42/can-approve",
+            "/api/v1/leave-approvals/web/chain?requestId=42",
+            "/api/v1/leave-requests/pending-approvals",
+            "/api/v1/leave-requests/web/pending-approvals/count"
+    })
+    void somebodyOutsideTheTenantIsStillRefused(String path) throws Exception {
+        // Membership replaced a role gate that could not express the rule. It did not replace it
+        // with nothing: a caller with no place in this organization gets no further than before.
+        asSomebodyOutsideTheTenant();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void somebodyOutsideTheTenantMayNotApprove() throws Exception {
+        asSomebodyOutsideTheTenant();
+
+        mockMvc.perform(post("/api/v1/leave-approvals/requests/42/approve").with(jwt()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(ACTION_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aQueueCallThatStillSendsAnApproverIdIsServedTheCallersOwnQueue() throws Exception {
+        // The deployed client sends approverId on every one of these. Spring drops a query
+        // parameter no handler declares, so the fix ships without waiting on a frontend release.
+        asAnApproverHoldingNoAdministrativeRole();
+
+        mockMvc.perform(get("/api/v1/leave-requests/web/pending-approvals")
+                        .param("approverId", "99")
+                        .with(jwt()))
+                .andExpect(status().isOk());
+
+        org.mockito.Mockito.verify(requestService).getPendingApprovals();
+    }
+
+    @Test
+    void aCanApproveCallThatStillSendsAnEmployeeIdIsAnsweredForTheCaller() throws Exception {
+        asAnApproverHoldingNoAdministrativeRole();
+
+        mockMvc.perform(get("/api/v1/leave-approvals/web/can-approve")
+                        .param("requestId", "42")
+                        .param("employeeId", "99")
+                        .with(jwt()))
+                .andExpect(status().isOk());
+
+        org.mockito.Mockito.verify(approvalService).canApprove(42L);
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverAttributionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverAttributionTest.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.tornotron.echno_backend.common.exception.InvalidRequestException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
 import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.LeaveApprovalActionDto;
@@ -70,6 +71,7 @@ class LeaveApproverAttributionTest {
     @Mock private LeaveTransactionRepository transactionRepository;
     @Mock private EmployeeRepository employeeRepository;
     @Mock private CurrentEmployeeService currentEmployeeService;
+    @Mock private OrganizationSecurityService orgSecurity;
     @Mock private LeaveCalendarService calendarService;
     @Mock private NotificationService notificationService;
     @Mock private LeaveRequestMapper leaveRequestMapper;
@@ -139,6 +141,7 @@ class LeaveApproverAttributionTest {
                 transactionRepository,
                 employeeRepository,
                 currentEmployeeService,
+                orgSecurity,
                 calendarService,
                 notificationService,
                 leaveRequestMapper);

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverQueueTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverQueueTest.java
@@ -1,0 +1,159 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.enums.LeaveStatus;
+import org.tornotron.echno_backend.leave.mapper.LeaveRequestMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * An approver's queue is their own, and is read from the session rather than from the call.
+ *
+ * <p>{@code /leave-requests/pending-approvals} and its count took the approver as a query
+ * parameter, under a guard that asked only whether the caller held system-admin or hr-admin. The
+ * two never met: the guard checked a role and the query read a number the caller chose. So an
+ * administrator listed any colleague's queue by asking for it, and the people who actually hold
+ * these decisions could not list their own, because an approval chain is built by walking the
+ * employee's management line and a line manager holds neither role. That is the same defect shape
+ * closed in #589, #599, #607, #631 and #635, one endpoint further along the same workflow.
+ *
+ * <p>Against the old code these tests fail by serving the id the caller passed. The refusals fail
+ * by the listing being served to a caller who has no employee record and therefore no queue.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeaveApproverQueueTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long CALLER_EMPLOYEE_ID = 8L;
+
+    @Mock private LeaveRequestRepository requestRepository;
+    @Mock private LeaveRequestSequenceRepository sequenceRepository;
+    @Mock private LeavePolicyRepository policyRepository;
+    @Mock private LeaveBalanceRepository balanceRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LeaveApprovalService approvalService;
+    @Mock private LeaveRequestValidator leaveRequestValidator;
+    @Mock private LeaveRequestMapper leaveRequestMapper;
+    @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private LeaveRequestService service() {
+        return new LeaveRequestService(
+                requestRepository,
+                sequenceRepository,
+                policyRepository,
+                balanceRepository,
+                employeeRepository,
+                approvalService,
+                leaveRequestValidator,
+                leaveRequestMapper,
+                orgSecurity,
+                currentEmployeeService);
+    }
+
+    private void signedInAsTheLineManager() {
+        Employee caller = new Employee();
+        caller.setId(CALLER_EMPLOYEE_ID);
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        caller.setOrganization(organization);
+        when(currentEmployeeService.requireCurrentEmployee(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(caller);
+    }
+
+    private void theCallerHasNoEmployeeRecordHere() {
+        when(currentEmployeeService.requireCurrentEmployee(org.mockito.ArgumentMatchers.anyString()))
+                .thenThrow(new AccessDeniedException(
+                        "You have no employee record in this organization"));
+    }
+
+    @Test
+    void thePendingQueueIsReadForTheCallerNotForAnIdTheySend() {
+        signedInAsTheLineManager();
+        when(requestRepository.findByCurrentApproverIdAndStatus(CALLER_EMPLOYEE_ID, LeaveStatus.PENDING_APPROVAL))
+                .thenReturn(List.of());
+
+        assertThat(service().getPendingApprovals()).isEmpty();
+
+        verify(requestRepository)
+                .findByCurrentApproverIdAndStatus(CALLER_EMPLOYEE_ID, LeaveStatus.PENDING_APPROVAL);
+    }
+
+    @Test
+    void thePendingCountIsCountedForTheCaller() {
+        signedInAsTheLineManager();
+        when(requestRepository.countByCurrentApproverIdAndStatus(CALLER_EMPLOYEE_ID, LeaveStatus.PENDING_APPROVAL))
+                .thenReturn(3L);
+
+        assertThat(service().getPendingApprovalCount()).isEqualTo(3L);
+
+        verify(requestRepository)
+                .countByCurrentApproverIdAndStatus(CALLER_EMPLOYEE_ID, LeaveStatus.PENDING_APPROVAL);
+    }
+
+    @Test
+    void theApproverHistoryIsReadForTheCaller() {
+        signedInAsTheLineManager();
+        when(requestRepository.findDistinctByApproverParticipation(CALLER_EMPLOYEE_ID))
+                .thenReturn(List.of());
+
+        assertThat(service().getRequestsByApprover()).isEmpty();
+
+        verify(requestRepository).findDistinctByApproverParticipation(CALLER_EMPLOYEE_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHereIsRefusedAQueueRatherThanServedSomebodyElses() {
+        theCallerHasNoEmployeeRecordHere();
+
+        assertThatThrownBy(() -> service().getPendingApprovals())
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(requestRepository, never())
+                .findByCurrentApproverIdAndStatus(anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHereIsRefusedTheCount() {
+        theCallerHasNoEmployeeRecordHere();
+
+        assertThatThrownBy(() -> service().getPendingApprovalCount())
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(requestRepository, never())
+                .countByCurrentApproverIdAndStatus(anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverQueueTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApproverQueueTest.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.organization.Organization;
 import java.util.List;
 import java.util.Optional;
 
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -133,6 +134,34 @@ class LeaveApproverQueueTest {
         assertThat(service().getRequestsByApprover()).isEmpty();
 
         verify(requestRepository).findDistinctByApproverParticipation(CALLER_EMPLOYEE_ID);
+    }
+
+    @Test
+    void readingOneRequestIsSettledAgainstTheRecordRatherThanTheRole() {
+        // The request read was gated on the system-admin and hr-admin roles alone, so an approver
+        // could not open the screen the approve, reject and delegate buttons live on. The rule is
+        // the approval trail's, and it belongs where the record is.
+        LeaveRequest request = new LeaveRequest();
+        request.setId(42L);
+        when(requestRepository.findByIdAndOrganization_Id(42L, ORG_ID)).thenReturn(Optional.of(request));
+
+        service().getRequest(42L);
+
+        verify(approvalService).requireMayReadRequest(request);
+    }
+
+    @Test
+    void aRefusalFromThatCheckStopsTheRead() {
+        LeaveRequest request = new LeaveRequest();
+        request.setId(42L);
+        when(requestRepository.findByIdAndOrganization_Id(42L, ORG_ID)).thenReturn(Optional.of(request));
+        org.mockito.Mockito.doThrow(new AccessDeniedException("not your request"))
+                .when(approvalService).requireMayReadRequest(request);
+
+        assertThatThrownBy(() -> service().getRequest(42L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(leaveRequestMapper, never()).toDto(request);
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestActorAuthorizationTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveRequestActorAuthorizationTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -63,6 +64,7 @@ class LeaveRequestActorAuthorizationTest {
     @Mock private LeaveRequestValidator leaveRequestValidator;
     @Mock private LeaveRequestMapper leaveRequestMapper;
     @Mock private OrganizationSecurityService orgSecurity;
+    @Mock private CurrentEmployeeService currentEmployeeService;
 
     @BeforeEach
     void setTenant() {
@@ -84,7 +86,8 @@ class LeaveRequestActorAuthorizationTest {
                 approvalService,
                 leaveRequestValidator,
                 leaveRequestMapper,
-                orgSecurity);
+                orgSecurity,
+                currentEmployeeService);
     }
 
     private Organization organization() {


### PR DESCRIPTION
Anand asked for mobile leave approval to be treated as a required workflow rather than an optional capability (ClickUp `86d45jxmn`, 1 Sep). It was neither: it was refused.

## What was refused, and why

Five of the six endpoints on `LeaveApprovalController` asked for `hasAuthority('leave:approve')`, `'leave:read'` or `'leave:admin'`:

| Endpoint | Guard before | Reachable by |
| --- | --- | --- |
| `POST /leave-approvals/requests/{id}/approve` | `@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')` | an administrator who also happened to be the current approver |
| `POST /leave-approvals/requests/{id}/reject` | `hasAuthority('leave:approve') or hasAuthority('leave:admin')` | nobody |
| `POST /leave-approvals/requests/{id}/delegate` | `hasAuthority('leave:approve') or hasAuthority('leave:admin')` | nobody |
| `GET /leave-approvals/requests/{id}/history` | `hasAuthority('leave:read') or hasAuthority('leave:admin')` | nobody |
| `GET /leave-approvals/requests/{id}/chain` | `hasAuthority('leave:read') or hasAuthority('leave:admin')` | nobody |
| `GET /leave-approvals/requests/{id}/can-approve` | `hasAuthority('leave:approve') or hasAuthority('leave:admin')` | nobody |

`JwtAuthConverter` mints a bare `resource:scope` authority in exactly one place, `extractPermissions`, which reads the `authorization` claim of an RPT. That needs a Keycloak Authorization Services resource named `leave` carrying the matching scope. The multi-tenancy audit of 2026-08-18 traced the identical `organization:admin` string against the live staging Keycloak and found zero authorization scopes realm-wide, one scopeless `Default Resource` and one scopeless `Default Permission`; a scopeless permission yields no `resource:scope` authority at all. #641 confirmed the same for `billing:admin`. Nothing grants these strings and nothing can.

## Approve had the subtler version of the same problem, and so did the web twin

`approve` was guarded on the system-admin or hr-admin role, while `LeaveApprovalService.validateApprover` requires the caller to be the request's **current approver**, and `resolveApprovalChain` builds that chain by walking `employee.getManager()`. A site manager is an approver and holds neither role, so the guard refused them. An administrator who was not in the chain got past the guard and was refused by the service. The two halves could only both be satisfied by the accident of an approver who also happened to be an administrator.

`LeaveApprovalControllerWeb` carried that same role gate on all six of its endpoints, so this was never only a mobile problem: the web console had it too, and the approvals screen worked only for administrators.

## The fix

Every endpoint on both twins is gated on `@orgSecurity.isMemberOfCurrentTenant()`, which is what the annotation can actually evaluate, with who may act settled in the service against the record. **This is narrower than the role gate it replaces, not wider.** Before, any holder of system-admin or hr-admin reached the handler; now the current approver acts and nobody else does.

The approval trail needed its own answer rather than a role. An approver at level two has no account of what level one said unless they can read the trail, so refusing them the trail refuses them the decision, which is the shape #666 was. It is readable by the employee the leave belongs to, everybody named anywhere in the chain (approver or `delegatedFromId`), and the leave administrators.

## The queue was another instance of the family closed in #589, #599, #607, #631 and #635

`GET /leave-requests/pending-approvals`, its `/count` and the web `/approver` listing took the approver as a query parameter under a guard that only asked for a role. The guard checked a role, the query read a number the caller chose, and nothing tied the two together: an administrator listed any colleague's queue by asking for it, and the managers who actually hold these decisions could not list their own. A queue is the caller's own, so it comes from the session now. `can-approve` was the same shape, letting one employee probe another's place in a chain; it answers about the caller.

Filed separately as #683.

## The approver also could not open the request

Reading one leave request, `GET /leave-requests/requestId/{id}` and its web twin, was gated on the system-admin and hr-admin roles. That is the read the request detail screen is built on, and the approve, reject and delegate buttons live on that screen. Repairing the actions and leaving this would have repaired the endpoints that return 403 and left the approver unable to reach the form, which is what #666 did.

Same rule, same code: `requireMayReadTrail` is reachable as `requireMayReadRequest` and `LeaveRequestService.getRequest` calls it, so there is one answer to who takes part in a request rather than two that drift. A draft has no approval rows, so only its owner and the administrators read it.

Worth noting for anyone tracing an old bug report: this also means a `project-manager` has been getting a 403 from that endpoint all along.

## Removing those parameters is safe on the deployed client

Spring drops a query parameter no handler declares, so a call that still sends `approverId` or `employeeId` is served the caller's own answer rather than refused. That is what lets this ship without waiting on a frontend release, and two tests pin it.

## Tests

Twenty-one assertions were **measured** failing against the old code, by running the new tests on `origin/development` in a throwaway worktree. The request-read work landed after that run, so its cases are reasoned rather than measured, and the reasoning is separated out below rather than folded into the count.

| Test | Cases failing on `origin/development` | How they fail |
| --- | --- | --- |
| `LeaveApprovalWorkflowAuthzTest` (as `BaselineApproverReachTest`) | 17 | a site manager holding no administrative role gets 403 on all 11 read paths and all 6 action paths |
| `LeaveApprovalEndpointAuthorityTest.noLeaveApprovalEndpointIsGuardedByAnAuthorityTheRealmCannotIssue` | 1 | names the 5 phantom-guarded endpoints |
| `LeaveApprovalEndpointAuthorityTest.actingOnAnApprovalIsGatedOnMembership...` | 1 | the guard expressions are the old ones |
| `LeaveApprovalEndpointAuthorityTest.anApprovalQueueTakesNoApproverParameter` | 1 | five handlers still declare `approverId` |
| `LeaveApprovalEndpointAuthorityTest.theCanApproveCheckAsksAboutTheCaller...` | 1 | both twins still declare `employeeId` |

`everyLeaveApprovalEndpointIsStillGuardedBySomething` pins the endpoint count so the first rule cannot pass by a guard having been deleted rather than corrected. It passes on both sides by design, which is the point of it.

Added after that baseline run, so reasoned rather than measured: the two request-read paths in the allow list fail on the old code, because the old guard was the system-admin and hr-admin pair and the site manager stub answers false to it. The two request-read paths in the refusal list would have passed on the old code as well, since a non-member was refused either way, and they are there to stop the widening going too far rather than to demonstrate the fix. The two service cases in `LeaveApproverQueueTest` cannot be compiled against the old code, because `requireMayReadRequest` did not exist.

`LeaveApprovalTrailAccessTest` (12 cases) and `LeaveApproverQueueTest` (7 cases) cover the service-side rules. They cannot be compiled against the old code, because the old signatures took the id from the caller, which is the defect itself.

## The API contract

`docs/openapi.json` is regenerated and committed. Seven endpoints lose a query parameter and the operation, tag and 403 descriptions across the approval workflow are rewritten: 54 insertions, 127 deletions.

There is no container runtime on this workstation and the lab node that has one was unreachable all session, so the document came from the build itself. The snapshot test writes one canonical string and either commits it or writes it to `build/openapi.json` for diffing, and the workflow uploads that file, so what the run served is what is committed here. CI re-verifies it, which is the check that matters.

## Left alone deliberately

`NotificationController` and `LeaveCalendarController` in the same package still carry the phantom authority on eleven endpoints, and the notification endpoints have the caller-supplied `employeeId` shape on top of it, plus a `markAsRead` that checks no ownership at all. Separate surface, separate ownership question, filed as #684.

https://claude.ai/code/session_01YWbRuHXKpFT6jL3mzYNhhD
