### PR TITLE
Let an approver read the notification telling them a request arrived

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -64033,9 +64033,259 @@
         ]
       }
     },
+    "/api/v1/leave-calendar/count": {
+      "get": {
+        "description": "Returns the number of employees in the caller's organization who are on leave on the given date.",
+        "operationId": "getEmployeesOnLeaveCount_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "date",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "additionalProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Count returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the system-admin or hr-admin role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Count employees on leave for a day",
+        "tags": [
+          "Leave Calendar"
+        ]
+      }
+    },
+    "/api/v1/leave-calendar/department": {
+      "get": {
+        "description": "Returns every leave calendar entry for the named department within the caller's organization between startDate and endDate, inclusive.",
+        "operationId": "getDepartmentCalendar_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "department",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LeaveCalendarDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Calendar entries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller lacks the system-admin or hr-admin role in the current tenant"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Get a department's leave calendar",
+        "tags": [
+          "Leave Calendar"
+        ]
+      }
+    },
     "/api/v1/leave-calendar/employee/{employeeId}": {
       "get": {
-        "description": "Returns every leave calendar entry for the employee between startDate and endDate, inclusive.",
+        "description": "Returns every leave calendar entry for the employee between startDate and endDate, inclusive. Readable by that employee, and by the leave administrators.",
         "operationId": "getEmployeeCalendar_1",
         "parameters": [
           {
@@ -64108,7 +64358,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -64118,7 +64368,7 @@
                 }
               }
             },
-            "description": "No employee with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -64167,422 +64417,11 @@
         ]
       }
     },
-    "/api/v1/leave-calendar/organization/{organizationId}": {
+    "/api/v1/leave-calendar/grouped": {
       "get": {
-        "description": "Returns every leave calendar entry for the organization between startDate and endDate, inclusive.",
-        "operationId": "getOrganizationCalendar_1",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "startDate",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "endDate",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LeaveCalendarDto"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Calendar entries returned"
-          },
-          "400": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "402": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
-                }
-              }
-            },
-            "description": "Payment Required"
-          },
-          "403": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Caller lacks the leave read or admin authority"
-          },
-          "404": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "No organization with the given id"
-          },
-          "409": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "422": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "502": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Gateway"
-          }
-        },
-        "summary": "Get an organization's leave calendar",
-        "tags": [
-          "Leave Calendar"
-        ]
-      }
-    },
-    "/api/v1/leave-calendar/organization/{organizationId}/count": {
-      "get": {
-        "description": "Returns the number of employees in the organization who are on leave on the given date.",
-        "operationId": "getEmployeesOnLeaveCount_1",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "date",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "additionalProperties": {
-                    "format": "int64",
-                    "type": "integer"
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Count returned"
-          },
-          "400": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "402": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
-                }
-              }
-            },
-            "description": "Payment Required"
-          },
-          "403": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Caller lacks the leave read or admin authority"
-          },
-          "404": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "No organization with the given id"
-          },
-          "409": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "422": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "502": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Gateway"
-          }
-        },
-        "summary": "Count employees on leave for a day",
-        "tags": [
-          "Leave Calendar"
-        ]
-      }
-    },
-    "/api/v1/leave-calendar/organization/{organizationId}/department": {
-      "get": {
-        "description": "Returns every leave calendar entry for the named department within the organization between startDate and endDate, inclusive.",
-        "operationId": "getDepartmentCalendar_1",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "department",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "startDate",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "endDate",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LeaveCalendarDto"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Calendar entries returned"
-          },
-          "400": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "402": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
-                }
-              }
-            },
-            "description": "Payment Required"
-          },
-          "403": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Caller lacks the leave read or admin authority"
-          },
-          "404": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "No organization with the given id"
-          },
-          "409": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "422": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "502": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Gateway"
-          }
-        },
-        "summary": "Get a department's leave calendar",
-        "tags": [
-          "Leave Calendar"
-        ]
-      }
-    },
-    "/api/v1/leave-calendar/organization/{organizationId}/grouped": {
-      "get": {
-        "description": "Returns the organization's leave calendar entries between startDate and endDate, inclusive, keyed by date for a day-by-day view.",
+        "description": "Returns the caller's organization's leave calendar entries between startDate and endDate, inclusive, keyed by date for a day-by-day view.",
         "operationId": "getCalendarGroupedByDate_1",
         "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "startDate",
@@ -64647,7 +64486,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller lacks the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -64657,7 +64496,7 @@
                 }
               }
             },
-            "description": "No organization with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -64700,26 +64539,17 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Get an organization's leave calendar grouped by date",
+        "summary": "Get your organization's leave calendar grouped by date",
         "tags": [
           "Leave Calendar"
         ]
       }
     },
-    "/api/v1/leave-calendar/team": {
+    "/api/v1/leave-calendar/organization": {
       "get": {
-        "description": "Returns every leave calendar entry for the direct reports of the given manager between startDate and endDate, inclusive.",
-        "operationId": "getTeamCalendar_1",
+        "description": "Returns every leave calendar entry for the caller's organization between startDate and endDate, inclusive. The organization used to be a path segment the guard never read; it comes from the session now.",
+        "operationId": "getOrganizationCalendar_1",
         "parameters": [
-          {
-            "in": "query",
-            "name": "managerId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "startDate",
@@ -64781,7 +64611,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller lacks the system-admin or hr-admin role in the current tenant"
           },
           "404": {
             "content": {
@@ -64791,7 +64621,7 @@
                 }
               }
             },
-            "description": "No manager with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -64834,7 +64664,132 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Get a manager's team leave calendar",
+        "summary": "Get your organization's leave calendar",
+        "tags": [
+          "Leave Calendar"
+        ]
+      }
+    },
+    "/api/v1/leave-calendar/team": {
+      "get": {
+        "description": "Returns every leave calendar entry for the signed-in caller's direct reports between startDate and endDate, inclusive. The manager used to be a query parameter under a guard that never read it, so an administrator read any manager's team and a manager could not read their own; a caller that still sends managerId is served their own team, because a query parameter no handler declares is ignored. A caller with no direct reports gets an empty list.",
+        "operationId": "getTeamCalendar_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LeaveCalendarDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Calendar entries returned"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no team to serve"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "Get your team's leave calendar",
         "tags": [
           "Leave Calendar"
         ]
@@ -64842,18 +64797,9 @@
     },
     "/api/v1/leave-calendar/web/count": {
       "get": {
-        "description": "Returns the number of employees in the organization who are on leave on the given date.",
+        "description": "Returns the number of employees in the caller's organization who are on leave on the given date.",
         "operationId": "getEmployeesOnLeaveCount",
         "parameters": [
-          {
-            "in": "query",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "date",
@@ -64917,7 +64863,7 @@
                 }
               }
             },
-            "description": "No organization with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -64968,18 +64914,9 @@
     },
     "/api/v1/leave-calendar/web/department": {
       "get": {
-        "description": "Returns every leave calendar entry for the named department within the organization between startDate and endDate, inclusive.",
+        "description": "Returns every leave calendar entry for the named department within the caller's organization between startDate and endDate, inclusive.",
         "operationId": "getDepartmentCalendar",
         "parameters": [
-          {
-            "in": "query",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "department",
@@ -65059,7 +64996,7 @@
                 }
               }
             },
-            "description": "No organization with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -65110,7 +65047,7 @@
     },
     "/api/v1/leave-calendar/web/employee": {
       "get": {
-        "description": "Returns every leave calendar entry for the employee between startDate and endDate, inclusive.",
+        "description": "Returns every leave calendar entry for the employee between startDate and endDate, inclusive. Readable by that employee, and by the leave administrators.",
         "operationId": "getEmployeeCalendar",
         "parameters": [
           {
@@ -65183,7 +65120,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"
           },
           "404": {
             "content": {
@@ -65244,18 +65181,9 @@
     },
     "/api/v1/leave-calendar/web/grouped": {
       "get": {
-        "description": "Returns the organization's leave calendar entries between startDate and endDate, inclusive, keyed by date for a day-by-day view.",
+        "description": "Returns the caller's organization's leave calendar entries between startDate and endDate, inclusive, keyed by date for a day-by-day view.",
         "operationId": "getCalendarGroupedByDate",
         "parameters": [
-          {
-            "in": "query",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "startDate",
@@ -65330,7 +65258,7 @@
                 }
               }
             },
-            "description": "No organization with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -65373,7 +65301,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Get an organization's leave calendar grouped by date",
+        "summary": "Get your organization's leave calendar grouped by date",
         "tags": [
           "Leave Calendar (Web)"
         ]
@@ -65381,18 +65309,9 @@
     },
     "/api/v1/leave-calendar/web/organization": {
       "get": {
-        "description": "Returns every leave calendar entry for the organization between startDate and endDate, inclusive.",
+        "description": "Returns every leave calendar entry for the caller's organization between startDate and endDate, inclusive. The organization used to be a query parameter the guard never read; it comes from the session now, and a caller that still sends organizationId is served their own tenant.",
         "operationId": "getOrganizationCalendar",
         "parameters": [
-          {
-            "in": "query",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "startDate",
@@ -65464,7 +65383,7 @@
                 }
               }
             },
-            "description": "No organization with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -65507,7 +65426,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Get an organization's leave calendar",
+        "summary": "Get your organization's leave calendar",
         "tags": [
           "Leave Calendar (Web)"
         ]
@@ -65515,18 +65434,9 @@
     },
     "/api/v1/leave-calendar/web/team": {
       "get": {
-        "description": "Returns every leave calendar entry for the direct reports of the given manager between startDate and endDate, inclusive.",
+        "description": "Returns every leave calendar entry for the signed-in caller's direct reports between startDate and endDate, inclusive. The manager used to be a query parameter under a guard that never read it, so an administrator read any manager's team and a manager could not read their own; a caller that still sends managerId is served their own team, because a query parameter no handler declares is ignored. A caller with no direct reports gets an empty list.",
         "operationId": "getTeamCalendar",
         "parameters": [
-          {
-            "in": "query",
-            "name": "managerId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "startDate",
@@ -65588,7 +65498,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no team to serve"
           },
           "404": {
             "content": {
@@ -65598,7 +65508,7 @@
                 }
               }
             },
-            "description": "No manager with the given id"
+            "description": "Not Found"
           },
           "409": {
             "content": {
@@ -65641,7 +65551,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Get a manager's team leave calendar",
+        "summary": "Get your team's leave calendar",
         "tags": [
           "Leave Calendar (Web)"
         ]
@@ -77994,18 +77904,9 @@
     },
     "/api/v1/notifications": {
       "get": {
-        "description": "Returns a page of notifications addressed to the given employee, newest first.",
+        "description": "Returns a page of the notifications addressed to the signed-in caller, newest first. The recipient used to be a query parameter under a guard that only asked for an authority nothing grants; a caller that still sends employeeId is served their own inbox, because a query parameter no handler declares is ignored.",
         "operationId": "getNotifications",
         "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "pageable",
@@ -78054,7 +77955,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve"
           },
           "404": {
             "content": {
@@ -78107,7 +78008,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List an employee's notifications",
+        "summary": "List your notifications",
         "tags": [
           "Notifications"
         ]
@@ -78115,19 +78016,8 @@
     },
     "/api/v1/notifications/mark-all-read": {
       "post": {
-        "description": "Marks every unread notification addressed to the given employee as read and returns how many were updated.",
+        "description": "Marks every unread notification addressed to the signed-in caller as read and returns how many were updated.",
         "operationId": "markAllAsRead_1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78171,7 +78061,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to update"
           },
           "404": {
             "content": {
@@ -78224,7 +78114,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Mark all of an employee's notifications as read",
+        "summary": "Mark all of your notifications as read",
         "tags": [
           "Notifications"
         ]
@@ -78232,19 +78122,8 @@
     },
     "/api/v1/notifications/unread": {
       "get": {
-        "description": "Returns every notification addressed to the given employee that has not yet been marked read.",
+        "description": "Returns every notification addressed to the signed-in caller that has not yet been marked read.",
         "operationId": "getUnreadNotifications_1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78287,7 +78166,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve"
           },
           "404": {
             "content": {
@@ -78340,7 +78219,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List an employee's unread notifications",
+        "summary": "List your unread notifications",
         "tags": [
           "Notifications"
         ]
@@ -78348,19 +78227,8 @@
     },
     "/api/v1/notifications/unread-count": {
       "get": {
-        "description": "Returns the number of notifications addressed to the given employee that have not yet been marked read.",
+        "description": "Returns the number of notifications addressed to the signed-in caller that have not yet been marked read, for the badge a client draws on the menu.",
         "operationId": "getUnreadCount_1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78404,7 +78272,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to count"
           },
           "404": {
             "content": {
@@ -78457,7 +78325,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Count an employee's unread notifications",
+        "summary": "Count your unread notifications",
         "tags": [
           "Notifications"
         ]
@@ -78465,18 +78333,9 @@
     },
     "/api/v1/notifications/web": {
       "get": {
-        "description": "Returns a page of notifications addressed to the given employee, newest first.",
+        "description": "Returns a page of the notifications addressed to the signed-in caller, newest first. The recipient used to be a query parameter under a role gate that never read it; a caller that still sends employeeId is served their own inbox, because a query parameter no handler declares is ignored.",
         "operationId": "getNotifications_1",
         "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
           {
             "in": "query",
             "name": "pageable",
@@ -78525,7 +78384,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve"
           },
           "404": {
             "content": {
@@ -78578,7 +78437,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List an employee's notifications",
+        "summary": "List your notifications",
         "tags": [
           "Notifications (Web)"
         ]
@@ -78586,19 +78445,8 @@
     },
     "/api/v1/notifications/web/mark-all-read": {
       "post": {
-        "description": "Marks every unread notification addressed to the given employee as read and returns how many were updated.",
+        "description": "Marks every unread notification addressed to the signed-in caller as read and returns how many were updated.",
         "operationId": "markAllAsRead",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78642,7 +78490,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to update"
           },
           "404": {
             "content": {
@@ -78695,7 +78543,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Mark all of an employee's notifications as read",
+        "summary": "Mark all of your notifications as read",
         "tags": [
           "Notifications (Web)"
         ]
@@ -78703,7 +78551,7 @@
     },
     "/api/v1/notifications/web/read": {
       "patch": {
-        "description": "Marks the given notification read and records the time it was read.",
+        "description": "Marks the given notification read and records the time it was read. Ownership is settled in NotificationService against the recipient stored on the row: this handler names no employee, so there is nothing here for a self-check to read. The recipient is the only person who may mark it, because the damage from marking somebody else's notification read is that they never see it.",
         "operationId": "markAsRead_1",
         "parameters": [
           {
@@ -78755,7 +78603,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "The notification is addressed to somebody else, or the caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -78765,7 +78613,7 @@
                 }
               }
             },
-            "description": "No notification with the given id"
+            "description": "No notification with the given id in this organization"
           },
           "409": {
             "content": {
@@ -78808,7 +78656,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Mark a notification as read",
+        "summary": "Mark one of your notifications as read",
         "tags": [
           "Notifications (Web)"
         ]
@@ -78816,19 +78664,8 @@
     },
     "/api/v1/notifications/web/unread": {
       "get": {
-        "description": "Returns every notification addressed to the given employee that has not yet been marked read.",
+        "description": "Returns every notification addressed to the signed-in caller that has not yet been marked read.",
         "operationId": "getUnreadNotifications",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78871,7 +78708,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve"
           },
           "404": {
             "content": {
@@ -78924,7 +78761,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "List an employee's unread notifications",
+        "summary": "List your unread notifications",
         "tags": [
           "Notifications (Web)"
         ]
@@ -78932,19 +78769,8 @@
     },
     "/api/v1/notifications/web/unread-count": {
       "get": {
-        "description": "Returns the number of notifications addressed to the given employee that have not yet been marked read.",
+        "description": "Returns the number of notifications addressed to the signed-in caller that have not yet been marked read, for the badge the console draws on the menu.",
         "operationId": "getUnreadCount",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "employeeId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -78988,7 +78814,7 @@
                 }
               }
             },
-            "description": "Caller lacks the required role in the current tenant"
+            "description": "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to count"
           },
           "404": {
             "content": {
@@ -79041,7 +78867,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Count an employee's unread notifications",
+        "summary": "Count your unread notifications",
         "tags": [
           "Notifications (Web)"
         ]
@@ -79049,7 +78875,7 @@
     },
     "/api/v1/notifications/{notificationId}/read": {
       "patch": {
-        "description": "Marks the given notification read and records the time it was read.",
+        "description": "Marks the given notification read and records the time it was read. Ownership is settled in NotificationService against the recipient stored on the row: this handler names no employee, so there is nothing here for a self-check to read. The recipient is the only person who may mark it, because the damage from marking somebody else's notification read is that they never see it.",
         "operationId": "markAsRead",
         "parameters": [
           {
@@ -79101,7 +78927,7 @@
                 }
               }
             },
-            "description": "Caller lacks the leave read or admin authority"
+            "description": "The notification is addressed to somebody else, or the caller is not a member of the current tenant"
           },
           "404": {
             "content": {
@@ -79111,7 +78937,7 @@
                 }
               }
             },
-            "description": "No notification with the given id"
+            "description": "No notification with the given id in this organization"
           },
           "409": {
             "content": {
@@ -79154,7 +78980,7 @@
             "description": "Bad Gateway"
           }
         },
-        "summary": "Mark a notification as read",
+        "summary": "Mark one of your notifications as read",
         "tags": [
           "Notifications"
         ]
@@ -108134,11 +107960,11 @@
       "name": "Leave Balances (Web)"
     },
     {
-      "description": "Day-by-day view of who is on leave, built from approved leave requests. Endpoints cover the whole organization, a single department, a single employee or a manager's team, over a given date range, plus a grouped-by-date view and a headcount for a single day. Access is gated by the leave read or admin authority.",
+      "description": "Day-by-day view of who is on leave, built from approved leave requests. Endpoints cover the caller's whole organization, a single department, a single employee or the caller's own team, over a given date range, plus a grouped-by-date view and a headcount for a single day. The organization is taken from the caller's session; the organization-wide views are gated to the system-admin or hr-admin role, an employee's own calendar to that employee or those roles, and the team view to the manager whose team it is.",
       "name": "Leave Calendar"
     },
     {
-      "description": "Web-console equivalent of the leave calendar endpoints, addressing the organization, department, employee or manager by query parameters instead of path segments. Covers the organization, department, employee, team, grouped-by-date and headcount views. All endpoints are gated to the system-admin or hr-admin role in the caller's tenant.",
+      "description": "Web-console equivalent of the leave calendar endpoints, addressing a department or employee by query parameters instead of path segments. Covers the organization, department, employee, team, grouped-by-date and headcount views. The organization is taken from the caller's session; the organization-wide views are gated to the system-admin or hr-admin role, an employee's own calendar to that employee or those roles, and the team view to the manager whose team it is.",
       "name": "Leave Calendar (Web)"
     },
     {
@@ -108190,11 +108016,11 @@
       "name": "Non-conformance reports"
     },
     {
-      "description": "In-app notifications raised by the leave workflow, such as a request being submitted, approved, rejected or delegated. Endpoints cover reading a page of notifications, listing or counting the unread ones, and marking one or all as read. Access is gated by the leave read or admin authority.",
+      "description": "The signed-in caller's own in-app notifications, raised by the leave workflow when a request is submitted, approved, rejected or delegated. Endpoints cover reading a page of them, listing or counting the unread ones, and marking one or all as read. An inbox is personal, so every endpoint answers about the caller and none takes an employee id; access is gated on membership of the caller's current tenant.",
       "name": "Notifications"
     },
     {
-      "description": "Web-console equivalent of the notification endpoints, addressing a notification by a notificationId query parameter instead of a path segment. Covers reading a page of notifications, listing or counting the unread ones, and marking one or all as read. All endpoints are gated to the system-admin or hr-admin role in the caller's tenant.",
+      "description": "Web-console equivalent of the notification endpoints, addressing a notification by a notificationId query parameter instead of a path segment. Covers reading a page of the caller's notifications, listing or counting the unread ones, and marking one or all as read. An inbox is personal, so every endpoint answers about the caller and none takes an employee id; access is gated on membership of the caller's current tenant.",
       "name": "Notifications (Web)"
     },
     {

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarController.java
@@ -13,15 +13,41 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Day-by-day view of who is on leave, built from approved leave requests.
+ *
+ * <p>All six endpoints asked for {@code hasAuthority('leave:read')} or
+ * {@code hasAuthority('leave:admin')}, authorities this realm has no mechanism to issue: a bare
+ * {@code resource:scope} authority is minted only by {@code JwtAuthConverter.extractPermissions}
+ * from the {@code authorization} claim of an RPT, and the only automated provisioner,
+ * {@code KeycloakInitializer.ensureAuthorizationSetup}, creates a scopeless {@code Default
+ * Resource} and a scopeless {@code Default Permission}. A permission with no scopes yields no
+ * {@code resource:scope} authority, so the whole calendar refused every caller on the phone while
+ * the web twin of the same six views was live and working on the role pair.
+ *
+ * <p>The guards now say what the web twin already said, so nothing is widened by repairing them:
+ * the organization-wide views stay with the system-admin and hr-admin roles, one employee's
+ * calendar is readable by that employee or those roles, and a manager's team calendar is readable
+ * by the manager whose team it is.
+ *
+ * <p>The paths of the four organization-wide views lost their {@code {organizationId}} segment.
+ * The tenant is settled by the session and taking it from the caller was the same shape as #683,
+ * with only the Hibernate {@code orgFilter} standing between a named id and another tenant's rows.
+ * Reshaping the path is safe here in a way it would not normally be, because these four refused
+ * every caller and so no client can be depending on the shape they had.
+ */
 @RestController
 @RequestMapping("/api/v1/leave-calendar")
 @Validated
 @Tag(
         name = "Leave Calendar",
         description = "Day-by-day view of who is on leave, built from approved leave requests. Endpoints "
-                + "cover the whole organization, a single department, a single employee or a manager's "
-                + "team, over a given date range, plus a grouped-by-date view and a headcount for a single "
-                + "day. Access is gated by the leave read or admin authority."
+                + "cover the caller's whole organization, a single department, a single employee or the "
+                + "caller's own team, over a given date range, plus a grouped-by-date view and a "
+                + "headcount for a single day. The organization is taken from the caller's session; the "
+                + "organization-wide views are gated to the system-admin or hr-admin role, an employee's "
+                + "own calendar to that employee or those roles, and the team view to the manager whose "
+                + "team it is."
 )
 public class LeaveCalendarController {
 
@@ -31,58 +57,54 @@ public class LeaveCalendarController {
         this.calendarService = calendarService;
     }
 
-    @GetMapping("/organization/{organizationId}")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @GetMapping("/organization")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
-            summary = "Get an organization's leave calendar",
-            description = "Returns every leave calendar entry for the organization between startDate and "
-                    + "endDate, inclusive."
+            summary = "Get your organization's leave calendar",
+            description = "Returns every leave calendar entry for the caller's organization between "
+                    + "startDate and endDate, inclusive. The organization used to be a path segment the "
+                    + "guard never read; it comes from the session now."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin or hr-admin role in the current tenant")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getOrganizationCalendar(
-            @PathVariable Long organizationId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarByOrganization(organizationId, startDate, endDate));
+                calendarService.getCalendarByOrganization(startDate, endDate));
     }
 
-    @GetMapping("/organization/{organizationId}/department")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @GetMapping("/department")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Get a department's leave calendar",
             description = "Returns every leave calendar entry for the named department within the "
-                    + "organization between startDate and endDate, inclusive."
+                    + "caller's organization between startDate and endDate, inclusive."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin or hr-admin role in the current tenant")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getDepartmentCalendar(
-            @PathVariable Long organizationId,
             @RequestParam String department,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarByDepartment(organizationId, department, startDate, endDate));
+                calendarService.getCalendarByDepartment(department, startDate, endDate));
     }
 
     @GetMapping("/employee/{employeeId}")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's leave calendar",
             description = "Returns every leave calendar entry for the employee between startDate and "
-                    + "endDate, inclusive."
+                    + "endDate, inclusive. Readable by that employee, and by the leave administrators."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of the system-admin or hr-admin role")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getEmployeeCalendar(
             @PathVariable Long employeeId,
@@ -93,61 +115,59 @@ public class LeaveCalendarController {
     }
 
     @GetMapping("/team")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Get a manager's team leave calendar",
-            description = "Returns every leave calendar entry for the direct reports of the given manager "
-                    + "between startDate and endDate, inclusive."
+            summary = "Get your team's leave calendar",
+            description = "Returns every leave calendar entry for the signed-in caller's direct reports "
+                    + "between startDate and endDate, inclusive. The manager used to be a query "
+                    + "parameter under a guard that never read it, so an administrator read any "
+                    + "manager's team and a manager could not read their own; a caller that still sends "
+                    + "managerId is served their own team, because a query parameter no handler declares "
+                    + "is ignored. A caller with no direct reports gets an empty list."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no team to serve")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getTeamCalendar(
-            @RequestParam Long managerId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getTeamCalendar(managerId, startDate, endDate));
+                calendarService.getMyTeamCalendar(startDate, endDate));
     }
 
-    @GetMapping("/organization/{organizationId}/grouped")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @GetMapping("/grouped")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
-            summary = "Get an organization's leave calendar grouped by date",
-            description = "Returns the organization's leave calendar entries between startDate and endDate, "
-                    + "inclusive, keyed by date for a day-by-day view."
+            summary = "Get your organization's leave calendar grouped by date",
+            description = "Returns the caller's organization's leave calendar entries between startDate "
+                    + "and endDate, inclusive, keyed by date for a day-by-day view."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grouped calendar returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin or hr-admin role in the current tenant")
     })
     public ResponseEntity<Map<LocalDate, List<LeaveCalendarDto>>> getCalendarGroupedByDate(
-            @PathVariable Long organizationId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarGroupedByDate(organizationId, startDate, endDate));
+                calendarService.getCalendarGroupedByDate(startDate, endDate));
     }
 
-    @GetMapping("/organization/{organizationId}/count")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @GetMapping("/count")
+    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Count employees on leave for a day",
-            description = "Returns the number of employees in the organization who are on leave on the "
-                    + "given date."
+            description = "Returns the number of employees in the caller's organization who are on leave "
+                    + "on the given date."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the system-admin or hr-admin role in the current tenant")
     })
     public ResponseEntity<Map<String, Long>> getEmployeesOnLeaveCount(
-            @PathVariable Long organizationId,
             @RequestParam LocalDate date) {
-        long count = calendarService.countEmployeesOnLeave(organizationId, date);
+        long count = calendarService.countEmployeesOnLeave(date);
         return ResponseEntity.ok(Map.of("count", count));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarControllerWeb.java
@@ -13,15 +13,34 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Web-console equivalent of {@link LeaveCalendarController}, addressing a department or employee by
+ * query parameters instead of path segments.
+ *
+ * <p>This twin was never phantom-guarded, so unlike the phone twin it worked. What it carried
+ * instead was the shape closed in #683: it asked for the system-admin or hr-admin role and then
+ * answered about whichever organization, employee or manager the caller named. An administrator
+ * read any manager's team calendar by naming them, and the manager whose team it was, holding
+ * neither role, was refused it.
+ *
+ * <p>The organization and the manager are settled by the session and are gone from the surface.
+ * Dropping them is safe on the deployed console, because Spring ignores a query parameter no
+ * handler declares: the calls {@code echno-core} makes today are served the caller's own tenant
+ * and the caller's own team rather than refused. The organization-wide views keep the role pair,
+ * so nothing here is widened except an employee's sight of their own calendar and a manager's of
+ * their own team.
+ */
 @RestController
 @RequestMapping("/api/v1/leave-calendar/web")
 @Validated
 @Tag(
         name = "Leave Calendar (Web)",
-        description = "Web-console equivalent of the leave calendar endpoints, addressing the organization, "
-                + "department, employee or manager by query parameters instead of path segments. Covers "
-                + "the organization, department, employee, team, grouped-by-date and headcount views. All "
-                + "endpoints are gated to the system-admin or hr-admin role in the caller's tenant."
+        description = "Web-console equivalent of the leave calendar endpoints, addressing a department or "
+                + "employee by query parameters instead of path segments. Covers the organization, "
+                + "department, employee, team, grouped-by-date and headcount views. The organization is "
+                + "taken from the caller's session; the organization-wide views are gated to the "
+                + "system-admin or hr-admin role, an employee's own calendar to that employee or those "
+                + "roles, and the team view to the manager whose team it is."
 )
 public class LeaveCalendarControllerWeb {
 
@@ -34,21 +53,21 @@ public class LeaveCalendarControllerWeb {
     @GetMapping("/organization")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
-            summary = "Get an organization's leave calendar",
-            description = "Returns every leave calendar entry for the organization between startDate and "
-                    + "endDate, inclusive."
+            summary = "Get your organization's leave calendar",
+            description = "Returns every leave calendar entry for the caller's organization between "
+                    + "startDate and endDate, inclusive. The organization used to be a query parameter "
+                    + "the guard never read; it comes from the session now, and a caller that still "
+                    + "sends organizationId is served their own tenant."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getOrganizationCalendar(
-            @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarByOrganization(organizationId, startDate, endDate));
+                calendarService.getCalendarByOrganization(startDate, endDate));
     }
 
     @GetMapping("/department")
@@ -56,32 +75,30 @@ public class LeaveCalendarControllerWeb {
     @Operation(
             summary = "Get a department's leave calendar",
             description = "Returns every leave calendar entry for the named department within the "
-                    + "organization between startDate and endDate, inclusive."
+                    + "caller's organization between startDate and endDate, inclusive."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getDepartmentCalendar(
-            @RequestParam Long organizationId,
             @RequestParam String department,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarByDepartment(organizationId, department, startDate, endDate));
+                calendarService.getCalendarByDepartment(department, startDate, endDate));
     }
 
     @GetMapping("/employee")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')")
     @Operation(
             summary = "Get an employee's leave calendar",
             description = "Returns every leave calendar entry for the employee between startDate and "
-                    + "endDate, inclusive."
+                    + "endDate, inclusive. Readable by that employee, and by the leave administrators."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither the employee named nor a holder of the system-admin or hr-admin role"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No employee with the given id")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getEmployeeCalendar(
@@ -93,61 +110,59 @@ public class LeaveCalendarControllerWeb {
     }
 
     @GetMapping("/team")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Get a manager's team leave calendar",
-            description = "Returns every leave calendar entry for the direct reports of the given manager "
-                    + "between startDate and endDate, inclusive."
+            summary = "Get your team's leave calendar",
+            description = "Returns every leave calendar entry for the signed-in caller's direct reports "
+                    + "between startDate and endDate, inclusive. The manager used to be a query "
+                    + "parameter under a guard that never read it, so an administrator read any "
+                    + "manager's team and a manager could not read their own; a caller that still sends "
+                    + "managerId is served their own team, because a query parameter no handler declares "
+                    + "is ignored. A caller with no direct reports gets an empty list."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Calendar entries returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No manager with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no team to serve")
     })
     public ResponseEntity<List<LeaveCalendarDto>> getTeamCalendar(
-            @RequestParam Long managerId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getTeamCalendar(managerId, startDate, endDate));
+                calendarService.getMyTeamCalendar(startDate, endDate));
     }
 
     @GetMapping("/grouped")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
-            summary = "Get an organization's leave calendar grouped by date",
-            description = "Returns the organization's leave calendar entries between startDate and endDate, "
-                    + "inclusive, keyed by date for a day-by-day view."
+            summary = "Get your organization's leave calendar grouped by date",
+            description = "Returns the caller's organization's leave calendar entries between startDate "
+                    + "and endDate, inclusive, keyed by date for a day-by-day view."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grouped calendar returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Map<LocalDate, List<LeaveCalendarDto>>> getCalendarGroupedByDate(
-            @RequestParam Long organizationId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate) {
         return ResponseEntity.ok(
-                calendarService.getCalendarGroupedByDate(organizationId, startDate, endDate));
+                calendarService.getCalendarGroupedByDate(startDate, endDate));
     }
 
     @GetMapping("/count")
     @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
     @Operation(
             summary = "Count employees on leave for a day",
-            description = "Returns the number of employees in the organization who are on leave on the "
-                    + "given date."
+            description = "Returns the number of employees in the caller's organization who are on leave "
+                    + "on the given date."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No organization with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
     })
     public ResponseEntity<Map<String, Long>> getEmployeesOnLeaveCount(
-            @RequestParam Long organizationId,
             @RequestParam LocalDate date) {
-        long count = calendarService.countEmployeesOnLeave(organizationId, date);
+        long count = calendarService.countEmployeesOnLeave(date);
         return ResponseEntity.ok(Map.of("count", count));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/LeaveCalendarService.java
@@ -3,6 +3,8 @@ package org.tornotron.echno_backend.leave;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.leave.mapper.LeaveCalendarMapper;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
@@ -22,14 +24,17 @@ public class LeaveCalendarService {
     private final LeaveCalendarRepository calendarRepository;
     private final EmployeeRepository employeeRepository;
     private final LeaveCalendarMapper leaveCalendarMapper;
+    private final CurrentEmployeeService currentEmployeeService;
 
     public LeaveCalendarService(
             LeaveCalendarRepository calendarRepository,
             EmployeeRepository employeeRepository,
-            LeaveCalendarMapper leaveCalendarMapper) {
+            LeaveCalendarMapper leaveCalendarMapper,
+            CurrentEmployeeService currentEmployeeService) {
         this.calendarRepository = calendarRepository;
         this.employeeRepository = employeeRepository;
         this.leaveCalendarMapper = leaveCalendarMapper;
+        this.currentEmployeeService = currentEmployeeService;
     }
 
     @Transactional
@@ -65,25 +70,34 @@ public class LeaveCalendarService {
         calendarRepository.deleteByLeaveRequestId(requestId);
     }
 
+    /**
+     * The current tenant's leave calendar over a date range.
+     *
+     * <p>The organization used to be an id the caller sent, on a path segment the guard never
+     * read. It answered about whichever organization the caller named, and only the Hibernate
+     * {@code orgFilter} kept that from reaching another tenant's rows: a defence in depth doing
+     * the work of the check itself. The tenant is settled by the session, so it comes from
+     * {@link TenantContext}.
+     */
     @Transactional(readOnly = true)
     public List<LeaveCalendarDto> getCalendarByOrganization(
-            Long organizationId,
             LocalDate startDate,
             LocalDate endDate) {
-        return calendarRepository.findByOrganizationAndDateRange(organizationId, startDate, endDate)
+        return calendarRepository.findByOrganizationAndDateRange(
+                        TenantContext.getCurrentOrgId(), startDate, endDate)
                 .stream()
                 .map(leaveCalendarMapper::toDto)
                 .collect(Collectors.toList());
     }
 
+    /** One department's leave calendar within the current tenant, over a date range. */
     @Transactional(readOnly = true)
     public List<LeaveCalendarDto> getCalendarByDepartment(
-            Long organizationId,
             String department,
             LocalDate startDate,
             LocalDate endDate) {
         return calendarRepository.findByOrganizationAndDepartmentAndDateRange(
-                        organizationId, department, startDate, endDate)
+                        TenantContext.getCurrentOrgId(), department, startDate, endDate)
                 .stream()
                 .map(leaveCalendarMapper::toDto)
                 .collect(Collectors.toList());
@@ -100,12 +114,22 @@ public class LeaveCalendarService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * The leave calendar of the caller's own direct reports, over a date range.
+     *
+     * <p>A team is the caller's own by definition. Taking the manager as a query parameter under a
+     * guard that only asked for a role was the same shape as the approval queue in #683: an
+     * administrator read any manager's team by naming them, and a manager, who holds neither
+     * system-admin nor hr-admin, could not read their own. The manager comes from the session.
+     */
     @Transactional(readOnly = true)
-    public List<LeaveCalendarDto> getTeamCalendar(
-            Long managerId,
+    public List<LeaveCalendarDto> getMyTeamCalendar(
             LocalDate startDate,
             LocalDate endDate) {
-        
+
+        Long managerId = currentEmployeeService
+                .requireCurrentEmployee("read your team's leave calendar").getId();
+
         List<Employee> directReports = employeeRepository.findByManager_Id(managerId);
 
         List<Long> employeeIds = directReports.stream()
@@ -122,20 +146,23 @@ public class LeaveCalendarService {
                 .collect(Collectors.toList());
     }
 
+    /** The current tenant's leave calendar over a date range, keyed by date for a day-by-day view. */
     @Transactional(readOnly = true)
     public Map<LocalDate, List<LeaveCalendarDto>> getCalendarGroupedByDate(
-            Long organizationId,
             LocalDate startDate,
             LocalDate endDate) {
-        return calendarRepository.findByOrganizationAndDateRange(organizationId, startDate, endDate)
+        return calendarRepository.findByOrganizationAndDateRange(
+                        TenantContext.getCurrentOrgId(), startDate, endDate)
                 .stream()
                 .map(leaveCalendarMapper::toDto)
                 .collect(Collectors.groupingBy(LeaveCalendarDto::getLeaveDate));
     }
 
+    /** How many employees in the current tenant are on leave on one date. */
     @Transactional(readOnly = true)
-    public long countEmployeesOnLeave(Long organizationId, LocalDate date) {
-        return calendarRepository.countEmployeesOnLeaveByOrgAndDate(organizationId, date);
+    public long countEmployeesOnLeave(LocalDate date) {
+        return calendarRepository.countEmployeesOnLeaveByOrgAndDate(
+                TenantContext.getCurrentOrgId(), date);
     }
 
     private HalfDayType determineDayType(LeaveRequest request, LocalDate date) {

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationController.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationController.java
@@ -15,15 +15,42 @@ import org.tornotron.echno_backend.leave.dto.NotificationDto;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The signed-in caller's notification inbox.
+ *
+ * <p>Every endpoint here used to ask for {@code hasAuthority('leave:read')} or
+ * {@code hasAuthority('leave:admin')}. {@code JwtAuthConverter} mints a bare
+ * {@code resource:scope} authority in exactly one place, {@code extractPermissions}, which reads
+ * the {@code authorization} claim of an RPT, so each of those strings needed a Keycloak
+ * Authorization Services resource named {@code leave} carrying the matching scope. Nothing defines
+ * one: the only automated provisioner, {@code KeycloakInitializer.ensureAuthorizationSetup},
+ * creates a scopeless {@code Default Resource} and a scopeless {@code Default Permission}, and a
+ * permission with no scopes yields no {@code resource:scope} authority at all. So the whole inbox
+ * refused every caller, and had done since the annotations were written.
+ *
+ * <p>That mattered more than a dead read surface usually would. {@code LeaveApprovalService}
+ * writes a notification on every routing step and every delegation, so the rows were being
+ * created and nobody could read them: an approver had no way to learn a request was waiting on
+ * them. The endpoints were repaired rather than removed, because the workflow they feed is
+ * required.
+ *
+ * <p>Underneath the phantom sat a second defect. Four of the five took the recipient as an
+ * {@code employeeId} query parameter that the guard never read, so repairing only the guard would
+ * have handed whoever got through every colleague's inbox. A notification is addressed to one
+ * person, so the recipient comes from the session and the parameter is gone. Removing it is safe
+ * on a deployed client, because Spring ignores a query parameter no handler declares: a call that
+ * still sends {@code employeeId} is served the caller's own inbox rather than refused.
+ */
 @RestController
 @RequestMapping("/api/v1/notifications")
 @Validated
 @Tag(
         name = "Notifications",
-        description = "In-app notifications raised by the leave workflow, such as a request being "
-                + "submitted, approved, rejected or delegated. Endpoints cover reading a page of "
-                + "notifications, listing or counting the unread ones, and marking one or all as read. "
-                + "Access is gated by the leave read or admin authority."
+        description = "The signed-in caller's own in-app notifications, raised by the leave workflow "
+                + "when a request is submitted, approved, rejected or delegated. Endpoints cover reading "
+                + "a page of them, listing or counting the unread ones, and marking one or all as read. "
+                + "An inbox is personal, so every endpoint answers about the caller and none takes an "
+                + "employee id; access is gated on membership of the caller's current tenant."
 )
 public class NotificationController {
 
@@ -34,64 +61,67 @@ public class NotificationController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List an employee's notifications",
-            description = "Returns a page of notifications addressed to the given employee, newest first."
+            summary = "List your notifications",
+            description = "Returns a page of the notifications addressed to the signed-in caller, newest "
+                    + "first. The recipient used to be a query parameter under a guard that only asked "
+                    + "for an authority nothing grants; a caller that still sends employeeId is served "
+                    + "their own inbox, because a query parameter no handler declares is ignored."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of notifications returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve")
     })
-    public ResponseEntity<Page<NotificationDto>> getNotifications(
-            @RequestParam Long employeeId,
-            Pageable pageable) {
-        return ResponseEntity.ok(notificationService.getNotifications(employeeId, pageable));
+    public ResponseEntity<Page<NotificationDto>> getNotifications(Pageable pageable) {
+        return ResponseEntity.ok(notificationService.getMyNotifications(pageable));
     }
 
     @GetMapping("/unread")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List an employee's unread notifications",
-            description = "Returns every notification addressed to the given employee that has not yet "
+            summary = "List your unread notifications",
+            description = "Returns every notification addressed to the signed-in caller that has not yet "
                     + "been marked read."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Unread notifications returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve")
     })
-    public ResponseEntity<List<NotificationDto>> getUnreadNotifications(
-            @RequestParam Long employeeId) {
-        return ResponseEntity.ok(notificationService.getUnreadNotifications(employeeId));
+    public ResponseEntity<List<NotificationDto>> getUnreadNotifications() {
+        return ResponseEntity.ok(notificationService.getMyUnreadNotifications());
     }
 
     @GetMapping("/unread-count")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Count an employee's unread notifications",
-            description = "Returns the number of notifications addressed to the given employee that have "
-                    + "not yet been marked read."
+            summary = "Count your unread notifications",
+            description = "Returns the number of notifications addressed to the signed-in caller that "
+                    + "have not yet been marked read, for the badge a client draws on the menu."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to count")
     })
-    public ResponseEntity<Map<String, Long>> getUnreadCount(
-            @RequestParam Long employeeId) {
-        long count = notificationService.getUnreadCount(employeeId);
+    public ResponseEntity<Map<String, Long>> getUnreadCount() {
+        long count = notificationService.getMyUnreadCount();
         return ResponseEntity.ok(Map.of("count", count));
     }
 
     @PatchMapping("/{notificationId}/read")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Mark a notification as read",
-            description = "Marks the given notification read and records the time it was read."
+            summary = "Mark one of your notifications as read",
+            description = "Marks the given notification read and records the time it was read. Ownership "
+                    + "is settled in NotificationService against the recipient stored on the row: this "
+                    + "handler names no employee, so there is nothing here for a self-check to read. The "
+                    + "recipient is the only person who may mark it, because the damage from marking "
+                    + "somebody else's notification read is that they never see it."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notification marked as read"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "The notification is addressed to somebody else, or the caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id in this organization")
     })
     public ResponseEntity<ApiResponse> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);
@@ -99,19 +129,18 @@ public class NotificationController {
     }
 
     @PostMapping("/mark-all-read")
-    @PreAuthorize("hasAuthority('leave:read') or hasAuthority('leave:admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Mark all of an employee's notifications as read",
-            description = "Marks every unread notification addressed to the given employee as read and "
+            summary = "Mark all of your notifications as read",
+            description = "Marks every unread notification addressed to the signed-in caller as read and "
                     + "returns how many were updated."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notifications marked as read"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the leave read or admin authority")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to update")
     })
-    public ResponseEntity<Map<String, Integer>> markAllAsRead(
-            @RequestParam Long employeeId) {
-        int count = notificationService.markAllAsRead(employeeId);
+    public ResponseEntity<Map<String, Integer>> markAllAsRead() {
+        int count = notificationService.markAllAsRead();
         return ResponseEntity.ok(Map.of("markedAsRead", count));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationControllerWeb.java
@@ -15,6 +15,29 @@ import org.tornotron.echno_backend.leave.dto.NotificationDto;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Web-console equivalent of {@link NotificationController}, addressing a notification by a
+ * {@code notificationId} query parameter instead of a path segment.
+ *
+ * <p>This twin was never phantom-guarded and so was never dead, which made it the reachable half
+ * of the same fault. It asked for the system-admin or hr-admin role and then served whichever
+ * employee the caller named, so an administrator read and cleared any colleague's inbox by passing
+ * their id, and the approvers a leave chain is actually built from, who are line managers and hold
+ * neither role, were refused the notification bell that tells them a request has arrived. Both
+ * halves are the shape closed in #589, #599, #607, #631, #635 and #683.
+ *
+ * <p>Marking read was worse in kind. It took only a notification id and checked no ownership at
+ * all, so any of the two roles' holders marked any colleague's notification read by counting ids,
+ * with the effect that the recipient never saw it. That one needed a check against the stored row
+ * rather than a repaired guard, and it has one now in {@code NotificationService.markAsRead}.
+ *
+ * <p>Both twins now answer the same question, "what is in my inbox", gated on membership. This is
+ * narrower than the role gate it replaces, not wider: before, any holder of system-admin or
+ * hr-admin reached every inbox in the tenant; now each caller reaches their own and nobody reaches
+ * anybody else's. Dropping {@code employeeId} is safe on the deployed console, because Spring
+ * ignores a query parameter no handler declares, so the call {@code echno-core} makes today is
+ * served the caller's own inbox rather than refused.
+ */
 @RestController
 @RequestMapping("/api/v1/notifications/web")
 @Validated
@@ -22,8 +45,9 @@ import java.util.Map;
         name = "Notifications (Web)",
         description = "Web-console equivalent of the notification endpoints, addressing a notification by "
                 + "a notificationId query parameter instead of a path segment. Covers reading a page of "
-                + "notifications, listing or counting the unread ones, and marking one or all as read. "
-                + "All endpoints are gated to the system-admin or hr-admin role in the caller's tenant."
+                + "the caller's notifications, listing or counting the unread ones, and marking one or "
+                + "all as read. An inbox is personal, so every endpoint answers about the caller and none "
+                + "takes an employee id; access is gated on membership of the caller's current tenant."
 )
 public class NotificationControllerWeb {
 
@@ -34,64 +58,67 @@ public class NotificationControllerWeb {
     }
 
     @GetMapping
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List an employee's notifications",
-            description = "Returns a page of notifications addressed to the given employee, newest first."
+            summary = "List your notifications",
+            description = "Returns a page of the notifications addressed to the signed-in caller, newest "
+                    + "first. The recipient used to be a query parameter under a role gate that never "
+                    + "read it; a caller that still sends employeeId is served their own inbox, because "
+                    + "a query parameter no handler declares is ignored."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Page of notifications returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve")
     })
-    public ResponseEntity<Page<NotificationDto>> getNotifications(
-            @RequestParam Long employeeId,
-            Pageable pageable) {
-        return ResponseEntity.ok(notificationService.getNotifications(employeeId, pageable));
+    public ResponseEntity<Page<NotificationDto>> getNotifications(Pageable pageable) {
+        return ResponseEntity.ok(notificationService.getMyNotifications(pageable));
     }
 
     @GetMapping("/unread")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "List an employee's unread notifications",
-            description = "Returns every notification addressed to the given employee that has not yet "
+            summary = "List your unread notifications",
+            description = "Returns every notification addressed to the signed-in caller that has not yet "
                     + "been marked read."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Unread notifications returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to serve")
     })
-    public ResponseEntity<List<NotificationDto>> getUnreadNotifications(
-            @RequestParam Long employeeId) {
-        return ResponseEntity.ok(notificationService.getUnreadNotifications(employeeId));
+    public ResponseEntity<List<NotificationDto>> getUnreadNotifications() {
+        return ResponseEntity.ok(notificationService.getMyUnreadNotifications());
     }
 
     @GetMapping("/unread-count")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Count an employee's unread notifications",
-            description = "Returns the number of notifications addressed to the given employee that have "
-                    + "not yet been marked read."
+            summary = "Count your unread notifications",
+            description = "Returns the number of notifications addressed to the signed-in caller that "
+                    + "have not yet been marked read, for the badge the console draws on the menu."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Count returned"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to count")
     })
-    public ResponseEntity<Map<String, Long>> getUnreadCount(
-            @RequestParam Long employeeId) {
-        long count = notificationService.getUnreadCount(employeeId);
+    public ResponseEntity<Map<String, Long>> getUnreadCount() {
+        long count = notificationService.getMyUnreadCount();
         return ResponseEntity.ok(Map.of("count", count));
     }
 
     @PatchMapping("/read")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Mark a notification as read",
-            description = "Marks the given notification read and records the time it was read."
+            summary = "Mark one of your notifications as read",
+            description = "Marks the given notification read and records the time it was read. Ownership "
+                    + "is settled in NotificationService against the recipient stored on the row: this "
+                    + "handler names no employee, so there is nothing here for a self-check to read. The "
+                    + "recipient is the only person who may mark it, because the damage from marking "
+                    + "somebody else's notification read is that they never see it."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notification marked as read"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "The notification is addressed to somebody else, or the caller is not a member of the current tenant"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No notification with the given id in this organization")
     })
     public ResponseEntity<ApiResponse> markAsRead(@RequestParam Long notificationId) {
         notificationService.markAsRead(notificationId);
@@ -99,19 +126,18 @@ public class NotificationControllerWeb {
     }
 
     @PostMapping("/mark-all-read")
-    @PreAuthorize("@orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant()")
     @Operation(
-            summary = "Mark all of an employee's notifications as read",
-            description = "Marks every unread notification addressed to the given employee as read and "
+            summary = "Mark all of your notifications as read",
+            description = "Marks every unread notification addressed to the signed-in caller as read and "
                     + "returns how many were updated."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Notifications marked as read"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller lacks the required role in the current tenant")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is not a member of the current tenant, or has no employee record in it, so there is no inbox to update")
     })
-    public ResponseEntity<Map<String, Integer>> markAllAsRead(
-            @RequestParam Long employeeId) {
-        int count = notificationService.markAllAsRead(employeeId);
+    public ResponseEntity<Map<String, Integer>> markAllAsRead() {
+        int count = notificationService.markAllAsRead();
         return ResponseEntity.ok(Map.of("markedAsRead", count));
     }
 }

--- a/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
+++ b/src/main/java/org/tornotron/echno_backend/leave/NotificationService.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.AccessDeniedException;
 import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
 import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
 import org.tornotron.echno_backend.employee.Employee;
 import org.tornotron.echno_backend.employee.EmployeeRepository;
 import org.tornotron.echno_backend.leave.dto.NotificationDto;
@@ -25,14 +27,17 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final EmployeeRepository employeeRepository;
     private final NotificationMapper notificationMapper;
+    private final CurrentEmployeeService currentEmployeeService;
 
     public NotificationService(
             NotificationRepository notificationRepository,
             EmployeeRepository employeeRepository,
-            NotificationMapper notificationMapper) {
+            NotificationMapper notificationMapper,
+            CurrentEmployeeService currentEmployeeService) {
         this.notificationRepository = notificationRepository;
         this.employeeRepository = employeeRepository;
         this.notificationMapper = notificationMapper;
+        this.currentEmployeeService = currentEmployeeService;
     }
 
     @Transactional
@@ -151,38 +156,77 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    /**
+     * The caller's own notifications, newest first.
+     *
+     * <p>The recipient used to be an {@code employeeId} the caller sent, under a guard that read
+     * nothing: the guard established that the caller held a role and the query answered about
+     * whoever the caller named, with nothing tying the two together. A notification is addressed to
+     * one person, so the inbox is the caller's own by definition and the recipient comes from the
+     * session.
+     */
     @Transactional(readOnly = true)
-    public Page<NotificationDto> getNotifications(Long employeeId, Pageable pageable) {
-        return notificationRepository.findByRecipientIdOrderByCreatedAtDesc(employeeId, pageable)
+    public Page<NotificationDto> getMyNotifications(Pageable pageable) {
+        Long recipientId = currentRecipientId("read your notifications");
+        return notificationRepository.findByRecipientIdOrderByCreatedAtDesc(recipientId, pageable)
                 .map(notificationMapper::toDto);
     }
 
+    /** The caller's own notifications that have not been marked read. */
     @Transactional(readOnly = true)
-    public List<NotificationDto> getUnreadNotifications(Long employeeId) {
-        return notificationRepository.findByRecipientIdAndIsReadFalseOrderByCreatedAtDesc(employeeId)
+    public List<NotificationDto> getMyUnreadNotifications() {
+        Long recipientId = currentRecipientId("read your notifications");
+        return notificationRepository.findByRecipientIdAndIsReadFalseOrderByCreatedAtDesc(recipientId)
                 .stream()
                 .map(notificationMapper::toDto)
                 .collect(Collectors.toList());
     }
 
+    /** How many of the caller's own notifications are unread, for the badge a client draws. */
     @Transactional(readOnly = true)
-    public long getUnreadCount(Long employeeId) {
-        return notificationRepository.countByRecipientIdAndIsReadFalse(employeeId);
+    public long getMyUnreadCount() {
+        return notificationRepository.countByRecipientIdAndIsReadFalse(
+                currentRecipientId("count your notifications"));
     }
 
+    /**
+     * Marks one of the caller's own notifications read.
+     *
+     * <p>This used to check nothing at all. It took a notification id, loaded the row by that id
+     * within the current tenant, and wrote {@code isRead} on whatever came back, so any caller who
+     * got past the guard marked any colleague's notification read by counting ids. It did not even
+     * have a recipient parameter to be wrong about, which is why a repaired guard alone would not
+     * have closed it: the check has to be made against the stored row.
+     *
+     * <p>Read state is personal, and the damage from marking someone else's notification read is
+     * that they never see it. The recipient on the row is the only person who may mark it.
+     */
     @Transactional
     public void markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findByIdAndOrganization_Id(notificationId, TenantContext.getCurrentOrgId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Notification with ID " + notificationId + " was not found in this organization"));
 
+        Long callerId = currentRecipientId("mark a notification read");
+        if (notification.getRecipient() == null
+                || !callerId.equals(notification.getRecipient().getId())) {
+            throw new AccessDeniedException(
+                    "This notification is addressed to somebody else, so it is not yours to mark read.");
+        }
+
         notification.setIsRead(true);
         notification.setReadAt(LocalDateTime.now());
         notificationRepository.save(notification);
     }
 
+    /** Marks every unread notification addressed to the caller read, and says how many that was. */
     @Transactional
-    public int markAllAsRead(Long employeeId) {
-        return notificationRepository.markAllAsReadByRecipientId(employeeId, TenantContext.getCurrentOrgId());
+    public int markAllAsRead() {
+        return notificationRepository.markAllAsReadByRecipientId(
+                currentRecipientId("mark your notifications read"), TenantContext.getCurrentOrgId());
+    }
+
+    private Long currentRecipientId(String action) {
+        return currentEmployeeService.requireCurrentEmployee(action).getId();
     }
 }

--- a/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalEndpointAuthorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/LeaveApprovalEndpointAuthorityTest.java
@@ -36,8 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * having been deleted rather than corrected, or by the controller having been emptied.
  *
  * <p>Scoped to the leave approval surface deliberately. {@code NotificationController} and
- * {@code LeaveCalendarController} in this same package still carry the phantom, and widening this
- * test is a change to endpoints it was not written for.
+ * {@code LeaveCalendarController} in this same package carried the same phantom and were repaired
+ * separately in #684; {@code NotificationAndCalendarEndpointAuthorityTest} is their ratchet.
  */
 class LeaveApprovalEndpointAuthorityTest {
 

--- a/src/test/java/org/tornotron/echno_backend/leave/NotificationAndCalendarEndpointAuthorityTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/NotificationAndCalendarEndpointAuthorityTest.java
@@ -1,0 +1,222 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The notification inbox and the leave calendar may not be guarded by an authority this realm has
+ * no way to issue, and may not take the person they answer about from the caller.
+ *
+ * <p>Eleven endpoints, all five on {@link NotificationController} and all six on
+ * {@link LeaveCalendarController}, asked for {@code hasAuthority('leave:read')} or
+ * {@code hasAuthority('leave:admin')}. A bare {@code resource:scope} authority is minted in exactly
+ * one place, {@code JwtAuthConverter.extractPermissions}, from the {@code authorization} claim of
+ * an RPT, so each needed a Keycloak Authorization Services resource named {@code leave} carrying
+ * the matching scope. The only automated provisioner is
+ * {@code KeycloakInitializer.ensureAuthorizationSetup}, and it registers a {@code Default Resource}
+ * on which {@code setScopes} is never called plus a scopeless {@code Default Permission}; a
+ * permission with no scopes yields no {@code resource:scope} authority at all. The multi-tenancy
+ * audit of 2026-08-18 confirmed the same end to end against the live staging Keycloak database for
+ * the identical {@code organization:admin} string, finding zero scopes realm-wide. #641 confirmed
+ * it for {@code billing:admin} and #685 for {@code leave:approve}.
+ *
+ * <p>This is the ratchet that stops the phantom being reintroduced by copying a neighbouring
+ * annotation. It reads the annotations off the production classes rather than the source text, and
+ * the second test pins the endpoint count so the first cannot pass by a guard having been deleted
+ * rather than corrected.
+ *
+ * <p>The remaining tests pin the other half. The {@code /web} twins of both controllers were never
+ * phantom-guarded and so were never dead: they asked for a role and then answered about whichever
+ * employee, manager or organization the caller named, which is the shape closed in #589, #599,
+ * #607, #631, #635 and #683. Repairing only the authority would have handed whoever got through
+ * every colleague's inbox rather than nobody's.
+ */
+class NotificationAndCalendarEndpointAuthorityTest {
+
+    /** Both twins of both controllers. Checking one twin is how the last one of these was missed. */
+    private static final List<Class<?>> CONTROLLERS = List.of(
+            NotificationController.class,
+            NotificationControllerWeb.class,
+            LeaveCalendarController.class,
+            LeaveCalendarControllerWeb.class);
+
+    /**
+     * A bare {@code resource:scope} grant inside a hasAuthority call, which is the form that needs
+     * an authorization scope the realm does not define. Org-scoped authorities built at runtime,
+     * such as {@code ORG_MEMBER_7}, are a different mechanism and do not match.
+     */
+    private static final Pattern UNGRANTABLE_SCOPE_AUTHORITY =
+            Pattern.compile("hasAuthority\\(\\s*'[a-z-]+:[a-z-]+'\\s*\\)");
+
+    /** Parameter names that name a person, or the tenant, rather than the thing being read. */
+    private static final List<String> CALLER_SUPPLIED_IDENTITY =
+            List.of("employeeId", "managerId", "approverId", "organizationId", "recipientId");
+
+    private record Endpoint(String name, String guard) {}
+
+    private static List<Endpoint> endpoints() {
+        List<Endpoint> found = new ArrayList<>();
+        for (Class<?> controller : CONTROLLERS) {
+            for (Method method : controller.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers()) || !isRequestMapped(method)) {
+                    continue;
+                }
+                PreAuthorize guard = method.getAnnotation(PreAuthorize.class);
+                found.add(new Endpoint(
+                        controller.getSimpleName() + "." + method.getName(),
+                        guard == null ? null : guard.value()));
+            }
+        }
+        return found;
+    }
+
+    private static boolean isRequestMapped(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .anyMatch(annotation ->
+                        annotation.annotationType().isAnnotationPresent(RequestMapping.class)
+                                || annotation.annotationType().equals(RequestMapping.class));
+    }
+
+    @Test
+    void noNotificationOrCalendarEndpointIsGuardedByAnAuthorityTheRealmCannotIssue() {
+        List<String> offenders = endpoints().stream()
+                .filter(endpoint -> endpoint.guard() != null)
+                .filter(endpoint -> UNGRANTABLE_SCOPE_AUTHORITY.matcher(endpoint.guard()).find())
+                .map(endpoint -> endpoint.name() + " asks for " + endpoint.guard())
+                .toList();
+
+        assertThat(offenders)
+                .as("notification and leave calendar endpoints guarded by a resource:scope authority "
+                        + "that nothing in the realm grants, so they refuse every caller forever")
+                .isEmpty();
+    }
+
+    @Test
+    void everyNotificationAndCalendarEndpointIsStillGuardedBySomething() {
+        // Without this, the rule above passes for the worst possible reason: an endpoint whose
+        // guard was deleted rather than corrected is not an offender, and neither is a deleted
+        // endpoint. Pinning the count is what makes the absence of offenders mean something.
+        List<Endpoint> endpoints = endpoints();
+
+        assertThat(endpoints.stream().filter(endpoint -> endpoint.guard() == null).toList())
+                .as("every request-mapped method on these four controllers carries a @PreAuthorize")
+                .isEmpty();
+
+        assertThat(endpoints)
+                .as("the notification inbox and the leave calendar still expose their endpoints on "
+                        + "both twins: five plus five plus six plus six")
+                .hasSize(22);
+    }
+
+    @Test
+    void noInboxOrCalendarEndpointTakesThePersonItAnswersAboutFromTheCaller() {
+        // The exception is the one endpoint whose guard reads the id it is given: an employee's own
+        // calendar is gated on isSelfOrHasAnyOrgRole(#employeeId, ...), which is the whole point of
+        // that parameter. Everywhere else the caller named somebody and the guard checked only a
+        // role or an authority, so nothing tied the two together.
+        List<String> offenders = new ArrayList<>();
+        for (Class<?> controller : CONTROLLERS) {
+            for (Method method : controller.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers()) || !isRequestMapped(method)) {
+                    continue;
+                }
+                PreAuthorize guard = method.getAnnotation(PreAuthorize.class);
+                String expression = guard == null ? "" : guard.value();
+                for (Parameter parameter : method.getParameters()) {
+                    if (!isBoundToTheRequest(parameter)) {
+                        continue;
+                    }
+                    String name = parameter.getName();
+                    if (CALLER_SUPPLIED_IDENTITY.contains(name) && !expression.contains("#" + name)) {
+                        offenders.add(controller.getSimpleName() + "." + method.getName()
+                                + " takes " + name + " under a guard that does not read it: " + expression);
+                    }
+                }
+            }
+        }
+
+        assertThat(offenders)
+                .as("handlers that answer about whoever the caller named, under a guard that only "
+                        + "establishes that the caller holds a role")
+                .isEmpty();
+    }
+
+    @Test
+    void anInboxIsTheCallersOwnOnBothTwins() {
+        // Each of these declared @RequestParam Long employeeId. A notification is addressed to one
+        // person, so there is nothing for a client to choose.
+        for (Class<?> controller : List.of(NotificationController.class, NotificationControllerWeb.class)) {
+            assertThat(requestParameterNames(controller, "getNotifications")).isEmpty();
+            assertThat(requestParameterNames(controller, "getUnreadNotifications")).isEmpty();
+            assertThat(requestParameterNames(controller, "getUnreadCount")).isEmpty();
+            assertThat(requestParameterNames(controller, "markAllAsRead")).isEmpty();
+        }
+
+        // Marking read still names the notification, on a path segment on the phone and a query
+        // parameter in the console. That id names the thing, not the person, and it is the reason
+        // a repaired guard could never have closed this one: there is no recipient here for a
+        // self-check to read, so ownership is settled against the recipient stored on the row.
+        // See NotificationInboxOwnershipTest.
+        assertThat(requestParameterNames(NotificationController.class, "markAsRead"))
+                .containsExactly("notificationId");
+        assertThat(requestParameterNames(NotificationControllerWeb.class, "markAsRead"))
+                .containsExactly("notificationId");
+    }
+
+    @Test
+    void aTeamCalendarIsTheCallersOwnAndTheTenantComesFromTheSession() {
+        for (Class<?> controller : List.of(LeaveCalendarController.class, LeaveCalendarControllerWeb.class)) {
+            assertThat(requestParameterNames(controller, "getTeamCalendar"))
+                    .as("the manager whose team it is comes from the session")
+                    .containsExactly("startDate", "endDate");
+            assertThat(requestParameterNames(controller, "getOrganizationCalendar"))
+                    .containsExactly("startDate", "endDate");
+            assertThat(requestParameterNames(controller, "getDepartmentCalendar"))
+                    .containsExactly("department", "startDate", "endDate");
+            assertThat(requestParameterNames(controller, "getCalendarGroupedByDate"))
+                    .containsExactly("startDate", "endDate");
+            assertThat(requestParameterNames(controller, "getEmployeesOnLeaveCount"))
+                    .containsExactly("date");
+        }
+    }
+
+    /**
+     * The names of the parameters this handler binds from the request, in declaration order.
+     *
+     * <p>Reads {@code @RequestParam} and {@code @PathVariable}, and falls back to the parameter's
+     * own name for the implicitly bound ones such as {@code Pageable}, which is why a value is
+     * only ever asserted against an explicit list.
+     */
+    private static List<String> requestParameterNames(Class<?> controller, String methodName) {
+        return Arrays.stream(endpointMethod(controller, methodName).getParameters())
+                .filter(NotificationAndCalendarEndpointAuthorityTest::isBoundToTheRequest)
+                .map(Parameter::getName)
+                .toList();
+    }
+
+    private static boolean isBoundToTheRequest(Parameter parameter) {
+        return parameter.isAnnotationPresent(RequestParam.class)
+                || parameter.isAnnotationPresent(PathVariable.class);
+    }
+
+    private static Method endpointMethod(Class<?> controller, String methodName) {
+        return Arrays.stream(controller.getDeclaredMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        controller.getSimpleName() + " has no method named " + methodName));
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/NotificationAndCalendarReachTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/NotificationAndCalendarReachTest.java
@@ -1,0 +1,214 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
+import org.tornotron.echno_backend.common.configuration.RPTCache;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * An ordinary employee reaches their own notification inbox, and a line manager reaches their own
+ * team calendar, on both twins.
+ *
+ * <p>This is the end-to-end proof, driven through the real security pipeline rather than against
+ * the annotation text. Every path here answered 403 to this caller before the change, for one of
+ * two reasons. The whole phone surface, eleven endpoints, asked for {@code hasAuthority('leave:read')}
+ * or {@code hasAuthority('leave:admin')}, which this realm defines no mechanism to issue, so it
+ * refused everybody. The web twins asked for the system-admin or hr-admin role, which an ordinary
+ * employee does not hold and which a line manager does not hold either: reporting lines come from
+ * {@code Employee.manager} and are independent of the Keycloak-derived role set.
+ *
+ * <p>That is the gap the leave work left open. {@code LeaveApprovalService} writes a notification
+ * on every routing step, so an approver was being told a request had arrived through a channel
+ * they could not read.
+ *
+ * <p>The counterpart matters as much, and the refusal cases carry it. Membership is a coarse gate
+ * and deliberately not the whole answer: {@code NotificationService} refuses anybody who is not the
+ * recipient stored on the row, and {@code NotificationInboxOwnershipTest} pins that. What this test
+ * adds is that the widening reached the workflow and not everybody, and that the organization-wide
+ * calendar views kept the administrative roles they already had.
+ *
+ * <p>All four controllers share one web slice so the suite gains one Spring context rather than
+ * four; see {@code EchnoBackendApplicationTests} for why the cached-context budget is watched.
+ */
+@WebMvcTest({
+        NotificationController.class,
+        NotificationControllerWeb.class,
+        LeaveCalendarController.class,
+        LeaveCalendarControllerWeb.class})
+@Import(LeaveApprovalWorkflowAuthzTest.TestSecurityConfig.class)
+class NotificationAndCalendarReachTest {
+
+    private static final String RANGE = "startDate=2026-09-01&endDate=2026-09-30";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private LeaveCalendarService calendarService;
+
+    @MockitoBean(name = "orgSecurity")
+    private OrganizationSecurityService orgSecurity;
+
+    // Satisfies RPTExchangeFilter, a custom filter the web slice loads; unused here because
+    // .with(jwt(...)) sets the authentication directly.
+    @MockitoBean
+    private KeycloakAuthorizationService keycloakAuthorizationService;
+
+    @MockitoBean
+    private RPTCache rptCache;
+
+    @BeforeEach
+    void stubTheInboxAndTheCalendar() {
+        when(notificationService.getMyNotifications(any(Pageable.class))).thenReturn(Page.empty());
+        when(notificationService.getMyUnreadNotifications()).thenReturn(List.of());
+        when(notificationService.getMyUnreadCount()).thenReturn(0L);
+        when(notificationService.markAllAsRead()).thenReturn(0);
+        when(calendarService.getCalendarByOrganization(any(), any())).thenReturn(List.of());
+        when(calendarService.getCalendarByDepartment(anyString(), any(), any())).thenReturn(List.of());
+        when(calendarService.getCalendarByEmployee(anyLong(), any(), any())).thenReturn(List.of());
+        when(calendarService.getMyTeamCalendar(any(), any())).thenReturn(List.of());
+        when(calendarService.getCalendarGroupedByDate(any(), any())).thenReturn(Map.of());
+        when(calendarService.countEmployeesOnLeave(any())).thenReturn(0L);
+    }
+
+    /** A site manager: a member of the tenant, holding neither administrative leave role. */
+    private void asAnEmployeeHoldingNoAdministrativeRole() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), anyString(), anyString())).thenReturn(false);
+    }
+
+    private void asALeaveAdministrator() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(true);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), anyString(), anyString())).thenReturn(true);
+    }
+
+    private void asSomebodyOutsideTheTenant() {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+        when(orgSecurity.hasAnyOrgRoleForCurrentTenant("system-admin", "hr-admin")).thenReturn(false);
+        when(orgSecurity.isSelfOrHasAnyOrgRole(anyLong(), anyString(), anyString())).thenReturn(false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/notifications",
+            "/api/v1/notifications/unread",
+            "/api/v1/notifications/unread-count",
+            "/api/v1/notifications/web",
+            "/api/v1/notifications/web/unread",
+            "/api/v1/notifications/web/unread-count",
+            // The team calendar. A team is the caller's own, and the manager whose team it is holds
+            // no administrative role, so the old role gate refused exactly the person it is for.
+            "/api/v1/leave-calendar/team?" + RANGE,
+            "/api/v1/leave-calendar/web/team?" + RANGE
+    })
+    void anEmployeeReadsTheirOwnInboxAndTheirOwnTeam(String path) throws Exception {
+        asAnEmployeeHoldingNoAdministrativeRole();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void anEmployeeMarksTheirOwnNotificationsRead() throws Exception {
+        asAnEmployeeHoldingNoAdministrativeRole();
+
+        mockMvc.perform(patch("/api/v1/notifications/42/read").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+        mockMvc.perform(patch("/api/v1/notifications/web/read?notificationId=42").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/v1/notifications/mark-all-read").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/v1/notifications/web/mark-all-read").with(jwt()).with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-calendar/organization?" + RANGE,
+            "/api/v1/leave-calendar/department?department=Civil&" + RANGE,
+            "/api/v1/leave-calendar/grouped?" + RANGE,
+            "/api/v1/leave-calendar/count?date=2026-09-15",
+            "/api/v1/leave-calendar/employee/7?" + RANGE,
+            "/api/v1/leave-calendar/web/organization?" + RANGE,
+            "/api/v1/leave-calendar/web/department?department=Civil&" + RANGE,
+            "/api/v1/leave-calendar/web/grouped?" + RANGE,
+            "/api/v1/leave-calendar/web/count?date=2026-09-15",
+            "/api/v1/leave-calendar/web/employee?employeeId=7&" + RANGE
+    })
+    void aLeaveAdministratorReadsTheOrganizationWideCalendarOnBothTwins(String path) throws Exception {
+        // The phone twin refused them too, because the authority it asked for is issued to nobody
+        // at all, administrators included.
+        asALeaveAdministrator();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/leave-calendar/organization?" + RANGE,
+            "/api/v1/leave-calendar/department?department=Civil&" + RANGE,
+            "/api/v1/leave-calendar/grouped?" + RANGE,
+            "/api/v1/leave-calendar/count?date=2026-09-15",
+            "/api/v1/leave-calendar/web/organization?" + RANGE,
+            "/api/v1/leave-calendar/web/department?department=Civil&" + RANGE,
+            "/api/v1/leave-calendar/web/grouped?" + RANGE,
+            "/api/v1/leave-calendar/web/count?date=2026-09-15"
+    })
+    void theOrganizationWideCalendarStaysWithTheAdministrators(String path) throws Exception {
+        // The repair must not turn a dead endpoint into an open one. Who is on leave across the
+        // whole organization is what the web twin already restricted to the two roles, and this
+        // change does not widen it.
+        asAnEmployeeHoldingNoAdministrativeRole();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/notifications",
+            "/api/v1/notifications/unread",
+            "/api/v1/notifications/unread-count",
+            "/api/v1/notifications/web",
+            "/api/v1/notifications/web/unread",
+            "/api/v1/notifications/web/unread-count",
+            "/api/v1/leave-calendar/team?" + RANGE,
+            "/api/v1/leave-calendar/web/team?" + RANGE
+    })
+    void somebodyOutsideTheTenantReachesNoneOfIt(String path) throws Exception {
+        asSomebodyOutsideTheTenant();
+
+        mockMvc.perform(get(path).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/leave/NotificationInboxOwnershipTest.java
+++ b/src/test/java/org/tornotron/echno_backend/leave/NotificationInboxOwnershipTest.java
@@ -1,0 +1,246 @@
+package org.tornotron.echno_backend.leave;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.service.CurrentEmployeeService;
+import org.tornotron.echno_backend.employee.Employee;
+import org.tornotron.echno_backend.employee.EmployeeRepository;
+import org.tornotron.echno_backend.leave.dto.NotificationDto;
+import org.tornotron.echno_backend.leave.mapper.NotificationMapper;
+import org.tornotron.echno_backend.organization.Organization;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A notification is addressed to one person, and only that person reads or clears it.
+ *
+ * <p>{@code markAsRead} is the case that was not merely dead. It took a notification id, loaded
+ * the row by that id within the tenant, and wrote {@code isRead} on whatever came back, checking
+ * nothing about who was asking. On the phone twin that was unreachable behind a phantom authority,
+ * but the web twin was guarded on the system-admin and hr-admin roles and worked, so any holder of
+ * either marked any colleague's notification read by counting ids. The consequence is quiet: the
+ * recipient's unread badge clears and they never see the notification, which for the leave
+ * workflow means an approver never learns a request is waiting on them.
+ *
+ * <p>It could not be closed by repairing the guard, because it had no recipient parameter to be
+ * wrong about. The check has to be made against the recipient stored on the row, which is what
+ * these cases pin.
+ *
+ * <p>The read cases carry the other half. Four of the five endpoints took the recipient as an
+ * {@code employeeId} the caller sent, so a repaired guard alone would have handed whoever got
+ * through every colleague's inbox instead of nobody's. The recipient comes from the session, and
+ * the parameter is gone from both twins.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NotificationInboxOwnershipTest {
+
+    private static final Long ORG_ID = 100L;
+    private static final Long NOTIFICATION_ID = 42L;
+    private static final Long RECIPIENT_ID = 7L;
+    private static final Long COLLEAGUE_ID = 8L;
+
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private NotificationMapper notificationMapper;
+    @Mock private CurrentEmployeeService currentEmployeeService;
+
+    @BeforeEach
+    void setTenant() {
+        TenantContext.setCurrentOrgId(ORG_ID);
+        when(notificationMapper.toDto(any(Notification.class))).thenReturn(new NotificationDto());
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    private NotificationService service() {
+        return new NotificationService(
+                notificationRepository, employeeRepository, notificationMapper, currentEmployeeService);
+    }
+
+    private Employee employee(Long id) {
+        Employee employee = new Employee();
+        employee.setId(id);
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        employee.setOrganization(organization);
+        return employee;
+    }
+
+    /** The caller the session resolves to, for both the optional and the required lookup. */
+    private void signedInAs(Long employeeId) {
+        Employee caller = employee(employeeId);
+        when(currentEmployeeService.currentEmployee()).thenReturn(Optional.of(caller));
+        when(currentEmployeeService.requireCurrentEmployee(any())).thenReturn(caller);
+    }
+
+    private void signedInWithNoEmployeeRecord() {
+        when(currentEmployeeService.currentEmployee()).thenReturn(Optional.empty());
+        when(currentEmployeeService.requireCurrentEmployee(any()))
+                .thenThrow(new AccessDeniedException("You have no employee record in this organization"));
+    }
+
+    private Notification notificationAddressedTo(Long recipientId) {
+        Notification notification = new Notification();
+        notification.setId(NOTIFICATION_ID);
+        notification.setRecipient(employee(recipientId));
+        notification.setIsRead(false);
+        return notification;
+    }
+
+    @Test
+    void theRecipientMarksTheirOwnNotificationRead() {
+        signedInAs(RECIPIENT_ID);
+        Notification notification = notificationAddressedTo(RECIPIENT_ID);
+        when(notificationRepository.findByIdAndOrganization_Id(NOTIFICATION_ID, ORG_ID))
+                .thenReturn(Optional.of(notification));
+
+        assertThatCode(() -> service().markAsRead(NOTIFICATION_ID)).doesNotThrowAnyException();
+
+        assertThat(notification.getIsRead()).isTrue();
+        assertThat(notification.getReadAt()).isNotNull();
+        verify(notificationRepository).save(notification);
+    }
+
+    @Test
+    void aColleagueCannotMarkSomebodyElsesNotificationRead() {
+        // The whole point of the issue. Before the check, this call succeeded for any caller the
+        // guard let through, silently clearing the recipient's unread badge.
+        signedInAs(COLLEAGUE_ID);
+        Notification notification = notificationAddressedTo(RECIPIENT_ID);
+        when(notificationRepository.findByIdAndOrganization_Id(NOTIFICATION_ID, ORG_ID))
+                .thenReturn(Optional.of(notification));
+
+        assertThatThrownBy(() -> service().markAsRead(NOTIFICATION_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(notification.getIsRead()).isFalse();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void anAdministratorIsNoDifferentFromAnyOtherColleagueHere() {
+        // Read state is personal. There is no role that makes marking somebody else's notification
+        // read a sensible thing to do, so the roles that used to gate this endpoint buy nothing:
+        // the check is against the recipient on the row and admins are not exempt from it.
+        signedInAs(COLLEAGUE_ID);
+        Notification notification = notificationAddressedTo(RECIPIENT_ID);
+        when(notificationRepository.findByIdAndOrganization_Id(NOTIFICATION_ID, ORG_ID))
+                .thenReturn(Optional.of(notification));
+
+        assertThatThrownBy(() -> service().markAsRead(NOTIFICATION_ID))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("addressed to somebody else");
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordMarksNothingRead() {
+        signedInWithNoEmployeeRecord();
+        when(notificationRepository.findByIdAndOrganization_Id(NOTIFICATION_ID, ORG_ID))
+                .thenReturn(Optional.of(notificationAddressedTo(RECIPIENT_ID)));
+
+        assertThatThrownBy(() -> service().markAsRead(NOTIFICATION_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void aRowWithNoRecipientIsNobodysToMark() {
+        // Fail closed rather than open. A notification with a null recipient should not exist, and
+        // if one does it belongs to nobody, so nobody clears it.
+        signedInAs(RECIPIENT_ID);
+        Notification orphan = new Notification();
+        orphan.setId(NOTIFICATION_ID);
+        orphan.setIsRead(false);
+        when(notificationRepository.findByIdAndOrganization_Id(NOTIFICATION_ID, ORG_ID))
+                .thenReturn(Optional.of(orphan));
+
+        assertThatThrownBy(() -> service().markAsRead(NOTIFICATION_ID))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void theInboxServedIsTheCallersOwn() {
+        signedInAs(RECIPIENT_ID);
+        Pageable pageable = PageRequest.of(0, 20);
+        when(notificationRepository.findByRecipientIdOrderByCreatedAtDesc(RECIPIENT_ID, pageable))
+                .thenReturn(Page.empty(pageable));
+
+        service().getMyNotifications(pageable);
+
+        // Named explicitly, so the test fails if the recipient is ever taken from anywhere but the
+        // session again.
+        verify(notificationRepository).findByRecipientIdOrderByCreatedAtDesc(RECIPIENT_ID, pageable);
+        verify(notificationRepository, never())
+                .findByRecipientIdOrderByCreatedAtDesc(eq(COLLEAGUE_ID), any(Pageable.class));
+    }
+
+    @Test
+    void theUnreadListAndCountAreTheCallersOwn() {
+        signedInAs(RECIPIENT_ID);
+        when(notificationRepository.findByRecipientIdAndIsReadFalseOrderByCreatedAtDesc(RECIPIENT_ID))
+                .thenReturn(List.of(notificationAddressedTo(RECIPIENT_ID)));
+        when(notificationRepository.countByRecipientIdAndIsReadFalse(RECIPIENT_ID)).thenReturn(3L);
+
+        NotificationService service = service();
+
+        assertThat(service.getMyUnreadNotifications()).hasSize(1);
+        assertThat(service.getMyUnreadCount()).isEqualTo(3L);
+
+        verify(notificationRepository, never())
+                .findByRecipientIdAndIsReadFalseOrderByCreatedAtDesc(COLLEAGUE_ID);
+        verify(notificationRepository, never()).countByRecipientIdAndIsReadFalse(COLLEAGUE_ID);
+    }
+
+    @Test
+    void markingAllReadClearsTheCallersOwnInboxAndNobodyElses() {
+        signedInAs(RECIPIENT_ID);
+        when(notificationRepository.markAllAsReadByRecipientId(RECIPIENT_ID, ORG_ID)).thenReturn(4);
+
+        assertThat(service().markAllAsRead()).isEqualTo(4);
+
+        verify(notificationRepository).markAllAsReadByRecipientId(RECIPIENT_ID, ORG_ID);
+        verify(notificationRepository, never()).markAllAsReadByRecipientId(COLLEAGUE_ID, ORG_ID);
+    }
+
+    @Test
+    void aCallerWithNoEmployeeRecordHasNoInboxToRead() {
+        signedInWithNoEmployeeRecord();
+
+        NotificationService service = service();
+
+        assertThatThrownBy(() -> service.getMyUnreadNotifications())
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(service::getMyUnreadCount)
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(service::markAllAsRead)
+                .isInstanceOf(AccessDeniedException.class);
+    }
+}


### PR DESCRIPTION
Closes #684.

## What was refused, and what was not

`NotificationController` and `LeaveCalendarController` carry eleven endpoints between them, and every one asked for `hasAuthority('leave:read')` or `hasAuthority('leave:admin')`.

`JwtAuthConverter` mints a bare `resource:scope` authority in exactly one place, `extractPermissions`, which reads the `authorization` claim of an RPT. Every request does get an RPT, because `RPTExchangeFilter` exchanges the caller's access token on every authenticated request, so the claim is present. What is not present is a scope. The only automated provisioner is `KeycloakInitializer.ensureAuthorizationSetup`, and reading it end to end: `ensureDefaultResource` builds a `ResourceRepresentation` named `Default Resource` with `setUris(Set.of("/*"))` and never calls `setScopes`, and `ensureDefaultPermission` grants it through a scopeless `Default Permission`. `extractPermissions` returns `Stream.empty()` for a permission whose `scopes` is null. So no `resource:scope` authority is ever minted for anybody, administrators included. The multi-tenancy audit of 2026-08-18 traced the identical `organization:admin` string against the live staging Keycloak database and found zero scopes realm-wide, one scopeless resource and one scopeless permission; #641 confirmed it for `billing:admin` and #685 for `leave:approve`.

The lab is unreachable this session, so the live database could not be re-queried. The source path above is verified here, and it is the path that decides the outcome.

The `/web` twins of both controllers were never phantom-guarded, so they were never dead. They asked for the system-admin or hr-admin role and then answered about whichever employee, manager or organization the caller named. That is the shape closed in #589, #599, #607, #631, #635 and #683, and it is why repairing only the authority would have been the wrong fix: whoever got through would have read every colleague's inbox rather than nobody's.

## Repair rather than remove

`LeaveApprovalService` calls `sendApprovalRequiredNotification` on every routing step and `sendDelegationNotification` on every handover. The rows were being written and nobody could read them, so an approver had no way to learn a request was waiting on them. With mobile approval a required workflow, deleting the channel that feeds it would have made those writes garbage.

The calendar is not dead either, only half dead: the web twin of the same six views is live and working on the role pair, so deleting the six would have deleted the phone's half of a feature the console already ships.

## `markAsRead` is the one that was not merely unreachable

It took a notification id, loaded the row by that id within the tenant with `findByIdAndOrganization_Id`, and wrote `isRead` on whatever came back. It checked nothing about who was asking.

On the phone that was unreachable behind the phantom. In the console it was guarded on the system-admin and hr-admin roles, so it worked, and `echno-core` calls it today at `PATCH /notifications/web/read?notificationId=`. Any holder of either role marked any colleague's notification read by counting ids. The damage is quiet: the recipient's unread badge clears and they never see the notification, which for this workflow means an approver never learns a request arrived.

It could not be closed by repairing the guard, because it had no recipient parameter for a self-check to read. Ownership is now settled against the recipient stored on the row, in `NotificationService.markAsRead`. Read state is personal, so no role is exempt: an administrator gets the same refusal as anybody else.

## The guards

| Endpoint | Before | Now |
| --- | --- | --- |
| the five notification endpoints, phone twin | `hasAuthority('leave:read')` or `'leave:admin'` | `@orgSecurity.isMemberOfCurrentTenant()`, recipient from the session |
| the five notification endpoints, web twin | `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')` | same |
| `markAsRead`, both twins | nothing at all about ownership | the recipient on the row, checked in the service |
| calendar: organization, department, grouped, count, both twins | phantom on the phone, the role pair in the console | `hasAnyOrgRoleForCurrentTenant('system-admin','hr-admin')` on both |
| calendar: one employee, both twins | phantom on the phone, the role pair in the console | `isSelfOrHasAnyOrgRole(#employeeId, 'system-admin', 'hr-admin')` |
| calendar: team, both twins | phantom on the phone, the role pair in the console | `isMemberOfCurrentTenant()`, manager from the session |

The organization-wide views keep exactly what the working web twin already gave them, so nothing is widened there, and `theOrganizationWideCalendarStaysWithTheAdministrators` pins it. The notification change is narrower than the role gate it replaces: before, any holder of either role reached every inbox in the tenant; now each caller reaches their own and nobody reaches anybody else's.

## Removing the parameters is safe on the deployed client

Spring drops a query parameter no handler declares, so a call that still sends `employeeId`, `managerId` or `organizationId` is served the caller's own answer rather than refused. That covers every path `echno-core` uses, which is the `/web` twins only.

The four organization-wide paths on the phone twin also lost their `{organizationId}` segment, and a path segment's absence is not something a query parameter's silence can cover. That is safe only because those four refused every caller, so no client can be depending on the shape they had, and `echno-core` declares no phone-twin calendar paths at all. They now mirror the web twin: `/organization`, `/department`, `/grouped`, `/count`.

## Tests

Eighteen assertions were **measured** failing against the old code, by running the new tests, and a baseline probe written against the old paths and old signatures, on `origin/development` in a throwaway worktree. Every reach failure was a 403 and not a 404, checked in the report rather than assumed.

| Test | Cases failing on `origin/development` | How they fail |
| --- | --- | --- |
| `NotificationAndCalendarReachTest` (as `BaselineInboxReachTest`) | 8 | an employee holding no administrative role gets 403 on all six inbox reads and on both team calendars |
| same, mark-read case | 1 | 403 on all four mark-as-read paths |
| same, administrator's calendar case | 5 of 10 | the five phone paths refuse an administrator too, because the authority is issued to nobody; the five web paths passed, which is correct and is why only five are counted |
| `NotificationAndCalendarEndpointAuthorityTest` | 4 of 5 | names the eleven phantom-guarded endpoints; names the handlers still taking `employeeId`, `managerId` and `organizationId` under a guard that does not read them |

`everyNotificationAndCalendarEndpointIsStillGuardedBySomething` pins the endpoint count at 22 so the first rule cannot pass by a guard having been deleted rather than corrected. It passes on both sides by design, which is the point of it, and it is not counted above.

**Reasoned rather than measured, and deliberately not folded into that count:** the nine cases in `NotificationInboxOwnershipTest` cannot be compiled against the old code, because the old `NotificationService` took no session dependency at all. That is not an inconvenience of the test, it is the defect: there was nothing in the old service for an ownership check to be made against. The two that carry the fix are `aColleagueCannotMarkSomebodyElsesNotificationRead` and `anAdministratorIsNoDifferentFromAnyOtherColleagueHere`.

## The API contract

`docs/openapi.json` needs regenerating and the workstation has no Docker, so the committed document here comes from the build's own `openapi-served` artifact, which `OpenApiSnapshotTest` writes from the identical canonical string the `-PupdateOpenApiSnapshot` flag writes. CI re-verifies it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Leave calendars now automatically use the signed-in user’s organization and team.
  - Employees can access their own calendars and notification inbox without supplying employee, manager, or organization identifiers.
  - Managers can view their own team calendar.
  - Organization-wide calendar views remain available to authorized administrators.
  - Notification actions are limited to the signed-in user’s inbox.

- **Bug Fixes**
  - Improved access controls prevent users from viewing or updating another employee’s notifications.
  - Users outside the current organization are denied access to calendars and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->