### PR TITLE
Let a stock adjustment name the document it was raised to answer

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16405,6 +16405,26 @@
             "format": "int64",
             "type": "integer"
           },
+          "sourceDocumentId": {
+            "description": "Id of the document named by sourceDocumentType. Required when that field is set, and refused when it is not.",
+            "example": 31,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sourceDocumentType": {
+            "description": "The kind of document this adjustment was raised to answer, where it answers one. Send it together with sourceDocumentId or leave both out: a type naming no document, or a document with nothing saying what kind it is, is refused rather than half-stored. The named document is looked up in the caller's organization when the adjustment is written, so an id that names nothing there is a 404 and not a dangling reference.",
+            "enum": [
+              "SITE_TRANSFER"
+            ],
+            "example": "SITE_TRANSFER",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "status": {
             "description": "State of the adjustment document. Optional, and draft is the only value accepted, so leaving it out is the same as sending draft. A document reaches its posted state through POST /{id}/approve, which is what refuses an approval by whoever raised it and writes the stock-ledger entries; a document created or edited into that state would carry neither, and would read as approved with nobody on record as having approved it and no movement behind it.",
             "enum": [
@@ -16600,6 +16620,26 @@
             "description": "Reason given for rejecting the adjustment.",
             "example": "Variance not supported by the count sheet",
             "type": "string"
+          },
+          "sourceDocumentId": {
+            "description": "Id of the document named by sourceDocumentType, within that kind. Null wherever the type is null.",
+            "example": 31,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sourceDocumentType": {
+            "description": "The kind of document this adjustment was raised to answer, null where it answers none. SITE_TRANSFER means the adjustment closes the open variance a transfer received short left behind, and the transfer it closes is sourceDocumentId. Always set together with that field.",
+            "enum": [
+              "SITE_TRANSFER"
+            ],
+            "example": "SITE_TRANSFER",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "Status of the adjustment document.",
@@ -95630,6 +95670,133 @@
           }
         },
         "summary": "Create a stock adjustment",
+        "tags": [
+          "Stock Adjustments (Web)"
+        ]
+      }
+    },
+    "/api/v1/stock-adjustments/web/by-source-document": {
+      "get": {
+        "description": "Returns the adjustments naming the given source document, most recently raised first, and an empty list where none do. This is the reverse of the reference an adjustment carries: a site transfer received short shows an open variance, and this is how the transfer finds out whether anybody has decided what became of the difference, so the variance can read as closed rather than staying open for ever. Anchored to one named document rather than a filter over the whole list, and scoped to the caller's own organization.",
+        "operationId": "readStockAdjustmentsBySourceDocument",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sourceDocumentType",
+            "required": true,
+            "schema": {
+              "enum": [
+                "SITE_TRANSFER"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sourceDocumentId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StockAdjustmentDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Stock adjustments naming the document returned, empty where none do"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "sourceDocumentType is not a known kind of document"
+          },
+          "402": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionErrorResponse"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Caller is neither a member of the current tenant nor holds an elevated role in it"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          }
+        },
+        "summary": "List the stock adjustments raised to answer one document",
         "tags": [
           "Stock Adjustments (Web)"
         ]

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustment.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.tornotron.echno_backend.common.multitenancy.TenantScopedEntity;
 import org.tornotron.echno_backend.organization.Organization;
 import org.tornotron.echno_backend.project.Project;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 
 import java.math.BigDecimal;
@@ -77,6 +78,37 @@ public class StockAdjustment implements TenantScopedEntity {
 
     @Column(name = "primary_reason")
     private String primaryReason;
+
+    /**
+     * The kind of document this adjustment was raised to answer, null when it answers none.
+     *
+     * <p>Stored as a name beside {@link #sourceDocumentId} rather than as a foreign key to one
+     * owner, the way {@code StatusTransition} and {@code Attachment} already are. The reasoning
+     * is theirs: a transfer variance is the first cause with a document behind it, a goods
+     * receipt and a consumption are the obvious next two, and a nullable foreign key per cause
+     * ends as a row of mutually exclusive columns with nothing enforcing that only one is set.
+     *
+     * <p>The difference from those two is that this is an enum rather than a free string. The set
+     * of causes is closed, so every value has a resolver that loads the named document within the
+     * caller's organization before the reference is written. What the database therefore does not
+     * constrain, the write path does.
+     *
+     * <p>A posted adjustment is a ledger fact and outlives the document that caused it, which is
+     * the same reason the status trail carries no foreign key: deleting the transfer must not
+     * erase the correction raised against it.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_document_type", length = 40)
+    private StockAdjustmentSourceType sourceDocumentType;
+
+    /**
+     * The id of the document named by {@link #sourceDocumentType}, within its own kind. Not a
+     * foreign key, deliberately, and never null while a type is set: the two are written together
+     * or not at all, because a type with no id names nothing and an id with no type says nothing
+     * about what it points at.
+     */
+    @Column(name = "source_document_id")
+    private Long sourceDocumentId;
 
     @Column(name = "justification", columnDefinition = "TEXT")
     private String justification;

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWeb.java
@@ -16,6 +16,7 @@ import org.tornotron.echno_backend.common.response.ApiResponse;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentRejectionRequest;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 import org.tornotron.echno_backend.common.pagination.UnpagedResultCap;
 
 import java.util.List;
@@ -90,6 +91,31 @@ public class StockAdjustmentControllerWeb {
     })
     public ResponseEntity<StockAdjustmentDto> readAStockAdjustment(@PathVariable Long id) {
         return new ResponseEntity<>(stockAdjustmentService.getById(id), HttpStatus.OK);
+    }
+
+    @GetMapping("/by-source-document")
+    @PreAuthorize("@orgSecurity.isMemberOfCurrentTenant() or @orgSecurity.hasAnyOrgRoleForCurrentTenant('system-admin','project-manager')")
+    @Operation(
+            summary = "List the stock adjustments raised to answer one document",
+            description = "Returns the adjustments naming the given source document, most recently "
+                    + "raised first, and an empty list where none do. This is the reverse of the "
+                    + "reference an adjustment carries: a site transfer received short shows an open "
+                    + "variance, and this is how the transfer finds out whether anybody has decided "
+                    + "what became of the difference, so the variance can read as closed rather than "
+                    + "staying open for ever. Anchored to one named document rather than a filter over "
+                    + "the whole list, and scoped to the caller's own organization."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Stock adjustments naming the document returned, empty where none do"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "sourceDocumentType is not a known kind of document"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Caller is neither a member of the current tenant nor holds an elevated role in it")
+    })
+    public ResponseEntity<List<StockAdjustmentDto>> readStockAdjustmentsBySourceDocument(
+            @RequestParam StockAdjustmentSourceType sourceDocumentType,
+            @RequestParam Long sourceDocumentId) {
+        return new ResponseEntity<>(
+                stockAdjustmentService.getBySourceDocument(sourceDocumentType, sourceDocumentId),
+                HttpStatus.OK);
     }
 
     @PostMapping

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StockAdjustmentRepository extends JpaRepository<StockAdjustment, Long> {
@@ -34,4 +36,14 @@ public interface StockAdjustmentRepository extends JpaRepository<StockAdjustment
     Optional<StockAdjustment> lockByIdAndOrganizationId(@Param("id") Long id, @Param("orgId") Long orgId);
 
     boolean existsByAdjustmentNumberAndOrganization_Id(String adjustmentNumber, Long organizationId);
+
+    /**
+     * The adjustments raised to answer one named document, newest first.
+     *
+     * <p>The organization is part of the query and not a filter applied around it. The source
+     * columns carry no foreign key, so the id in them is an id a caller supplied; matching on it
+     * alone would return whatever adjustment in any tenant happened to name the same number.
+     */
+    List<StockAdjustment> findBySourceDocumentTypeAndSourceDocumentIdAndOrganization_IdOrderByCreatedAtDesc(
+            StockAdjustmentSourceType sourceDocumentType, Long sourceDocumentId, Long organizationId);
 }

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentService.java
@@ -23,7 +23,11 @@ import org.tornotron.echno_backend.project.Project;
 import org.tornotron.echno_backend.project.ProjectRepository;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto;
+import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
 import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentLineItemCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
@@ -99,6 +103,7 @@ public class StockAdjustmentService {
     private final UserContextService userContextService;
     private final SelfApprovalPolicy selfApprovalPolicy;
     private final UserNameDirectory userNameDirectory;
+    private final SiteTransferRepository siteTransferRepository;
 
     public StockAdjustmentService(StockAdjustmentRepository stockAdjustmentRepository,
                                   StockAdjustmentMapper stockAdjustmentMapper,
@@ -110,7 +115,8 @@ public class StockAdjustmentService {
                                   InventoryTransactionRepository inventoryTransactionRepository,
                                   UserContextService userContextService,
                                   SelfApprovalPolicy selfApprovalPolicy,
-                                  UserNameDirectory userNameDirectory) {
+                                  UserNameDirectory userNameDirectory,
+                                  SiteTransferRepository siteTransferRepository) {
         this.stockAdjustmentRepository = stockAdjustmentRepository;
         this.stockAdjustmentMapper = stockAdjustmentMapper;
         this.tenantEntityHelper = tenantEntityHelper;
@@ -122,6 +128,7 @@ public class StockAdjustmentService {
         this.userContextService = userContextService;
         this.selfApprovalPolicy = selfApprovalPolicy;
         this.userNameDirectory = userNameDirectory;
+        this.siteTransferRepository = siteTransferRepository;
     }
 
     /** Status a document carries once its movements are on the ledger. */
@@ -750,6 +757,121 @@ public class StockAdjustmentService {
 
         stockAdjustment.setLocation(resolveLocation(dto.getLocationId()));
         stockAdjustment.setProject(resolveProject(dto.getProjectId()));
+        applySourceDocument(stockAdjustment, dto);
+    }
+
+    /**
+     * Records the document this adjustment was raised to answer, having first established that it
+     * exists and belongs to the caller's organization.
+     *
+     * <p>The pair is written together or not at all. A type with no id names nothing, and an id
+     * with no type says nothing about what it points at; either half on its own would be stored
+     * as a reference that cannot be followed, which is worse than no reference, because a reader
+     * would believe there was one.
+     *
+     * <p><strong>The id is never taken on trust.</strong> The column holds no foreign key, so
+     * nothing in the database would stop a caller naming a document in somebody else's
+     * organization, and a later reader following the reference would be handed a row across a
+     * tenant boundary. So the id supplied by the caller is the id that is loaded, and it is
+     * loaded organization-scoped: what is checked and what is stored are the same lookup, not two
+     * lookups by different keys that can disagree.
+     */
+    private void applySourceDocument(StockAdjustment stockAdjustment, StockAdjustmentCreationDto dto) {
+        StockAdjustmentSourceType type = dto.getSourceDocumentType();
+        Long sourceId = dto.getSourceDocumentId();
+
+        if (type == null && sourceId == null) {
+            stockAdjustment.setSourceDocumentType(null);
+            stockAdjustment.setSourceDocumentId(null);
+            return;
+        }
+        if (type == null) {
+            throw new InvalidRequestException("The adjustment names source document " + sourceId
+                    + " without saying what kind of document it is. Send sourceDocumentType "
+                    + "alongside sourceDocumentId, or leave both out.");
+        }
+        if (sourceId == null) {
+            throw new InvalidRequestException("The adjustment says its source document is a "
+                    + type.name() + " without naming which one. Send sourceDocumentId alongside "
+                    + "sourceDocumentType, or leave both out.");
+        }
+
+        requireSourceDocumentExists(type, sourceId);
+        stockAdjustment.setSourceDocumentType(type);
+        stockAdjustment.setSourceDocumentId(sourceId);
+    }
+
+    /**
+     * Resolves the named source document in the caller's organization, refusing one that is not
+     * there or that cannot have caused an adjustment.
+     *
+     * <p>Every value of {@link StockAdjustmentSourceType} is answered here. A value that reached
+     * this method with no branch of its own would be an id written with nothing having checked
+     * it, so the fallthrough refuses rather than saving it, and adding a source type without its
+     * resolver fails loudly instead of quietly storing an unchecked reference.
+     */
+    private void requireSourceDocumentExists(StockAdjustmentSourceType type, Long sourceId) {
+        switch (type) {
+            case SITE_TRANSFER -> {
+                SiteTransfer transfer = siteTransferRepository
+                        .findByIdAndOrganization_Id(sourceId, TenantContext.getCurrentOrgId())
+                        .orElseThrow(() -> new ResourceNotFoundException("Site transfer with ID "
+                                + sourceId + " was not found in this organization"));
+                requireTransferCouldHaveCausedAnAdjustment(transfer);
+            }
+            default -> throw new InvalidRequestException("Source document type " + type.name()
+                    + " has no resolver, so the document it names cannot be checked. An adjustment "
+                    + "may not reference a document nothing has verified exists.");
+        }
+    }
+
+    /**
+     * Refuses a reference to a cancelled transfer.
+     *
+     * <p>Cancelling is reachable only from {@code PENDING}, which is the state in which nothing
+     * has been received, and it returns the whole sent quantity to the sending site. So a
+     * cancelled transfer moved no stock on balance and left no variance for an adjustment to
+     * close. What its lines still show as in transit is history rather than a live shortage, and
+     * an adjustment claiming to answer it would be a correction attributed to a document that
+     * caused nothing.
+     *
+     * <p>An adjustment raised while the transfer was still open keeps its reference: this refuses
+     * writing the reference, not holding one. The stock the cancellation returned is on the
+     * ledger either way.
+     */
+    private void requireTransferCouldHaveCausedAnAdjustment(SiteTransfer transfer) {
+        if (transfer.getStatus() == SiteTransferStatus.CANCELLED) {
+            throw new InvalidRequestException("Site transfer with ID " + transfer.getId()
+                    + " was cancelled, which returned the whole sent quantity to the sending site, "
+                    + "so it left no variance for an adjustment to close.");
+        }
+    }
+
+    /**
+     * Reads the adjustments raised to answer one named document, most recently created first.
+     *
+     * <p>This is the reverse of the reference: a transfer whose receipt left a variance is read
+     * from its own screen, and what it needs to know is whether anybody has decided what became
+     * of the difference. Without this the variance stays amber for ever, because the transfer has
+     * no way to see the adjustment that closed it.
+     *
+     * <p>Scoped to the caller's organization, in the query rather than around it. The id comes
+     * from the caller and the column it matches is not a foreign key, so an unscoped lookup would
+     * hand back another tenant's adjustments to anyone who guessed a transfer id.
+     *
+     * @param type The kind of document to look for.
+     * @param sourceDocumentId The id of that document.
+     * @return The adjustments naming it, newest first, empty where none do.
+     */
+    @Transactional(readOnly = true)
+    public List<StockAdjustmentDto> getBySourceDocument(StockAdjustmentSourceType type, Long sourceDocumentId) {
+        List<StockAdjustment> adjustments = stockAdjustmentRepository
+                .findBySourceDocumentTypeAndSourceDocumentIdAndOrganization_IdOrderByCreatedAtDesc(
+                        type, sourceDocumentId, TenantContext.getCurrentOrgId());
+        UserNameLookup names = namesFor(adjustments);
+        return adjustments.stream()
+                .map(adjustment -> stockAdjustmentMapper.toDto(adjustment, names))
+                .toList();
     }
 
     /**

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentCreationDto.java
@@ -3,6 +3,7 @@ package org.tornotron.echno_backend.stockAdjustment.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -50,6 +51,19 @@ public class StockAdjustmentCreationDto {
 
     @Schema(description = "Primary reason category for the adjustment.", example = "PHYSICAL_COUNT_VARIANCE")
     private String primaryReason;
+
+    @Schema(description = "The kind of document this adjustment was raised to answer, where it "
+            + "answers one. Send it together with sourceDocumentId or leave both out: a type "
+            + "naming no document, or a document with nothing saying what kind it is, is refused "
+            + "rather than half-stored. The named document is looked up in the caller's "
+            + "organization when the adjustment is written, so an id that names nothing there is "
+            + "a 404 and not a dangling reference.",
+            example = "SITE_TRANSFER", nullable = true)
+    private StockAdjustmentSourceType sourceDocumentType;
+
+    @Schema(description = "Id of the document named by sourceDocumentType. Required when that "
+            + "field is set, and refused when it is not.", example = "31", nullable = true)
+    private Long sourceDocumentId;
 
     @Schema(description = "Total monetary value of the adjustment across all line items. Summed from "
             + "the line items, so any value sent here is ignored: it is arithmetic over figures the "

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/dto/StockAdjustmentDto.java
@@ -2,6 +2,7 @@ package org.tornotron.echno_backend.stockAdjustment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -49,6 +50,17 @@ public class StockAdjustmentDto {
 
     @Schema(description = "Primary reason category for the adjustment.", example = "PHYSICAL_COUNT_VARIANCE")
     private String primaryReason;
+
+    @Schema(description = "The kind of document this adjustment was raised to answer, null where it "
+            + "answers none. SITE_TRANSFER means the adjustment closes the open variance a transfer "
+            + "received short left behind, and the transfer it closes is sourceDocumentId. Always "
+            + "set together with that field.",
+            example = "SITE_TRANSFER", nullable = true)
+    private StockAdjustmentSourceType sourceDocumentType;
+
+    @Schema(description = "Id of the document named by sourceDocumentType, within that kind. Null "
+            + "wherever the type is null.", example = "31", nullable = true)
+    private Long sourceDocumentId;
 
     @Schema(description = "Justification for the adjustment.", example = "Quarterly physical count found a shortfall in River Sand at Main Site Store")
     private String justification;

--- a/src/main/java/org/tornotron/echno_backend/stockAdjustment/enums/StockAdjustmentSourceType.java
+++ b/src/main/java/org/tornotron/echno_backend/stockAdjustment/enums/StockAdjustmentSourceType.java
@@ -1,0 +1,29 @@
+package org.tornotron.echno_backend.stockAdjustment.enums;
+
+/**
+ * The kind of document a stock adjustment was raised to answer.
+ *
+ * <p>An adjustment usually stands on its own: somebody counted a location and the count
+ * disagreed with the balance. Some are raised for a named reason instead, and then the document
+ * that caused them is part of what the adjustment means. A closed set is what makes that
+ * reference safe to store: every value here has a resolver that loads the named document within
+ * the caller's organization before the reference is written, so an id that names nothing, or
+ * names something belonging to somebody else, is refused at the door rather than saved as a
+ * pointer into another tenant's data.
+ *
+ * <p>Adding a value means adding its resolver. That is deliberate: a type with no resolver would
+ * be an id taken on trust, which is the shape of the bug this enum exists to prevent.
+ */
+public enum StockAdjustmentSourceType {
+
+    /**
+     * A site transfer whose receipt left an open variance.
+     *
+     * <p>A transfer received short leaves the sending site down the full sent quantity and the
+     * receiving site up only what arrived. The transfer writes no loss movement for the
+     * difference on purpose, because a loss written automatically is a stock correction nobody
+     * authorised. The adjustment that decides what became of the difference names the transfer
+     * here, so the correction and the transfer that caused it can be read from either end.
+     */
+    SITE_TRANSFER
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -403,4 +403,7 @@
     <!-- v4.0 - Compliance: the curated Kerala and Tamil Nadu statutory catalogue, replacing the 037 placeholders -->
     <include file="db/changelog/v4.0/089-seed-compliance-rules-kl-tn.xml"/>
 
+    <!-- v4.0 - Stock adjustments: name the document the correction answers, so a transfer variance can be closed and read as closed -->
+    <include file="db/changelog/v4.0/090-add-stock-adjustment-source-document.xml"/>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/090-add-stock-adjustment-source-document.xml
+++ b/src/main/resources/db/changelog/v4.0/090-add-stock-adjustment-source-document.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        A stock adjustment can now say which document it was raised to answer.
+
+        The immediate cause is the site transfer received short. 086 gave a transfer an inbound leg
+        of its own, which meant a transfer could arrive with less than was sent, and the difference
+        is left as an open variance rather than written off automatically, because a loss written
+        automatically is a stock correction nobody authorised. The document that decides what
+        became of the difference is a stock adjustment, and until now it had nowhere to say which
+        transfer it answered. So the correction and the transfer that caused it could not be read
+        from either end: the transfer's variance stayed open for ever, and the adjustment read as
+        an unexplained count variance.
+
+        Why a type and an id rather than a foreign key to site_transfer. A transfer variance is the
+        first cause with a document behind it and it will not be the last; a goods receipt and a
+        material consumption are the obvious next two. A nullable foreign key per cause ends as a
+        row of mutually exclusive columns with nothing enforcing that only one of them is set,
+        whereas one typed pair carries any of them. The table already has this shape twice:
+        status_transition and attachment are both keyed by an entity type and an id rather than by
+        a foreign key to one owner.
+
+        What the pair gives up is the database refusing an id that names nothing, so the write path
+        does that instead: the set of types is a Java enum, every value has a resolver that loads
+        the named document within the caller's organization, and a type with no resolver is
+        refused rather than stored. A type nothing has checked would be an id taken on trust across
+        a tenant boundary, which is the whole reason the set is closed.
+
+        What it gains, besides room for the next cause, is that a posted adjustment outlives the
+        document that caused it. That is the same reason the status trail carries no foreign key:
+        an adjustment is a ledger fact, and deleting the transfer must not take the record of the
+        correction raised against it with it.
+
+        Nothing is backfilled. No adjustment that already exists was raised against a named
+        document, and inventing a reference for one would be asserting a cause nobody recorded.
+    -->
+
+    <changeSet id="090-01-add-stock-adjustment-source-document-columns" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="stock_adjustment" columnName="source_document_type"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The kind of document the adjustment answers, and which document of that kind.
+
+            Both nullable, and null on both is the ordinary case: most adjustments answer no
+            document at all, because somebody counted a location and the count disagreed with the
+            balance. The two are written together or not at all. A type with no id names nothing
+            and an id with no type says nothing about what it points at, so either half on its own
+            is refused by the write path rather than saved as a reference that cannot be followed.
+
+            source_document_type holds the enum name, at the width the other enum-name columns in
+            the schema use. source_document_id is an id within that kind and is deliberately not a
+            foreign key: see the note above the change set.
+        </comment>
+
+        <addColumn tableName="stock_adjustment">
+            <column name="source_document_type" type="VARCHAR(40)"/>
+            <column name="source_document_id" type="BIGINT"/>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="stock_adjustment" columnName="source_document_type"/>
+            <dropColumn tableName="stock_adjustment" columnName="source_document_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="090-02-index-stock-adjustment-source-document" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="stock_adjustment" indexName="idx_stock_adjustment_source_document"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            The reverse of the reference is the read that matters most, so it gets the index.
+
+            A transfer whose receipt left a variance is looked at from its own screen, and what it
+            needs to know is whether an adjustment has closed the difference. That asks for every
+            adjustment naming this document, which without an index is a scan of every adjustment
+            in the tenant on a screen somebody opens whenever a delivery arrives short.
+
+            The organization leads the index because every read of these columns is organization
+            explicit. The id in source_document_id is one a caller supplied against a column
+            carrying no foreign key, so matching on it alone would reach across tenants; scoping
+            belongs in the query, and an index that leads with the organization is the one that
+            query can use.
+        </comment>
+
+        <createIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_source_document">
+            <column name="organization_id"/>
+            <column name="source_document_type"/>
+            <column name="source_document_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="stock_adjustment" indexName="idx_stock_adjustment_source_document"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v4.0/090-add-stock-adjustment-source-document.xml
+++ b/src/main/resources/db/changelog/v4.0/090-add-stock-adjustment-source-document.xml
@@ -40,7 +40,17 @@
         document, and inventing a reference for one would be asserting a cause nobody recorded.
     -->
 
-    <changeSet id="090-01-add-stock-adjustment-source-document-columns" author="echno">
+    <!--
+        One column per change set, each guarded on its own column.
+
+        The two are written together by the application and mean nothing apart, so the temptation
+        is to add them in one change set guarded on one of them. That guard is wrong in the one
+        case a guard is for: a database where only the first column is already present marks the
+        change set as ran and never adds the second, leaving the entity mapped to a column that
+        does not exist. Guarding each column on itself cannot do that, and the pair is still
+        written together because it is the write path, not the schema, that enforces it.
+    -->
+    <changeSet id="090-01-add-stock-adjustment-source-document-type" author="echno">
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="stock_adjustment" columnName="source_document_type"/>
@@ -48,31 +58,48 @@
         </preConditions>
 
         <comment>
-            The kind of document the adjustment answers, and which document of that kind.
+            The kind of document the adjustment answers.
 
-            Both nullable, and null on both is the ordinary case: most adjustments answer no
-            document at all, because somebody counted a location and the count disagreed with the
-            balance. The two are written together or not at all. A type with no id names nothing
-            and an id with no type says nothing about what it points at, so either half on its own
-            is refused by the write path rather than saved as a reference that cannot be followed.
-
-            source_document_type holds the enum name, at the width the other enum-name columns in
-            the schema use. source_document_id is an id within that kind and is deliberately not a
-            foreign key: see the note above the change set.
+            Nullable, and null is the ordinary case: most adjustments answer no document at all,
+            because somebody counted a location and the count disagreed with the balance. Holds
+            the enum name, at the width the other enum-name columns in the schema use.
         </comment>
 
         <addColumn tableName="stock_adjustment">
             <column name="source_document_type" type="VARCHAR(40)"/>
-            <column name="source_document_id" type="BIGINT"/>
         </addColumn>
 
         <rollback>
             <dropColumn tableName="stock_adjustment" columnName="source_document_type"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="090-02-add-stock-adjustment-source-document-id" author="echno">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="stock_adjustment" columnName="source_document_id"/>
+            </not>
+        </preConditions>
+
+        <comment>
+            Which document of that kind.
+
+            Deliberately not a foreign key: see the note above the change sets. Written together
+            with the type or not at all. A type with no id names nothing and an id with no type
+            says nothing about what it points at, so either half on its own is refused by the
+            write path rather than saved as a reference that cannot be followed.
+        </comment>
+
+        <addColumn tableName="stock_adjustment">
+            <column name="source_document_id" type="BIGINT"/>
+        </addColumn>
+
+        <rollback>
             <dropColumn tableName="stock_adjustment" columnName="source_document_id"/>
         </rollback>
     </changeSet>
 
-    <changeSet id="090-02-index-stock-adjustment-source-document" author="echno">
+    <changeSet id="090-03-index-stock-adjustment-source-document" author="echno">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists tableName="stock_adjustment" indexName="idx_stock_adjustment_source_document"/>

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentApprovalTest.java
@@ -26,6 +26,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.math.BigDecimal;
@@ -71,6 +72,7 @@ class StockAdjustmentApprovalTest {
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -92,7 +94,8 @@ class StockAdjustmentApprovalTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
 
         organization = new Organization();
         organization.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentControllerWebAuthzTest.java
@@ -16,6 +16,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.tornotron.echno_backend.common.configuration.KeycloakAuthorizationService;
 import org.tornotron.echno_backend.common.configuration.RPTCache;
 import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
+
+import java.util.List;
 
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -76,6 +79,49 @@ class StockAdjustmentControllerWebAuthzTest {
 
         mockMvc.perform(get("/api/v1/stock-adjustments/web").with(jwt()))
                 .andExpect(status().isForbidden());
+    }
+
+    /**
+     * The reverse of the adjustment's own reference: a transfer left with an open variance asks
+     * whether anybody has closed it. Read by the same guard as the other reads, because the
+     * answer is a stock adjustment and any member may already read those. Pinned so a later
+     * tightening of the write guard cannot be applied here by analogy and leave whoever received
+     * the transfer unable to see the adjustment they are being sent to raise.
+     */
+    @Test
+    void readBySourceDocument_isOk_forAnyMember() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+        when(stockAdjustmentService.getBySourceDocument(StockAdjustmentSourceType.SITE_TRANSFER, 31L))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/stock-adjustments/web/by-source-document")
+                        .param("sourceDocumentType", "SITE_TRANSFER")
+                        .param("sourceDocumentId", "31")
+                        .with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void readBySourceDocument_isForbidden_forANonMember() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/stock-adjustments/web/by-source-document")
+                        .param("sourceDocumentType", "SITE_TRANSFER")
+                        .param("sourceDocumentId", "31")
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    /** A kind of document nobody can resolve is a bad request, not an empty result. */
+    @Test
+    void readBySourceDocument_refusesAnUnknownKindOfDocument() throws Exception {
+        when(orgSecurity.isMemberOfCurrentTenant()).thenReturn(true);
+
+        mockMvc.perform(get("/api/v1/stock-adjustments/web/by-source-document")
+                        .param("sourceDocumentType", "PURCHASE_ORDER")
+                        .param("sourceDocumentId", "31")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentCreateStatusTest.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDt
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.util.Optional;
@@ -49,6 +50,7 @@ class StockAdjustmentCreateStatusTest {
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -67,7 +69,8 @@ class StockAdjustmentCreateStatusTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(call -> {
             Organization org = new Organization();
             org.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentRejectionTest.java
@@ -21,6 +21,7 @@ import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDt
 import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.time.LocalDateTime;
@@ -62,6 +63,7 @@ class StockAdjustmentRejectionTest {
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -81,7 +83,8 @@ class StockAdjustmentRejectionTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                selfApprovalPolicy, userNameDirectory);
+                selfApprovalPolicy, userNameDirectory,
+                siteTransferRepository);
 
         organization = new Organization();
         organization.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentServiceTest.java
@@ -25,6 +25,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.util.List;
@@ -59,6 +60,7 @@ class StockAdjustmentServiceTest {
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -77,7 +79,8 @@ class StockAdjustmentServiceTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
             Organization org = new Organization();
             org.setId(ORG);

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentSourceDocumentTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentSourceDocumentTest.java
@@ -1,0 +1,336 @@
+package org.tornotron.echno_backend.stockAdjustment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tornotron.echno_backend.common.approval.SelfApprovalPolicy;
+import org.tornotron.echno_backend.common.exception.InvalidRequestException;
+import org.tornotron.echno_backend.common.exception.ResourceNotFoundException;
+import org.tornotron.echno_backend.common.multitenancy.TenantContext;
+import org.tornotron.echno_backend.common.multitenancy.TenantEntityHelper;
+import org.tornotron.echno_backend.common.service.OrganizationSecurityService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryService;
+import org.tornotron.echno_backend.inventoryTransaction.InventoryTransactionRepository;
+import org.tornotron.echno_backend.material.MaterialRepository;
+import org.tornotron.echno_backend.organization.Organization;
+import org.tornotron.echno_backend.project.ProjectRepository;
+import org.tornotron.echno_backend.siteTransfer.SiteTransfer;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
+import org.tornotron.echno_backend.siteTransfer.enums.SiteTransferStatus;
+import org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentCreationDto;
+import org.tornotron.echno_backend.stockAdjustment.enums.StockAdjustmentSourceType;
+import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
+import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
+import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.user.UserNameDirectory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A stock adjustment can name the document it was raised to answer, and the first such document
+ * is a site transfer whose receipt left an open variance.
+ *
+ * <p>The reference is what the whole feature rests on. A prefilled adjustment form that dropped
+ * it on submit would leave a correction nobody can trace back to what caused it, which is worse
+ * than offering no route at all, so these pin that what the caller sends is what is stored and
+ * what is read back.
+ *
+ * <p>The other half of what they pin is that the id is not taken on trust. The column carries no
+ * foreign key, so nothing in the database stops a caller naming a transfer in somebody else's
+ * organization; the write path has to, and the reverse read has to scope its match the same way.
+ *
+ * <p>Plain Mockito, no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class StockAdjustmentSourceDocumentTest {
+
+    private static final Long ORG = 100L;
+    private static final Long TRANSFER = 31L;
+
+    @Mock private StockAdjustmentRepository stockAdjustmentRepository;
+    @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
+    @Mock private StockAdjustmentMapper stockAdjustmentMapper;
+    @Mock private TenantEntityHelper tenantEntityHelper;
+    @Mock private MaterialRepository materialRepository;
+    @Mock private StorageLocationRepository storageLocationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private InventoryService inventoryService;
+    @Mock private InventoryTransactionRepository inventoryTransactionRepository;
+    @Mock private UserContextService userContextService;
+    @Mock private OrganizationSecurityService orgSecurity;
+
+    private StockAdjustmentService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setCurrentOrgId(ORG);
+        service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
+                tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
+                inventoryService, inventoryTransactionRepository, userContextService,
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
+        lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(call -> {
+            Organization org = new Organization();
+            org.setId(ORG);
+            return org;
+        });
+        lenient().when(stockAdjustmentRepository.saveAndFlush(any(StockAdjustment.class)))
+                .thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private StockAdjustmentCreationDto dto() {
+        StockAdjustmentCreationDto dto = new StockAdjustmentCreationDto();
+        dto.setAdjustmentNumber("ADJ-001");
+        dto.setType("write_off");
+        dto.setJustification("Two bags did not arrive with transfer TRF-0031");
+        return dto;
+    }
+
+    private SiteTransfer transfer(SiteTransferStatus status) {
+        SiteTransfer transfer = new SiteTransfer();
+        transfer.setId(TRANSFER);
+        transfer.setStatus(status);
+        return transfer;
+    }
+
+    private StockAdjustment saved() {
+        ArgumentCaptor<StockAdjustment> captor = ArgumentCaptor.forClass(StockAdjustment.class);
+        verify(stockAdjustmentRepository).saveAndFlush(captor.capture());
+        return captor.getValue();
+    }
+
+    /**
+     * The one this whole piece of work exists for: the reference the caller sent is on the
+     * document that is written. Without it the prefilled form posts a transfer id into nothing.
+     */
+    @Test
+    void create_withATransferReference_writesItOntoTheDocument() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.of(transfer(SiteTransferStatus.COMPLETED)));
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        service.create(dto);
+
+        StockAdjustment written = saved();
+        assertThat(written.getSourceDocumentType()).isEqualTo(StockAdjustmentSourceType.SITE_TRANSFER);
+        assertThat(written.getSourceDocumentId()).isEqualTo(TRANSFER);
+    }
+
+    /**
+     * A transfer that is still being received is a live cause too: the variance on a partially
+     * received transfer is the case the two-step document was built for.
+     */
+    @Test
+    void create_againstAPartiallyReceivedTransfer_isAllowed() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.of(transfer(SiteTransferStatus.PARTIALLY_TRANSFERRED)));
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        service.create(dto);
+
+        assertThat(saved().getSourceDocumentId()).isEqualTo(TRANSFER);
+    }
+
+    /** An adjustment that answers no document stores neither half, which is the ordinary case. */
+    @Test
+    void create_withNoReference_storesNeitherHalf() {
+        service.create(dto());
+
+        StockAdjustment written = saved();
+        assertThat(written.getSourceDocumentType()).isNull();
+        assertThat(written.getSourceDocumentId()).isNull();
+    }
+
+    /**
+     * The cross-tenant guard. The column holds no foreign key, so a caller naming a transfer that
+     * belongs to somebody else would otherwise be stored as a working pointer into another
+     * tenant's data, and every reader of the adjustment would follow it.
+     */
+    @Test
+    void create_namingATransferOutsideTheCallersOrganization_isRefused() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.empty());
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.create(dto))
+                .withMessageContaining("was not found in this organization");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    /**
+     * The id the caller sent is the id that is checked. A guard that looked the document up by
+     * one key while the value written came from another is the defect this codebase keeps
+     * finding, so this pins that the lookup uses the caller's own id and the caller's own
+     * organization.
+     */
+    @Test
+    void create_checksTheSameTransferIdItStores() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.of(transfer(SiteTransferStatus.COMPLETED)));
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        service.create(dto);
+
+        verify(siteTransferRepository).findByIdAndOrganization_Id(TRANSFER, ORG);
+        assertThat(saved().getSourceDocumentId()).isEqualTo(TRANSFER);
+    }
+
+    /**
+     * Cancelling is reachable only from PENDING and returns the whole sent quantity to the
+     * sending site, so a cancelled transfer left no variance to close. Its lines still read as
+     * in transit, which is the trap: that figure is history, not a live shortage.
+     */
+    @Test
+    void create_namingACancelledTransfer_isRefused() {
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.of(transfer(SiteTransferStatus.CANCELLED)));
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.create(dto))
+                .withMessageContaining("left no variance for an adjustment to close");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    /** An id with nothing saying what kind of document it is cannot be followed. */
+    @Test
+    void create_withAnIdAndNoType_isRefused() {
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentId(TRANSFER);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.create(dto))
+                .withMessageContaining("without saying what kind of document it is");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    /** A type naming no document is a claim to a reference that is not there. */
+    @Test
+    void create_withATypeAndNoId_isRefused() {
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+                .isThrownBy(() -> service.create(dto))
+                .withMessageContaining("without naming which one");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    /**
+     * The edit path writes the same header, so it takes the same checks. Without this an
+     * adjustment could be raised clean and then edited onto a transfer belonging to somebody
+     * else, which is the create guard with an extra step.
+     */
+    @Test
+    void update_namingATransferOutsideTheCallersOrganization_isRefused() {
+        StockAdjustment existing = new StockAdjustment();
+        existing.setId(9L);
+        Organization org = new Organization();
+        org.setId(ORG);
+        existing.setOrganization(org);
+        when(stockAdjustmentRepository.lockByIdAndOrganizationId(9L, ORG))
+                .thenReturn(Optional.of(existing));
+        when(siteTransferRepository.findByIdAndOrganization_Id(TRANSFER, ORG))
+                .thenReturn(Optional.empty());
+
+        StockAdjustmentCreationDto dto = dto();
+        dto.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        dto.setSourceDocumentId(TRANSFER);
+
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> service.update(9L, dto))
+                .withMessageContaining("was not found in this organization");
+
+        verify(stockAdjustmentRepository, never()).saveAndFlush(any());
+    }
+
+    /**
+     * The reverse read is anchored on an id the caller supplied against a column with no foreign
+     * key behind it. Matching on the type and id alone would hand back whichever tenant's
+     * adjustment happened to name the same number, so the organization is part of the query.
+     */
+    @Test
+    void getBySourceDocument_matchesWithinTheCallersOrganizationOnly() {
+        when(stockAdjustmentRepository
+                .findBySourceDocumentTypeAndSourceDocumentIdAndOrganization_IdOrderByCreatedAtDesc(
+                        StockAdjustmentSourceType.SITE_TRANSFER, TRANSFER, ORG))
+                .thenReturn(List.of());
+
+        assertThat(service.getBySourceDocument(StockAdjustmentSourceType.SITE_TRANSFER, TRANSFER))
+                .isEmpty();
+
+        verify(stockAdjustmentRepository)
+                .findBySourceDocumentTypeAndSourceDocumentIdAndOrganization_IdOrderByCreatedAtDesc(
+                        StockAdjustmentSourceType.SITE_TRANSFER, TRANSFER, ORG);
+    }
+
+    /** What the transfer screen reads to know its variance has been answered. */
+    @Test
+    void getBySourceDocument_returnsTheAdjustmentsNamingTheDocument() {
+        StockAdjustment closing = new StockAdjustment();
+        closing.setId(14L);
+        closing.setSourceDocumentType(StockAdjustmentSourceType.SITE_TRANSFER);
+        closing.setSourceDocumentId(TRANSFER);
+        when(stockAdjustmentRepository
+                .findBySourceDocumentTypeAndSourceDocumentIdAndOrganization_IdOrderByCreatedAtDesc(
+                        StockAdjustmentSourceType.SITE_TRANSFER, TRANSFER, ORG))
+                .thenReturn(List.of(closing));
+        when(stockAdjustmentMapper.toDto(any(StockAdjustment.class), any()))
+                .thenAnswer(call -> {
+                    var dto = new org.tornotron.echno_backend.stockAdjustment.dto.StockAdjustmentDto();
+                    StockAdjustment source = call.getArgument(0);
+                    dto.setId(source.getId());
+                    dto.setSourceDocumentType(source.getSourceDocumentType());
+                    dto.setSourceDocumentId(source.getSourceDocumentId());
+                    return dto;
+                });
+
+        var found = service.getBySourceDocument(StockAdjustmentSourceType.SITE_TRANSFER, TRANSFER);
+
+        assertThat(found).singleElement().satisfies(dto -> {
+            assertThat(dto.getId()).isEqualTo(14L);
+            assertThat(dto.getSourceDocumentId()).isEqualTo(TRANSFER);
+            assertThat(dto.getSourceDocumentType())
+                    .isEqualTo(StockAdjustmentSourceType.SITE_TRANSFER);
+        });
+    }
+}

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentStampNameTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentStampNameTest.java
@@ -23,6 +23,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapperI
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
 import org.tornotron.echno_backend.user.UserDisplayName;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 import org.tornotron.echno_backend.user.UserNameLookup;
 
@@ -69,6 +70,7 @@ class StockAdjustmentStampNameTest {
     @Mock private UserContextService userContextService;
     @Mock private OrganizationSecurityService orgSecurity;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
 
     private final StockAdjustmentMapper mapper = new StockAdjustmentMapperImpl();
 
@@ -80,7 +82,8 @@ class StockAdjustmentStampNameTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, mapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
     }
 
     @AfterEach

--- a/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentTotalsTest.java
+++ b/src/test/java/org/tornotron/echno_backend/stockAdjustment/StockAdjustmentTotalsTest.java
@@ -24,6 +24,7 @@ import org.tornotron.echno_backend.stockAdjustment.mapper.StockAdjustmentMapper;
 import org.tornotron.echno_backend.storageLocation.StorageLocation;
 import org.tornotron.echno_backend.storageLocation.StorageLocationRepository;
 import org.tornotron.echno_backend.user.UserContextService;
+import org.tornotron.echno_backend.siteTransfer.SiteTransferRepository;
 import org.tornotron.echno_backend.user.UserNameDirectory;
 
 import java.math.BigDecimal;
@@ -65,6 +66,7 @@ class StockAdjustmentTotalsTest {
 
     @Mock private StockAdjustmentRepository stockAdjustmentRepository;
     @Mock private UserNameDirectory userNameDirectory;
+    @Mock private SiteTransferRepository siteTransferRepository;
     @Mock private StockAdjustmentMapper stockAdjustmentMapper;
     @Mock private TenantEntityHelper tenantEntityHelper;
     @Mock private MaterialRepository materialRepository;
@@ -83,7 +85,8 @@ class StockAdjustmentTotalsTest {
         service = new StockAdjustmentService(stockAdjustmentRepository, stockAdjustmentMapper,
                 tenantEntityHelper, materialRepository, storageLocationRepository, projectRepository,
                 inventoryService, inventoryTransactionRepository, userContextService,
-                new SelfApprovalPolicy(orgSecurity), userNameDirectory);
+                new SelfApprovalPolicy(orgSecurity), userNameDirectory,
+                siteTransferRepository);
         lenient().when(tenantEntityHelper.resolveCurrentOrganization()).thenAnswer(inv -> {
             Organization org = new Organization();
             org.setId(ORG);


### PR DESCRIPTION
Backend half of tornotron/echno-web#398. The web half is a separate PR and depends on this contract.

## Why

A cross-project site transfer received short leaves an open variance. The sending site is down the full sent quantity, the receiving site is up what arrived, and the difference is unaccounted for. The transfer deliberately writes no loss movement for it (#660), because a loss written automatically is a stock correction nobody authorised. The document that decides what became of the difference is a stock adjustment, and until now it had nowhere to say which transfer it answered. So the correction and its cause could not be read from either end: the transfer's variance stayed amber for ever, and the adjustment read as an unexplained count variance.

web#392 shows and names the variance but offers no route to the adjustment, and that was left out on purpose: a link built against the web mock shape's `transferId` would have produced a prefilled form that silently dropped the reference on submit.

## The shape, and why not a foreign key

`sourceDocumentType` (enum) plus `sourceDocumentId` (long), both nullable, written together or not at all.

A transfer variance is the first cause with a document behind it and it will not be the last: a goods receipt and a consumption are the obvious next two. A nullable foreign key per cause ends as a row of mutually exclusive columns with nothing enforcing that only one of them is set. The schema already carries a type-and-id key twice, in `status_transition` and `attachment`, and for the further reason those give: a posted adjustment is a ledger fact and has to outlive the document that caused it, so deleting a transfer must not take the record of the correction raised against it.

The departure from those two is that this is an enum rather than a free string. What the pair gives up is the database refusing an id that names nothing, so the write path does it instead: every value has a resolver that loads the named document within the caller's organization, and a value with no resolver is refused rather than stored. Adding a source type therefore means adding its resolver, which is deliberate.

## The reference is not taken on trust

The id the caller sent is the id that is looked up, organization scoped, and the id that is written. There is no second key for a guard and a write to disagree about, which is the defect shape this repo keeps finding. The reverse read is scoped in the query for the same reason: matching on a caller supplied id against a column with no foreign key behind it would otherwise reach across tenants.

A cancelled transfer is refused as a cause. Cancelling is reachable only from `PENDING`, which is the state in which nothing has been received, and it returns the whole sent quantity to the sending site, so it left no variance to close. Its lines still read as in transit, and that figure is history rather than a live shortage.

## Authorization

`GET /api/v1/stock-adjustments/web/by-source-document` reads under the same guard as the other stock adjustment reads (any tenant member), so whoever received the transfer can also see the adjustment they are being sent to raise. Receiving a transfer needs `system-admin`, and creating an adjustment needs `system-admin` or `project-manager`, so the whole path holds for the person who is actually offered the link.

One mismatch found while tracing that path is filed separately rather than fixed here: a `project-manager` may raise and approve a stock adjustment but may not read a site transfer at all, so they cannot follow a source reference back to its transfer. Widening site transfer reads is a decision of its own and does not belong in this change.

## Tests

New `StockAdjustmentSourceDocumentTest`, 11 cases, plus three cases on the controller authorization slice. Each was confirmed red by reverting the specific line it covers.

`docs/openapi.json` is regenerated on a runner: this workstation has no container runtime, so the snapshot test cannot be run locally.

https://claude.ai/code/session_01YWbRuHXKpFT6jL3mzYNhhD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stock adjustments can now reference the source document they address, currently supporting site transfers.
  - Added an endpoint to retrieve stock adjustments associated with a specific source document.
  - Source documents are validated for organization access and eligible status when creating or updating adjustments.
  - API responses now include source document type and ID when available.

- **Bug Fixes**
  - Prevented cross-organization source-document matches and invalid document references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->